### PR TITLE
feat(inward): add worklist for pharmacy issues awaiting ward acceptance

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardPharmacyEncounterReportController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardPharmacyEncounterReportController.java
@@ -117,6 +117,14 @@ public class InwardPharmacyEncounterReportController implements Serializable {
     private double returnBillsToPatientEncounterNetTotal;
     private List<InpatientPharmacyBillItemDTO> returnBillItemsToPatientEncounter;
 
+    // 4) Unaccepted Issues list (issue #22515) - ISSUE_MEDICINE_ON_REQUEST_INWARD
+    // bills for this patientEncounter with no matching
+    // ACCEPT_ISSUED_MEDICINE_INWARD backward reference yet, i.e. pharmacy
+    // has issued but the ward hasn't accepted receipt. Same NOT EXISTS shape
+    // proven in NursingDischargeController.fetchUnacceptedIssues().
+    private List<Bill> unacceptedIssueBillsToPatientEncounter;
+    private double unacceptedIssueBillsToPatientEncounterNetTotal;
+
     /**
      * Replaces "BHT Issue Requests" + "View Pharmacy Requests". Lists all
      * InwardPharmacyRequest bills for this patientEncounter, each carrying
@@ -682,6 +690,57 @@ public class InwardPharmacyEncounterReportController implements Serializable {
     }
 
     /**
+     * Worklist for pharmacy issues awaiting ward acceptance (issue #22515).
+     * Lists ISSUE_MEDICINE_ON_REQUEST_INWARD bills for this patientEncounter
+     * that have no matching ACCEPT_ISSUED_MEDICINE_INWARD backward reference
+     * yet - previously this state only surfaced as a discharge blocker on
+     * the Nursing Discharge page (NursingDischargeController.fetchUnacceptedIssues()),
+     * too late for pharmacy/ward staff to act on proactively.
+     */
+    public String navigateToInpatientPharmacyUnacceptedIssuesList() {
+        if (patientEncounter == null) {
+            JsfUtil.addErrorMessage("No encounter");
+            return null;
+        }
+        unacceptedIssueBillsToPatientEncounter = new ArrayList<>();
+        unacceptedIssueBillsToPatientEncounterNetTotal = 0.0;
+        try {
+            unacceptedIssueBillsToPatientEncounter = fetchUnacceptedIssueBills();
+            for (Bill b : unacceptedIssueBillsToPatientEncounter) {
+                unacceptedIssueBillsToPatientEncounterNetTotal += b.getNetTotal();
+            }
+        } catch (Exception e) {
+            Logger.getLogger(InwardPharmacyEncounterReportController.class.getName())
+                    .log(Level.SEVERE, "Error loading unaccepted pharmacy issue bills", e);
+            JsfUtil.addErrorMessage("Error loading unaccepted issue data");
+            return null;
+        }
+        return "/inward/reports/inpatient_pharmacy_unaccepted_issues_list?faces-redirect=true";
+    }
+
+    private List<Bill> fetchUnacceptedIssueBills() {
+        String jpql = "SELECT b FROM Bill b "
+                + "WHERE b.patientEncounter = :pe "
+                + "AND b.billTypeAtomic = :bta "
+                + "AND b.cancelled = false "
+                + "AND NOT EXISTS ("
+                + "  SELECT r FROM Bill r "
+                + "  WHERE r.backwardReferenceBill = b "
+                + "  AND r.billTypeAtomic = :acceptBta "
+                + "  AND r.cancelled = false"
+                + ") "
+                + "ORDER BY b.createdAt DESC";
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("pe", patientEncounter);
+        params.put("bta", BillTypeAtomic.ISSUE_MEDICINE_ON_REQUEST_INWARD);
+        params.put("acceptBta", BillTypeAtomic.ACCEPT_ISSUED_MEDICINE_INWARD);
+
+        List<Bill> result = billFacade.findByJpql(jpql, params, TemporalType.TIMESTAMP);
+        return result != null ? result : new ArrayList<>();
+    }
+
+    /**
      * Back-nav for the ward-wide Pharmacy Requests page (issue #22428) - there
      * is no single admission to return to, so this goes back to the Nursing
      * Dashboard instead of {@link #navigateToAdmissionProfile()}.
@@ -963,5 +1022,21 @@ public class InwardPharmacyEncounterReportController implements Serializable {
 
     public void setReturnBillItemsToPatientEncounter(List<InpatientPharmacyBillItemDTO> returnBillItemsToPatientEncounter) {
         this.returnBillItemsToPatientEncounter = returnBillItemsToPatientEncounter;
+    }
+
+    public List<Bill> getUnacceptedIssueBillsToPatientEncounter() {
+        return unacceptedIssueBillsToPatientEncounter;
+    }
+
+    public void setUnacceptedIssueBillsToPatientEncounter(List<Bill> unacceptedIssueBillsToPatientEncounter) {
+        this.unacceptedIssueBillsToPatientEncounter = unacceptedIssueBillsToPatientEncounter;
+    }
+
+    public double getUnacceptedIssueBillsToPatientEncounterNetTotal() {
+        return unacceptedIssueBillsToPatientEncounterNetTotal;
+    }
+
+    public void setUnacceptedIssueBillsToPatientEncounterNetTotal(double unacceptedIssueBillsToPatientEncounterNetTotal) {
+        this.unacceptedIssueBillsToPatientEncounterNetTotal = unacceptedIssueBillsToPatientEncounterNetTotal;
     }
 }

--- a/src/main/java/com/divudi/bean/inward/InwardPharmacyEncounterReportController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardPharmacyEncounterReportController.java
@@ -722,11 +722,13 @@ public class InwardPharmacyEncounterReportController implements Serializable {
         String jpql = "SELECT b FROM Bill b "
                 + "WHERE b.patientEncounter = :pe "
                 + "AND b.billTypeAtomic = :bta "
+                + "AND b.retired = false "
                 + "AND b.cancelled = false "
                 + "AND NOT EXISTS ("
                 + "  SELECT r FROM Bill r "
                 + "  WHERE r.backwardReferenceBill = b "
                 + "  AND r.billTypeAtomic = :acceptBta "
+                + "  AND r.retired = false "
                 + "  AND r.cancelled = false"
                 + ") "
                 + "ORDER BY b.createdAt DESC";

--- a/src/main/webapp/inward/admission_profile.xhtml
+++ b/src/main/webapp/inward/admission_profile.xhtml
@@ -1143,6 +1143,20 @@
                                                 target="#{inwardPharmacyEncounterReportController.patientEncounter}" />
                                         </p:commandButton>
                                     </div>
+                                    <div class="col-6">
+                                        <p:commandButton
+                                            id="btnUnacceptedIssuesHistory"
+                                            value="Unaccepted Issues"
+                                            action="#{inwardPharmacyEncounterReportController.navigateToInpatientPharmacyUnacceptedIssuesList()}"
+                                            rendered="#{webUserController.hasPrivilege('PharmacyBHTIssueAccept') or webUserController.hasPrivilege('InwardPharmacyIssueRequestSearch')}"
+                                            icon="fa fa-triangle-exclamation"
+                                            class="w-100"
+                                            ajax="false">
+                                            <f:setPropertyActionListener
+                                                value="#{admissionController.current}"
+                                                target="#{inwardPharmacyEncounterReportController.patientEncounter}" />
+                                        </p:commandButton>
+                                    </div>
                                 </div>
                             </div>
                         </p:panel>

--- a/src/main/webapp/inward/reports/inpatient_pharmacy_unaccepted_issues_list.xhtml
+++ b/src/main/webapp/inward/reports/inpatient_pharmacy_unaccepted_issues_list.xhtml
@@ -77,32 +77,32 @@
                                 <div class="row">
                                     <div class="col-md-5"><p:outputLabel value="Name" /></div>
                                     <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
-                                    <div class="col-md-6"><h:outputText value="#{admissionController.current.patient.person.nameWithTitle}" /></div>
+                                    <div class="col-md-6"><h:outputText value="#{inwardPharmacyEncounterReportController.patientEncounter.patient.person.nameWithTitle}" /></div>
 
                                     <div class="col-md-5"><p:outputLabel value="Gender" /></div>
                                     <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
-                                    <div class="col-md-6"><h:outputText value="#{admissionController.current.patient.person.sex}" /></div>
+                                    <div class="col-md-6"><h:outputText value="#{inwardPharmacyEncounterReportController.patientEncounter.patient.person.sex}" /></div>
 
                                     <div class="col-md-5"><p:outputLabel value="Age" /></div>
                                     <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
-                                    <div class="col-md-6"><h:outputText value="#{admissionController.current.patient.person.ageAsString}" /></div>
+                                    <div class="col-md-6"><h:outputText value="#{inwardPharmacyEncounterReportController.patientEncounter.patient.person.ageAsString}" /></div>
 
                                     <div class="col-md-5"><p:outputLabel value="Mobile No." /></div>
                                     <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
-                                    <div class="col-md-6"><h:outputText value="#{admissionController.current.patient.person.mobile}" /></div>
+                                    <div class="col-md-6"><h:outputText value="#{inwardPharmacyEncounterReportController.patientEncounter.patient.person.mobile}" /></div>
 
                                     <div class="col-md-5"><p:outputLabel value="Phone No." /></div>
                                     <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
-                                    <div class="col-md-6"><h:outputText value="#{admissionController.current.patient.person.phone}" /></div>
+                                    <div class="col-md-6"><h:outputText value="#{inwardPharmacyEncounterReportController.patientEncounter.patient.person.phone}" /></div>
 
                                     <div class="col-md-5"><p:outputLabel value="NIC" /></div>
                                     <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
-                                    <div class="col-md-6"><h:outputText value="#{empty admissionController.current.patient.person.nic ? 'N/A' : admissionController.current.patient.person.nic}" /></div>
+                                    <div class="col-md-6"><h:outputText value="#{empty inwardPharmacyEncounterReportController.patientEncounter.patient.person.nic ? 'N/A' : inwardPharmacyEncounterReportController.patientEncounter.patient.person.nic}" /></div>
                                 </div>
                             </p:panel>
                         </div>
                         <div class="m-1">
-                            <common:admission_details admission="#{admissionController.current}" class="w-100 m-1"></common:admission_details>
+                            <common:admission_details admission="#{inwardPharmacyEncounterReportController.patientEncounter}" class="w-100 m-1"></common:admission_details>
                         </div>
                     </div>
                     <div class="col-9">

--- a/src/main/webapp/inward/reports/inpatient_pharmacy_unaccepted_issues_list.xhtml
+++ b/src/main/webapp/inward/reports/inpatient_pharmacy_unaccepted_issues_list.xhtml
@@ -1,0 +1,199 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/resources/template/template.xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:p="http://primefaces.org/ui"
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:common="http://xmlns.jcp.org/jsf/composite/ezcomp/common">
+
+    <ui:define name="content">
+        <h:form id="form">
+            <p:growl id="inpatientPharmacyUnacceptedIssuesGrowl"></p:growl>
+            <p:panel>
+                <f:facet name="header">
+                    <div class="d-flex justify-content-between align-items-center w-100">
+                        <div class="d-flex align-items-center gap-2">
+                            <h:outputText styleClass="fa fa-triangle-exclamation"></h:outputText>
+                            <p:outputLabel value="Pharmacy Issues Awaiting Ward Acceptance"></p:outputLabel>
+                        </div>
+                        <div class="d-flex gap-2">
+                            <p:commandButton
+                                id="btnBackToProfile"
+                                value="Inpatient Dashboard"
+                                action="#{inwardPharmacyEncounterReportController.navigateToAdmissionProfile()}"
+                                ajax="false"
+                                icon="fa fa-arrow-circle-left"
+                                styleClass="ui-button-info ui-button-outlined">
+                            </p:commandButton>
+                        </div>
+                        <div class="d-flex gap-2">
+                            <p:commandButton
+                                id="btnRefresh"
+                                title="Reload the latest unaccepted pharmacy issues for this admission"
+                                value="Refresh"
+                                action="#{inwardPharmacyEncounterReportController.navigateToInpatientPharmacyUnacceptedIssuesList()}"
+                                ajax="false"
+                                icon="fa fa-sync-alt"
+                                styleClass="ui-button-secondary">
+                            </p:commandButton>
+                            <p:commandButton
+                                id="btnDownload"
+                                value="Download"
+                                ajax="false"
+                                icon="fa fa-download"
+                                styleClass="ui-button-secondary">
+                                <p:dataExporter fileName="Inpatient Pharmacy Unaccepted Issues" target="tbl1" type="xlsx"></p:dataExporter>
+                            </p:commandButton>
+                            <p:commandButton
+                                id="btnPrint"
+                                value="Print"
+                                ajax="false"
+                                icon="fa fa-print"
+                                styleClass="ui-button-secondary">
+                                <p:printer target="tbl1"></p:printer>
+                            </p:commandButton>
+                        </div>
+                    </div>
+                </f:facet>
+
+                <style>
+                    @media print {
+                        body {
+                            margin: 0px 5px;
+                        }
+                    }
+                </style>
+
+                <div class="row">
+                    <div class="col-3">
+                        <div class="m-1">
+                            <p:panel class="w-100 m-1">
+                                <f:facet name="header">
+                                    <h:outputText styleClass="fas fa-user"></h:outputText>
+                                    <h:outputLabel value="Patient Details" class="mx-4"></h:outputLabel>
+                                </f:facet>
+                                <div class="row">
+                                    <div class="col-md-5"><p:outputLabel value="Name" /></div>
+                                    <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                                    <div class="col-md-6"><h:outputText value="#{admissionController.current.patient.person.nameWithTitle}" /></div>
+
+                                    <div class="col-md-5"><p:outputLabel value="Gender" /></div>
+                                    <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                                    <div class="col-md-6"><h:outputText value="#{admissionController.current.patient.person.sex}" /></div>
+
+                                    <div class="col-md-5"><p:outputLabel value="Age" /></div>
+                                    <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                                    <div class="col-md-6"><h:outputText value="#{admissionController.current.patient.person.ageAsString}" /></div>
+
+                                    <div class="col-md-5"><p:outputLabel value="Mobile No." /></div>
+                                    <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                                    <div class="col-md-6"><h:outputText value="#{admissionController.current.patient.person.mobile}" /></div>
+
+                                    <div class="col-md-5"><p:outputLabel value="Phone No." /></div>
+                                    <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                                    <div class="col-md-6"><h:outputText value="#{admissionController.current.patient.person.phone}" /></div>
+
+                                    <div class="col-md-5"><p:outputLabel value="NIC" /></div>
+                                    <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                                    <div class="col-md-6"><h:outputText value="#{empty admissionController.current.patient.person.nic ? 'N/A' : admissionController.current.patient.person.nic}" /></div>
+                                </div>
+                            </p:panel>
+                        </div>
+                        <div class="m-1">
+                            <common:admission_details admission="#{admissionController.current}" class="w-100 m-1"></common:admission_details>
+                        </div>
+                    </div>
+                    <div class="col-9">
+                        <p:panel>
+                            <f:facet name="header">
+                                <p:outputLabel value="Pharmacy Issues Awaiting Ward Acceptance" style="font-weight: bold"></p:outputLabel>
+                            </f:facet>
+
+                            <p:dataTable
+                                id="tbl1"
+                                rowIndexVar="rowIndex"
+                                rowKey="#{b.id}"
+                                value="#{inwardPharmacyEncounterReportController.unacceptedIssueBillsToPatientEncounter}"
+                                var="b">
+
+                                <p:column width="2em" style="padding: 2px">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="No" />
+                                    </f:facet>
+                                    <h:outputLabel value="#{rowIndex+1}" />
+                                </p:column>
+
+                                <p:column width="8em" style="padding: 2px">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Bill No" />
+                                    </f:facet>
+                                    <h:outputLabel value="#{b.deptId}" />
+                                </p:column>
+
+                                <p:column width="12em" style="padding: 2px">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Issued At" />
+                                    </f:facet>
+                                    <h:outputLabel value="#{b.createdAt}">
+                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" timeZone="Asia/Colombo" />
+                                    </h:outputLabel>
+                                </p:column>
+
+                                <p:column width="10em" style="padding: 2px">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Issued By" />
+                                    </f:facet>
+                                    <h:outputLabel value="#{b.creater.webUserPerson.name}" />
+                                </p:column>
+
+                                <p:column width="10em" style="padding: 2px">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="To Staff" />
+                                    </f:facet>
+                                    <h:outputLabel value="#{b.toStaff.person.nameWithTitle}" />
+                                </p:column>
+
+                                <p:column width="8em" style="padding: 2px; text-align: right;">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Net Total" />
+                                    </f:facet>
+                                    <h:outputLabel value="#{b.netTotal}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </p:column>
+
+                                <p:column width="10em" style="padding: 2px" exportable="false">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Actions" />
+                                    </f:facet>
+                                    <p:commandButton
+                                        id="btnViewBill"
+                                        value="View Bill"
+                                        class="ui-button-primary m-1"
+                                        ajax="false"
+                                        icon="fa fa-eye"
+                                        action="/ward/ward_pharmacy_reprint_bht_issue_bill_reprint?faces-redirect=true">
+                                        <f:setPropertyActionListener target="#{pharmacyBillSearch.bill}" value="#{b}"/>
+                                    </p:commandButton>
+                                </p:column>
+
+                            </p:dataTable>
+
+                            <div class="d-flex justify-content-end p-2">
+                                <h:outputLabel value="Total Net: " style="font-weight: bold;" />
+                                <h:outputLabel value="#{inwardPharmacyEncounterReportController.unacceptedIssueBillsToPatientEncounterNetTotal}" style="font-weight: bold; margin-left: 6px;">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </div>
+
+                        </p:panel>
+
+                    </div>
+                </div>
+            </p:panel>
+
+        </h:form>
+    </ui:define>
+</ui:composition>


### PR DESCRIPTION
## Summary

Adds a dedicated report for pharmacy issues that are still awaiting ward acceptance — bills in `ISSUE_MEDICINE_ON_REQUEST_INWARD` state with no matching `ACCEPT_ISSUED_MEDICINE_INWARD` backward reference. Previously this state only surfaced as a discharge blocker on the Nursing Discharge page, too late for pharmacy/ward staff to act on proactively.

- New "Unaccepted Issues" dashboard link/report on the Inpatient Dashboard, alongside the existing Pharmacy Requests / Direct Issues / Issue Returns reports.
- `InwardPharmacyEncounterReportController` gains `navigateToInpatientPharmacyUnacceptedIssuesList()` + `fetchUnacceptedIssueBills()`, entity-based (`List<Bill>`) to match the sibling reports' established pattern — no new DTO.
- The `NOT EXISTS` JPQL shape mirrors the one already proven in `NursingDischargeController.fetchUnacceptedIssues()`.
- New page `inpatient_pharmacy_unaccepted_issues_list.xhtml` copies the sibling "Pharmacy Requests" report's structure exactly (Patient/Admission Details panel, header buttons, print styling).

Note: the plan's original brief assumed a DTO-based design (`UnacceptedPharmacyIssueDTO`). Before implementation, I read `InwardPharmacyEncounterReportController.java` and its sibling XHTML in full and found the actual established pattern for this controller's reports is entity-based — so the DTO was dropped in favor of matching existing conventions.

Closes #22515

## Test plan

- [x] Build: `mvn clean package -DskipTests` — success, 185 tests passed.
- [x] Full browser + DB end-to-end verification: created a real pharmacy request for admitted patient BHT/53360 (Mrs. Kushari), issued it from Main Pharmacy (bill `MP//26/000157`, `ISSUE_MEDICINE_ON_REQUEST_INWARD`) without accepting it from the ward, then confirmed the new "Unaccepted Issues" report renders that exact bill with Bill No / Issued At / Issued By / To Staff / Net Total all correctly populated, and the "View Bill" action navigates correctly.
- [x] DB query confirmed zero `ACCEPT_ISSUED_MEDICINE_INWARD` bills reference the issued bill via `backwardReferenceBill` — exactly the state the new query is designed to surface.
- [x] Confirmed no existing methods/constructors were modified — diff is purely additive (288 insertions, 0 deletions across 3 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **“Unaccepted Issues”** option under **Pharmaceuticals & Consumables → Reports & History** for inpatient admissions.
  * Introduced a new worklist report showing **pharmacy issues awaiting ward acceptance**, including patient/admission details, bill/issue metadata, issuing information, and **net total**.
  * Added per-row **“View Bill”** and overall **Total Net** display.
  * Included **Refresh**, **Print**, and **XLSX export** actions.
  * The option is shown based on the user’s **pharmacy-related permissions**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->