### PR TITLE
refactor(ward): convert pharmacy issue-request list to DTO-based

### DIFF
--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -85,6 +85,8 @@ import com.divudi.core.data.dto.OpdBillItemDTO;
 import com.divudi.core.data.dto.OpdSaleSummaryDTO;
 import com.divudi.core.data.dto.PharmacyCashierPreBillSearchDTO;
 import com.divudi.core.data.dto.PharmacyAdjustmentBillItemDTO;
+import com.divudi.core.data.dto.PharmacyBhtIssueRequestDTO;
+import com.divudi.core.data.dto.PharmacyBhtIssuedBillDTO;
 import com.divudi.core.data.dto.PharmacyItemPurchaseDTO;
 import com.divudi.core.data.dto.PharmacyPreBillSearchDTO;
 import com.divudi.core.data.dto.PharmacyTransferRequestIssueDTO;
@@ -312,6 +314,10 @@ public class SearchController implements Serializable {
     private List<BillListReportDTO> billListReportDtos;
     // DTO list for pharmacy pre-bill search for return items and cash
     private List<PharmacyPreBillSearchDTO> preBillSearchDtos;
+    // DTO list for the pharmacy BHT issue-request list page (issue #22517).
+    // Kept separate from `bills` because `bills` is a shared List<Bill> field
+    // consumed by many other pages/flows.
+    private List<PharmacyBhtIssueRequestDTO> bhtIssueRequestRows;
     // DTO list for cashier pharmacy pre-bill search
     private List<PharmacyCashierPreBillSearchDTO> cashierPreBillSearchDtos;
     // Map to store return bills grouped by parent bill ID for nested datatable display
@@ -5501,6 +5507,21 @@ public class SearchController implements Serializable {
             } else {
                 bills.removeAll(bs);
             }
+        }
+
+        // View-layer DTO mapping for issue #22517 — built in plain Java from
+        // the already-filtered entity list above (not a JPQL projection),
+        // since `bills` must stay List<Bill> for checkBillComponentBatch and
+        // the downstream action listeners. See PharmacyBhtIssueRequestDTO.
+        bhtIssueRequestRows = new ArrayList<>();
+        for (Bill b : bills) {
+            PharmacyBhtIssueRequestDTO dto = new PharmacyBhtIssueRequestDTO(b);
+            List<PharmacyBhtIssuedBillDTO> issuedDtos = new ArrayList<>();
+            for (Bill issued : b.getListOfBill()) {
+                issuedDtos.add(new PharmacyBhtIssuedBillDTO(issued));
+            }
+            dto.setListOfBill(issuedDtos);
+            bhtIssueRequestRows.add(dto);
         }
 
     }
