### PR TITLE
refactor(pharmacy): single "Retail Sale" menu item instead of Sale 1-4

### DIFF
--- a/src/main/webapp/resources/ezcomp/menu.xhtml
+++ b/src/main/webapp/resources/ezcomp/menu.xhtml
@@ -1054,35 +1054,13 @@
                             ajax="false"
                             action="/pharmacy/pharmacy_bill_retail_sale_native?faces-redirect=true"
                             actionListener="#{retailSaleNativeSqlController.resetAll()}"
-                            value="Sale"
+                            value="Retail Sale"
                             icon="fas fa-mortar-pestle"
                             style="font-weight: bold;"
                             styleClass="menu-item-optimised"
                             rendered="#{webUserController.hasPrivilege('PharmacySale')}" ></p:menuitem>
-                        <p:menuitem
-                            ajax="false"
-                            action="/pharmacy/pharmacy_bill_retail_sale_native_1?faces-redirect=true"
-                            actionListener="#{retailSaleNativeSqlController1.switchToThisSaleWindow()}"
-                            value="Sale 2"
-                            icon="fas fa-mortar-pestle"
-                            styleClass="menu-item-optimised"
-                            rendered="#{webUserController.hasPrivilege('PharmacySale')}" ></p:menuitem>
-                        <p:menuitem
-                            ajax="false"
-                            action="/pharmacy/pharmacy_bill_retail_sale_native_2?faces-redirect=true"
-                            actionListener="#{retailSaleNativeSqlController2.switchToThisSaleWindow()}"
-                            value="Sale 3"
-                            icon="fas fa-mortar-pestle"
-                            styleClass="menu-item-optimised"
-                            rendered="#{webUserController.hasPrivilege('PharmacySale')}" ></p:menuitem>
-                        <p:menuitem
-                            ajax="false"
-                            action="/pharmacy/pharmacy_bill_retail_sale_native_3?faces-redirect=true"
-                            actionListener="#{retailSaleNativeSqlController3.switchToThisSaleWindow()}"
-                            value="Sale 4"
-                            icon="fas fa-mortar-pestle"
-                            styleClass="menu-item-optimised"
-                            rendered="#{webUserController.hasPrivilege('PharmacySale')}" ></p:menuitem>
+                        <!-- Sale 2, 3 and 4 are the same feature's parallel windows. They are
+                             reached from the Sale 1 page's window-switch row, not from the menu. -->
                         <p:menuitem
                             ajax="false"
                             action="#{pharmacySaleController.navigateToPharmacyRetailSale()}"


### PR DESCRIPTION
Closes #22535

## Problem

**Pharmacy → Sale** listed four entries — `Sale`, `Sale 2`, `Sale 3`, `Sale 4` — for what is really one feature with four parallel cashier windows. The menu read as four different features.

## Change

`src/main/webapp/resources/ezcomp/menu.xhtml`:

- Removed the `Sale 2`, `Sale 3`, `Sale 4` menu items.
- Renamed the remaining item to **Retail Sale** — it still opens Sale 1 (`pharmacy_bill_retail_sale_native`) with `retailSaleNativeSqlController.resetAll()` as before.
- Left a comment marking where the removed windows now come from.

## Why no window is orphaned

All four native sale pages (`pharmacy_bill_retail_sale_native`, `_1`, `_2`, `_3`) already render a `Sale 1 | Sale 2 | Sale 3 | Sale 4` window-switch button row in both the top and bottom toolbars, wired to `retailSaleNativeSqlController{,1,2,3}.switchToThisSaleWindow()`. Verified present in all four files before removing the menu entries — so every window stays reachable from Sale 1, and from each other.

## Notes

- JSF-only change; no Java touched, so no compilation/test run required per project convention.
- No privilege change — all four removed items were gated on the same `PharmacySale` privilege that the surviving item uses.
- `Sale (Legacy)`, `Sale by Item`, `Sale for cashier` and the search items in the same submenu are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Renamed the Pharmacy menu’s primary sales option to **“Retail Sale.”**
  * Removed the additional “Sale 2,” “Sale 3,” and “Sale 4” menu entries.
  * Sales windows remain accessible through the window-switching controls on the primary Sale page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->