### PR TITLE
Optimize pharmacy return pending list with DTO projection

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyReturnFromWardReceiveController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyReturnFromWardReceiveController.java
@@ -122,36 +122,105 @@ public class PharmacyReturnFromWardReceiveController implements Serializable {
         // Defense for pre-#21510 data: returns fully accepted before this change
         // were never stamped with fullyIssued/completed, so the flag filter above
         // alone would resurface them. Drop anything already fully accepted.
-        pendingReturnBills = new ArrayList<>();
-        for (PharmacyReturnFromWardPendingReturnDTO dto : candidates) {
-            if (!isFullyAcceptedByBillId(dto.getId())) {
-                pendingReturnBills.add(dto);
-            }
-        }
+        pendingReturnBills = filterOutFullyAccepted(candidates);
     }
 
     /**
+     * Drops candidates whose every return line has already been fully accepted.
      * Bill-item-only variant of {@link #isFullyAccepted(Bill)} for the
      * pending-list filter above, so listing candidates do not need a full
      * {@link Bill} entity fetch just to check remaining quantities.
+     *
+     * <p>Outstanding quantities are resolved with two grouped queries covering
+     * the whole candidate set rather than one query per bill plus one per bill
+     * item, so the pending list stays a fixed number of queries however long
+     * the return queue grows.</p>
      */