@@ -23305,6 +23326,14 @@ public class SearchController implements Serializable {
 
     public void setBills(List<Bill> bills) {
         this.bills = bills;
+    }
+
+    public List<PharmacyBhtIssueRequestDTO> getBhtIssueRequestRows() {
+        return bhtIssueRequestRows;
+    }
+
+    public void setBhtIssueRequestRows(List<PharmacyBhtIssueRequestDTO> bhtIssueRequestRows) {
+        this.bhtIssueRequestRows = bhtIssueRequestRows;
     }
 
     public List<Bill> getFilteredBills() {

--- a/src/main/java/com/divudi/core/data/dto/PharmacyBhtIssueRequestDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/PharmacyBhtIssueRequestDTO.java
@@ -1,0 +1,120 @@
+package com.divudi.core.data.dto;
+
+import com.divudi.core.entity.Bill;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * View-layer wrapper for a pharmacy BHT issue-request row
+ * (ward_pharmacy_bht_issue_request_list_for_issue.xhtml).
+ *
+ * This is intentionally a plain Java wrapper constructor, NOT a JPQL
+ * SELECT NEW constructor-query projection (see issue #22517). The outer
+ * query in SearchController#createInwardBHTForIssueTable must keep
+ * returning real Bill entities because they're passed unchanged to
+ * PharmacySaleBhtController#checkBillComponentBatch and are needed by the
+ * "View Request" / "Issue Medicines" action listeners downstream
+ * (pharmacyBillSearch.bill, pharmacySaleBhtController.bhtRequestBill).
+ * This DTO removes the deep multi-hop EL navigation from the XHTML while
+ * still carrying the original entity via {@link #getBill()}.
+ */
+public class PharmacyBhtIssueRequestDTO implements Serializable {
+
+    private final Bill bill;
+    private final Long billId;
+    private final String deptId;
+    private final String departmentName;
+    private final String bhtNo;
+    private final String patientName;
+    private final String roomName;
+    private final Date requestedAt;
+    private final String requestedByName;
+    private final boolean cancelled;
+    private final Date cancelledAt;
+    private final String cancelledByName;
+    private List<PharmacyBhtIssuedBillDTO> listOfBill = new ArrayList<>();
+
+    public PharmacyBhtIssueRequestDTO(Bill bill) {
+        this.bill = bill;
+        this.billId = bill.getId();
+        this.deptId = bill.getDeptId();
+        this.departmentName = bill.getDepartment() != null ? bill.getDepartment().getName() : null;
+        this.bhtNo = (bill.getPatientEncounter() != null) ? bill.getPatientEncounter().getBhtNo() : null;
+        this.patientName = (bill.getPatientEncounter() != null && bill.getPatientEncounter().getPatient() != null
+                && bill.getPatientEncounter().getPatient().getPerson() != null)
+                ? bill.getPatientEncounter().getPatient().getPerson().getNameWithTitle() : null;
+        this.roomName = (bill.getPatientEncounter() != null
+                && bill.getPatientEncounter().getCurrentPatientRoom() != null
+                && bill.getPatientEncounter().getCurrentPatientRoom().getRoomFacilityCharge() != null
+                && bill.getPatientEncounter().getCurrentPatientRoom().getRoomFacilityCharge().getRoom() != null)
+                ? bill.getPatientEncounter().getCurrentPatientRoom().getRoomFacilityCharge().getRoom().getName() : null;
+        this.requestedAt = bill.getCreatedAt();
+        this.requestedByName = (bill.getCreater() != null && bill.getCreater().getWebUserPerson() != null)
+                ? bill.getCreater().getWebUserPerson().getName() : null;
+        this.cancelled = bill.isCancelled();
+        this.cancelledAt = (bill.isCancelled() && bill.getCancelledBill() != null)
+                ? bill.getCancelledBill().getCreatedAt() : null;
+        this.cancelledByName = (bill.isCancelled() && bill.getCancelledBill() != null
+                && bill.getCancelledBill().getCreater() != null
+                && bill.getCancelledBill().getCreater().getWebUserPerson() != null)
+                ? bill.getCancelledBill().getCreater().getWebUserPerson().getName() : null;
+    }
+
+    public Bill getBill() {
+        return bill;
+    }
+
+    public Long getBillId() {
+        return billId;
+    }
+
+    public String getDeptId() {
+        return deptId;
+    }
+
+    public String getDepartmentName() {
+        return departmentName;
+    }
+
+    public String getBhtNo() {
+        return bhtNo;
+    }
+
+    public String getPatientName() {
+        return patientName;
+    }
+
+    public String getRoomName() {
+        return roomName;
+    }
+
+    public Date getRequestedAt() {
+        return requestedAt;
+    }
+
+    public String getRequestedByName() {
+        return requestedByName;
+    }
+
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    public Date getCancelledAt() {
+        return cancelledAt;
+    }
+
+    public String getCancelledByName() {
+        return cancelledByName;
+    }
+
+    public List<PharmacyBhtIssuedBillDTO> getListOfBill() {
+        return listOfBill;
+    }
+
+    public void setListOfBill(List<PharmacyBhtIssuedBillDTO> listOfBill) {
+        this.listOfBill = listOfBill;
+    }
+}

--- a/src/main/java/com/divudi/core/data/dto/PharmacyBhtIssuedBillDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/PharmacyBhtIssuedBillDTO.java
@@ -1,0 +1,82 @@
+package com.divudi.core.data.dto;
+
+import com.divudi.core.entity.Bill;
+import java.io.Serializable;
+import java.util.Date;
+
+/**
+ * View-layer wrapper for a "PharmacyBhtPre" issued bill nested under a
+ * pharmacy BHT issue-request row (ward_pharmacy_bht_issue_request_list_for_issue.xhtml).
+ *
+ * This is intentionally a plain Java wrapper constructor, NOT a JPQL
+ * SELECT NEW constructor-query projection. The underlying Bill entity is
+ * already loaded (and needed) by SearchController#getBHTIssudBills and is
+ * carried through via {@link #getBill()} so downstream action listeners
+ * (pharmacyBillSearch.bill) can keep operating on the real entity.
+ */
+public class PharmacyBhtIssuedBillDTO implements Serializable {
+
+    private final Bill bill;
+    private final Long billId;
+    private final String deptId;
+    private final Date createdAt;
+    private final boolean cancelled;
+    private final Date cancelledAt;
+    private final String cancelledByName;
+    private final String issuedByName;
+    private final String toStaffName;
+
+    public PharmacyBhtIssuedBillDTO(Bill bill) {
+        this.bill = bill;
+        this.billId = bill.getId();
+        this.deptId = bill.getDeptId();
+        this.createdAt = bill.getCreatedAt();
+        this.cancelled = bill.isCancelled();
+        this.cancelledAt = (bill.isCancelled() && bill.getCancelledBill() != null)
+                ? bill.getCancelledBill().getCreatedAt() : null;
+        this.cancelledByName = (bill.isCancelled() && bill.getCancelledBill() != null
+                && bill.getCancelledBill().getCreater() != null
+                && bill.getCancelledBill().getCreater().getWebUserPerson() != null)
+                ? bill.getCancelledBill().getCreater().getWebUserPerson().getName() : null;
+        this.issuedByName = (bill.getCreater() != null && bill.getCreater().getWebUserPerson() != null)
+                ? bill.getCreater().getWebUserPerson().getName() : null;
+        this.toStaffName = (bill.getToStaff() != null && bill.getToStaff().getPerson() != null)
+                ? bill.getToStaff().getPerson().getNameWithTitle() : null;
+    }
+
+    public Bill getBill() {
+        return bill;
+    }
+
+    public Long getBillId() {
+        return billId;
+    }
+
+    public String getDeptId() {
+        return deptId;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    public Date getCancelledAt() {
+        return cancelledAt;
+    }
+
+    public String getCancelledByName() {
+        return cancelledByName;
+    }
+
+    public String getIssuedByName() {
+        return issuedByName;
+    }
+
+    public String getToStaffName() {
+        return toStaffName;
+    }
+}

--- a/src/main/webapp/ward/ward_pharmacy_bht_issue_request_list_for_issue.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_bht_issue_request_list_for_issue.xhtml
@@ -96,9 +96,9 @@
 
                     </div>
                     <div class="col-md-10">
-                        <p:dataTable 
-                            value="#{searchController.bills}" 
-                            var="p" 
+                        <p:dataTable
+                            value="#{searchController.bhtIssueRequestRows}"
+                            var="p"
                             rows="10"
                             paginator="true"
                             paginatorPosition="bottom"
@@ -110,40 +110,40 @@
                                 <h:outputText value="#{p.deptId}" />
                             </p:column>
 
-                            <p:column headerText="Requested Department" >                      
-                                <h:outputLabel value="#{p.department.name}"/>                          
-                            </p:column> 
-                            <p:column headerText="BHT No" >                      
-                                <h:outputLabel value="#{p.patientEncounter.bhtNo}"/>                          
-                            </p:column> 
-                            <p:column headerText="Name" >                      
-                                <h:outputLabel value="#{p.patientEncounter.patient.person.nameWithTitle}"/>                          
-                            </p:column> 
-                            <p:column headerText="Room" >                      
-                                <h:outputLabel value="#{p.patientEncounter.currentPatientRoom.roomFacilityCharge.room.name}"/>                          
-                            </p:column> 
+                            <p:column headerText="Requested Department" >
+                                <h:outputLabel value="#{p.departmentName}"/>
+                            </p:column>
+                            <p:column headerText="BHT No" >
+                                <h:outputLabel value="#{p.bhtNo}"/>
+                            </p:column>
+                            <p:column headerText="Name" >
+                                <h:outputLabel value="#{p.patientName}"/>
+                            </p:column>
+                            <p:column headerText="Room" >
+                                <h:outputLabel value="#{p.roomName}"/>
+                            </p:column>
                             <p:column headerText="Requested At"  >
-                                <h:outputLabel value="#{p.createdAt}" >
+                                <h:outputLabel value="#{p.requestedAt}" >
                                     <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
                                 </h:outputLabel>
                                 <br/>
                                 <h:panelGroup rendered="#{p.cancelled}" >
                                     <h:outputLabel style="color: red;" value="Cancelled At " />
-                                    <h:outputLabel style="color: red;" rendered="#{p.cancelled}" 
-                                                   value="#{p.cancelledBill.createdAt}" >
+                                    <h:outputLabel style="color: red;" rendered="#{p.cancelled}"
+                                                   value="#{p.cancelledAt}" >
                                         <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
                                     </h:outputLabel>
                                 </h:panelGroup>
 
-                            </p:column>   
-                            <p:column headerText="Requested By"  >    
+                            </p:column>
+                            <p:column headerText="Requested By"  >
 
-                                <h:outputLabel value="#{p.creater.webUserPerson.name}" >                                      
-                                </h:outputLabel>                          
+                                <h:outputLabel value="#{p.requestedByName}" >
+                                </h:outputLabel>
                                 <br/>
                                 <h:panelGroup rendered="#{p.cancelled}" >
                                     <h:outputLabel style="color: red;" value="Cancelled By " />
-                                    <h:outputLabel style="color: red;" rendered="#{p.cancelled}" value="#{p.cancelledBill.creater.webUserPerson.name}" >                                       
+                                    <h:outputLabel style="color: red;" rendered="#{p.cancelled}" value="#{p.cancelledByName}" >
                                     </h:outputLabel>
                                 </h:panelGroup>
                             </p:column>
@@ -155,10 +155,10 @@
                                     ajax="false" 
                                     icon="fa fa-eye"
                                     action="ward_pharmacy_reprint_bht_issue_request?faces-redirect=true">
-                                    <f:setPropertyActionListener value="#{p}" target="#{pharmacyBillSearch.bill}"/>
+                                    <f:setPropertyActionListener value="#{p.bill}" target="#{pharmacyBillSearch.bill}"/>
                                     <f:setPropertyActionListener value="/ward/ward_pharmacy_bht_issue_request_list_for_issue?faces-redirect=true" target="#{pharmacyBillSearch.returnPage}"/>
                                 </p:commandButton>
-                                
+
                                 <p:commandButton
                                     id="btnNavigtateToIssueMedicine"
                                     title="Issue Medicines"
@@ -168,7 +168,7 @@
                                     onclick="PF('issueMedicinesProcessingDialog').show();"
                                     action="#{pharmacySaleBhtController.navigateToIssueMedicinesDirectlyForBhtRequest()}"
                                     disabled="#{p.cancelled eq true}">
-                                    <f:setPropertyActionListener value="#{p}" target="#{pharmacySaleBhtController.bhtRequestBill}" />
+                                    <f:setPropertyActionListener value="#{p.bill}" target="#{pharmacySaleBhtController.bhtRequestBill}" />
                                 </p:commandButton>
                             </p:column>
 
@@ -186,26 +186,26 @@
                                         <h:panelGroup rendered="#{b.cancelled}" >
                                             <h:outputLabel style="color: red;" value="Cancelled At " />
                                             <h:outputLabel style="color: red;" rendered="#{b.cancelled}"
-                                                           value="#{b.cancelledBill.createdAt}" >
+                                                           value="#{b.cancelledAt}" >
                                                 <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
                                             </h:outputLabel>
-                                        </h:panelGroup>                               
-                                    </p:column>                             
+                                        </h:panelGroup>
+                                    </p:column>
                                     <p:column width="15%">
-                                        <h:outputLabel value="#{b.creater.webUserPerson.name}"/>     
+                                        <h:outputLabel value="#{b.issuedByName}"/>
                                         <br/>
                                         <h:panelGroup rendered="#{b.cancelled}" >
                                             <h:outputLabel style="color: red;" value="Cancelled By " />
-                                            <h:outputLabel style="color: red;" rendered="#{b.cancelled}" value="#{b.cancelledBill.creater.webUserPerson.name}" >                                       
+                                            <h:outputLabel style="color: red;" rendered="#{b.cancelled}" value="#{b.cancelledByName}" >
                                             </h:outputLabel>
                                         </h:panelGroup>
-                                    </p:column> 
-                                    <p:column width="15%">                              
-                                        <h:outputLabel value="#{b.toStaff.person.nameWithTitle}" />                                   
-                                    </p:column> 
+                                    </p:column>
+                                    <p:column width="15%">
+                                        <h:outputLabel value="#{b.toStaffName}" />
+                                    </p:column>
                                     <p:column style="width: 12%;">
                                         <p:commandButton ajax="false" value="View Bill" action="/ward/ward_pharmacy_reprint_bht_issue_bill_reprint?faces-redirect=true" >
-                                            <f:setPropertyActionListener target="#{pharmacyBillSearch.bill}" value="#{b}"/>
+                                            <f:setPropertyActionListener target="#{pharmacyBillSearch.bill}" value="#{b.bill}"/>
                                         </p:commandButton>
                                     </p:column>
 


### PR DESCRIPTION
## Summary
- Adds `PharmacyBhtIssueRequestDTO`/`PharmacyBhtIssuedBillDTO` — plain Java wrapper DTOs (not JPQL constructor-query projections) that carry a `Bill bill` field alongside flat display fields.
- `SearchController.createInwardBHTForIssueTable` keeps its existing JPQL and "Not Issued"/"Issued Only" filtering (via `pharmacySaleBhtController.checkBillComponentBatch`, which needs real `Bill` entities) completely unchanged; DTOs are built only in a mapping step after filtering, for the view layer.
- Adds a new `bhtIssueRequestRows` field rather than repurposing `SearchController.bills`, which is shared by ~150 other pages.
- `ward_pharmacy_bht_issue_request_list_for_issue.xhtml` now binds to flat DTO getters instead of deep entity-graph EL paths (`p.department.name` → `p.departmentName`, etc.), and the two `f:setPropertyActionListener` targets (`pharmacyBillSearch.bill`, `pharmacySaleBhtController.bhtRequestBill`) plus the nested "View Bill" listener are rebound from the bare row var to `#{p.bill}`/`#{b.bill}`.

Closes #22517

## Design note
The original plan assumed a straightforward JPQL `SELECT NEW DTO(...)` projection. Investigation found that's not viable here because the query result feeds `checkBillComponentBatch(List<Bill>)` and two downstream action-listener targets that all require real `Bill` entities — so this uses plain-Java wrapper DTOs built from the already-fetched, already-filtered entity list instead.

## Test plan
- [x] Browser-verified all 3 search modes (Search All / Not Issued / Issued Only) against real local data — row counts consistent (11 / 7 / 4)
- [x] Verified "View Request", "Issue Medicines", and nested "View Bill" each navigate to and operate on the correct bill after the `#{p}`→`#{p.bill}` / `#{b}`→`#{b.bill}` rebinding — the key regression risk of this change
- [x] Cross-checked "Search All" results against a manual SQL query on the local DB — row-for-row match
- [x] JPQL/filtering logic and `SearchController.bills` confirmed untouched (grep-verified `bills` is used by ~150 other pages)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the pharmacy BHT issue-request list with clearer request, patient, room, department, and staff details.
  * Added structured display of issued medicine bills, including cancellation information.
  * Updated “View Request,” “Issue Medicines,” and “View Bill” actions to open the correct records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->