### PR TITLE
fix(ci): hardcode NetBeans-bundled mvn path for ruhunu local staging deploy

### DIFF
--- a/.github/workflows/ruhunu_local_server_ci_cd.yml
+++ b/.github/workflows/ruhunu_local_server_ci_cd.yml
@@ -72,9 +72,7 @@ jobs:
           # metacharacter would corrupt the remote argv. Base64-encode it instead.
           PAYARA_ADMIN_PASS_B64=$(printf '%s' "$PAYARA_ADMIN_PASS" | base64 -w0)
 
-          # -l makes this a login shell so it sources the same profile (and PATH,
-          # e.g. for mvn) that an interactive SSH session would get.
-          ssh -i private_key.pem -o StrictHostKeyChecking=no $SERVER_USER@$SERVER_IP bash -ls -- "$PAYARA_ADMIN_PASS_B64" "${{ github.sha }}" <<'REMOTE_SCRIPT'
+          ssh -i private_key.pem -o StrictHostKeyChecking=no $SERVER_USER@$SERVER_IP bash -s -- "$PAYARA_ADMIN_PASS_B64" "${{ github.sha }}" <<'REMOTE_SCRIPT'
           set -e
 
           PAYARA_ADMIN_PASS=$(printf '%s' "$1" | base64 -d)
@@ -103,7 +101,11 @@ jobs:
           sed -i 's|<jta-data-source>${JDBC_DATASOURCE}</jta-data-source>|<jta-data-source>jdbc/ruhunu</jta-data-source>|' src/main/resources/META-INF/persistence.xml
           sed -i 's|<jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>|<jta-data-source>jdbc/ruhunuaudit</jta-data-source>|' src/main/resources/META-INF/persistence.xml
 
-          mvn clean package -DskipTests
+          # mvn on this server is a NetBeans-bundled binary, never added to any
+          # shell's PATH (confirmed 2026-07-30: `which mvn` is blank even in an
+          # interactive login session). Java itself resolves fine via the system
+          # PATH (/usr/lib/jvm/java-11-openjdk-amd64), so only mvn needs the full path.
+          /opt/netbeans/java/maven/bin/mvn clean package -DskipTests
 
           NEW_WAR=$(ls target/*.war | head -n1)
           NEW_WAR_SIZE=$(stat -c%s "$NEW_WAR" 2>/dev/null || echo 0)


### PR DESCRIPTION
## Summary
Root cause of the `mvn: command not found` failures on the last two runs of the ruhunu local staging deploy: `mvn` on 124.43.4.189 is a NetBeans-bundled binary at `/opt/netbeans/java/maven/bin/mvn`, never added to any shell's PATH (confirmed live: `which mvn` returns blank even in an interactive login session). The earlier `bash -ls` login-shell attempt couldn't have fixed this since there's no PATH entry to source in the first place.

- Hardcode the full mvn path, matching how `asadmin`'s path is already hardcoded in this workflow.
- Dropped the now-pointless `bash -ls` login shell flag (back to plain `bash -s`) since it wasn't the actual fix and adds no value here — Java itself already resolves via the system PATH (`/usr/lib/jvm/java-11-openjdk-amd64`), confirmed via `mvn -version` output.

## Test plan
- [ ] Merge `development` → `rh-local-staging` and confirm the deploy job gets past the mvn build step
- [ ] Confirm `http://124.43.4.189:8010/rhLocal` is reachable and serving the latest code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment reliability by using a non-login shell during remote deployment.
  * Updated the server-side build process to use the available Maven installation directly.
  * Added deployment comments to clarify the server’s Maven configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->