### PR TITLE
fix(pharmacy): refresh natively settled bills so their items stay visible

### DIFF
--- a/src/main/java/com/divudi/service/pharmacy/RetailSaleNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/RetailSaleNativeSqlService.java
@@ -270,6 +270,17 @@ public class RetailSaleNativeSqlService {
         // for ordinary methods; one Payment per component for MultiplePaymentMethods.
         List<Payment> payments = insertPayment(saleBill, billId, billTotals[1], paymentMethod, paymentMethodData, paymentScheme);
 
+        // Both bills were persisted with billItems nulled (steps 1a/1b) because the items are
+        // inserted natively, so the in-memory entities claim they have none — and
+        // Bill.getBillItems() hands out an empty list rather than a lazy one. Anything that
+        // later merges these instances writes that empty collection into the shared cache, so
+        // every subsequent read of the bill shows a bill with no items (a reprint printing
+        // "No of Items: 0" while the total is correct). Issue #22511, same cause as #22506.
+        // Refreshing rebuilds the lazy collections from the rows just written, and also picks
+        // up the totals updated above.
+        em.refresh(preBill);
+        em.refresh(saleBill);
+
         LOGGER.log(Level.INFO, "[RetailNativeSettle] DONE items={0} ms={1}",
                 new Object[]{items.size(), System.currentTimeMillis() - t0});
 

--- a/src/main/java/com/divudi/service/pharmacy/TransferIssueNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/TransferIssueNativeSqlService.java
@@ -705,6 +705,15 @@ public class TransferIssueNativeSqlService {
                             ? bill.getCreater().getId() : null);
         }
 
+        // The bill was persisted with billItems nulled because the items are inserted
+        // natively, so the in-memory entity claims it has none — and Bill.getBillItems()
+        // hands out an empty list rather than a lazy one. Anything that later merges this
+        // instance writes that empty collection into the shared cache, so every subsequent
+        // read of the bill shows a bill with no items. Issue #22511, same cause as #22506.
+        // Refreshing rebuilds the lazy collection from the rows just written, and also picks
+        // up the totals and reference links updated above.
+        em.refresh(bill);
+
         LOGGER.log(Level.INFO, "[TINativeSettle] DONE items={0} ms={1}",
                 new Object[]{itemsToProcess.size(), System.currentTimeMillis() - t0});
 

--- a/src/main/java/com/divudi/service/pharmacy/TransferReceiveNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/TransferReceiveNativeSqlService.java
@@ -492,6 +492,15 @@ public class TransferReceiveNativeSqlService {
                             ? bill.getCreater().getId() : null);
         }
 
+        // The bill was persisted with billItems nulled because the items are inserted
+        // natively, so the in-memory entity claims it has none — and Bill.getBillItems()
+        // hands out an empty list rather than a lazy one. Anything that later merges this
+        // instance writes that empty collection into the shared cache, so every subsequent
+        // read of the bill shows a bill with no items. Issue #22511, same cause as #22506.
+        // Refreshing rebuilds the lazy collection from the rows just written, and also picks
+        // up the totals and reference links updated above.
+        em.refresh(bill);
+
         LOGGER.log(Level.INFO, "[TRNativeSettle] DONE items={0} ms={1}",
                 new Object[]{itemsToProcess.size(), System.currentTimeMillis() - t0});
 

--- a/src/main/java/com/divudi/service/pharmacy/WholesaleSaleNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/WholesaleSaleNativeSqlService.java
@@ -265,6 +265,17 @@ public class WholesaleSaleNativeSqlService {
         // for ordinary methods; one Payment per component for MultiplePaymentMethods.
         List<Payment> payments = insertPayment(saleBill, billId, billTotals[1], paymentMethod, paymentMethodData, paymentScheme);
 
+        // Both bills were persisted with billItems nulled (steps 1a/1b) because the items are
+        // inserted natively, so the in-memory entities claim they have none — and
+        // Bill.getBillItems() hands out an empty list rather than a lazy one. Anything that
+        // later merges these instances writes that empty collection into the shared cache, so
+        // every subsequent read of the bill shows a bill with no items (a reprint printing
+        // "No of Items: 0" while the total is correct). Issue #22511, same cause as #22506.
+        // Refreshing rebuilds the lazy collections from the rows just written, and also picks
+        // up the totals updated above.
+        em.refresh(preBill);
+        em.refresh(saleBill);
+
         LOGGER.log(Level.INFO, "[WholesaleNativeSettle] DONE items={0} ms={1}",
                 new Object[]{items.size(), System.currentTimeMillis() - t0});
 


### PR DESCRIPTION
Closes #22511. Applies the fix merged for #22506 (PR #22510) to the four remaining native SQL settle services.

## The bug

Each of these services persists its bill(s) with `setBillItems(null)` because the `BILLITEM` rows are inserted with native SQL. `Bill.getBillItems()` returns a **new empty list** when the field is null rather than a lazy collection, so the in-memory entity claims the bill has no items. Anything that later merges that instance writes the empty collection into the shared EclipseLink cache, and every subsequent read of the bill sees a bill with no items — a reprint showing `No of Items: 0` while the total is correct.

The in-transaction `cache.evict()` already present in each service does not help: the commit merges the persistence context back into the shared cache *after* the eviction runs. That was established while fixing #22506, where a post-commit eviction was also implemented, deployed and measured, and did not work.

## The change

`em.refresh(...)` at the end of `settle()`, after the native totals `UPDATE`:

| Service | Bills refreshed |
|---|---|
| `RetailSaleNativeSqlService` | `preBill` + `saleBill` |
| `WholesaleSaleNativeSqlService` | `preBill` + `saleBill` |
| `TransferIssueNativeSqlService` | `bill` |
| `TransferReceiveNativeSqlService` | `bill` |

Refreshing rebuilds the lazy collection from the rows just written and also picks up the totals and reference links updated natively. `InpatientDirectIssueNativeSqlService` does not null the collection and is unaffected.

## Verification

#22511 was deliberately split out of PR #22510 because these are shared financial paths that could not be exercised in a browser at the time. They have now been, on a local deploy (OPD Pharmacy / Main Pharmacy):

- **Retail sale `OP/SPB/26/037946`** — settle, then the **first** reprint via Search Sale Bills shows `No of Items: 1` and the item row. This is the exact check that failed before #22506.
- **Transfer issue `DTI/COOP/26/000573`** — settles and prints its item.
- **Transfer receive `MPPHTI/73`** — receives and prints its item.
- **Stock reconciles exactly** — OPD Pharmacy 1534 → 1527 (−3 retail sale, −4 transfer issue), no double deduction.
- **`server.log` clean** — no `SEVERE`, `PropertyNotFound`, `ELException` or `NullPointerException`.

### Not covered

The **wholesale** page has no menu route from these departments, so its settle path was not exercised in a browser. Its change is character-for-character the same as the retail sale one, which was verified — but flagging it rather than implying otherwise.

Refs #22506, #22475, #22442

🤖 Generated with [Claude Code](https://claude.com/claude-code)