### PR TITLE
feat(inward): record delivering and billing department on timed services

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -1432,8 +1432,9 @@ public class BhtSummeryController implements Serializable {
     }
 
     private double updatePatientItems(InwardChargeType inwardChargeType, double discountPercent) {
+        double disTot = updateTimedServiceBillItems(inwardChargeType, discountPercent);
+
         List<PatientItem> list = getInwardBean().fetchTimedPatientItemByInwardChargeType(inwardChargeType, getPatientEncounter());
-        double disTot = 0;
         if (list == null || list.isEmpty()) {
             return disTot;
         }
@@ -1449,8 +1450,44 @@ public class BhtSummeryController implements Serializable {
         return disTot;
     }
 
+    /**
+     * Discounts timed services that carry their charge on a BillItem.
+     * <p>
+     * A timed service added from the consume page now creates its own Bill and
+     * BillItem, and the inward total for it is summed from the BillItem side —
+     * so the discount has to land there. It cannot go through
+     * {@code updateServiceBillFees}, because a timed service has no BillFee and
+     * recomputing its net value from fees would zero the charge. The matching
+     * PatientItem is kept in step so the breakdown screens agree with the bill.
+     */
+    private double updateTimedServiceBillItems(InwardChargeType inwardChargeType, double discountPercent) {
+        List<BillItem> list = getInwardBean().fetchTimedServiceBillItemsByInwardChargeType(inwardChargeType, getPatientEncounter());
+        double disTot = 0;
+        if (list == null || list.isEmpty()) {
+            return disTot;
+        }
+
+        for (BillItem bi : list) {
+            double value = bi.getGrossValue() + bi.getMarginValue();
+            double dis = (value * discountPercent) / 100;
+            disTot += dis;
+            bi.setDiscount(dis);
+            bi.setNetValue(value - dis);
+            getBillItemFacade().edit(bi);
+
+            PatientItem pi = getInwardBean().fetchPatientItemByBillItem(bi);
+            if (pi != null) {
+                pi.setDiscount(dis);
+                getPatientItemFacade().edit(pi);
+            }
+        }
+
+        return disTot;
+    }
+
     private void updatePatientItemsWithOutMatrix(InwardChargeType inwardChargeType) {
         getInwardBean().bulkClearPatientItemsWithOutMatrix(inwardChargeType, getPatientEncounter());
+        getInwardBean().bulkClearTimedServiceBillItemsWithOutMatrix(inwardChargeType, getPatientEncounter());
     }
 
     private double updatePatientRoomCharge(InwardChargeType inwardChargeType) {
@@ -2658,16 +2695,76 @@ public class BhtSummeryController implements Serializable {
         }
     }
 
-    private boolean checkPatientItems() {
-        List<PatientItem> lst = createPatientItems();
-
-        for (PatientItem pi : lst) {
-            if (pi != null && pi.getToTime() == null) {
-                return true;
-            }
+    /**
+     * Closes off any timed service still running at discharge, stopping it at
+     * the discharge time and pricing it for that duration.
+     * <p>
+     * This used to be a hard block ("Please Finalize Patient Timed Service")
+     * that made staff go back and stop each service by hand. Stopping them at
+     * the discharge time is what that manual step amounted to anyway, and doing
+     * it here guarantees the charge is priced for the real length of stay
+     * instead of whatever stale value was last persisted.
+     */
+    private void finalizeRunningTimedServices(Date dischargeTime) {
+        List<PatientItem> running = getInwardBean().fetchRunningTimedPatientItems(getPatientEncounter());
+        if (running == null || running.isEmpty()) {
+            return;
         }
 
-        return false;
+        int closed = 0;
+        for (PatientItem pi : running) {
+            if (pi.getBillItem() != null && pi.getBillItem().isFromPackage()) {
+                continue;
+            }
+            if (pi.getFromTime() != null && dischargeTime.before(pi.getFromTime())) {
+                continue;
+            }
+            TimedItemFee timedItemFee = getInwardBean().getTimedItemFee((TimedItem) pi.getItem());
+            if (timedItemFee == null) {
+                // No fee configured for this item — leave it alone rather than
+                // failing the whole discharge over one unpriceable service.
+                continue;
+            }
+            pi.setToTime(dischargeTime);
+            double count = getInwardBean().calCount(timedItemFee, pi.getFromTime(), pi.getToTime());
+            pi.setServiceValue(count * timedItemFee.getFee());
+            getPatientItemFacade().edit(pi);
+            syncTimedServiceCharge(pi);
+            closed++;
+        }
+
+        if (closed > 0) {
+            patientItems = null;
+            JsfUtil.addSuccessMessage(closed + " running timed service(s) were stopped at the discharge time.");
+        }
+    }
+
+    /**
+     * Pushes a recalculated timed-service charge onto its BillItem and Bill, so
+     * the inward totals (which sum the BillItem side) never read a stale
+     * duration. Package-locked items keep their fixed price.
+     */
+    private void syncTimedServiceCharge(PatientItem patientItem) {
+        if (patientItem == null || patientItem.getBillItem() == null) {
+            return;
+        }
+        BillItem bi = patientItem.getBillItem();
+        if (bi.isFromPackage()) {
+            return;
+        }
+        bi.setGrossValue(patientItem.getServiceValue());
+        bi.setDiscount(patientItem.getDiscount());
+        bi.setNetValue(patientItem.getServiceValue() + bi.getMarginValue() - patientItem.getDiscount());
+        bi.setFromTime(patientItem.getFromTime());
+        bi.setToTime(patientItem.getToTime());
+        getBillItemFacade().edit(bi);
+
+        Bill b = bi.getBill();
+        if (b != null) {
+            b.setTotal(bi.getGrossValue());
+            b.setNetTotal(bi.getNetValue());
+            getBillFacade().edit(b);
+        }
     }
 
     public void dischargeCancel() {
@@ -2753,10 +2850,7 @@ public class BhtSummeryController implements Serializable {
             return;
         }
 
-        if (checkPatientItems()) {
-            JsfUtil.addErrorMessage("Please Finalize Patient Timed Service");
-            return;
-        }
+        finalizeRunningTimedServices(date);
 
         if (!getPatientEncounter().isClinicallyDischarged()) {
             JsfUtil.addErrorMessage("Warning: Clinical discharge has not been confirmed for this patient.");
@@ -3625,6 +3719,7 @@ public class BhtSummeryController implements Serializable {
         patientItem.setServiceValue(count * timedItemFee.getFee());
 
         getPatientItemFacade().edit(patientItem);
+        syncTimedServiceCharge(patientItem);
 
         createPatientItems();
 
@@ -4446,11 +4541,18 @@ public class BhtSummeryController implements Serializable {
      */
     private void setGrossMarginVatBreakdown() {
         Map<InwardChargeType, double[]> serviceBreakdown = getInwardBean().calServiceBillItemsGrossMarginVatByInwardChargeTypeBulk(getPatientEncounter(), childPatientEncouters);
+        // Timed services that predate the bill-at-add change still carry their
+        // charge on the PatientItem alone. They are part of the gross for their
+        // charge type, so they have to be added to the BillItem-side breakdown —
+        // otherwise a charge type holding both kinds would report only the
+        // BillItem half as gross while Total and Net show the full amount.
+        Map<InwardChargeType, Double> timedItemTotals = getInwardBean().getTimedItemFeeTotalByInwardChargeTypeBulk(getPatientEncounter(), childPatientEncouters);
 
         for (ChargeItemTotal cit : chargeItemTotals) {
             double[] values = serviceBreakdown.get(cit.getInwardChargeType());
+            Double timedTotal = timedItemTotals.get(cit.getInwardChargeType());
             if (values != null) {
-                cit.setGross(values[0]);
+                cit.setGross(values[0] + (timedTotal != null ? timedTotal : 0.0));
                 cit.setMargin(values[1]);
                 cit.setVat(values[2]);
             } else {

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -2706,7 +2706,10 @@ public class BhtSummeryController implements Serializable {
      * instead of whatever stale value was last persisted.
      */
     private void finalizeRunningTimedServices(Date dischargeTime) {
-        List<PatientItem> running = getInwardBean().fetchRunningTimedPatientItems(getPatientEncounter());
+        if (childPatientEncouters == null || childPatientEncouters.isEmpty()) {
+            childPatientEncouters = getInwardBean().fetchChildPatientEncounter(getPatientEncounter());
+        }
+        List<PatientItem> running = getInwardBean().fetchRunningTimedPatientItems(getPatientEncounter(), childPatientEncouters);
         if (running == null || running.isEmpty()) {
             return;
         }
@@ -2730,9 +2733,13 @@ public class BhtSummeryController implements Serializable {
             // Priced through calTotalTimedChargeForItem, the same path the
             // manual stop uses, so tiered fee blocks and foreigner rates give
             // the same amount whether a service is stopped by hand or here.
+            // The foreigner flag comes from the item's own encounter, which for
+            // a baby's service is the child encounter, not the mother's.
+            PatientEncounter owner = pi.getPatientEncounter() != null
+                    ? pi.getPatientEncounter() : getPatientEncounter();
             pi.setServiceValue(getInwardBean().calTotalTimedChargeForItem(
                     (TimedItem) pi.getItem(), pi.getFromTime(), pi.getToTime(),
-                    getPatientEncounter().isForiegner()));
+                    owner.isForiegner()));
             getPatientItemFacade().edit(pi);
             syncTimedServiceCharge(pi);
             closed++;

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -2719,15 +2719,20 @@ public class BhtSummeryController implements Serializable {
             if (pi.getFromTime() != null && dischargeTime.before(pi.getFromTime())) {
                 continue;
             }
-            TimedItemFee timedItemFee = getInwardBean().getTimedItemFee((TimedItem) pi.getItem());
-            if (timedItemFee == null) {
-                // No fee configured for this item — leave it alone rather than
-                // failing the whole discharge over one unpriceable service.
+            // getTimedItemFee never returns null — it hands back an empty fee
+            // with durationHours = 0, which would price the service at zero.
+            // Check for a real fee row instead, and skip rather than wipe the
+            // charge of a service nobody has configured a price for.
+            if (getInwardBean().getAllTimedItemFees((TimedItem) pi.getItem()).isEmpty()) {
                 continue;
             }
             pi.setToTime(dischargeTime);
-            double count = getInwardBean().calCount(timedItemFee, pi.getFromTime(), pi.getToTime());
-            pi.setServiceValue(count * timedItemFee.getFee());
+            // Priced through calTotalTimedChargeForItem, the same path the
+            // manual stop uses, so tiered fee blocks and foreigner rates give
+            // the same amount whether a service is stopped by hand or here.
+            pi.setServiceValue(getInwardBean().calTotalTimedChargeForItem(
+                    (TimedItem) pi.getItem(), pi.getFromTime(), pi.getToTime(),
+                    getPatientEncounter().isForiegner()));
             getPatientItemFacade().edit(pi);
             syncTimedServiceCharge(pi);
             closed++;
@@ -2743,6 +2748,13 @@ public class BhtSummeryController implements Serializable {
      * Pushes a recalculated timed-service charge onto its BillItem and Bill, so
      * the inward totals (which sum the BillItem side) never read a stale
      * duration. Package-locked items keep their fixed price.
+     * <p>
+     * The discount is read from the BillItem, not the PatientItem. The BillItem
+     * is the side the discount routines clear when no price matrix applies, and
+     * the bulk clear cannot reach the PatientItem (it filters on
+     * {@code billItem is null}). Taking the discount from the PatientItem would
+     * silently re-apply one that had just been removed. The PatientItem is
+     * mirrored back so the breakdown screens still agree with the bill.
      */
     private void syncTimedServiceCharge(PatientItem patientItem) {
         if (patientItem == null || patientItem.getBillItem() == null) {
@@ -2752,12 +2764,17 @@ public class BhtSummeryController implements Serializable {
         if (bi.isFromPackage()) {
             return;
         }
+        double discount = bi.getDiscount();
         bi.setGrossValue(patientItem.getServiceValue());
-        bi.setDiscount(patientItem.getDiscount());
-        bi.setNetValue(patientItem.getServiceValue() + bi.getMarginValue() - patientItem.getDiscount());
+        bi.setNetValue(patientItem.getServiceValue() + bi.getMarginValue() - discount);
         bi.setFromTime(patientItem.getFromTime());
         bi.setToTime(patientItem.getToTime());
         getBillItemFacade().edit(bi);
+
+        if (patientItem.getDiscount() != discount) {
+            patientItem.setDiscount(discount);
+            getPatientItemFacade().edit(patientItem);
+        }
 
         Bill b = bi.getBill();
         if (b != null) {

--- a/src/main/java/com/divudi/bean/inward/InwardBeanController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardBeanController.java
@@ -158,24 +158,40 @@ public class InwardBeanController implements Serializable {
         return getBillItemFacade().findByJpql(sql, hm, TemporalType.TIME);
     }
 
+    /**
+     * Inward service BillItems for the "Inward Services" breakdown.
+     * <p>
+     * TimedItems are excluded because the breakdown screens list them
+     * separately from their PatientItems (see
+     * {@code resources/inward/breakDown/timedService.xhtml}); leaving them in
+     * would show each timed service twice on the same page.
+     */
     public List<BillItem> fetchBillItems(PatientEncounter patientEncounter) {
         String sql = "SELECT  b FROM BillItem b "
                 + " WHERE b.retired=false "
                 + " and b.bill.billType=:btp "
+                + " and type(b.item)!=:cls "
                 + " and b.bill.patientEncounter=:pe ";
         HashMap hm = new HashMap();
         hm.put("btp", BillType.InwardBill);
+        hm.put("cls", TimedItem.class);
         hm.put("pe", patientEncounter);
         return getBillItemFacade().findByJpql(sql, hm);
     }
 
+    /**
+     * Uncached variant of {@link #fetchBillItems(PatientEncounter)}; TimedItems
+     * are excluded for the same reason.
+     */
     public List<BillItem> fetchEagerBillItems(PatientEncounter patientEncounter) {
         String sql = "SELECT  b FROM BillItem b "
                 + " WHERE b.retired=false "
                 + " and b.bill.billType=:btp "
+                + " and type(b.item)!=:cls "
                 + " and b.bill.patientEncounter=:pe ";
         HashMap hm = new HashMap();
         hm.put("btp", BillType.InwardBill);
+        hm.put("cls", TimedItem.class);
         hm.put("pe", patientEncounter);
         return getBillItemFacade().findByJpqlWithoutCache(sql, hm);
     }
@@ -673,19 +689,107 @@ public class InwardBeanController implements Serializable {
 
     }
 
+    /**
+     * Service BillItems whose net value is derived from their BillFees.
+     * <p>
+     * TimedItem BillItems are excluded on purpose. A timed service is priced by
+     * duration and carries no BillFee, so running it through
+     * {@code updateBillItemByBillFee} would recompute its net value as the sum
+     * of zero fees and silently wipe the charge. Timed services are discounted
+     * directly on the BillItem instead — see
+     * {@link #fetchTimedServiceBillItemsByInwardChargeType}.
+     */
     public List<BillItem> getServiceBillItemByInwardChargeType(InwardChargeType inwardChargeType, PatientEncounter patientEncounter) {
         String sql = "Select s From BillItem s"
                 + " where s.retired=false "
                 + " and s.bill.billType=:btp "
                 + " and s.bill.patientEncounter=:pe"
+                + " and type(s.item)!=:cls "
                 + " and s.item.inwardChargeType=:inw ";
         HashMap hm = new HashMap();
         hm.put("btp", BillType.InwardBill);
         hm.put("pe", patientEncounter);
+        hm.put("cls", TimedItem.class);
         hm.put("inw", inwardChargeType);
 
         return getBillItemFacade().findByJpql(sql, hm);
 
+    }
+
+    /**
+     * Timed-service BillItems for one charge type, excluding package-locked
+     * ones (their price is fixed by the package and must not be discounted).
+     * These are priced from the PatientItem duration, so their discount is
+     * applied straight to the BillItem rather than through BillFees.
+     */
+    public List<BillItem> fetchTimedServiceBillItemsByInwardChargeType(InwardChargeType inwardChargeType, PatientEncounter patientEncounter) {
+        String sql = "Select s From BillItem s"
+                + " where s.retired=false "
+                + " and s.bill.billType=:btp "
+                + " and s.bill.patientEncounter=:pe"
+                + " and type(s.item)=:cls "
+                + " and s.fromPackage=false "
+                + " and s.item.inwardChargeType=:inw ";
+        HashMap hm = new HashMap();
+        hm.put("btp", BillType.InwardBill);
+        hm.put("pe", patientEncounter);
+        hm.put("cls", TimedItem.class);
+        hm.put("inw", inwardChargeType);
+
+        return getBillItemFacade().findByJpql(sql, hm);
+    }
+
+    /**
+     * The PatientItem carrying the timing behind a timed-service BillItem.
+     * BillItem has no back-reference, so it is looked up from the owning side.
+     */
+    public PatientItem fetchPatientItemByBillItem(BillItem billItem) {
+        if (billItem == null) {
+            return null;
+        }
+        String sql = "Select i From PatientItem i"
+                + " where i.retired=false"
+                + " and i.billItem=:bi";
+        HashMap hm = new HashMap();
+        hm.put("bi", billItem);
+        return getPatientItemFacade().findFirstByJpql(sql, hm);
+    }
+
+    /**
+     * Timed services on an admission that are still running (no stop time).
+     * Used to close them off automatically at discharge.
+     */
+    public List<PatientItem> fetchRunningTimedPatientItems(PatientEncounter patientEncounter) {
+        String sql = "Select i From PatientItem i"
+                + " where i.retired=false"
+                + " and type(i.item)=:cls"
+                + " and i.patientEncounter=:pe"
+                + " and i.toTime is null";
+        HashMap hm = new HashMap();
+        hm.put("cls", TimedItem.class);
+        hm.put("pe", patientEncounter);
+        return getPatientItemFacade().findByJpql(sql, hm);
+    }
+
+    /**
+     * Clears any previously applied discount on timed-service BillItems when no
+     * price matrix applies. Mirrors {@link #bulkClearPatientItemsWithOutMatrix}
+     * for the BillItem side.
+     */
+    public void bulkClearTimedServiceBillItemsWithOutMatrix(InwardChargeType inwardChargeType, PatientEncounter patientEncounter) {
+        String sql = "UPDATE BillItem s SET s.discount = 0.0, s.netValue = s.grossValue + s.marginValue"
+                + " WHERE s.retired = false"
+                + " AND s.bill.billType = :btp"
+                + " AND s.bill.patientEncounter = :pe"
+                + " AND type(s.item) = :cls"
+                + " AND s.fromPackage = false"
+                + " AND s.item.inwardChargeType = :inw";
+        HashMap hm = new HashMap();
+        hm.put("btp", BillType.InwardBill);
+        hm.put("cls", TimedItem.class);
+        hm.put("pe", patientEncounter);
+        hm.put("inw", inwardChargeType);
+        getBillItemFacade().updateByJpql(sql, hm);
     }
 
     public List<BillFee> createDoctorAndNurseFee(PatientEncounter patientEncounter, List<PatientEncounter> cpts) {

--- a/src/main/java/com/divudi/bean/inward/InwardBeanController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardBeanController.java
@@ -756,18 +756,28 @@ public class InwardBeanController implements Serializable {
     }
 
     /**
-     * Timed services on an admission that are still running (no stop time).
-     * Used to close them off automatically at discharge.
+     * Timed services still running (no stop time) on an admission and on any
+     * child encounters attached to it. Used to close them off automatically at
+     * discharge.
+     * <p>
+     * Child encounters are included because a baby's charges are settled on the
+     * mother's final bill — the timed-service totals already sum both — so a
+     * baby's running service has to be stopped and repriced along with hers.
      */
-    public List<PatientItem> fetchRunningTimedPatientItems(PatientEncounter patientEncounter) {
+    public List<PatientItem> fetchRunningTimedPatientItems(PatientEncounter patientEncounter, List<PatientEncounter> cpts) {
         String sql = "Select i From PatientItem i"
                 + " where i.retired=false"
                 + " and type(i.item)=:cls"
-                + " and i.patientEncounter=:pe"
+                + " and i.patientEncounter IN :pe"
                 + " and i.toTime is null";
+        List<PatientEncounter> pts = new ArrayList<>();
+        pts.add(patientEncounter);
+        if (cpts != null && !cpts.isEmpty()) {
+            pts.addAll(cpts);
+        }
         HashMap hm = new HashMap();
         hm.put("cls", TimedItem.class);
-        hm.put("pe", patientEncounter);
+        hm.put("pe", pts);
         return getPatientItemFacade().findByJpql(sql, hm);
     }
 
@@ -775,6 +785,14 @@ public class InwardBeanController implements Serializable {
      * Clears any previously applied discount on timed-service BillItems when no
      * price matrix applies. Mirrors {@link #bulkClearPatientItemsWithOutMatrix}
      * for the BillItem side.
+     * <p>
+     * The matching PatientItems are cleared too. Their discount is a mirror of
+     * the BillItem's, kept for the breakdown screens and for
+     * {@code InwardChargeTypeBreakdownController} /
+     * {@code InwardChargeTypeDetailController}, which subtract it to show a net
+     * figure. {@link #bulkClearPatientItemsWithOutMatrix} cannot reach them —
+     * it filters on {@code billItem is null} — so without this they would keep
+     * displaying a discount that has just been removed from the bill.
      */
     public void bulkClearTimedServiceBillItemsWithOutMatrix(InwardChargeType inwardChargeType, PatientEncounter patientEncounter) {
         String sql = "UPDATE BillItem s SET s.discount = 0.0, s.netValue = s.grossValue + s.marginValue"
@@ -790,6 +808,23 @@ public class InwardBeanController implements Serializable {
         hm.put("pe", patientEncounter);
         hm.put("inw", inwardChargeType);
         getBillItemFacade().updateByJpql(sql, hm);
+
+        // Deliberately not filtered on billItem.fromPackage. A package item's
+        // price is fixed and never discounted, so its mirrored discount is
+        // already zero and clearing it changes nothing — and avoiding that
+        // navigation keeps this a plain bulk update over PatientItem's own
+        // columns, matching bulkClearPatientItemsWithOutMatrix.
+        String piSql = "UPDATE PatientItem s SET s.discount = 0.0"
+                + " WHERE s.retired = false"
+                + " AND type(s.item) = :cls"
+                + " AND s.billItem is not null"
+                + " AND s.patientEncounter = :pe"
+                + " AND s.item.inwardChargeType = :inw";
+        HashMap piHm = new HashMap();
+        piHm.put("cls", TimedItem.class);
+        piHm.put("pe", patientEncounter);
+        piHm.put("inw", inwardChargeType);
+        getPatientItemFacade().updateByJpql(piSql, piHm);
     }
 
     public List<BillFee> createDoctorAndNurseFee(PatientEncounter patientEncounter, List<PatientEncounter> cpts) {

--- a/src/main/java/com/divudi/bean/inward/InwardTimedItemController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardTimedItemController.java
@@ -14,6 +14,8 @@ import com.divudi.bean.common.WebUserController;
 
 import com.divudi.core.data.BillClassType;
 import com.divudi.core.data.BillNumberSuffix;
+import com.divudi.core.data.BillType;
+import com.divudi.core.data.BillTypeAtomic;
 import com.divudi.core.data.inward.SurgeryBillType;
 import com.divudi.ejb.BillNumberGenerator;
 import com.divudi.core.util.JsfUtil;
@@ -102,6 +104,7 @@ public class InwardTimedItemController implements Serializable {
     private Institution institution;
     private Institution site;
     private Department department;
+    private Department fromDepartment;
 
     public BillNumberGenerator getBillNumberBean() {
         return billNumberBean;
@@ -391,15 +394,43 @@ public class InwardTimedItemController implements Serializable {
             JsfUtil.addErrorMessage("This item is included in the admission's package and cannot be removed.");
             return;
         }
+        if (patientItem != null && isLockedForChanges(patientItem.getPatientEncounter())) {
+            return;
+        }
         if (patientItem != null) {
             patientItem.setRetirer(getSessionController().getLoggedUser());
             patientItem.setRetiredAt(new Date());
             patientItem.setRetired(true);
             getPatientItemFacade().edit(patientItem);
+            retireTimedServiceBill(patientItem);
 
             createPatientItems();
 
             JsfUtil.addSuccessMessage("Removed successfully.");
+        }
+    }
+
+    /**
+     * Retires the BillItem and Bill behind a removed timed service. Without
+     * this the charge would survive the removal, since the inward totals are
+     * summed from the BillItem side.
+     */
+    private void retireTimedServiceBill(PatientItem patientItem) {
+        BillItem bi = patientItem.getBillItem();
+        if (bi == null || bi.isFromPackage()) {
+            return;
+        }
+        bi.setRetired(true);
+        bi.setRetiredAt(new Date());
+        bi.setRetirer(getSessionController().getLoggedUser());
+        getBillItemFacade().edit(bi);
+
+        Bill b = bi.getBill();
+        if (b != null) {
+            b.setRetired(true);
+            b.setRetiredAt(new Date());
+            b.setRetirer(getSessionController().getLoggedUser());
+            getBillFacade().edit(b);
         }
     }
 
@@ -571,6 +602,7 @@ public class InwardTimedItemController implements Serializable {
         timedEncounterComponents = null;
         batchBill = null;
         bill = null;
+        fromDepartment = null;
 
     }
 
@@ -611,12 +643,61 @@ public class InwardTimedItemController implements Serializable {
             JsfUtil.addErrorMessage("Please Select Service");
             return true;
         }
+        if (isLockedForChanges(getCurrent().getPatientEncounter())) {
+            return true;
+        }
         if (getCurrent().getPatientEncounter().isNursingDischarged()
                 && !webUserController.hasPrivilege("InwardAddChargesAfterNursingDischarge")) {
             JsfUtil.addErrorMessage("Cannot add charges: nursing discharge has been confirmed for this patient.");
             return true;
         }
         return false;
+    }
+
+    /**
+     * A timed service and its bill stay mutable for the whole stay — the charge
+     * keeps growing while the service runs — but become immutable once the
+     * patient is discharged or the final payment is settled.
+     */
+    private boolean isLockedForChanges(PatientEncounter pe) {
+        if (pe == null) {
+            return false;
+        }
+        if (pe.isPaymentFinalized()) {
+            JsfUtil.addErrorMessage("Final payment has been settled for this admission. Timed services can no longer be changed.");
+            return true;
+        }
+        if (pe.isDischarged()) {
+            JsfUtil.addErrorMessage("This patient has been discharged. Timed services can no longer be changed.");
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Department the service was physically delivered in. Defaults to the
+     * service item's own department and can be overridden by the user before
+     * adding, since the same service may be given in a different ward or unit.
+     */
+    public Department getFromDepartment() {
+        if (fromDepartment == null && current != null && current.getItem() != null) {
+            fromDepartment = current.getItem().getDepartment();
+        }
+        return fromDepartment;
+    }
+
+    public void setFromDepartment(Department fromDepartment) {
+        this.fromDepartment = fromDepartment;
+    }
+
+    /**
+     * Resets the delivering department to the newly selected service's own
+     * department, so the default follows the item rather than sticking to
+     * whatever was chosen for the previous service.
+     */
+    public void serviceSelectListener() {
+        fromDepartment = current != null && current.getItem() != null
+                ? current.getItem().getDepartment() : null;
     }
 
     public void save() {
@@ -635,7 +716,10 @@ public class InwardTimedItemController implements Serializable {
 
         getCurrent().setCreater(getSessionController().getLoggedUser());
         getCurrent().setCreatedAt(Calendar.getInstance().getTime());
+        getCurrent().setPatient(getCurrent().getPatientEncounter().getPatient());
+
         if (getCurrent().getId() == null) {
+            createBillForTimedService(getCurrent());
             getPatientItemFacade().create(getCurrent());
         }
 
@@ -644,6 +728,7 @@ public class InwardTimedItemController implements Serializable {
         current = new PatientItem();
         current.setPatientEncounter(tmp);
         current.setItem(null);
+        fromDepartment = null;
 
         createPatientItems();
 
@@ -651,9 +736,106 @@ public class InwardTimedItemController implements Serializable {
 
     }
 
+    /**
+     * Creates the Bill and BillItem that carry a newly added timed service.
+     * <p>
+     * One bill per service, so a bill never mixes items from two departments
+     * and each service can be traced to where it was delivered:
+     * {@code fromDepartment} is where the service was given (defaulting to the
+     * item's department), {@code toDepartment} is the department that entered
+     * it. The BillItem holds the charge; the PatientItem keeps holding the
+     * timing. Both are kept in step by {@link #syncTimedServiceCharge}.
+     */
+    private void createBillForTimedService(PatientItem patientItem) {
+        PatientEncounter pe = patientItem.getPatientEncounter();
+        Department deliveringDepartment = getFromDepartment();
+        if (deliveringDepartment == null) {
+            deliveringDepartment = getSessionController().getDepartment();
+        }
+
+        BilledBill newBill = new BilledBill();
+        newBill.setBillType(BillType.InwardBill);
+        newBill.setBillTypeAtomic(BillTypeAtomic.INWARD_SERVICE_BILL);
+        newBill.setPatient(pe.getPatient());
+        newBill.setPatientEncounter(pe);
+        newBill.setPaymentScheme(pe.getPaymentScheme());
+        newBill.setPaymentMethod(pe.getPaymentMethod());
+        newBill.setDepartment(getSessionController().getDepartment());
+        newBill.setInstitution(getSessionController().getInstitution());
+        newBill.setFromDepartment(deliveringDepartment);
+        newBill.setFromInstitution(deliveringDepartment.getInstitution());
+        newBill.setToDepartment(getSessionController().getDepartment());
+        newBill.setToInstitution(getSessionController().getInstitution());
+        newBill.setBillDate(new Date());
+        newBill.setBillTime(new Date());
+        newBill.setCreatedAt(new Date());
+        newBill.setCreater(getSessionController().getLoggedUser());
+        newBill.setTotal(patientItem.getServiceValue());
+        newBill.setNetTotal(patientItem.getServiceValue());
+        newBill.setDeptId(getBillNumberBean().departmentBillNumberGenerator(
+                newBill.getDepartment(), BillType.InwardBill, BillClassType.BilledBill, BillNumberSuffix.INWSER));
+        newBill.setInsId(getBillNumberBean().institutionBillNumberGenerator(
+                newBill.getInstitution(), BillType.InwardBill, BillClassType.BilledBill, BillNumberSuffix.INWSER));
+        getBillFacade().create(newBill);
+
+        BillItem newBillItem = new BillItem();
+        newBillItem.setBill(newBill);
+        newBillItem.setItem(patientItem.getItem());
+        newBillItem.setQty(1.0);
+        newBillItem.setInwardChargeType(patientItem.getItem().getInwardChargeType());
+        newBillItem.setPatientEncounter(pe);
+        newBillItem.setGrossValue(patientItem.getServiceValue());
+        newBillItem.setNetValue(patientItem.getServiceValue());
+        newBillItem.setFromTime(patientItem.getFromTime());
+        newBillItem.setToTime(patientItem.getToTime());
+        newBillItem.setRequestedFromDepartment(deliveringDepartment);
+        newBillItem.setRequestedToDepartment(getSessionController().getDepartment());
+        newBillItem.setPeformedDepartment(deliveringDepartment);
+        newBillItem.setCreatedAt(new Date());
+        newBillItem.setCreater(getSessionController().getLoggedUser());
+        getBillItemFacade().create(newBillItem);
+
+        patientItem.setBill(newBill);
+        patientItem.setBillItem(newBillItem);
+    }
+
+    /**
+     * Pushes a recalculated timed-service charge onto its BillItem and Bill.
+     * <p>
+     * The BillItem is what the inward totals actually sum (see
+     * {@code InwardBeanController.calServiceBillItemsTotalByInwardChargeTypeBulk}),
+     * so it must never be left holding a stale duration. Package-locked items
+     * are skipped — their price is fixed by the package.
+     */
+    private void syncTimedServiceCharge(PatientItem patientItem) {
+        if (patientItem == null || patientItem.getBillItem() == null) {
+            return;
+        }
+        BillItem bi = patientItem.getBillItem();
+        if (bi.isFromPackage()) {
+            return;
+        }
+        bi.setGrossValue(patientItem.getServiceValue());
+        bi.setDiscount(patientItem.getDiscount());
+        bi.setNetValue(patientItem.getServiceValue() + bi.getMarginValue() - patientItem.getDiscount());
+        bi.setFromTime(patientItem.getFromTime());
+        bi.setToTime(patientItem.getToTime());
+        getBillItemFacade().edit(bi);
+
+        Bill b = bi.getBill();
+        if (b != null) {
+            b.setTotal(bi.getGrossValue());
+            b.setNetTotal(bi.getNetValue());
+            getBillFacade().edit(b);
+        }
+    }
+
     public void finalizeService(PatientItem pic) {
         if (pic != null && pic.getBillItem() != null && pic.getBillItem().isFromPackage()) {
             JsfUtil.addErrorMessage("This item is included in the admission's package and its charge cannot be changed.");
+            return;
+        }
+        if (pic != null && isLockedForChanges(pic.getPatientEncounter())) {
             return;
         }
         PatientItem temPi;
@@ -689,6 +871,7 @@ public class InwardTimedItemController implements Serializable {
         pic.setServiceValue(value);
 
         getPatientItemFacade().edit(pic);
+        syncTimedServiceCharge(pic);
 
         createPatientItems();
 

--- a/src/main/java/com/divudi/bean/inward/InwardTimedItemController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardTimedItemController.java
@@ -806,6 +806,11 @@ public class InwardTimedItemController implements Serializable {
      * {@code InwardBeanController.calServiceBillItemsTotalByInwardChargeTypeBulk}),
      * so it must never be left holding a stale duration. Package-locked items
      * are skipped — their price is fixed by the package.
+     * <p>
+     * The discount comes from the BillItem, which is the side the inward
+     * discount routines clear when no price matrix applies; reading it from the
+     * PatientItem would re-apply a discount that had just been removed. The
+     * PatientItem is mirrored back so the breakdown screens still agree.
      */
     private void syncTimedServiceCharge(PatientItem patientItem) {
         if (patientItem == null || patientItem.getBillItem() == null) {
@@ -815,12 +820,17 @@ public class InwardTimedItemController implements Serializable {
         if (bi.isFromPackage()) {
             return;
         }
+        double discount = bi.getDiscount();
         bi.setGrossValue(patientItem.getServiceValue());
-        bi.setDiscount(patientItem.getDiscount());
-        bi.setNetValue(patientItem.getServiceValue() + bi.getMarginValue() - patientItem.getDiscount());
+        bi.setNetValue(patientItem.getServiceValue() + bi.getMarginValue() - discount);
         bi.setFromTime(patientItem.getFromTime());
         bi.setToTime(patientItem.getToTime());
         getBillItemFacade().edit(bi);
+
+        if (patientItem.getDiscount() != discount) {
+            patientItem.setDiscount(discount);
+            getPatientItemFacade().edit(patientItem);
+        }
 
         Bill b = bi.getBill();
         if (b != null) {

--- a/src/main/java/com/divudi/bean/report/ReportController.java
+++ b/src/main/java/com/divudi/bean/report/ReportController.java
@@ -4253,7 +4253,10 @@ public class ReportController implements Serializable, ControllerWithReportFilte
                 .append("per.name, ")
                 .append("COALESCE(procItem.name, biProcItem.name, (SELECT MAX(bfProcItem.name) FROM BillFee bf JOIN bf.patienEncounter bfProc JOIN bfProc.item bfProcItem WHERE bf.patientItem = pi AND bf.retired = false)), ")
                 .append("COALESCE(proc.name, biProc.name, (SELECT MAX(bfProc.name) FROM BillFee bf JOIN bf.patienEncounter bfProc WHERE bf.patientItem = pi AND bf.retired = false)), ")
-                .append("dept.name, ")
+                // Where the service was actually delivered, recorded on the bill
+                // since the bill-at-add change. Older rows have no bill, so they
+                // fall back to the service item's own department.
+                .append("COALESCE(billFromDept.name, dept.name), ")
                 .append("timedItem.name, ")
                 .append("cat.name, ")
                 .append("pi.fromTime, ")
@@ -4270,7 +4273,9 @@ public class ReportController implements Serializable, ControllerWithReportFilte
                 .append("bill.createdAt, ")
                 .append("finalBill.createdAt, ")
                 .append("cc.id, ")
-                .append("COALESCE(bDept.name, rfcDept.name) ) ")
+                // Department that entered the charge; falls back to the bill's
+                // own department, then the patient's current room department.
+                .append("COALESCE(billToDept.name, bDept.name, rfcDept.name) ) ")
                 .append("FROM PatientItem pi ")
                 .append("JOIN pi.patientEncounter pe ")
                 .append("LEFT JOIN pe.patient pat ")
@@ -4301,6 +4306,8 @@ public class ReportController implements Serializable, ControllerWithReportFilte
                 .append("LEFT JOIN pe.currentPatientRoom room ")
                 .append("LEFT JOIN room.roomFacilityCharge rfc ")
                 .append("LEFT JOIN bill.department bDept ")
+                .append("LEFT JOIN bill.fromDepartment billFromDept ")
+                .append("LEFT JOIN bill.toDepartment billToDept ")
                 .append("LEFT JOIN rfc.department rfcDept ");
 
         jpql.append("WHERE pi.retired = :ret ")
@@ -4348,13 +4355,24 @@ public class ReportController implements Serializable, ControllerWithReportFilte
                 params.put("roomCategoryIds", roomCategoryIds);
             }
         }
+        // Both filters mirror the COALESCE used for their columns, so filtering
+        // never contradicts what the report shows: match the recorded
+        // department when there is one, otherwise the fallback that is
+        // displayed in its place.
+        //
+        // These compare the LEFT JOIN aliases rather than navigating
+        // bill.fromDepartment directly. A path expression through the optional
+        // bill would be resolved as an inner join and silently drop every row
+        // that has no bill — exactly the older rows the fallback exists for.
         if (serviceDepartment != null) {
-            jpql.append("AND timedItem.department = :serviceDepartment ");
+            jpql.append("AND (billFromDept = :serviceDepartment ")
+                    .append("OR (billFromDept IS NULL AND dept = :serviceDepartment)) ");
             params.put("serviceDepartment", serviceDepartment);
         }
         if (billedDepartment != null) {
-            jpql.append("AND (bill.department = :billedDepartment ")
-                    .append("OR (bill IS NULL AND finalBill.department = :billedDepartment)) ");
+            jpql.append("AND (billToDept = :billedDepartment ")
+                    .append("OR (billToDept IS NULL AND bDept = :billedDepartment) ")
+                    .append("OR (billToDept IS NULL AND bDept IS NULL AND rfcDept = :billedDepartment)) ");
             params.put("billedDepartment", billedDepartment);
         }
         if (serviceGroup != null && !serviceGroup.trim().isEmpty()) {

--- a/src/main/webapp/inward/inward_timed_service_consume.xhtml
+++ b/src/main/webapp/inward/inward_timed_service_consume.xhtml
@@ -228,6 +228,7 @@
                                 <div class="row m-1">
                                     <div class="col-4">
                                         <p:outputLabel value="Service Department"
+                                                       for="serviceDepartment"
                                                        title="Where the service is given. Defaults to the service's own department."/>
                                     </div>
                                     <div class="col-4">

--- a/src/main/webapp/inward/inward_timed_service_consume.xhtml
+++ b/src/main/webapp/inward/inward_timed_service_consume.xhtml
@@ -218,9 +218,34 @@
                                                 <h:outputLabel  value="#{ix.total}" ></h:outputLabel>
                                             </p:column>
 
+                                            <p:ajax event="itemSelect"
+                                                    listener="#{inwardTimedItemController.serviceSelectListener}"
+                                                    update="serviceDepartment"/>
                                         </p:autoComplete>
                                     </div>
                                 </div>
+
+                                <div class="row m-1">
+                                    <div class="col-4">
+                                        <p:outputLabel value="Service Department"
+                                                       title="Where the service is given. Defaults to the service's own department."/>
+                                    </div>
+                                    <div class="col-4">
+                                        <p:selectOneMenu
+                                            class="mx-2"
+                                            id="serviceDepartment"
+                                            filter="true"
+                                            filterMatchMode="contains"
+                                            value="#{inwardTimedItemController.fromDepartment}">
+                                            <f:selectItem itemLabel="Select Department" noSelectionOption="true"/>
+                                            <f:selectItems value="#{departmentController.items}"
+                                                           var="dep"
+                                                           itemLabel="#{dep.name}"
+                                                           itemValue="#{dep}"/>
+                                        </p:selectOneMenu>
+                                    </div>
+                                </div>
+
                                 <div class="row m-1">
                                     <div class="col-4">
                                         <p:outputLabel value="Start Time"/>
@@ -284,7 +309,15 @@
                         <p:column headerText="Service Name" style="padding: 8px;">
                             #{ti.item.name}
                         </p:column>
-                        
+
+                        <p:column headerText="Service Department" style="padding: 8px;">
+                            <h:outputLabel value="#{ti.bill.fromDepartment.name}"/>
+                        </p:column>
+
+                        <p:column headerText="Billed Department" style="padding: 8px;">
+                            <h:outputLabel value="#{ti.bill.toDepartment.name}"/>
+                        </p:column>
+
                         <p:column headerText="Start Time" style="padding: 8px;">
                             <p:datePicker
                                 showTime="true"


### PR DESCRIPTION
Follow-up to #22521, completing issue #22498.

## Problem

A timed service was recorded only as a `PatientItem`, and `PatientItem` carries no department. The Duration Service Report could therefore only ever show the **service item's configured department** — never where the service was actually given — and had nothing at all to show for the billing department.

## What changed

Each add on the consume page now creates its own `Bill` + `BillItem` alongside the `PatientItem`:

| Field | Meaning |
|---|---|
| `bill.fromDepartment` | where the service was delivered — defaults to the item's department, shown on the page and changeable |
| `bill.toDepartment` | department that entered the charge (session department) |

One bill per service, so a bill can never mix items from two departments.

The **BillItem carries the charge**, the **PatientItem keeps the timing**. `syncTimedServiceCharge()` keeps them in step on every recalculation, and removing a service retires its BillItem and Bill so the charge does not survive the removal.

### Things that had to follow the charge

- **Discounts** — timed BillItems are excluded from the BillFee-driven service path. A timed service has no BillFee, so `updateBillItemByBillFee` would have recomputed its net value as the sum of zero fees and **silently wiped the charge**. They are discounted directly on the BillItem instead.
- **Breakdown screens** — TimedItems excluded from `fetchBillItems`/`fetchEagerBillItems`, which already list them separately from their PatientItems. Without this each timed service appeared twice on the same page.
- **Gross column** — `setGrossMarginVatBreakdown` reported only the BillItem half for a charge type holding both old and new timed services, while Total and Net showed the full amount.

### Discharge

No longer blocks on unfinalized timed services. Anything still running is stopped at the discharge time and priced for that duration — which is what the manual "Please Finalize Patient Timed Service" step amounted to, except it now also guarantees the charge reflects the real length of stay rather than whatever value was last persisted. After discharge or final settlement, timed services become immutable.

### Report

Prefers the recorded departments, falling back to the item's department (and the room's department for billing) for rows predating this change. **Both filters mirror the same fallback**, comparing the LEFT JOIN aliases rather than navigating `bill.fromDepartment` — a path expression through the optional bill is resolved as an inner join and drops every older row. Caught in testing: filtering by THEATRE returned 1 row instead of 3.

## Verification

Local Payara, BHT/55356.

**Bill created with the override applied:**

| deptId | billType | fromDept | toDept | total |
|---|---|---|---|---|
| `Inward/INWSER/8` | InwardBill / INWARD_SERVICE_BILL | THEATRE | Inward | 32,000 |

BillItem carried `requestedFrom=THEATRE`, `requestedTo=Inward`, `peformed=THEATRE`, `inwardChargeType=OxygenCharges`, plus from/to times.

**Totals counted exactly once** across every step:

| Step | Oxygen Charges | Check |
|---|---|---|
| Before | 61,500 | 30,000 + 31,500 (PatientItem side) |
| After adding 32,000 | **93,500** | + BillItem side |
| Gross column | **93,500** | matches Total (was 32,000 before the fix) |
| After removing one | **62,000** | 30,000 + 31,500 + 500 |

Intensive Care Management stayed at 147,600 throughout.

**Auto-finalize at discharge** — a running service was stopped at the discharge time, repriced 32,000 → 500 for its real 15-minute duration, with BillItem *and* Bill synced to match. Message: `1 running timed service(s) were stopped at the discharge time.`

**Immutability** — adding to the discharged patient was refused with *"This patient has been discharged. Timed services can no longer be changed."*; no PatientItem, BillItem or Bill was created.

**Removal** — retired the PatientItem, BillItem and Bill together; the neighbouring service was untouched.

**Report** — new row shows `THEATRE / Inward` from the bill; older rows fall back to the item and room departments. Filtering by Service Department = THEATRE returns all 3 rows that display THEATRE (bill-recorded *and* fallback); Billed Department = Inward returns all 5.

## Notes

- The suspected **package double-charge** in `createLockedTimedItem()` is resolved by the `billItem is null` guard from #22521 — package timed items are now counted on the BillItem side only. Still worth confirming against real package data; the local DB has zero `FROMPACKAGE=1` rows.
- **OP visit type** (bullet 4 of #22498) is left as-is — no code path creates a `PatientItem` against an outpatient visit, and every row in the DB is `DTYPE = Admission`. Explained in [a comment on the issue](https://github.com/hmislk/hmis/issues/22498#issuecomment-5115050051).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Timed services now maintain accurate billing details end-to-end, including department tracking and updated report department logic.
  - Discharge now finalizes running timed services automatically (instead of blocking discharge), syncing amounts consistently across billing records.
  - The consumed timed service screen now shows Service Department and Billed Department, and selecting a timed service updates the service department options.

- **Bug Fixes**
  - Prevented duplicate timed-service charges in inward service breakdowns.
  - Improved discount/charge synchronization and totals (including gross figures) for timed services.
  - Locked encounters and completed payments prevent unauthorized timed-service edits/removals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->