### PR TITLE
fix(ward): distinct colors/icons for the 3 pharmacy issue search buttons

### DIFF
--- a/src/main/webapp/ward/ward_pharmacy_bht_issue_request_list_for_issue.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_bht_issue_request_list_for_issue.xhtml
@@ -52,26 +52,26 @@
                             timeInput="true" 
                             pattern="#{sessionController.applicationPreference.longDateTimeFormat}" >                                                                              
                         </p:datePicker>
-                        <p:commandButton 
-                            id="btnSearch1" 
-                            ajax="false" 
-                            value="Search All" 
-                            class="w-100 ui-button-warning mt-3" 
-                            icon="fas fa-search"
+                        <p:commandButton
+                            id="btnSearch1"
+                            ajax="false"
+                            value="Search All"
+                            class="w-100 ui-button-secondary mt-3"
+                            icon="fas fa-list"
                             action="#{searchController.createInwardBHTForIssueTableAll}" />
-                        <p:commandButton 
-                            id="btnSearch2" 
-                            ajax="false" 
-                            value="Search Not Issued" 
-                            class="w-100  ui-button-warning my-2" 
-                            icon="fas fa-search"
+                        <p:commandButton
+                            id="btnSearch2"
+                            ajax="false"
+                            value="Search Not Issued"
+                            class="w-100  ui-button-warning my-2"
+                            icon="fas fa-clock"
                             action="#{searchController.createInwardBHTForNotIssueTable}" />
-                        <p:commandButton 
-                            id="btnSearch3" 
-                            class="w-100 ui-button-warning mb-2" 
-                            icon="fas fa-search"
-                            ajax="false" 
-                            value="Search Isssued Only" 
+                        <p:commandButton
+                            id="btnSearch3"
+                            class="w-100 ui-button-success mb-2"
+                            icon="fas fa-check-circle"
+                            ajax="false"
+                            value="Search Issued Only"
                             action="#{searchController.createInwardBHTForIssueOnlyTable}" />
                         <p:spacer height="10"/>
 


### PR DESCRIPTION
## Summary
- Button 1 "Search All" → secondary color + list icon
- Button 2 "Search Not Issued" → keeps warning color, gets clock icon
- Button 3 "Search Issued Only" → success color + check-circle icon, fixes "Isssued" typo
- No `action` bindings changed

Closes #22516

## Test plan
- [x] Browser-verified: all three buttons render with corrected labels/colors/icons
- [x] Clicked "Search All" — non-AJAX action fires correctly, returns expected result set
- [x] JSF-only change, no Java touched, no Maven build required per project convention

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated date-filter search buttons with clearer visual styles and icons.
  * Corrected the “Search Issued Only” label spelling.
  * Improved button formatting for a more consistent interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->