-    private boolean isFullyAcceptedByBillId(Long billId) {
-        if (billId == null) {
-            return false;
+    private List<PharmacyReturnFromWardPendingReturnDTO> filterOutFullyAccepted(
+            List<PharmacyReturnFromWardPendingReturnDTO> candidates) {
+        List<PharmacyReturnFromWardPendingReturnDTO> remaining = new ArrayList<>();
+        if (candidates == null || candidates.isEmpty()) {
+            return remaining;
         }
-        String jpql = "SELECT bi FROM BillItem bi WHERE bi.bill.id = :billId";
-        Map<String, Object> params = new HashMap<>();
-        params.put("billId", billId);
-        List<BillItem> items = billItemFacade.findByJpql(jpql, params);
-        if (items == null || items.isEmpty()) {
-            return false;
-        }
-        for (BillItem item : items) {
-            if (getRemainingQuantityForReturnItem(item) > 0.001) {
-                return false;
+
+        List<Long> billIds = new ArrayList<>();
+        for (PharmacyReturnFromWardPendingReturnDTO dto : candidates) {
+            if (dto.getId() != null) {
+                billIds.add(dto.getId());
             }
         }
-        return true;
+
+        // billId -> (returnItemId -> returned qty)
+        Map<Long, Map<Long, Double>> returnedQtyByBill = new HashMap<>();
+        List<Long> returnItemIds = new ArrayList<>();
+        if (!billIds.isEmpty()) {
+            String itemJpql = "SELECT bi.bill.id, bi.id, bi.qty FROM BillItem bi "
+                    + "WHERE bi.bill.id IN :billIds";
+            Map<String, Object> itemParams = new HashMap<>();
+            itemParams.put("billIds", billIds);
+            List<Object[]> itemRows = billItemFacade.findObjectsArrayByJpql(itemJpql, itemParams, TemporalType.TIMESTAMP);
+            if (itemRows != null) {
+                for (Object[] row : itemRows) {
+                    Long billId = (Long) row[0];
+                    Long itemId = (Long) row[1];
+                    if (billId == null || itemId == null) {
+                        continue;
+                    }
+                    double qty = row[2] != null ? ((Number) row[2]).doubleValue() : 0.0;
+                    Map<Long, Double> lines = returnedQtyByBill.get(billId);
+                    if (lines == null) {
+                        lines = new HashMap<>();
+                        returnedQtyByBill.put(billId, lines);
+                    }
+                    lines.put(itemId, qty);
+                    returnItemIds.add(itemId);
+                }
+            }
+        }
+
+        // returnItemId -> qty already accepted, mirroring the filters in
+        // getRemainingQuantityForReturnItem.
+        Map<Long, Double> acceptedQtyByItem = new HashMap<>();
+        if (!returnItemIds.isEmpty()) {
+            String acceptedJpql = "SELECT bi.referanceBillItem.id, SUM(ABS(bi.qty)) FROM BillItem bi "
+                    + "WHERE bi.referanceBillItem.id IN :refIds "
+                    + "AND bi.bill.billTypeAtomic = :acceptBta "
+                    + "AND (bi.bill.retired = false OR bi.bill.retired IS NULL) "
+                    + "AND bi.bill.cancelled = false "
+                    + "GROUP BY bi.referanceBillItem.id";
+            Map<String, Object> acceptedParams = new HashMap<>();
+            acceptedParams.put("refIds", returnItemIds);
+            acceptedParams.put("acceptBta", BillTypeAtomic.ACCEPT_RETURN_MEDICINE_INWARD);
+            List<Object[]> acceptedRows = billItemFacade.findObjectsArrayByJpql(acceptedJpql, acceptedParams, TemporalType.TIMESTAMP);
+            if (acceptedRows != null) {
+                for (Object[] row : acceptedRows) {
+                    Long itemId = (Long) row[0];
+                    if (itemId == null) {
+                        continue;
+                    }
+                    acceptedQtyByItem.put(itemId, row[1] != null ? ((Number) row[1]).doubleValue() : 0.0);
+                }
+            }
+        }
+
+        for (PharmacyReturnFromWardPendingReturnDTO dto : candidates) {
+            Map<Long, Double> lines = dto.getId() != null ? returnedQtyByBill.get(dto.getId()) : null;
+            // A return with no lines at all counts as not fully accepted, as in
+            // the per-bill check this replaced, so anomalous bills stay visible.
+            if (lines == null || lines.isEmpty()) {
+                remaining.add(dto);
+                continue;
+            }
+            for (Map.Entry<Long, Double> line : lines.entrySet()) {
+                Double accepted = acceptedQtyByItem.get(line.getKey());
+                double outstanding = line.getValue() - (accepted != null ? accepted : 0.0);
+                if (outstanding > 0.001) {
+                    remaining.add(dto);
+                    break;
+                }
+            }
+        }
+        return remaining;
     }
 
     public String navigateToReceive() {
@@ -160,8 +229,15 @@ public class PharmacyReturnFromWardReceiveController implements Serializable {
             return null;
         }
         returnedBill = billFacade.find(returnedBillId);
-        if (returnedBill == null) {
+        if (returnedBill == null || !isWithinPendingScope(returnedBill)) {
+            // This bean is @SessionScoped, so a department switch after the
+            // pending list was rendered can leave a stale row pointing at
+            // another department's return. Receiving it would credit the stock
+            // to the current department instead (#21471).
+            returnedBill = null;
+            returnedBillId = null;
             JsfUtil.addErrorMessage("No return selected.");
+            loadPendingReturnBills();
             return null;
         }
         if (isFullyAccepted(returnedBill)) {
@@ -173,6 +249,20 @@ public class PharmacyReturnFromWardReceiveController implements Serializable {
         printPreview = false;
         completed = false;
         return "/pharmacy/pharmacy_return_from_ward_receive?faces-redirect=true";
+    }
+
+    /**
+     * Whether a bill still satisfies the predicates of
+     * {@link #loadPendingReturnBills()}, i.e. it really is an uncancelled
+     * ward return addressed to the department currently in session.
+     */
+    private boolean isWithinPendingScope(Bill bill) {
+        return bill.getBillType() == BillType.PharmacyIssue
+                && bill.getBillTypeAtomic() == BillTypeAtomic.RETURN_MEDICINE_INWARD
+                && !bill.isCancelled()
+                && bill.getToDepartment() != null
+                && sessionController.getDepartment() != null
+                && bill.getToDepartment().equals(sessionController.getDepartment());
     }
 
     private void generateBillComponent() {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyReturnFromWardReceiveController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyReturnFromWardReceiveController.java
@@ -5,6 +5,7 @@ import com.divudi.bean.common.WebUserController;
 import com.divudi.core.data.BillType;
 import com.divudi.core.data.BillTypeAtomic;
 import com.divudi.core.data.Privileges;
+import com.divudi.core.data.dto.PharmacyReturnFromWardPendingReturnDTO;
 import com.divudi.core.entity.Bill;
 import com.divudi.core.entity.BilledBill;
 import com.divudi.core.entity.BillItem;
@@ -28,6 +29,7 @@ import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.persistence.TemporalType;
 import org.primefaces.event.RowEditEvent;
 
 /**
@@ -71,14 +73,16 @@ public class PharmacyReturnFromWardReceiveController implements Serializable {
     private BillService billService;
 
     private Bill returnedBill;
+    private Long returnedBillId;
     private Bill receivedBill;
-    private List<Bill> pendingReturnBills;
+    private List<PharmacyReturnFromWardPendingReturnDTO> pendingReturnBills;
     private boolean printPreview;
     private boolean settling;
     private boolean completed;
 
     public void makeNull() {
         returnedBill = null;
+        returnedBillId = null;
         receivedBill = null;
         printPreview = false;
         completed = false;
@@ -91,7 +95,18 @@ public class PharmacyReturnFromWardReceiveController implements Serializable {
     }
 
     public void loadPendingReturnBills() {
-        String jpql = "SELECT b FROM Bill b WHERE b.billType = :bt AND b.billTypeAtomic = :bta "
+        // DTO projection avoids loading full Bill entities (and their lazy
+        // associations) for what is a read-only listing (#21471).
+        String jpql = "SELECT new com.divudi.core.data.dto.PharmacyReturnFromWardPendingReturnDTO("
+                + "b.id, b.deptId, COALESCE(fromDept.name, ''), COALESCE(createrPerson.name, ''), "
+                + "toStaff.id, toStaffPerson.title, COALESCE(toStaffPerson.name, ''), b.createdAt) "
+                + "FROM Bill b "
+                + "LEFT JOIN b.fromDepartment fromDept "
+                + "LEFT JOIN b.creater creater "
+                + "LEFT JOIN creater.webUserPerson createrPerson "
+                + "LEFT JOIN b.toStaff toStaff "
+                + "LEFT JOIN toStaff.person toStaffPerson "
+                + "WHERE b.billType = :bt AND b.billTypeAtomic = :bta "
                 + "AND b.toDepartment = :dept "
                 + "AND b.cancelled = false "
                 + "AND (b.fullyIssued = false OR b.fullyIssued IS NULL) "
@@ -101,21 +116,51 @@ public class PharmacyReturnFromWardReceiveController implements Serializable {
         params.put("bt", BillType.PharmacyIssue);
         params.put("bta", BillTypeAtomic.RETURN_MEDICINE_INWARD);
         params.put("dept", sessionController.getDepartment());
-        List<Bill> candidates = billFacade.findByJpql(jpql, params);
+        List<PharmacyReturnFromWardPendingReturnDTO> candidates
+                = (List<PharmacyReturnFromWardPendingReturnDTO>) billFacade.findLightsByJpql(jpql, params, TemporalType.TIMESTAMP);
 
         // Defense for pre-#21510 data: returns fully accepted before this change
         // were never stamped with fullyIssued/completed, so the flag filter above
         // alone would resurface them. Drop anything already fully accepted.
         pendingReturnBills = new ArrayList<>();
-        for (Bill b : candidates) {
-            if (!isFullyAccepted(b)) {
-                pendingReturnBills.add(b);
+        for (PharmacyReturnFromWardPendingReturnDTO dto : candidates) {
+            if (!isFullyAcceptedByBillId(dto.getId())) {
+                pendingReturnBills.add(dto);
             }
         }
     }
 
+    /**
+     * Bill-item-only variant of {@link #isFullyAccepted(Bill)} for the
+     * pending-list filter above, so listing candidates do not need a full
+     * {@link Bill} entity fetch just to check remaining quantities.
+     */
+    private boolean isFullyAcceptedByBillId(Long billId) {
+        if (billId == null) {
+            return false;
+        }
+        String jpql = "SELECT bi FROM BillItem bi WHERE bi.bill.id = :billId";
+        Map<String, Object> params = new HashMap<>();
+        params.put("billId", billId);
+        List<BillItem> items = billItemFacade.findByJpql(jpql, params);
+        if (items == null || items.isEmpty()) {
+            return false;
+        }
+        for (BillItem item : items) {
+            if (getRemainingQuantityForReturnItem(item) > 0.001) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     public String navigateToReceive() {
-        if (returnedBill == null || returnedBill.getId() == null) {
+        if (returnedBillId == null) {
+            JsfUtil.addErrorMessage("No return selected.");
+            return null;
+        }
+        returnedBill = billFacade.find(returnedBillId);
+        if (returnedBill == null) {
             JsfUtil.addErrorMessage("No return selected.");
             return null;
         }
@@ -440,6 +485,14 @@ public class PharmacyReturnFromWardReceiveController implements Serializable {
         this.returnedBill = returnedBill;
     }
 
+    public Long getReturnedBillId() {
+        return returnedBillId;
+    }
+
+    public void setReturnedBillId(Long returnedBillId) {
+        this.returnedBillId = returnedBillId;
+    }
+
     public Bill getReceivedBill() {
         if (receivedBill == null) {
             receivedBill = new BilledBill();
@@ -451,14 +504,14 @@ public class PharmacyReturnFromWardReceiveController implements Serializable {
         this.receivedBill = receivedBill;
     }
 
-    public List<Bill> getPendingReturnBills() {
+    public List<PharmacyReturnFromWardPendingReturnDTO> getPendingReturnBills() {
         if (pendingReturnBills == null) {
             pendingReturnBills = new ArrayList<>();
         }
         return pendingReturnBills;
     }
 
-    public void setPendingReturnBills(List<Bill> pendingReturnBills) {
+    public void setPendingReturnBills(List<PharmacyReturnFromWardPendingReturnDTO> pendingReturnBills) {
         this.pendingReturnBills = pendingReturnBills;
     }
 

--- a/src/main/java/com/divudi/core/data/dto/PharmacyReturnFromWardPendingReturnDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/PharmacyReturnFromWardPendingReturnDTO.java
@@ -1,0 +1,99 @@
+package com.divudi.core.data.dto;
+
+import com.divudi.core.data.Title;
+import java.io.Serializable;
+import java.util.Date;
+
+/**
+ * Row DTO for the pharmacy-side "Medicine Returns Pending Receipt" list
+ * ({@code pharmacy_return_from_ward_receive_list.xhtml}), avoiding a full
+ * {@link com.divudi.core.entity.Bill} entity fetch for what is a read-only
+ * listing (#21471).
+ */
+public class PharmacyReturnFromWardPendingReturnDTO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Long id;
+    private String deptId;
+    private String fromDepartmentName;
+    private String createrPersonName;
+    private Long toStaffId;
+    private String toStaffNameWithTitle;
+    private Date createdAt;
+
+    public PharmacyReturnFromWardPendingReturnDTO() {
+    }
+
+    public PharmacyReturnFromWardPendingReturnDTO(Long id, String deptId, String fromDepartmentName,
+            String createrPersonName, Long toStaffId, Title toStaffTitle, String toStaffPersonName, Date createdAt) {
+        this.id = id;
+        this.deptId = deptId;
+        this.fromDepartmentName = fromDepartmentName;
+        this.createrPersonName = createrPersonName;
+        this.toStaffId = toStaffId;
+        this.toStaffNameWithTitle = buildNameWithTitle(toStaffTitle, toStaffPersonName);
+        this.createdAt = createdAt;
+    }
+
+    private static String buildNameWithTitle(Title title, String name) {
+        String label = title != null ? title.getLabel() : "";
+        return (label + " " + (name != null ? name : "")).trim();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getDeptId() {
+        return deptId;
+    }
+
+    public void setDeptId(String deptId) {
+        this.deptId = deptId;
+    }
+
+    public String getFromDepartmentName() {
+        return fromDepartmentName;
+    }
+
+    public void setFromDepartmentName(String fromDepartmentName) {
+        this.fromDepartmentName = fromDepartmentName;
+    }
+
+    public String getCreaterPersonName() {
+        return createrPersonName;
+    }
+
+    public void setCreaterPersonName(String createrPersonName) {
+        this.createrPersonName = createrPersonName;
+    }
+
+    public Long getToStaffId() {
+        return toStaffId;
+    }
+
+    public void setToStaffId(Long toStaffId) {
+        this.toStaffId = toStaffId;
+    }
+
+    public String getToStaffNameWithTitle() {
+        return toStaffNameWithTitle;
+    }
+
+    public void setToStaffNameWithTitle(String toStaffNameWithTitle) {
+        this.toStaffNameWithTitle = toStaffNameWithTitle;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/com/divudi/core/data/dto/PharmacyReturnFromWardPendingReturnDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/PharmacyReturnFromWardPendingReturnDTO.java
@@ -36,9 +36,18 @@ public class PharmacyReturnFromWardPendingReturnDTO implements Serializable {
         this.createdAt = createdAt;
     }
 
+    /**
+     * {@link Title#getLabel()} already ends with a space for most titles, so
+     * the delimiter is only added when both parts are non-empty. Otherwise
+     * values come out as {@code "Dr.  Smith"} with a double space.
+     */
     private static String buildNameWithTitle(Title title, String name) {
-        String label = title != null ? title.getLabel() : "";
-        return (label + " " + (name != null ? name : "")).trim();
+        String label = title != null && title.getLabel() != null ? title.getLabel().trim() : "";
+        String staffName = name != null ? name.trim() : "";
+        if (label.isEmpty() || staffName.isEmpty()) {
+            return label + staffName;
+        }
+        return label + " " + staffName;
     }
 
     public Long getId() {

--- a/src/main/webapp/pharmacy/pharmacy_return_from_ward_receive_list.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_return_from_ward_receive_list.xhtml
@@ -46,15 +46,15 @@
                     </p:column>
 
                     <p:column headerText="Returned From Ward">
-                        <h:outputLabel value="#{p.fromDepartment.name}"/>
+                        <h:outputLabel value="#{p.fromDepartmentName}"/>
                     </p:column>
 
                     <p:column headerText="Returned By">
-                        <h:outputLabel value="#{p.creater.webUserPerson.name}"/>
+                        <h:outputLabel value="#{p.createrPersonName}"/>
                     </p:column>
 
                     <p:column headerText="Carried By">
-                        <h:outputLabel value="#{p.toStaff.person.nameWithTitle}"/>
+                        <h:outputLabel value="#{p.toStaffNameWithTitle}"/>
                     </p:column>
 
                     <p:column headerText="Returned At">
@@ -72,7 +72,7 @@
                             icon="fa fa-check-circle"
                             value="Receive"
                             action="#{pharmacyReturnFromWardReceiveController.navigateToReceive}">
-                            <f:setPropertyActionListener value="#{p}" target="#{pharmacyReturnFromWardReceiveController.returnedBill}"/>
+                            <f:setPropertyActionListener value="#{p.id}" target="#{pharmacyReturnFromWardReceiveController.returnedBillId}"/>
                         </p:commandButton>
                     </p:column>
 


### PR DESCRIPTION
## Summary
Optimize the pharmacy "Medicine Returns Pending Receipt" list by using DTO projection instead of loading full `Bill` entities, reducing database overhead and improving performance for read-only listing operations.

## Key Changes
- **New DTO class**: `PharmacyReturnFromWardPendingReturnDTO` — lightweight projection containing only the fields needed for the pending returns list (id, department info, staff names, creation date)
- **Query optimization**: Replaced full `Bill` entity fetch with JPQL `SELECT new` constructor projection, avoiding lazy-load associations
- **Controller refactoring**: 
  - Changed `pendingReturnBills` from `List<Bill>` to `List<PharmacyReturnFromWardPendingReturnDTO>`
  - Introduced `returnedBillId` field to defer full `Bill` fetch until user selects a return for processing
  - Added `isFullyAcceptedByBillId()` method to check acceptance status without loading full entity
- **View updates**: Updated `pharmacy_return_from_ward_receive_list.xhtml` to bind DTO properties directly instead of navigating entity relationships

## Implementation Details
- DTO constructor accepts `Title` and person name separately, building the formatted `toStaffNameWithTitle` string during construction
- Pending list filtering now uses bill ID lookups for remaining quantity checks, avoiding unnecessary entity loads
- Full `Bill` entity is only fetched when user clicks "Receive" button via `navigateToReceive()`
- Maintains backward compatibility with pre-#21510 data by filtering fully-accepted returns

Closes #21471

https://claude.ai/code/session_01VfZ6y8CsLXRRpZeNMqTkEN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced the “Medicine Returns Pending Receipt” table to use cleaner, precomputed row fields for department, creator, and receiving staff display.
  * Streamlined the pending list to load lightweight data and exclude fully processed returns in a more efficient, bulk manner.
  * Updated the Receive workflow to track the selected return by its identifier, and validate it against the current pending scope.
  * Improved staff name formatting to avoid extra/double spaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->