### PR TITLE
fix(inward): final bill version numbering, retire, and email

### DIFF
--- a/src/main/java/com/divudi/bean/common/UserPrivilageController.java
+++ b/src/main/java/com/divudi/bean/common/UserPrivilageController.java
@@ -302,6 +302,8 @@ public class UserPrivilageController implements Serializable {
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSettleFinalBill, "Inward Settle Final Bill"), additionalPrivilegesNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardFinalBillCreateVersion, "Inward Final Bill Create New Version"), additionalPrivilegesNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardFinalBillSetConfirmed, "Inward Final Bill Set As Confirmed"), additionalPrivilegesNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardFinalBillRetire, "Inward Final Bill Retire"), additionalPrivilegesNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardFinalBillEmail, "Inward Final Bill Email"), additionalPrivilegesNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSaveProvisionalFinalBill, "Inward Save Provisional Final Bill"), additionalPrivilegesNode);
 
         // Theatre Privileges

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -3141,7 +3141,8 @@ public class BhtSummeryController implements Serializable {
         getCurrent().setSettledAmountByPatient(paidByPatient);
         getCurrent().setPaymentMethod(getPatientEncounter().getPaymentMethod());
         getCurrent().setCreditCompany(getPatientEncounter().getCreditCompany());
-        getCurrent().setInstitution(getSessionController().getInstitution());
+        getCurrent().setInstitution(patientEncounter.getInstitution());
+        getCurrent().setDepartment(patientEncounter.getDepartment());
         getCurrent().setBillTypeAtomic(BillTypeAtomic.INWARD_FINAL_BILL);
         getCurrent().setBillType(BillType.InwardFinalBill);
 
@@ -3162,8 +3163,8 @@ public class BhtSummeryController implements Serializable {
         getBillNumberBean().withFinalBillVersionLock(patientEncounter, () -> {
             int versionSerial = getBillNumberBean().computeNextFinalBillVersionSerial(patientEncounter);
             getCurrent().setFinalBillVersionSerial(versionSerial);
-            getCurrent().setDeptId(getBillNumberBean().departmentBillNumberGenerator(getSessionController().getDepartment(), BillType.InwardFinalBill, BillClassType.BilledBill, BillNumberSuffix.INWFINAL) + "/" + versionSerial);
-            getCurrent().setInsId(getBillNumberBean().institutionBillNumberGenerator(getSessionController().getInstitution(), BillType.InwardFinalBill, BillClassType.BilledBill, BillNumberSuffix.INWFINAL) + "/" + versionSerial);
+            getCurrent().setDeptId(getBillNumberBean().departmentBillNumberGenerator(patientEncounter.getDepartment(), BillType.InwardFinalBill, BillClassType.BilledBill, BillNumberSuffix.INWFINAL) + "/" + versionSerial);
+            getCurrent().setInsId(getBillNumberBean().institutionBillNumberGenerator(patientEncounter.getInstitution(), BillType.InwardFinalBill, BillClassType.BilledBill, BillNumberSuffix.INWFINAL) + "/" + versionSerial);
 
             if (getCurrent().getId() == null) {
                 getBillFacade().create(getCurrent());
@@ -3220,10 +3221,11 @@ public class BhtSummeryController implements Serializable {
         getOriginalBill().setSettledAmountByPatient(paidByPatient);
         getOriginalBill().setPaymentMethod(getPatientEncounter().getPaymentMethod());
         getOriginalBill().setCreditCompany(getPatientEncounter().getCreditCompany());
-        getOriginalBill().setInstitution(getSessionController().getInstitution());
+        getOriginalBill().setInstitution(patientEncounter.getInstitution());
+        getOriginalBill().setDepartment(patientEncounter.getDepartment());
         getOriginalBill().setBillTypeAtomic(BillTypeAtomic.INWARD_ORIGINAL_FINAL_BILL);
-        getOriginalBill().setDeptId(getBillNumberBean().departmentBillNumberGenerator(getSessionController().getDepartment(), BillType.InwardOriginalFinalBill, BillClassType.BilledBill, BillNumberSuffix.INWFINALORG));
-        getOriginalBill().setInsId(getBillNumberBean().institutionBillNumberGenerator(getSessionController().getInstitution(), BillType.InwardOriginalFinalBill, BillClassType.BilledBill, BillNumberSuffix.INWFINALORG));
+        getOriginalBill().setDeptId(getBillNumberBean().departmentBillNumberGenerator(patientEncounter.getDepartment(), BillType.InwardOriginalFinalBill, BillClassType.BilledBill, BillNumberSuffix.INWFINALORG));
+        getOriginalBill().setInsId(getBillNumberBean().institutionBillNumberGenerator(patientEncounter.getInstitution(), BillType.InwardOriginalFinalBill, BillClassType.BilledBill, BillNumberSuffix.INWFINALORG));
 
         getOriginalBill().setBillType(BillType.InwardOriginalFinalBill);
 
@@ -3250,12 +3252,13 @@ public class BhtSummeryController implements Serializable {
         creditCompanyBill.setGrantTotal(value);
         creditCompanyBill.setTotal(value);
         creditCompanyBill.setNetTotal(value);
-        creditCompanyBill.setInstitution(getSessionController().getInstitution());
+        creditCompanyBill.setInstitution(patientEncounter.getInstitution());
+        creditCompanyBill.setDepartment(patientEncounter.getDepartment());
         creditCompanyBill.setCreditCompany(ecc.getInstitution());
         creditCompanyBill.setPaymentMethod(PaymentMethod.Credit);
 
-        creditCompanyBill.setDeptId(getBillNumberBean().departmentBillNumberGenerator(getSessionController().getDepartment(), BillType.InwardFinalBillCCPayment, BillClassType.BilledBill, BillNumberSuffix.INWFINALCCPAY));
-        creditCompanyBill.setInsId(getBillNumberBean().institutionBillNumberGenerator(getSessionController().getInstitution(), BillType.InwardFinalBillCCPayment, BillClassType.BilledBill, BillNumberSuffix.INWFINALCCPAY));
+        creditCompanyBill.setDeptId(getBillNumberBean().departmentBillNumberGenerator(patientEncounter.getDepartment(), BillType.InwardFinalBillCCPayment, BillClassType.BilledBill, BillNumberSuffix.INWFINALCCPAY));
+        creditCompanyBill.setInsId(getBillNumberBean().institutionBillNumberGenerator(patientEncounter.getInstitution(), BillType.InwardFinalBillCCPayment, BillClassType.BilledBill, BillNumberSuffix.INWFINALCCPAY));
 
         creditCompanyBill.setBillType(BillType.InwardFinalBillCCPayment);
         creditCompanyBill.setBillTypeAtomic(BillTypeAtomic.INWARD_FINAL_BILL_PAYMENT_BY_CREDIT_COMPANY);
@@ -3283,12 +3286,13 @@ public class BhtSummeryController implements Serializable {
         creditCompanyBill.setGrantTotal(value);
         creditCompanyBill.setTotal(value);
         creditCompanyBill.setNetTotal(value);
-        creditCompanyBill.setInstitution(getSessionController().getInstitution());
+        creditCompanyBill.setInstitution(patientEncounter.getInstitution());
+        creditCompanyBill.setDepartment(patientEncounter.getDepartment());
         creditCompanyBill.setCreditCompany(company);
         creditCompanyBill.setPaymentMethod(PaymentMethod.Credit);
 
-        creditCompanyBill.setDeptId(getBillNumberBean().departmentBillNumberGenerator(getSessionController().getDepartment(), BillType.InwardFinalBillCCPayment, BillClassType.BilledBill, BillNumberSuffix.INWFINALCCPAY));
-        creditCompanyBill.setInsId(getBillNumberBean().institutionBillNumberGenerator(getSessionController().getInstitution(), BillType.InwardFinalBillCCPayment, BillClassType.BilledBill, BillNumberSuffix.INWFINALCCPAY));
+        creditCompanyBill.setDeptId(getBillNumberBean().departmentBillNumberGenerator(patientEncounter.getDepartment(), BillType.InwardFinalBillCCPayment, BillClassType.BilledBill, BillNumberSuffix.INWFINALCCPAY));
+        creditCompanyBill.setInsId(getBillNumberBean().institutionBillNumberGenerator(patientEncounter.getInstitution(), BillType.InwardFinalBillCCPayment, BillClassType.BilledBill, BillNumberSuffix.INWFINALCCPAY));
 
         creditCompanyBill.setBillType(BillType.InwardFinalBillCCPayment);
         creditCompanyBill.setBillTypeAtomic(BillTypeAtomic.INWARD_FINAL_BILL_PAYMENT_BY_CREDIT_COMPANY);

--- a/src/main/java/com/divudi/bean/inward/InwardSearch.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSearch.java
@@ -18,6 +18,8 @@ import com.divudi.core.data.Sex;
 import com.divudi.core.data.dataStructure.ComponentDetail;
 import com.divudi.core.data.dataStructure.PaymentMethodData;
 import com.divudi.core.data.dataStructure.YearMonthDay;
+import com.divudi.core.data.EmailAttachment;
+import com.divudi.core.data.MessageType;
 import com.divudi.core.data.hr.ReportKeyWord;
 import com.divudi.core.data.inward.SurgeryBillType;
 import com.divudi.ejb.BillNumberGenerator;
@@ -46,9 +48,12 @@ import com.divudi.core.util.CommonFunctions;
 import com.divudi.service.DrawerService;
 import com.divudi.service.PaymentService;
 import com.divudi.service.RequestService;
+import java.io.ByteArrayOutputStream;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -95,6 +100,10 @@ public class InwardSearch implements Serializable {
     DrawerService drawerService;
     @EJB
     private com.divudi.service.AuditService auditService;
+    @EJB
+    private com.divudi.core.facade.EmailFacade emailFacade;
+    @EJB
+    private com.divudi.ejb.EmailManagerEjb emailManagerEjb;
 
     /**
      * JSF Controllers
@@ -705,6 +714,182 @@ public class InwardSearch implements Serializable {
         auditService.logEncounterAudit(pe, "Final Bill Version Confirmed",
                 previousFinalBillId, newConfirmed.getId(), sessionController.getLoggedUser(),
                 "Bill", newConfirmed.getId());
+    }
+
+    /**
+     * User-facing action to retire (soft delete) a final bill version.
+     * Irreversible — there is no un-retire action. Privilege checks are done
+     * in the XHTML via {@code rendered}, not here.
+     */
+    public void retireFinalBillVersion(Bill b) {
+        if (b == null) {
+            JsfUtil.addErrorMessage("No bill selected");
+            return;
+        }
+        if (b.isRetired()) {
+            JsfUtil.addErrorMessage("Bill is already retired");
+            return;
+        }
+        if (b.isConfirmedFinalBill()) {
+            JsfUtil.addErrorMessage("Cannot retire the Confirmed Final Bill. Confirm a different version first.");
+            return;
+        }
+        List<Bill> versions = fetchFinalBillVersions(b.getPatientEncounter());
+        if (versions.size() <= 1) {
+            JsfUtil.addErrorMessage("Cannot retire the only remaining final bill version");
+            return;
+        }
+
+        b.setRetired(true);
+        b.setRetirer(sessionController.getLoggedUser());
+        b.setRetiredAt(new Date());
+        getBillFacade().edit(b);
+
+        auditService.logEncounterAudit(b.getPatientEncounter(), "Final Bill Version Retired",
+                b.getId(), null, sessionController.getLoggedUser(),
+                "Bill", b.getId());
+
+        JsfUtil.addSuccessMessage("Final Bill Version Retired");
+        finalBillVersions = null;
+    }
+
+    private String emailRecipient;
+    private List<AppEmail> sentEmailsForBill;
+
+    public String getEmailRecipient() {
+        return emailRecipient;
+    }
+
+    public void setEmailRecipient(String emailRecipient) {
+        this.emailRecipient = emailRecipient;
+    }
+
+    /**
+     * Emails a one-page summary of the given final bill version (patient,
+     * admission, and totals — not a full itemized reprint) as a PDF
+     * attachment, and logs the send via {@link AppEmail} so it shows up in
+     * the "Sent Emails" history on the view/print screen.
+     */
+    public void emailFinalBillVersion(Bill b) {
+        if (b == null) {
+            JsfUtil.addErrorMessage("No bill selected");
+            return;
+        }
+        if (emailRecipient == null || emailRecipient.trim().isEmpty()) {
+            JsfUtil.addErrorMessage("No recipient Email");
+            return;
+        }
+        if (!CommonFunctions.isValidEmail(emailRecipient)) {
+            JsfUtil.addErrorMessage("Recipient Email is NOT valid");
+            return;
+        }
+
+        AppEmail email = new AppEmail();
+        email.setCreatedAt(new Date());
+        email.setCreater(sessionController.getLoggedUser());
+        email.setReceipientEmail(emailRecipient);
+        email.setMessageSubject("Final Bill " + b.getDeptId());
+        email.setMessageBody("Please find attached the final bill " + b.getDeptId() + ".");
+        email.setDepartment(b.getDepartment());
+        email.setInstitution(b.getInstitution());
+        email.setBill(b);
+        email.setPatientEncounter(b.getPatientEncounter());
+        email.setMessageType(MessageType.InwardFinalBillEmail);
+        email.setSentSuccessfully(false);
+        email.setPending(true);
+        emailFacade.create(email);
+
+        try {
+            byte[] pdfBytes = buildFinalBillPdf(b);
+            EmailAttachment attachment = new EmailAttachment(
+                    "FinalBill_" + b.getFinalBillVersionSerial() + ".pdf",
+                    "application/pdf",
+                    Base64.getEncoder().encodeToString(pdfBytes));
+
+            boolean success = emailManagerEjb.sendEmail(
+                    Collections.singletonList(email.getReceipientEmail()),
+                    email.getMessageBody(),
+                    email.getMessageSubject(),
+                    false,
+                    Collections.singletonList(attachment));
+
+            if (success) {
+                email.setSentAt(new Date());
+                email.setSentSuccessfully(true);
+                email.setPending(false);
+                emailFacade.edit(email);
+                JsfUtil.addSuccessMessage("Email Sent Successfully");
+            } else {
+                emailFacade.edit(email);
+                JsfUtil.addErrorMessage("Sending Email Failed");
+            }
+        } catch (Exception ex) {
+            emailFacade.edit(email);
+            JsfUtil.addErrorMessage("Sending Email Failed");
+            java.util.logging.Logger.getLogger(InwardSearch.class.getName())
+                    .log(java.util.logging.Level.SEVERE, "Final bill email failed", ex);
+        }
+
+        sentEmailsForBill = null;
+    }
+
+    private byte[] buildFinalBillPdf(Bill b) throws Exception {
+        String html = buildFinalBillHtml(b);
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            com.itextpdf.kernel.pdf.PdfWriter writer = new com.itextpdf.kernel.pdf.PdfWriter(out);
+            com.itextpdf.kernel.pdf.PdfDocument pdfDoc = new com.itextpdf.kernel.pdf.PdfDocument(writer);
+            pdfDoc.setDefaultPageSize(com.itextpdf.kernel.geom.PageSize.A4);
+            com.itextpdf.html2pdf.HtmlConverter.convertToPdf(html, pdfDoc, new com.itextpdf.html2pdf.ConverterProperties());
+            return out.toByteArray();
+        }
+    }
+
+    private String buildFinalBillHtml(Bill b) {
+        PatientEncounter pe = b.getPatientEncounter();
+        String patientName = pe != null && pe.getPatient() != null && pe.getPatient().getPerson() != null
+                ? pe.getPatient().getPerson().getNameWithTitle() : "";
+        String bhtNo = pe != null ? pe.getBhtNo() : "";
+        java.text.DecimalFormat df = new java.text.DecimalFormat("#,##0.00");
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("<html><body style='font-family:sans-serif;font-size:12px;'>");
+        sb.append("<h2>Final Bill</h2>");
+        sb.append("<table style='width:100%;margin-bottom:10px;'>");
+        sb.append("<tr><td><b>Bill Number</b></td><td>").append(escapeHtml(b.getDeptId())).append("</td></tr>");
+        sb.append("<tr><td><b>Version</b></td><td>").append(b.getFinalBillVersionSerial()).append("</td></tr>");
+        sb.append("<tr><td><b>Patient</b></td><td>").append(escapeHtml(patientName)).append("</td></tr>");
+        sb.append("<tr><td><b>BHT No</b></td><td>").append(escapeHtml(bhtNo)).append("</td></tr>");
+        sb.append("</table>");
+        sb.append("<table style='width:100%;border-collapse:collapse;' border='1' cellpadding='4'>");
+        sb.append("<tr><th style='text-align:left;'>Description</th><th style='text-align:right;'>Amount</th></tr>");
+        sb.append("<tr><td>Gross Total</td><td style='text-align:right;'>").append(df.format(b.getGrantTotal())).append("</td></tr>");
+        sb.append("<tr><td>Discount</td><td style='text-align:right;'>").append(df.format(b.getDiscount())).append("</td></tr>");
+        sb.append("<tr><td>Net Total</td><td style='text-align:right;'>").append(df.format(b.getNetTotal())).append("</td></tr>");
+        sb.append("<tr><td>Claimable Total</td><td style='text-align:right;'>").append(df.format(b.getClaimableTotal())).append("</td></tr>");
+        sb.append("</table>");
+        sb.append("</body></html>");
+        return sb.toString();
+    }
+
+    private String escapeHtml(String s) {
+        if (s == null) {
+            return "";
+        }
+        return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
+    }
+
+    public List<AppEmail> getSentEmailsForBill() {
+        if (sentEmailsForBill == null && bill != null) {
+            sentEmailsForBill = fetchSentEmailsForBill(bill);
+        }
+        return sentEmailsForBill;
+    }
+
+    private List<AppEmail> fetchSentEmailsForBill(Bill b) {
+        String jpql = "select e from AppEmail e where e.bill = :bill order by e.createdAt desc";
+        Map<String, Object> params = new HashMap<>();
+        params.put("bill", b);
+        return emailFacade.findByJpql(jpql, params);
     }
 
     public String navigateToProvisionalBillForAdmission() {

--- a/src/main/java/com/divudi/bean/inward/InwardSearch.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSearch.java
@@ -64,6 +64,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
+import org.primefaces.PrimeFaces;
 
 /**
  *
@@ -579,6 +580,7 @@ public class InwardSearch implements Serializable {
         refundingItems = null;
         bills = null;
         tempbillItems = null;
+        sentEmailsForBill = null;
     }
 
     public WebUser getUser() {
@@ -771,17 +773,31 @@ public class InwardSearch implements Serializable {
      * the "Sent Emails" history on the view/print screen.
      */
     public void emailFinalBillVersion(Bill b) {
+        boolean sent = false;
+        try {
+            sent = emailFinalBillVersionInternal(b);
+        } finally {
+            // Tell the client whether the send succeeded so the dialog closes
+            // only on success (see the Send button's oncomplete), mirroring
+            // BhtSummeryController.addNewCreditCompany()'s creditCompanyAdded.
+            if (PrimeFaces.current().isAjaxRequest()) {
+                PrimeFaces.current().ajax().addCallbackParam("emailSent", sent);
+            }
+        }
+    }
+
+    private boolean emailFinalBillVersionInternal(Bill b) {
         if (b == null) {
             JsfUtil.addErrorMessage("No bill selected");
-            return;
+            return false;
         }
         if (emailRecipient == null || emailRecipient.trim().isEmpty()) {
             JsfUtil.addErrorMessage("No recipient Email");
-            return;
+            return false;
         }
         if (!CommonFunctions.isValidEmail(emailRecipient)) {
             JsfUtil.addErrorMessage("Recipient Email is NOT valid");
-            return;
+            return false;
         }
 
         AppEmail email = new AppEmail();
@@ -799,6 +815,7 @@ public class InwardSearch implements Serializable {
         email.setPending(true);
         emailFacade.create(email);
 
+        boolean success = false;
         try {
             byte[] pdfBytes = buildFinalBillPdf(b);
             EmailAttachment attachment = new EmailAttachment(
@@ -806,7 +823,7 @@ public class InwardSearch implements Serializable {
                     "application/pdf",
                     Base64.getEncoder().encodeToString(pdfBytes));
 
-            boolean success = emailManagerEjb.sendEmail(
+            success = emailManagerEjb.sendEmail(
                     Collections.singletonList(email.getReceipientEmail()),
                     email.getMessageBody(),
                     email.getMessageSubject(),
@@ -820,10 +837,12 @@ public class InwardSearch implements Serializable {
                 emailFacade.edit(email);
                 JsfUtil.addSuccessMessage("Email Sent Successfully");
             } else {
+                email.setPending(false);
                 emailFacade.edit(email);
                 JsfUtil.addErrorMessage("Sending Email Failed");
             }
         } catch (Exception ex) {
+            email.setPending(false);
             emailFacade.edit(email);
             JsfUtil.addErrorMessage("Sending Email Failed");
             java.util.logging.Logger.getLogger(InwardSearch.class.getName())
@@ -831,6 +850,7 @@ public class InwardSearch implements Serializable {
         }
 
         sentEmailsForBill = null;
+        return success;
     }
 
     private byte[] buildFinalBillPdf(Bill b) throws Exception {
@@ -1082,6 +1102,7 @@ public class InwardSearch implements Serializable {
         printPreview = false;
         tempbillItems = null;
         comment = null;
+        sentEmailsForBill = null;
     }
 
     private void cancelBillComponents(Bill can, BillItem bt) {

--- a/src/main/java/com/divudi/core/data/MessageType.java
+++ b/src/main/java/com/divudi/core/data/MessageType.java
@@ -43,5 +43,6 @@ public enum MessageType {
     InpatientClinicalDocument,
     ClientPortalRegistrationOTP,
     ClientPortalPasswordResetOTP,
-    ClientPortalEmailRegistrationOTP
+    ClientPortalEmailRegistrationOTP,
+    InwardFinalBillEmail
 }

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -111,6 +111,8 @@ public enum Privileges {
     InwardSettleFinalBill("Inward Settle Final Bill"),
     InwardFinalBillCreateVersion("Inward Final Bill Create New Version"),
     InwardFinalBillSetConfirmed("Inward Final Bill Set As Confirmed"),
+    InwardFinalBillRetire("Inward Final Bill Retire"),
+    InwardFinalBillEmail("Inward Final Bill Email"),
     InwardSaveProvisionalFinalBill("Inward Save Provisional Final Bill"),
     InwardReport("Inward Report"),
     InwardPostDischargeReports("Inward Post-Discharge Reports"),
@@ -1246,6 +1248,8 @@ public enum Privileges {
             case InwardSettleFinalBill:
             case InwardFinalBillCreateVersion:
             case InwardFinalBillSetConfirmed:
+            case InwardFinalBillRetire:
+            case InwardFinalBillEmail:
             case InwardSaveProvisionalFinalBill:
             case InwardLaboratory:
             case InwardLaboratoryBarcodeGeneration:

--- a/src/main/webapp/inward/inward_final_bill_list.xhtml
+++ b/src/main/webapp/inward/inward_final_bill_list.xhtml
@@ -66,10 +66,6 @@
                                 paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink}"
                                 class="w-100">
 
-                                <p:column headerText="Serial" width="80">
-                                    <h:outputText value="/#{b.finalBillVersionSerial}" />
-                                </p:column>
-
                                 <p:column headerText="Bill Number">
                                     <h:outputText value="#{b.deptId}" />
                                 </p:column>
@@ -100,7 +96,7 @@
                                     <p:tag value="Available" severity="secondary" rendered="#{not b.confirmedFinalBill and not b.cancelled}" />
                                 </p:column>
 
-                                <p:column headerText="Actions" width="320">
+                                <p:column headerText="Actions" width="420">
 
                                     <p:commandButton
                                         ajax="false"
@@ -129,11 +125,35 @@
                                     <p:commandButton
                                         ajax="false"
                                         icon="fa fa-plus"
-                                        class="ui-button-warning"
+                                        class="ui-button-warning me-1"
                                         value="Create New Version"
                                         title="Create New Version from #{b.deptId}"
                                         action="#{bhtSummeryController.createNewVersionFromBill(b)}"
                                         rendered="#{not b.cancelled and webUserController.hasPrivilege('InwardFinalBillCreateVersion')}">
+                                    </p:commandButton>
+
+                                    <p:commandButton
+                                        ajax="false"
+                                        icon="fa fa-trash"
+                                        class="ui-button-danger me-1"
+                                        value="Retire"
+                                        title="Retire #{b.deptId}"
+                                        actionListener="#{inwardSearch.retireFinalBillVersion(b)}"
+                                        rendered="#{not b.retired and not b.confirmedFinalBill and webUserController.hasPrivilege('InwardFinalBillRetire')}">
+                                        <p:confirm header="Confirm" message="Retire bill #{b.deptId}? This cannot be undone." icon="pi pi-exclamation-triangle" />
+                                    </p:commandButton>
+
+                                    <p:commandButton
+                                        ajax="true"
+                                        icon="fa fa-envelope"
+                                        class="ui-button-help"
+                                        value="Email"
+                                        title="Email #{b.deptId}"
+                                        update=":formFinalBillVersions:emailDialog"
+                                        oncomplete="PF('wEmailDialog').show()"
+                                        rendered="#{webUserController.hasPrivilege('InwardFinalBillEmail')}">
+                                        <f:setPropertyActionListener value="#{b}" target="#{inwardSearch.bill}"/>
+                                        <f:setPropertyActionListener value="#{b.patientEncounter.patient.person.email}" target="#{inwardSearch.emailRecipient}"/>
                                     </p:commandButton>
 
                                 </p:column>
@@ -143,6 +163,22 @@
                         </p:panel>
 
                     </p:panel>
+
+                    <p:dialog id="emailDialog" widgetVar="wEmailDialog" header="Email Final Bill" modal="true" width="420">
+                        <h:panelGrid columns="1" style="width:100%;">
+                            <p:outputLabel value="Bill Number: #{inwardSearch.bill.deptId}" rendered="#{inwardSearch.bill ne null}" />
+                            <p:outputLabel for="txtEmailRecipient" value="Recipient Email" />
+                            <p:inputText id="txtEmailRecipient" value="#{inwardSearch.emailRecipient}" style="width:100%;" />
+                            <p:commandButton
+                                ajax="true"
+                                icon="fa fa-envelope"
+                                class="ui-button-help"
+                                value="Send"
+                                update=":formFinalBillVersions"
+                                oncomplete="PF('wEmailDialog').hide()"
+                                actionListener="#{inwardSearch.emailFinalBillVersion(inwardSearch.bill)}" />
+                        </h:panelGrid>
+                    </p:dialog>
 
                     <p:confirmDialog global="true" showEffect="fade" hideEffect="fade">
                         <p:commandButton value="Yes" type="button" styleClass="ui-confirmdialog-yes ui-button-success" icon="pi pi-check" />

--- a/src/main/webapp/inward/inward_final_bill_list.xhtml
+++ b/src/main/webapp/inward/inward_final_bill_list.xhtml
@@ -174,8 +174,8 @@
                                 icon="fa fa-envelope"
                                 class="ui-button-help"
                                 value="Send"
-                                update=":formFinalBillVersions"
-                                oncomplete="PF('wEmailDialog').hide()"
+                                update=":growl"
+                                oncomplete="if (args &amp;&amp; args.emailSent) { PF('wEmailDialog').hide(); }"
                                 actionListener="#{inwardSearch.emailFinalBillVersion(inwardSearch.bill)}" />
                         </h:panelGrid>
                     </p:dialog>

--- a/src/main/webapp/inward/inward_reprint_bill_final.xhtml
+++ b/src/main/webapp/inward/inward_reprint_bill_final.xhtml
@@ -293,6 +293,34 @@
                                 </div>
                             </div>
 
+                            <div class="row mt-3">
+                                <div class="col-lg-12">
+                                    <p:panel header="Sent Emails">
+                                        <p:dataTable
+                                            value="#{inwardSearch.sentEmailsForBill}"
+                                            var="e"
+                                            emptyMessage="No emails sent for this bill.">
+                                            <p:column headerText="Recipient">
+                                                <h:outputText value="#{e.receipientEmail}" />
+                                            </p:column>
+                                            <p:column headerText="Subject">
+                                                <h:outputText value="#{e.messageSubject}" />
+                                            </p:column>
+                                            <p:column headerText="Sent At">
+                                                <h:outputText value="#{e.sentAt}">
+                                                    <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                                </h:outputText>
+                                            </p:column>
+                                            <p:column headerText="Status">
+                                                <p:tag value="Sent" severity="success" rendered="#{e.sentSuccessfully}" />
+                                                <p:tag value="Pending" severity="warning" rendered="#{e.pending and not e.sentSuccessfully}" />
+                                                <p:tag value="Failed" severity="danger" rendered="#{not e.pending and not e.sentSuccessfully}" />
+                                            </p:column>
+                                        </p:dataTable>
+                                    </p:panel>
+                                </div>
+                            </div>
+
                             <p:tabView rendered="true">
                                 <p:tab title="Final Bill"  >
 


### PR DESCRIPTION
## Summary

Fixes #22541 — a real regression found via browser testing of the ~10-day-old "Final Bill Versions" page (#22282), plus two new features requested alongside it.

- **Numbering bug fix**: `BhtSummeryController.saveBill()`/`saveOriginalBill()`/`saveCCBill()`/`saveCCBillByInstitution()` generated final-bill-version bill numbers from the *acting user's session* department/institution instead of the admission's own — so two versions of the same admission's final bill could get completely different institution prefixes and sequence numbers depending on who created each one. Now sourced from `patientEncounter.getDepartment()`/`.getInstitution()`, which is stable across all versions of one admission. `Bill.department` is also now persisted (previously always `null` for every final bill). The redundant "Serial" column is removed from the versions list — the version number is already visible as the trailing segment of the bill number.
- **Retire (new)**: soft-delete a bad version via the existing `Bill.retired`/`retirer`/`retiredAt` fields — no schema change. Blocked on the currently Confirmed version and on the last remaining version. Irreversible by design (no un-retire path exists for `Bill` anywhere in the codebase, so this is consistent, not a special case).
- **Email (new)**: emails a PDF summary of a final bill version via the existing `EmailManagerEjb`/`AppEmail`/`EmailAttachment` infrastructure (PDF built with `com.itextpdf.html2pdf.HtmlConverter`, the same library already used in `InwardReportController`). Logged via `AppEmail`, shown in a new "Sent Emails" panel on the bill view/print screen.

Two new privileges added (`InwardFinalBillRetire`, `InwardFinalBillEmail`), registered the same way as the existing `InwardFinalBillCreateVersion`/`InwardFinalBillSetConfirmed`.

## Test plan

All verified against the same admission (BHT/53362) used to originally find the bug, department Inward, local Payara — see [issue comment](https://github.com/hmislk/hmis/issues/22541#issuecomment-5127014165) for screenshots.

- [x] Created a new final bill version while logged in under a *different* department (Main Pharmacy) than version 1's creator (Inward) — new version correctly kept the `Inward` prefix and continued the same department sequence (`70` → `71`), not a new `MP/...` sequence. Confirmed in DB: `DEPARTMENT_ID` now populated (was `NULL`).
- [x] Confirmed the "Serial" column is gone; version number still visible in the bill number text.
- [x] Retired a non-confirmed version — confirm dialog shown, bill disappears from the list, `RETIRED=1`/`RETIRER`/`RETIREDAT` set in DB. Confirmed Retire is hidden on the Confirmed version. Confirmed no un-retire control exists.
- [x] Sent a test final bill via the new Email dialog — recipient defaulted from the patient's email, `AppEmail` row created with correct `bill`/`messageType`/status, PDF generation succeeded (no exception; local send failure was purely "Email Gateway URL is not configured", an environment limitation not a code bug). Confirmed the new "Sent Emails" panel on the view/print screen lists it correctly.
- [x] `mvn clean package` — build green, all 185 existing unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added options to retire and email inward final-bill versions, including an email dialog with PDF summary generation.
  - Expanded the final-bill list actions with privilege-gated “Create New Version,” “Retire,” and “Email.”
  - Added a “Sent Emails” section to view recipients, send dates, and delivery status.
- **Bug Fixes**
  - Final-bill and related credit-company bill persistence now uses the active encounter’s institution and department.
- **Permissions**
  - Introduced dedicated privileges for inward final-bill retire and inward final-bill email.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->