### PR TITLE
fix(inward): sync professional payment hold across all modules and stop silent overrides (#22483, #22484)

### DIFF
--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -8325,7 +8325,7 @@ public class SearchController implements Serializable {
             }
         }
         billFees.removeAll(removeingBillFees);
-        calTotal();
+        calTotalSplittingHeldProfessionalFees();
 
     }
 
@@ -8413,7 +8413,7 @@ public class SearchController implements Serializable {
             }
         }
         billFees.removeAll(removeingBillFees);
-        calTotal();
+        calTotalSplittingHeldProfessionalFees();
 
     }
 
@@ -8473,7 +8473,7 @@ public class SearchController implements Serializable {
         temMap.put("feeType", FeeType.Staff);
 
         billFees = getBillFeeFacade().findByJpql(sql, temMap, TemporalType.TIMESTAMP);
-        calTotal();
+        calTotalSplittingHeldProfessionalFees();
     }
 
     double total;
@@ -8494,6 +8494,37 @@ public class SearchController implements Serializable {
 
         for (BillFee billFee : billFees) {
             total += billFee.getFeeValue();
+        }
+    }
+
+    double totalOnHold;
+
+    public double getTotalOnHold() {
+        return totalOnHold;
+    }
+
+    public void setTotalOnHold(double totalOnHold) {
+        this.totalOnHold = totalOnHold;
+    }
+
+    /**
+     * Totals for the inward professional-payment due lists, split so the
+     * payable figure is not inflated by fees that cannot currently be paid.
+     * A fee is held either individually or because its whole BHT is on hold —
+     * see {@link BillFee#isProfessionalPaymentHeld()}. (Issue #22483)
+     */
+    private void calTotalSplittingHeldProfessionalFees() {
+        total = 0;
+        totalOnHold = 0;
+        if (billFees == null) {
+            return;
+        }
+        for (BillFee billFee : billFees) {
+            if (billFee.isProfessionalPaymentHeld()) {
+                totalOnHold += billFee.getFeeValue();
+            } else {
+                total += billFee.getFeeValue();
+            }
         }
     }
 
@@ -8585,6 +8616,7 @@ public class SearchController implements Serializable {
         temMap.put("btp2", BillType.InwardProfessional);
 
         billFees = getBillFeeFacade().findByJpql(sql, temMap, TemporalType.TIMESTAMP);
+        calTotalSplittingHeldProfessionalFees();
 
     }
 

--- a/src/main/java/com/divudi/bean/inward/InwardStaffPaymentBillController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardStaffPaymentBillController.java
@@ -28,6 +28,7 @@ import com.divudi.core.entity.Payment;
 import com.divudi.core.entity.Speciality;
 import com.divudi.core.entity.Staff;
 import com.divudi.core.entity.WebUser;
+import com.divudi.core.entity.PatientEncounter;
 import com.divudi.core.entity.cashTransaction.Drawer;
 import com.divudi.core.entity.inward.AdmissionType;
 import com.divudi.core.facade.BillComponentFacade;
@@ -41,6 +42,7 @@ import com.divudi.core.facade.RefundBillFacade;
 import com.divudi.core.facade.StaffFacade;
 import com.divudi.core.data.ProfessionalPaymentVoucherGroup;
 import com.divudi.core.util.CommonFunctions;
+import com.divudi.service.AuditService;
 import com.divudi.service.DrawerService;
 import com.divudi.service.ProfessionalPaymentService;
 import java.io.Serializable;
@@ -48,6 +50,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import javax.ejb.EJB;
@@ -90,6 +93,8 @@ public class InwardStaffPaymentBillController implements Serializable {
     BillNumberGenerator billNumberBean;
     @EJB
     StaffFacade staffFacade;
+    @EJB
+    private AuditService auditService;
     // </editor-fold>
     // <editor-fold defaultstate="collapsed" desc="Controllers">
     @Inject
@@ -131,8 +136,11 @@ public class InwardStaffPaymentBillController implements Serializable {
     private Double withholdingTaxLimit;
     private Double withholdingTaxPercentage;
     private double totalDue;
+    private double totalOnHold;
     private double totalPaying;
     private double totalPayingWithoutWht;
+    private boolean holdOverrideAcknowledged;
+    private String holdOverrideReason;
 
     private Boolean printPreview = false;
     private PaymentMethod paymentMethod;
@@ -327,7 +335,8 @@ public class InwardStaffPaymentBillController implements Serializable {
                 + " and bf.bill.cancelled=false "
                 + " and bf.bill.createdAt between :fd and :td "
                 + " and (bf.feeValue - bf.paidValue) > 0 "
-                + " and (bf.feePaymentOnHold=false or bf.feePaymentOnHold is null) "
+                // Held fees are listed (flagged "On Hold" in the UI) rather than
+                // hidden, so the payer can see the money exists — issue #22484.
                 + " and bf.staff=:stf "
                 + " order by bf.createdAt desc";
 
@@ -409,8 +418,19 @@ public class InwardStaffPaymentBillController implements Serializable {
         Payment newlyCreatedPayment = createPayment(newlyCreatedPaymentBill, paymentMethod);
         drawerController.updateDrawerForOuts(newlyCreatedPayment);
         saveBillCompo(newlyCreatedPaymentBill, newlyCreatedPayment);
+        boolean paidPastHold = isSelectionContainsHeldFees();
+        if (paidPastHold) {
+            recordHoldOverride(newlyCreatedPaymentBill);
+            getBillFacade().edit(newlyCreatedPaymentBill);
+        }
         printPreview = true;
-        JsfUtil.addSuccessMessage("Successfully Paid");
+        if (paidPastHold) {
+            JsfUtil.addSuccessMessage("Successfully Paid. Payments on hold were paid using your override privilege"
+                    + " — this has been recorded on the payment bill and in the admission's audit trail.");
+        } else {
+            JsfUtil.addSuccessMessage("Successfully Paid");
+        }
+        resetHoldOverride();
     }
 
     public Payment createPayment(Bill bill, PaymentMethod pm) {
@@ -1283,6 +1303,8 @@ public class InwardStaffPaymentBillController implements Serializable {
         payingBillFees = new ArrayList<>();
         totalPaying = 0.0;
         totalDue = 0.0;
+        totalOnHold = 0.0;
+        resetHoldOverride();
         printPreview = false;
 
         String sql;
@@ -1294,7 +1316,8 @@ public class InwardStaffPaymentBillController implements Serializable {
                 + " and b.bill.cancelled=false "
                 //                + " and b.bill.refunded=false "
                 + " and (b.feeValue - b.paidValue) > 0 "
-                + " and (b.feePaymentOnHold=false or b.feePaymentOnHold is null) "
+                // Held fees are listed (flagged "On Hold" in the UI) rather than
+                // hidden, so the payer can see the money exists — issue #22484.
                 + " and b.staff=:stf ";
 //            h.put("btp", BillType.ChannelPaid);
         h.put("stf", currentStaff);
@@ -1318,18 +1341,30 @@ public class InwardStaffPaymentBillController implements Serializable {
 
         }
         dueBillFees.removeAll(removeingBillFees);
-        calculatePaymentsSelected();
+        // performCalculations (not just the selection) so the payable/on-hold
+        // split is right on the first render of the payment page — issue #22483.
+        performCalculations();
         return "/inward/inward_bill_professional_payment";
     }
 
+    /**
+     * Splits the listed dues into a payable total and an on-hold total, so the
+     * payable figure is not inflated by fees that cannot be paid — issue #22483.
+     */
     public void calculateTotalDue() {
         totalDue = 0;
-        for (BillFee f : dueBillFees) {
-            totalDue = totalDue + f.getFeeValue() - f.getPaidValue();
-            System.out.println("f.getFeeValue() - f.getPaidValue() = " + (f.getFeeValue() - f.getPaidValue()));
-            System.out.println("totalDue = " + totalDue);
+        totalOnHold = 0;
+        if (dueBillFees == null) {
+            return;
         }
-        System.out.println("total = " + totalDue);
+        for (BillFee f : dueBillFees) {
+            double outstanding = f.getFeeValue() - f.getPaidValue();
+            if (f.isProfessionalPaymentHeld()) {
+                totalOnHold = totalOnHold + outstanding;
+            } else {
+                totalDue = totalDue + outstanding;
+            }
+        }
     }
 
     public void performCalculations() {
@@ -1362,14 +1397,169 @@ public class InwardStaffPaymentBillController implements Serializable {
 
     public void calculatePaymentsSelected() {
         totalPaying = 0;
-        System.out.println("payingBillFees = " + getPayingBillFees().size());
-        for (BillFee f : getPayingBillFees()) {
-            totalPaying = totalPaying + (f.getFeeValue() - f.getPaidValue());
-            System.out.println("f.getFeeValue() - f.getPaidValue() = " + (f.getFeeValue() - f.getPaidValue()));
-            System.out.println("totalPaying = " + totalPaying);
+        if (payingBillFees == null) {
+            return;
         }
-        System.out.println("total = " + totalPaying);
+        for (BillFee f : payingBillFees) {
+            totalPaying = totalPaying + (f.getFeeValue() - f.getPaidValue());
+        }
     }
+
+    // <editor-fold defaultstate="collapsed" desc="Professional payment hold (#22483, #22484)">
+    /**
+     * Called by the due-fee table's selection AJAX events. Changing the
+     * selection invalidates any earlier override acknowledgement, so a held fee
+     * cannot be slipped in after the confirmation box was ticked.
+     */
+    public void onSelectionChanged() {
+        resetHoldOverride();
+        performCalculations();
+    }
+
+    private void resetHoldOverride() {
+        holdOverrideAcknowledged = false;
+        holdOverrideReason = null;
+    }
+
+    /**
+     * Held fees among the current selection. Drives the warning panel and the
+     * override acknowledgement on the payment page.
+     */
+    public List<BillFee> getHeldFeesSelected() {
+        List<BillFee> held = new ArrayList<>();
+        if (payingBillFees == null) {
+            return held;
+        }
+        for (BillFee bf : payingBillFees) {
+            if (bf.isProfessionalPaymentHeld()) {
+                held.add(bf);
+            }
+        }
+        return held;
+    }
+
+    public boolean isSelectionContainsHeldFees() {
+        return !getHeldFeesSelected().isEmpty();
+    }
+
+    /**
+     * True when the logged user is allowed to pay past a hold. Used by the page
+     * to decide between a hard "cannot pay" notice and the override panel.
+     */
+    public boolean isCanOverrideHold() {
+        return webUserController.hasPrivilege("InwardPayProfessionalFeesWhileOnHold");
+    }
+
+    /**
+     * "BHT/56552, BHT/56335" — the admissions the held selection belongs to.
+     */
+    public String getHeldFeesSelectedBhtNumbers() {
+        List<String> bhtNos = new ArrayList<>();
+        for (BillFee bf : getHeldFeesSelected()) {
+            PatientEncounter pe = bf.getPatienEncounter();
+            String bhtNo = pe != null && pe.getBhtNo() != null ? pe.getBhtNo() : "(no BHT)";
+            if (!bhtNos.contains(bhtNo)) {
+                bhtNos.add(bhtNo);
+            }
+        }
+        return String.join(", ", bhtNos);
+    }
+
+    public double getHeldFeesSelectedValue() {
+        double total = 0.0;
+        for (BillFee bf : getHeldFeesSelected()) {
+            total = total + (bf.getFeeValue() - bf.getPaidValue());
+        }
+        return total;
+    }
+
+    /**
+     * Guards the selection against held fees. Returns an error message to show,
+     * or null when the payment may proceed.
+     *
+     * A user without {@code InwardPayProfessionalFeesWhileOnHold} is blocked
+     * outright. A user who holds it may still pay, but only after explicitly
+     * acknowledging the override — it is no longer silent (issue #22483).
+     */
+    private String checkHoldsOnSelection() {
+        List<BillFee> held = getHeldFeesSelected();
+        if (held.isEmpty()) {
+            return null;
+        }
+        if (!isCanOverrideHold()) {
+            return "Cannot pay: professional payments are on hold for " + getHeldFeesSelectedBhtNumbers()
+                    + ". Release the hold before paying, or ask a user with the"
+                    + " 'Pay Professional Fees While On Hold' privilege.";
+        }
+        if (!holdOverrideAcknowledged) {
+            return "The selection includes professional payments on hold for " + getHeldFeesSelectedBhtNumbers()
+                    + ". Tick the override confirmation and give a reason before settling.";
+        }
+        if (holdOverrideReason == null || holdOverrideReason.trim().isEmpty()) {
+            return "Please give a reason for paying professional payments that are on hold.";
+        }
+        return null;
+    }
+
+    /**
+     * Records the override on the payment bill and in the admission's audit
+     * trail, so a payment made past a hold is traceable afterwards.
+     */
+    private void recordHoldOverride(Bill paymentBill) {
+        List<BillFee> held = getHeldFeesSelected();
+        if (held.isEmpty()) {
+            return;
+        }
+        String reason = holdOverrideReason == null ? "" : holdOverrideReason.trim();
+        String note = "Paid while on hold (" + getHeldFeesSelectedBhtNumbers() + ") by "
+                + sessionController.getLoggedUser().getName() + ". Reason: " + reason;
+        if (paymentBill != null) {
+            String existing = paymentBill.getComments();
+            paymentBill.setComments(existing == null || existing.trim().isEmpty()
+                    ? note : existing + " | " + note);
+        }
+        for (BillFee bf : held) {
+            PatientEncounter pe = bf.getPatienEncounter();
+            if (pe == null) {
+                continue;
+            }
+            Map<String, Object> before = new LinkedHashMap<>();
+            before.put("billFeeId", bf.getId());
+            before.put("feePaymentOnHold", bf.isFeePaymentOnHold());
+            before.put("bhtProfessionalPaymentsOnHold", pe.isProfessionalPaymentsOnHold());
+            Map<String, Object> after = new LinkedHashMap<>(before);
+            after.put("paidWhileOnHold", Boolean.TRUE);
+            after.put("overrideReason", reason);
+            after.put("paymentBillId", paymentBill != null ? paymentBill.getId() : null);
+            auditService.logEncounterAudit(pe, "Professional Fee Paid While On Hold",
+                    before, after, sessionController.getLoggedUser(), "BillFee", bf.getId());
+        }
+    }
+
+    public boolean isHoldOverrideAcknowledged() {
+        return holdOverrideAcknowledged;
+    }
+
+    public void setHoldOverrideAcknowledged(boolean holdOverrideAcknowledged) {
+        this.holdOverrideAcknowledged = holdOverrideAcknowledged;
+    }
+
+    public String getHoldOverrideReason() {
+        return holdOverrideReason;
+    }
+
+    public void setHoldOverrideReason(String holdOverrideReason) {
+        this.holdOverrideReason = holdOverrideReason;
+    }
+
+    public double getTotalOnHold() {
+        return totalOnHold;
+    }
+
+    public void setTotalOnHold(double totalOnHold) {
+        this.totalOnHold = totalOnHold;
+    }
+    // </editor-fold>
 
     private void calculateWithholdingTaxDependingOnPayments() {
         if (totalPaidForCurrentProfessionalForCurrentMonthForCurrentInstitute == 0.0) {
@@ -1476,21 +1666,10 @@ public class InwardStaffPaymentBillController implements Serializable {
     }
 
     private boolean errorCheck() {
-        if (getPayingBillFees() != null) {
-            for (BillFee bf : getPayingBillFees()) {
-                com.divudi.core.entity.PatientEncounter pe = bf.getPatienEncounter();
-                if (pe != null && Boolean.TRUE.equals(pe.getProfessionalPaymentsOnHold())
-                        && !webUserController.hasPrivilege("InwardPayProfessionalFeesWhileOnHold")) {
-                    JsfUtil.addErrorMessage("Cannot pay: professional payments are on hold for BHT " + pe.getBhtNo() + ".");
-                    return true;
-                }
-                if (bf.isFeePaymentOnHold()
-                        && !webUserController.hasPrivilege("InwardPayProfessionalFeesWhileOnHold")) {
-                    JsfUtil.addErrorMessage("Cannot pay: this professional payment is individually on hold"
-                            + (pe != null ? " (BHT " + pe.getBhtNo() + ")" : "") + ".");
-                    return true;
-                }
-            }
+        String holdError = checkHoldsOnSelection();
+        if (holdError != null) {
+            JsfUtil.addErrorMessage(holdError);
+            return true;
         }
         if (currentStaff == null) {
             JsfUtil.addErrorMessage("Please select a Staff Memeber");
@@ -1530,12 +1709,16 @@ public class InwardStaffPaymentBillController implements Serializable {
         }
 
         saveBillCompo(b);
+        if (isSelectionContainsHeldFees()) {
+            recordHoldOverride(b);
+        }
         getBillFacade().edit(b);
         printPreview = true;
 
         WebUser wb = getCashTransactionBean().saveBillCashOutTransaction(b, getSessionController().getLoggedUser());
         getSessionController().setLoggedUser(wb);
         JsfUtil.addSuccessMessage("Successfully Paid");
+        resetHoldOverride();
         //   ////// // System.out.println("Paid");
     }
 

--- a/src/main/java/com/divudi/bean/inward/InwardStaffPaymentBillController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardStaffPaymentBillController.java
@@ -141,6 +141,7 @@ public class InwardStaffPaymentBillController implements Serializable {
     private double totalPayingWithoutWht;
     private boolean holdOverrideAcknowledged;
     private String holdOverrideReason;
+    private List<BillFee> feesHeldAtSettle;
 
     private Boolean printPreview = false;
     private PaymentMethod paymentMethod;
@@ -418,9 +419,10 @@ public class InwardStaffPaymentBillController implements Serializable {
         Payment newlyCreatedPayment = createPayment(newlyCreatedPaymentBill, paymentMethod);
         drawerController.updateDrawerForOuts(newlyCreatedPayment);
         saveBillCompo(newlyCreatedPaymentBill, newlyCreatedPayment);
-        boolean paidPastHold = isSelectionContainsHeldFees();
+        List<BillFee> heldPaid = feesHeldAtSettle;
+        boolean paidPastHold = heldPaid != null && !heldPaid.isEmpty();
         if (paidPastHold) {
-            recordHoldOverride(newlyCreatedPaymentBill);
+            recordHoldOverride(newlyCreatedPaymentBill, heldPaid);
             getBillFacade().edit(newlyCreatedPaymentBill);
         }
         printPreview = true;
@@ -1419,6 +1421,7 @@ public class InwardStaffPaymentBillController implements Serializable {
     private void resetHoldOverride() {
         holdOverrideAcknowledged = false;
         holdOverrideReason = null;
+        feesHeldAtSettle = null;
     }
 
     /**
@@ -1474,6 +1477,69 @@ public class InwardStaffPaymentBillController implements Serializable {
     }
 
     /**
+     * Fee IDs in {@code selection} that are on hold <em>right now</em>, read
+     * fresh from the database rather than from the in-memory selection.
+     *
+     * This bean is {@code @SessionScoped}, so the due-fee list may have been
+     * loaded minutes ago and its hold flags can be stale — a hold applied by
+     * another user in the meantime must still block the payment. A scalar
+     * projection is used so the check reads columns rather than being served a
+     * cached entity, and the encounter is joined with an explicit LEFT JOIN so
+     * fees with no admission are not silently dropped from the fee-level
+     * branch of the OR. (Issue #22483)
+     */
+    private List<Long> findCurrentlyHeldFeeIds(List<BillFee> selection) {
+        List<Long> heldIds = new ArrayList<>();
+        if (selection == null || selection.isEmpty()) {
+            return heldIds;
+        }
+        List<Long> ids = new ArrayList<>();
+        for (BillFee bf : selection) {
+            if (bf != null && bf.getId() != null) {
+                ids.add(bf.getId());
+            }
+        }
+        if (ids.isEmpty()) {
+            return heldIds;
+        }
+        String jpql = "select bf.id from BillFee bf "
+                + " left join bf.patienEncounter pe "
+                + " where bf.id in :ids "
+                + " and (bf.feePaymentOnHold = true or pe.professionalPaymentsOnHold = true) ";
+        Map<String, Object> params = new HashMap<>();
+        params.put("ids", ids);
+        for (Object o : getBillFeeFacade().findObjects(jpql, params)) {
+            if (o instanceof Number) {
+                heldIds.add(((Number) o).longValue());
+            }
+        }
+        return heldIds;
+    }
+
+    /**
+     * BHT numbers for the given fee IDs, taken from the loaded selection. The
+     * BHT number itself never changes, so the in-memory copy is safe here even
+     * when the hold flags on it are stale.
+     */
+    private String describeBhtsForFeeIds(List<Long> feeIds) {
+        List<String> bhtNos = new ArrayList<>();
+        if (payingBillFees == null) {
+            return "";
+        }
+        for (BillFee bf : payingBillFees) {
+            if (bf.getId() == null || !feeIds.contains(bf.getId())) {
+                continue;
+            }
+            PatientEncounter pe = bf.getPatienEncounter();
+            String bhtNo = pe != null && pe.getBhtNo() != null ? pe.getBhtNo() : "(no BHT)";
+            if (!bhtNos.contains(bhtNo)) {
+                bhtNos.add(bhtNo);
+            }
+        }
+        return String.join(", ", bhtNos);
+    }
+
+    /**
      * Guards the selection against held fees. Returns an error message to show,
      * or null when the payment may proceed.
      *
@@ -1482,17 +1548,37 @@ public class InwardStaffPaymentBillController implements Serializable {
      * acknowledging the override — it is no longer silent (issue #22483).
      */
     private String checkHoldsOnSelection() {
-        List<BillFee> held = getHeldFeesSelected();
-        if (held.isEmpty()) {
+        List<Long> heldNow = findCurrentlyHeldFeeIds(payingBillFees);
+        // Remember what this authoritative read found, so the settle path audits
+        // exactly what the guard let through without re-querying.
+        feesHeldAtSettle = new ArrayList<>();
+        if (payingBillFees != null) {
+            for (BillFee bf : payingBillFees) {
+                if (bf.getId() != null && heldNow.contains(bf.getId())) {
+                    feesHeldAtSettle.add(bf);
+                }
+            }
+        }
+        if (heldNow.isEmpty()) {
             return null;
         }
+        String bhtNumbers = describeBhtsForFeeIds(heldNow);
         if (!isCanOverrideHold()) {
-            return "Cannot pay: professional payments are on hold for " + getHeldFeesSelectedBhtNumbers()
+            return "Cannot pay: professional payments are on hold for " + bhtNumbers
                     + ". Release the hold before paying, or ask a user with the"
                     + " 'Pay Professional Fees While On Hold' privilege.";
         }
+        // A hold applied after this page was loaded was never shown to the user,
+        // so an acknowledgement given before it existed cannot cover it.
+        for (BillFee bf : payingBillFees) {
+            if (bf.getId() != null && heldNow.contains(bf.getId()) && !bf.isProfessionalPaymentHeld()) {
+                resetHoldOverride();
+                return "Professional payments for " + bhtNumbers + " were put on hold while this page was open."
+                        + " Run the search again to see the current hold status before settling.";
+            }
+        }
         if (!holdOverrideAcknowledged) {
-            return "The selection includes professional payments on hold for " + getHeldFeesSelectedBhtNumbers()
+            return "The selection includes professional payments on hold for " + bhtNumbers
                     + ". Tick the override confirmation and give a reason before settling.";
         }
         if (holdOverrideReason == null || holdOverrideReason.trim().isEmpty()) {
@@ -1505,13 +1591,20 @@ public class InwardStaffPaymentBillController implements Serializable {
      * Records the override on the payment bill and in the admission's audit
      * trail, so a payment made past a hold is traceable afterwards.
      */
-    private void recordHoldOverride(Bill paymentBill) {
-        List<BillFee> held = getHeldFeesSelected();
-        if (held.isEmpty()) {
+    private void recordHoldOverride(Bill paymentBill, List<BillFee> held) {
+        if (held == null || held.isEmpty()) {
             return;
         }
+        List<String> bhtNos = new ArrayList<>();
+        for (BillFee bf : held) {
+            PatientEncounter bhtPe = bf.getPatienEncounter();
+            String bhtNo = bhtPe != null && bhtPe.getBhtNo() != null ? bhtPe.getBhtNo() : "(no BHT)";
+            if (!bhtNos.contains(bhtNo)) {
+                bhtNos.add(bhtNo);
+            }
+        }
         String reason = holdOverrideReason == null ? "" : holdOverrideReason.trim();
-        String note = "Paid while on hold (" + getHeldFeesSelectedBhtNumbers() + ") by "
+        String note = "Paid while on hold (" + String.join(", ", bhtNos) + ") by "
                 + sessionController.getLoggedUser().getName() + ". Reason: " + reason;
         if (paymentBill != null) {
             String existing = paymentBill.getComments();
@@ -1709,8 +1802,8 @@ public class InwardStaffPaymentBillController implements Serializable {
         }
 
         saveBillCompo(b);
-        if (isSelectionContainsHeldFees()) {
-            recordHoldOverride(b);
+        if (feesHeldAtSettle != null && !feesHeldAtSettle.isEmpty()) {
+            recordHoldOverride(b, feesHeldAtSettle);
         }
         getBillFacade().edit(b);
         printPreview = true;

--- a/src/main/java/com/divudi/bean/inward/InwardSurgeryPaymentBillController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSurgeryPaymentBillController.java
@@ -20,6 +20,7 @@ import com.divudi.core.entity.BillItem;
 import com.divudi.core.entity.BilledBill;
 import com.divudi.core.entity.Institution;
 import com.divudi.core.entity.Payment;
+import com.divudi.core.entity.PatientEncounter;
 import com.divudi.core.entity.Staff;
 import com.divudi.core.entity.WebUser;
 import com.divudi.core.entity.cashTransaction.Drawer;
@@ -34,6 +35,7 @@ import com.divudi.core.facade.PaymentFacade;
 import com.divudi.core.facade.RefundBillFacade;
 import com.divudi.core.facade.StaffFacade;
 import com.divudi.core.data.ProfessionalPaymentVoucherGroup;
+import com.divudi.service.AuditService;
 import com.divudi.service.DrawerService;
 import com.divudi.service.ProfessionalPaymentService;
 import java.io.Serializable;
@@ -41,6 +43,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import javax.ejb.EJB;
@@ -85,6 +88,8 @@ public class InwardSurgeryPaymentBillController implements Serializable {
     StaffFacade staffFacade;
     @EJB
     private CashTransactionBean cashTransactionBean;
+    @EJB
+    private AuditService auditService;
     // </editor-fold>
 
     // <editor-fold defaultstate="collapsed" desc="Controllers">
@@ -119,8 +124,11 @@ public class InwardSurgeryPaymentBillController implements Serializable {
     private Double withholdingTaxLimit;
     private Double withholdingTaxPercentage;
     private double totalDue;
+    private double totalOnHold;
     private double totalPaying;
     private double totalPayingWithoutWht;
+    private boolean holdOverrideAcknowledged;
+    private String holdOverrideReason;
 
     private Boolean printPreview = false;
     private PaymentMethod paymentMethod;
@@ -168,7 +176,8 @@ public class InwardSurgeryPaymentBillController implements Serializable {
                 + " and bf.bill.cancelled=false "
                 + " and bf.bill.createdAt between :fd and :td "
                 + " and (bf.feeValue - bf.paidValue) > 0 "
-                + " and (bf.feePaymentOnHold=false or bf.feePaymentOnHold is null) "
+                // Held fees are listed (flagged "On Hold" in the UI) rather than
+                // hidden, so the payer can see the money exists — issue #22484.
                 + " and bf.staff=:stf ";
 
         sql += " order by bf.createdAt desc";
@@ -226,13 +235,23 @@ public class InwardSurgeryPaymentBillController implements Serializable {
         }
     }
 
+    /**
+     * Splits the listed dues into a payable total and an on-hold total, so the
+     * payable figure is not inflated by fees that cannot be paid — issue #22483.
+     */
     private void calculateTotalDue() {
         totalDue = 0.0;
+        totalOnHold = 0.0;
         if (dueSurgeryFees == null) {
             return;
         }
         for (BillFee f : dueSurgeryFees) {
-            totalDue += (f.getFeeValue() - f.getPaidValue());
+            double outstanding = f.getFeeValue() - f.getPaidValue();
+            if (f.isProfessionalPaymentHeld()) {
+                totalOnHold += outstanding;
+            } else {
+                totalDue += outstanding;
+            }
         }
     }
 
@@ -245,6 +264,148 @@ public class InwardSurgeryPaymentBillController implements Serializable {
             totalPaying = totalPaying + (f.getFeeValue() - f.getPaidValue());
         }
     }
+
+    // <editor-fold defaultstate="collapsed" desc="Professional payment hold (#22483, #22484)">
+    /**
+     * Called by the due-fee table's selection AJAX events. Changing the
+     * selection invalidates any earlier override acknowledgement, so a held fee
+     * cannot be slipped in after the confirmation box was ticked.
+     */
+    public void onSelectionChanged() {
+        resetHoldOverride();
+        performCalculations();
+    }
+
+    private void resetHoldOverride() {
+        holdOverrideAcknowledged = false;
+        holdOverrideReason = null;
+    }
+
+    public List<BillFee> getHeldFeesSelected() {
+        List<BillFee> held = new ArrayList<>();
+        if (payingSurgeryFees == null) {
+            return held;
+        }
+        for (BillFee bf : payingSurgeryFees) {
+            if (bf.isProfessionalPaymentHeld()) {
+                held.add(bf);
+            }
+        }
+        return held;
+    }
+
+    public boolean isSelectionContainsHeldFees() {
+        return !getHeldFeesSelected().isEmpty();
+    }
+
+    public boolean isCanOverrideHold() {
+        return webUserController.hasPrivilege("InwardPayProfessionalFeesWhileOnHold");
+    }
+
+    public String getHeldFeesSelectedBhtNumbers() {
+        List<String> bhtNos = new ArrayList<>();
+        for (BillFee bf : getHeldFeesSelected()) {
+            PatientEncounter pe = bf.getPatienEncounter();
+            String bhtNo = pe != null && pe.getBhtNo() != null ? pe.getBhtNo() : "(no BHT)";
+            if (!bhtNos.contains(bhtNo)) {
+                bhtNos.add(bhtNo);
+            }
+        }
+        return String.join(", ", bhtNos);
+    }
+
+    public double getHeldFeesSelectedValue() {
+        double total = 0.0;
+        for (BillFee bf : getHeldFeesSelected()) {
+            total = total + (bf.getFeeValue() - bf.getPaidValue());
+        }
+        return total;
+    }
+
+    /**
+     * Guards the selection against held fees. Returns an error message to show,
+     * or null when the payment may proceed. A user without
+     * {@code InwardPayProfessionalFeesWhileOnHold} is blocked outright; a user
+     * who holds it must explicitly acknowledge the override (issue #22483).
+     */
+    private String checkHoldsOnSelection() {
+        if (getHeldFeesSelected().isEmpty()) {
+            return null;
+        }
+        if (!isCanOverrideHold()) {
+            return "Cannot pay: professional payments are on hold for " + getHeldFeesSelectedBhtNumbers()
+                    + ". Release the hold before paying, or ask a user with the"
+                    + " 'Pay Professional Fees While On Hold' privilege.";
+        }
+        if (!holdOverrideAcknowledged) {
+            return "The selection includes professional payments on hold for " + getHeldFeesSelectedBhtNumbers()
+                    + ". Tick the override confirmation and give a reason before settling.";
+        }
+        if (holdOverrideReason == null || holdOverrideReason.trim().isEmpty()) {
+            return "Please give a reason for paying professional payments that are on hold.";
+        }
+        return null;
+    }
+
+    /**
+     * Records the override on the payment bill and in the admission's audit
+     * trail, so a payment made past a hold is traceable afterwards.
+     */
+    private void recordHoldOverride(Bill paymentBill) {
+        List<BillFee> held = getHeldFeesSelected();
+        if (held.isEmpty()) {
+            return;
+        }
+        String reason = holdOverrideReason == null ? "" : holdOverrideReason.trim();
+        String note = "Paid while on hold (" + getHeldFeesSelectedBhtNumbers() + ") by "
+                + sessionController.getLoggedUser().getName() + ". Reason: " + reason;
+        if (paymentBill != null) {
+            String existing = paymentBill.getComments();
+            paymentBill.setComments(existing == null || existing.trim().isEmpty()
+                    ? note : existing + " | " + note);
+        }
+        for (BillFee bf : held) {
+            PatientEncounter pe = bf.getPatienEncounter();
+            if (pe == null) {
+                continue;
+            }
+            Map<String, Object> before = new LinkedHashMap<>();
+            before.put("billFeeId", bf.getId());
+            before.put("feePaymentOnHold", bf.isFeePaymentOnHold());
+            before.put("bhtProfessionalPaymentsOnHold", pe.isProfessionalPaymentsOnHold());
+            Map<String, Object> after = new LinkedHashMap<>(before);
+            after.put("paidWhileOnHold", Boolean.TRUE);
+            after.put("overrideReason", reason);
+            after.put("paymentBillId", paymentBill != null ? paymentBill.getId() : null);
+            auditService.logEncounterAudit(pe, "Surgery Professional Fee Paid While On Hold",
+                    before, after, sessionController.getLoggedUser(), "BillFee", bf.getId());
+        }
+    }
+
+    public boolean isHoldOverrideAcknowledged() {
+        return holdOverrideAcknowledged;
+    }
+
+    public void setHoldOverrideAcknowledged(boolean holdOverrideAcknowledged) {
+        this.holdOverrideAcknowledged = holdOverrideAcknowledged;
+    }
+
+    public String getHoldOverrideReason() {
+        return holdOverrideReason;
+    }
+
+    public void setHoldOverrideReason(String holdOverrideReason) {
+        this.holdOverrideReason = holdOverrideReason;
+    }
+
+    public double getTotalOnHold() {
+        return totalOnHold;
+    }
+
+    public void setTotalOnHold(double totalOnHold) {
+        this.totalOnHold = totalOnHold;
+    }
+    // </editor-fold>
 
     private void calculateWithholdingTaxDependingOnPayments() {
         if (totalPaidForCurrentSurgeonForCurrentMonthForCurrentInstitute == 0.0) {
@@ -305,8 +466,19 @@ public class InwardSurgeryPaymentBillController implements Serializable {
         }
         
         saveBillCompo(newlyCreatedPaymentBill, newlyCreatedPayment);
+        boolean paidPastHold = isSelectionContainsHeldFees();
+        if (paidPastHold) {
+            recordHoldOverride(newlyCreatedPaymentBill);
+            getBillFacade().edit(newlyCreatedPaymentBill);
+        }
         printPreview = true;
-        JsfUtil.addSuccessMessage("Surgery Payment Successfully Processed");
+        if (paidPastHold) {
+            JsfUtil.addSuccessMessage("Surgery Payment Successfully Processed. Payments on hold were paid using your"
+                    + " override privilege — this has been recorded on the payment bill and in the admission's audit trail.");
+        } else {
+            JsfUtil.addSuccessMessage("Surgery Payment Successfully Processed");
+        }
+        resetHoldOverride();
     }
 
     public void settleWithoutPayment() {
@@ -331,27 +503,21 @@ public class InwardSurgeryPaymentBillController implements Serializable {
             
             getBillFeeFacade().edit(originalBillFee);
         }
-        
+
+        if (isSelectionContainsHeldFees()) {
+            recordHoldOverride(null);
+        }
+
         printPreview = true;
         JsfUtil.addSuccessMessage("Surgery Fees Successfully Settled (No Payment Record Created)");
+        resetHoldOverride();
     }
 
     private boolean errorCheck() {
-        if (getPayingSurgeryFees() != null) {
-            for (BillFee bf : getPayingSurgeryFees()) {
-                com.divudi.core.entity.PatientEncounter pe = bf.getPatienEncounter();
-                if (pe != null && Boolean.TRUE.equals(pe.getProfessionalPaymentsOnHold())
-                        && !webUserController.hasPrivilege("InwardPayProfessionalFeesWhileOnHold")) {
-                    JsfUtil.addErrorMessage("Cannot pay: professional payments are on hold for BHT " + pe.getBhtNo() + ".");
-                    return true;
-                }
-                if (bf.isFeePaymentOnHold()
-                        && !webUserController.hasPrivilege("InwardPayProfessionalFeesWhileOnHold")) {
-                    JsfUtil.addErrorMessage("Cannot pay: this professional payment is individually on hold"
-                            + (pe != null ? " (BHT " + pe.getBhtNo() + ")" : "") + ".");
-                    return true;
-                }
-            }
+        String holdError = checkHoldsOnSelection();
+        if (holdError != null) {
+            JsfUtil.addErrorMessage(holdError);
+            return true;
         }
         if (currentSurgeon == null) {
             JsfUtil.addErrorMessage("Please select a Surgeon");

--- a/src/main/java/com/divudi/bean/inward/InwardSurgeryPaymentBillController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSurgeryPaymentBillController.java
@@ -129,6 +129,7 @@ public class InwardSurgeryPaymentBillController implements Serializable {
     private double totalPayingWithoutWht;
     private boolean holdOverrideAcknowledged;
     private String holdOverrideReason;
+    private List<BillFee> feesHeldAtSettle;
 
     private Boolean printPreview = false;
     private PaymentMethod paymentMethod;
@@ -279,6 +280,7 @@ public class InwardSurgeryPaymentBillController implements Serializable {
     private void resetHoldOverride() {
         holdOverrideAcknowledged = false;
         holdOverrideReason = null;
+        feesHeldAtSettle = null;
     }
 
     public List<BillFee> getHeldFeesSelected() {
@@ -329,16 +331,37 @@ public class InwardSurgeryPaymentBillController implements Serializable {
      * who holds it must explicitly acknowledge the override (issue #22483).
      */
     private String checkHoldsOnSelection() {
-        if (getHeldFeesSelected().isEmpty()) {
+        List<Long> heldNow = findCurrentlyHeldFeeIds(payingSurgeryFees);
+        // Remember what this authoritative read found, so the settle path audits
+        // exactly what the guard let through without re-querying.
+        feesHeldAtSettle = new ArrayList<>();
+        if (payingSurgeryFees != null) {
+            for (BillFee bf : payingSurgeryFees) {
+                if (bf.getId() != null && heldNow.contains(bf.getId())) {
+                    feesHeldAtSettle.add(bf);
+                }
+            }
+        }
+        if (heldNow.isEmpty()) {
             return null;
         }
+        String bhtNumbers = describeBhtsForFeeIds(heldNow);
         if (!isCanOverrideHold()) {
-            return "Cannot pay: professional payments are on hold for " + getHeldFeesSelectedBhtNumbers()
+            return "Cannot pay: professional payments are on hold for " + bhtNumbers
                     + ". Release the hold before paying, or ask a user with the"
                     + " 'Pay Professional Fees While On Hold' privilege.";
         }
+        // A hold applied after this page was loaded was never shown to the user,
+        // so an acknowledgement given before it existed cannot cover it.
+        for (BillFee bf : payingSurgeryFees) {
+            if (bf.getId() != null && heldNow.contains(bf.getId()) && !bf.isProfessionalPaymentHeld()) {
+                resetHoldOverride();
+                return "Professional payments for " + bhtNumbers + " were put on hold while this page was open."
+                        + " Run the search again to see the current hold status before settling.";
+            }
+        }
         if (!holdOverrideAcknowledged) {
-            return "The selection includes professional payments on hold for " + getHeldFeesSelectedBhtNumbers()
+            return "The selection includes professional payments on hold for " + bhtNumbers
                     + ". Tick the override confirmation and give a reason before settling.";
         }
         if (holdOverrideReason == null || holdOverrideReason.trim().isEmpty()) {
@@ -348,16 +371,86 @@ public class InwardSurgeryPaymentBillController implements Serializable {
     }
 
     /**
+     * Fee IDs in {@code selection} that are on hold <em>right now</em>, read
+     * fresh from the database rather than from the in-memory selection.
+     *
+     * This bean is {@code @SessionScoped}, so the due-fee list may have been
+     * loaded minutes ago and its hold flags can be stale — a hold applied by
+     * another user in the meantime must still block the payment. A scalar
+     * projection is used so the check reads columns rather than being served a
+     * cached entity, and the encounter is joined with an explicit LEFT JOIN so
+     * fees with no admission are not silently dropped from the fee-level
+     * branch of the OR. (Issue #22483)
+     */
+    private List<Long> findCurrentlyHeldFeeIds(List<BillFee> selection) {
+        List<Long> heldIds = new ArrayList<>();
+        if (selection == null || selection.isEmpty()) {
+            return heldIds;
+        }
+        List<Long> ids = new ArrayList<>();
+        for (BillFee bf : selection) {
+            if (bf != null && bf.getId() != null) {
+                ids.add(bf.getId());
+            }
+        }
+        if (ids.isEmpty()) {
+            return heldIds;
+        }
+        String jpql = "select bf.id from BillFee bf "
+                + " left join bf.patienEncounter pe "
+                + " where bf.id in :ids "
+                + " and (bf.feePaymentOnHold = true or pe.professionalPaymentsOnHold = true) ";
+        Map<String, Object> params = new HashMap<>();
+        params.put("ids", ids);
+        for (Object o : getBillFeeFacade().findObjects(jpql, params)) {
+            if (o instanceof Number) {
+                heldIds.add(((Number) o).longValue());
+            }
+        }
+        return heldIds;
+    }
+
+    /**
+     * BHT numbers for the given fee IDs, taken from the loaded selection. The
+     * BHT number itself never changes, so the in-memory copy is safe here even
+     * when the hold flags on it are stale.
+     */
+    private String describeBhtsForFeeIds(List<Long> feeIds) {
+        List<String> bhtNos = new ArrayList<>();
+        if (payingSurgeryFees == null) {
+            return "";
+        }
+        for (BillFee bf : payingSurgeryFees) {
+            if (bf.getId() == null || !feeIds.contains(bf.getId())) {
+                continue;
+            }
+            PatientEncounter pe = bf.getPatienEncounter();
+            String bhtNo = pe != null && pe.getBhtNo() != null ? pe.getBhtNo() : "(no BHT)";
+            if (!bhtNos.contains(bhtNo)) {
+                bhtNos.add(bhtNo);
+            }
+        }
+        return String.join(", ", bhtNos);
+    }
+
+    /**
      * Records the override on the payment bill and in the admission's audit
      * trail, so a payment made past a hold is traceable afterwards.
      */
-    private void recordHoldOverride(Bill paymentBill) {
-        List<BillFee> held = getHeldFeesSelected();
-        if (held.isEmpty()) {
+    private void recordHoldOverride(Bill paymentBill, List<BillFee> held) {
+        if (held == null || held.isEmpty()) {
             return;
         }
+        List<String> overriddenBhtNos = new ArrayList<>();
+        for (BillFee bf : held) {
+            PatientEncounter bhtPe = bf.getPatienEncounter();
+            String bhtNo = bhtPe != null && bhtPe.getBhtNo() != null ? bhtPe.getBhtNo() : "(no BHT)";
+            if (!overriddenBhtNos.contains(bhtNo)) {
+                overriddenBhtNos.add(bhtNo);
+            }
+        }
         String reason = holdOverrideReason == null ? "" : holdOverrideReason.trim();
-        String note = "Paid while on hold (" + getHeldFeesSelectedBhtNumbers() + ") by "
+        String note = "Paid while on hold (" + String.join(", ", overriddenBhtNos) + ") by "
                 + sessionController.getLoggedUser().getName() + ". Reason: " + reason;
         if (paymentBill != null) {
             String existing = paymentBill.getComments();
@@ -466,9 +559,10 @@ public class InwardSurgeryPaymentBillController implements Serializable {
         }
         
         saveBillCompo(newlyCreatedPaymentBill, newlyCreatedPayment);
-        boolean paidPastHold = isSelectionContainsHeldFees();
+        List<BillFee> heldPaid = feesHeldAtSettle;
+        boolean paidPastHold = heldPaid != null && !heldPaid.isEmpty();
         if (paidPastHold) {
-            recordHoldOverride(newlyCreatedPaymentBill);
+            recordHoldOverride(newlyCreatedPaymentBill, heldPaid);
             getBillFacade().edit(newlyCreatedPaymentBill);
         }
         printPreview = true;
@@ -490,26 +584,35 @@ public class InwardSurgeryPaymentBillController implements Serializable {
         }
         
         performCalculations();
-        
+
+        // Record the override before the fees are marked paid, so the hold is
+        // captured even if a later write fails part-way (#22483).
+        List<BillFee> heldPaid = feesHeldAtSettle;
+        boolean paidPastHold = heldPaid != null && !heldPaid.isEmpty();
+        if (paidPastHold) {
+            recordHoldOverride(null, heldPaid);
+        }
+
         // Update bill fees without creating payment records
         for (BillFee originalBillFee : getPayingSurgeryFees()) {
             originalBillFee.setPaidValue(originalBillFee.getFeeValue());
             originalBillFee.setSettleValue(originalBillFee.getFeeValue());
-            
+
             // Mark as collected by doctor if flag is set
             if (feeCollectedByDoctor) {
                 originalBillFee.setFeeCollectedByDoctor(true);
             }
-            
+
             getBillFeeFacade().edit(originalBillFee);
         }
 
-        if (isSelectionContainsHeldFees()) {
-            recordHoldOverride(null);
-        }
-
         printPreview = true;
-        JsfUtil.addSuccessMessage("Surgery Fees Successfully Settled (No Payment Record Created)");
+        if (paidPastHold) {
+            JsfUtil.addSuccessMessage("Surgery Fees Successfully Settled (No Payment Record Created). Payments on hold"
+                    + " were settled using your override privilege — this has been recorded in the admission's audit trail.");
+        } else {
+            JsfUtil.addSuccessMessage("Surgery Fees Successfully Settled (No Payment Record Created)");
+        }
         resetHoldOverride();
     }
 

--- a/src/main/java/com/divudi/core/entity/BillFee.java
+++ b/src/main/java/com/divudi/core/entity/BillFee.java
@@ -965,4 +965,86 @@ public class BillFee implements Serializable, RetirableEntity {
         this.feePaymentHoldNotes = feePaymentHoldNotes;
     }
 
+    /**
+     * Single source of truth for "may this professional fee be paid?".
+     *
+     * A professional fee is held either because this individual fee was put on
+     * hold ({@link #isFeePaymentOnHold()}) or because the whole admission was
+     * put on hold
+     * ({@link PatientEncounter#isProfessionalPaymentsOnHold()}). Every page
+     * that lists or pays professional fees must consult this, so the two hold
+     * levels stay in sync across the application. (Issues #22483, #22484)
+     */
+    @Transient
+    public boolean isProfessionalPaymentHeld() {
+        return isFeePaymentOnHold() || isBhtProfessionalPaymentsOnHold();
+    }
+
+    @Transient
+    public boolean isBhtProfessionalPaymentsOnHold() {
+        return patienEncounter != null && patienEncounter.isProfessionalPaymentsOnHold();
+    }
+
+    /**
+     * Short label describing where the hold comes from, for the "Hold Status"
+     * column: {@code Payable}, {@code On Hold (This Fee)},
+     * {@code On Hold (Whole BHT)} or {@code On Hold (This Fee + Whole BHT)}.
+     */
+    @Transient
+    public String getProfessionalPaymentHoldStatus() {
+        boolean fee = isFeePaymentOnHold();
+        boolean bht = isBhtProfessionalPaymentsOnHold();
+        if (fee && bht) {
+            return "On Hold (This Fee + Whole BHT)";
+        }
+        if (fee) {
+            return "On Hold (This Fee)";
+        }
+        if (bht) {
+            return "On Hold (Whole BHT)";
+        }
+        return "Payable";
+    }
+
+    /**
+     * Who held it, when, and why — used as the tooltip beside the hold status.
+     */
+    @Transient
+    public String getProfessionalPaymentHoldDetails() {
+        StringBuilder sb = new StringBuilder();
+        if (isFeePaymentOnHold()) {
+            sb.append("This fee was held");
+            if (feePaymentHoldBy != null) {
+                sb.append(" by ").append(feePaymentHoldBy.getName());
+            }
+            if (feePaymentHoldDateTime != null) {
+                sb.append(" on ").append(feePaymentHoldDateTime);
+            }
+            if (feePaymentHoldNotes != null && !feePaymentHoldNotes.trim().isEmpty()) {
+                sb.append(" — ").append(feePaymentHoldNotes.trim());
+            }
+            sb.append('.');
+        }
+        if (isBhtProfessionalPaymentsOnHold()) {
+            if (sb.length() > 0) {
+                sb.append(' ');
+            }
+            sb.append("All professional payments for BHT ")
+                    .append(patienEncounter.getBhtNo())
+                    .append(" are held");
+            if (patienEncounter.getProfessionalPaymentsHoldBy() != null) {
+                sb.append(" by ").append(patienEncounter.getProfessionalPaymentsHoldBy().getName());
+            }
+            if (patienEncounter.getProfessionalPaymentsHoldDateTime() != null) {
+                sb.append(" on ").append(patienEncounter.getProfessionalPaymentsHoldDateTime());
+            }
+            String bhtNotes = patienEncounter.getProfessionalPaymentsHoldNotes();
+            if (bhtNotes != null && !bhtNotes.trim().isEmpty()) {
+                sb.append(" — ").append(bhtNotes.trim());
+            }
+            sb.append('.');
+        }
+        return sb.toString();
+    }
+
 }

--- a/src/main/webapp/inward/inward_bill_professional_payment.xhtml
+++ b/src/main/webapp/inward/inward_bill_professional_payment.xhtml
@@ -111,14 +111,14 @@
                                 var="bf" 
                                 rowKey="#{bf.id}" >
 
-                                <p:ajax  event="rowSelectCheckbox" process="tblFee" listener="#{inwardStaffPaymentBillController.performCalculations()}"   
-                                         update=":#{p:resolveFirstComponentWithId('pTotals',view).clientId}"  />  
+                                <p:ajax  event="rowSelectCheckbox" process="tblFee" listener="#{inwardStaffPaymentBillController.onSelectionChanged()}"
+                                         update=":#{p:resolveFirstComponentWithId('pTotals',view).clientId} :#{p:resolveFirstComponentWithId('pnlHoldOverride',view).clientId}"  />
 
-                                <p:ajax  event="rowUnselectCheckbox" process="tblFee" listener="#{inwardStaffPaymentBillController.performCalculations()}"   
-                                         update=":#{p:resolveFirstComponentWithId('pTotals',view).clientId}"  />  
+                                <p:ajax  event="rowUnselectCheckbox" process="tblFee" listener="#{inwardStaffPaymentBillController.onSelectionChanged()}"
+                                         update=":#{p:resolveFirstComponentWithId('pTotals',view).clientId} :#{p:resolveFirstComponentWithId('pnlHoldOverride',view).clientId}"  />
 
-                                <p:ajax  event="toggleSelect" process="tblFee" listener="#{inwardStaffPaymentBillController.performCalculations()}"   
-                                         update=":#{p:resolveFirstComponentWithId('pTotals',view).clientId}"  />  
+                                <p:ajax  event="toggleSelect" process="tblFee" listener="#{inwardStaffPaymentBillController.onSelectionChanged()}"
+                                         update=":#{p:resolveFirstComponentWithId('pTotals',view).clientId} :#{p:resolveFirstComponentWithId('pnlHoldOverride',view).clientId}"  />
 
                                 <p:column selectionBox="true" width="20"></p:column>
 
@@ -145,21 +145,69 @@
                                     </f:facet>
                                     <h:outputLabel value="#{bf.bill.patientEncounter.bhtNo}">
                                     </h:outputLabel>
-                                    <h:panelGroup layout="block" rendered="#{bf.patienEncounter.professionalPaymentsOnHold}">
-                                        <span class="ui-tag ui-tag-danger" title="Professional payments are on hold for this BHT">On Hold</span>
-                                    </h:panelGroup>
                                 </p:column>
 
                                 <p:column headerText="Charge" width="7em;" class="text-end">
                                     <f:facet name="header">
                                         <h:outputLabel value="Charge"/>
-                                    </f:facet>    
+                                    </f:facet>
                                     <h:outputLabel value="#{bf.feeValue}" >
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
                                 </p:column>
 
+                                <p:column headerText="Hold Status" width="14em;">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Hold Status"/>
+                                    </f:facet>
+                                    <h:panelGroup layout="block" rendered="#{bf.professionalPaymentHeld}">
+                                        <span class="ui-tag ui-tag-danger"
+                                              title="#{bf.professionalPaymentHoldDetails}">#{bf.professionalPaymentHoldStatus}</span>
+                                    </h:panelGroup>
+                                    <h:panelGroup layout="block" rendered="#{not bf.professionalPaymentHeld}">
+                                        <span class="ui-tag ui-tag-success">Payable</span>
+                                    </h:panelGroup>
+                                </p:column>
+
                             </p:dataTable>
+
+                            <!-- Professional payment hold: block, or require an explicit override (#22483) -->
+                            <h:panelGroup id="pnlHoldOverride" layout="block">
+                                <h:panelGroup layout="block" rendered="#{inwardStaffPaymentBillController.selectionContainsHeldFees}">
+                                    <p:panel styleClass="w-100 m-1 ui-state-error">
+                                        <f:facet name="header">
+                                            <h:outputLabel value="Professional Payments On Hold Selected" />
+                                        </f:facet>
+
+                                        <h:outputText
+                                            value="#{inwardStaffPaymentBillController.heldFeesSelected.size()} of the selected professional payment(s) are on hold (#{inwardStaffPaymentBillController.heldFeesSelectedBhtNumbers})."
+                                            styleClass="fw-bold" />
+
+                                        <h:panelGroup layout="block" styleClass="mt-2"
+                                                      rendered="#{not inwardStaffPaymentBillController.canOverrideHold}">
+                                            <h:outputText value="These payments cannot be settled. Release the hold first, or ask a user with the 'Pay Professional Fees While On Hold' privilege." />
+                                        </h:panelGroup>
+
+                                        <h:panelGroup layout="block" styleClass="mt-2"
+                                                      rendered="#{inwardStaffPaymentBillController.canOverrideHold}">
+                                            <p:selectBooleanCheckbox
+                                                id="chkHoldOverride"
+                                                widgetVar="chkHoldOverride"
+                                                value="#{inwardStaffPaymentBillController.holdOverrideAcknowledged}"
+                                                itemLabel="I am authorised to pay these professional payments while they are on hold" />
+                                            <p:outputLabel for="txtHoldOverrideReason" value="Reason for the override" styleClass="d-block mt-2 fw-bold" />
+                                            <p:inputTextarea
+                                                id="txtHoldOverrideReason"
+                                                widgetVar="txtHoldOverrideReason"
+                                                value="#{inwardStaffPaymentBillController.holdOverrideReason}"
+                                                class="w-100"
+                                                autoResize="true"
+                                                rows="2"
+                                                placeholder="Why is this held payment being paid now? Recorded on the payment bill and in the admission's audit trail." />
+                                        </h:panelGroup>
+                                    </p:panel>
+                                </h:panelGroup>
+                            </h:panelGroup>
 
                             <p:panel   >
                                 <f:facet name="header">
@@ -228,8 +276,12 @@
                                         <p:panelGrid 
                                             id="pTotals"
                                             columns="2" layout="tabular" class="w-100" columnClasses="text-left, text-end">
-                                            <h:outputLabel value="Total Due" ></h:outputLabel>
+                                            <h:outputLabel value="Total Due (Payable)" ></h:outputLabel>
                                             <h:outputLabel id="lblDue" value="#{inwardStaffPaymentBillController.totalDue}" >
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                            <h:outputLabel value="Total On Hold" styleClass="text-danger" ></h:outputLabel>
+                                            <h:outputLabel id="lblOnHold" value="#{inwardStaffPaymentBillController.totalOnHold}" styleClass="text-danger" >
                                                 <f:convertNumber pattern="#,##0.00" />
                                             </h:outputLabel>
                                             <h:outputLabel value="Paying This time" ></h:outputLabel>

--- a/src/main/webapp/inward/inward_bill_surgery_payment.xhtml
+++ b/src/main/webapp/inward/inward_bill_surgery_payment.xhtml
@@ -111,14 +111,14 @@
                                 var="bf" 
                                 rowKey="#{bf.id}" >
 
-                                <p:ajax  event="rowSelectCheckbox" process="tblFee" listener="#{inwardSurgeryPaymentBillController.performCalculations()}"   
-                                         update=":#{p:resolveFirstComponentWithId('pTotals',view).clientId}"  />  
+                                <p:ajax  event="rowSelectCheckbox" process="tblFee" listener="#{inwardSurgeryPaymentBillController.onSelectionChanged()}"
+                                         update=":#{p:resolveFirstComponentWithId('pTotals',view).clientId} :#{p:resolveFirstComponentWithId('pnlHoldOverride',view).clientId}"  />
 
-                                <p:ajax  event="rowUnselectCheckbox" process="tblFee" listener="#{inwardSurgeryPaymentBillController.performCalculations()}"   
-                                         update=":#{p:resolveFirstComponentWithId('pTotals',view).clientId}"  />  
+                                <p:ajax  event="rowUnselectCheckbox" process="tblFee" listener="#{inwardSurgeryPaymentBillController.onSelectionChanged()}"
+                                         update=":#{p:resolveFirstComponentWithId('pTotals',view).clientId} :#{p:resolveFirstComponentWithId('pnlHoldOverride',view).clientId}"  />
 
-                                <p:ajax  event="toggleSelect" process="tblFee" listener="#{inwardSurgeryPaymentBillController.performCalculations()}"   
-                                         update=":#{p:resolveFirstComponentWithId('pTotals',view).clientId}"  />  
+                                <p:ajax  event="toggleSelect" process="tblFee" listener="#{inwardSurgeryPaymentBillController.onSelectionChanged()}"
+                                         update=":#{p:resolveFirstComponentWithId('pTotals',view).clientId} :#{p:resolveFirstComponentWithId('pnlHoldOverride',view).clientId}"  />
 
                                 <p:column selectionBox="true" width="20"></p:column>
 
@@ -145,21 +145,69 @@
                                     </f:facet>
                                     <h:outputLabel value="#{bf.bill.patientEncounter.bhtNo}">
                                     </h:outputLabel>
-                                    <h:panelGroup layout="block" rendered="#{bf.patienEncounter.professionalPaymentsOnHold}">
-                                        <span class="ui-tag ui-tag-danger" title="Professional payments are on hold for this BHT">On Hold</span>
-                                    </h:panelGroup>
                                 </p:column>
 
                                 <p:column headerText="Surgery Fee" width="7em;" class="text-end">
                                     <f:facet name="header">
                                         <h:outputLabel value="Surgery Fee"/>
-                                    </f:facet>    
+                                    </f:facet>
                                     <h:outputLabel value="#{bf.feeValue}" >
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
                                 </p:column>
 
+                                <p:column headerText="Hold Status" width="14em;">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Hold Status"/>
+                                    </f:facet>
+                                    <h:panelGroup layout="block" rendered="#{bf.professionalPaymentHeld}">
+                                        <span class="ui-tag ui-tag-danger"
+                                              title="#{bf.professionalPaymentHoldDetails}">#{bf.professionalPaymentHoldStatus}</span>
+                                    </h:panelGroup>
+                                    <h:panelGroup layout="block" rendered="#{not bf.professionalPaymentHeld}">
+                                        <span class="ui-tag ui-tag-success">Payable</span>
+                                    </h:panelGroup>
+                                </p:column>
+
                             </p:dataTable>
+
+                            <!-- Professional payment hold: block, or require an explicit override (#22483) -->
+                            <h:panelGroup id="pnlHoldOverride" layout="block">
+                                <h:panelGroup layout="block" rendered="#{inwardSurgeryPaymentBillController.selectionContainsHeldFees}">
+                                    <p:panel styleClass="w-100 m-1 ui-state-error">
+                                        <f:facet name="header">
+                                            <h:outputLabel value="Professional Payments On Hold Selected" />
+                                        </f:facet>
+
+                                        <h:outputText
+                                            value="#{inwardSurgeryPaymentBillController.heldFeesSelected.size()} of the selected surgery professional payment(s) are on hold (#{inwardSurgeryPaymentBillController.heldFeesSelectedBhtNumbers})."
+                                            styleClass="fw-bold" />
+
+                                        <h:panelGroup layout="block" styleClass="mt-2"
+                                                      rendered="#{not inwardSurgeryPaymentBillController.canOverrideHold}">
+                                            <h:outputText value="These payments cannot be settled. Release the hold first, or ask a user with the 'Pay Professional Fees While On Hold' privilege." />
+                                        </h:panelGroup>
+
+                                        <h:panelGroup layout="block" styleClass="mt-2"
+                                                      rendered="#{inwardSurgeryPaymentBillController.canOverrideHold}">
+                                            <p:selectBooleanCheckbox
+                                                id="chkHoldOverride"
+                                                widgetVar="chkHoldOverride"
+                                                value="#{inwardSurgeryPaymentBillController.holdOverrideAcknowledged}"
+                                                itemLabel="I am authorised to pay these professional payments while they are on hold" />
+                                            <p:outputLabel for="txtHoldOverrideReason" value="Reason for the override" styleClass="d-block mt-2 fw-bold" />
+                                            <p:inputTextarea
+                                                id="txtHoldOverrideReason"
+                                                widgetVar="txtHoldOverrideReason"
+                                                value="#{inwardSurgeryPaymentBillController.holdOverrideReason}"
+                                                class="w-100"
+                                                autoResize="true"
+                                                rows="2"
+                                                placeholder="Why is this held payment being paid now? Recorded on the payment bill and in the admission's audit trail." />
+                                        </h:panelGroup>
+                                    </p:panel>
+                                </h:panelGroup>
+                            </h:panelGroup>
 
                             <p:panel   >
                                 <f:facet name="header">
@@ -234,8 +282,12 @@
                                         <p:panelGrid 
                                             id="pTotals"
                                             columns="2" layout="tabular" class="w-100" columnClasses="text-left, text-end">
-                                            <h:outputLabel value="Total Due" ></h:outputLabel>
+                                            <h:outputLabel value="Total Due (Payable)" ></h:outputLabel>
                                             <h:outputLabel id="lblDue" value="#{inwardSurgeryPaymentBillController.totalDue}" >
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                            <h:outputLabel value="Total On Hold" styleClass="text-danger" ></h:outputLabel>
+                                            <h:outputLabel id="lblOnHold" value="#{inwardSurgeryPaymentBillController.totalOnHold}" styleClass="text-danger" >
                                                 <f:convertNumber pattern="#,##0.00" />
                                             </h:outputLabel>
                                             <h:outputLabel value="Paying This time" ></h:outputLabel>

--- a/src/main/webapp/inward/inward_professional_fee_hold.xhtml
+++ b/src/main/webapp/inward/inward_professional_fee_hold.xhtml
@@ -61,6 +61,28 @@
                                         </div>
                                     </f:facet>
 
+                                    <!-- The whole-BHT hold overrides every row here; releasing an
+                                         individual fee alone will not make it payable (#22483) -->
+                                    <h:panelGroup layout="block" styleClass="mb-3"
+                                                  rendered="#{professionalFeeHoldController.currentEncounter.professionalPaymentsOnHold}">
+                                        <p:panel styleClass="w-100 ui-state-error">
+                                            <h:outputText
+                                                value="All professional payments for this BHT are on hold — held by #{professionalFeeHoldController.currentEncounter.professionalPaymentsHoldBy.name}."
+                                                styleClass="fw-bold" />
+                                            <h:outputText value=" #{professionalFeeHoldController.currentEncounter.professionalPaymentsHoldNotes}"
+                                                          rendered="#{not empty professionalFeeHoldController.currentEncounter.professionalPaymentsHoldNotes}" />
+                                            <h:outputText value=" Releasing an individual payment below will not make it payable until the whole-BHT hold is released on the Hold Professional Payments page."
+                                                          styleClass="d-block mt-1" />
+                                            <p:commandButton
+                                                id="btnGoToBhtHold"
+                                                value="Hold Professional Payments"
+                                                ajax="false"
+                                                icon="fa fa-unlock"
+                                                class="mt-2"
+                                                action="#{professionalPaymentHoldController.navigateToProfessionalPaymentHold(professionalFeeHoldController.currentEncounter)}" />
+                                        </p:panel>
+                                    </h:panelGroup>
+
                                     <p:outputLabel for="txtFeeHoldNotes" value="Hold Notes (applied to newly held payments):" styleClass="font-weight-bold" />
                                     <p:inputTextarea
                                         id="txtFeeHoldNotes"
@@ -121,17 +143,14 @@
                                             </h:outputLabel>
                                         </p:column>
 
+                                        <!-- Reflects BOTH the per-fee hold and the whole-BHT hold, so the
+                                             two levels stay in sync with the payment pages (#22483) -->
                                         <p:column headerText="Hold Status">
-                                            <h:panelGroup layout="block" rendered="#{bf.feePaymentOnHold}">
-                                                <span class="ui-tag ui-tag-danger" title="#{bf.feePaymentHoldNotes}">
-                                                    On Hold since
-                                                    <h:outputText value="#{bf.feePaymentHoldDateTime}">
-                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateTimeFormat}" />
-                                                    </h:outputText>
-                                                    by #{bf.feePaymentHoldBy.name}
-                                                </span>
+                                            <h:panelGroup layout="block" rendered="#{bf.professionalPaymentHeld}">
+                                                <span class="ui-tag ui-tag-danger"
+                                                      title="#{bf.professionalPaymentHoldDetails}">#{bf.professionalPaymentHoldStatus}</span>
                                             </h:panelGroup>
-                                            <h:panelGroup layout="block" rendered="#{not bf.feePaymentOnHold}">
+                                            <h:panelGroup layout="block" rendered="#{not bf.professionalPaymentHeld}">
                                                 <span class="ui-tag ui-tag-success">Payable</span>
                                             </h:panelGroup>
                                         </p:column>

--- a/src/main/webapp/inward/inward_report_professional_payment_due.xhtml
+++ b/src/main/webapp/inward/inward_report_professional_payment_due.xhtml
@@ -127,6 +127,9 @@
                                 <h:outputLabel value="#{searchController.toDate}">
                                     <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"/>
                                 </h:outputLabel>
+                                <h:outputLabel value=" | Payable: #{searchController.total}"/>
+                                <h:outputLabel value=" | On Hold: #{searchController.totalOnHold}" styleClass="text-danger"
+                                               rendered="#{searchController.totalOnHold gt 0}"/>
                             </f:facet>
 
                             <p:column headerText="No" styleClass="alignTop">
@@ -204,6 +207,21 @@
                                     <f:convertNumber pattern="#,##0.00"/>
                                 </h:outputLabel>
 
+                            </p:column>
+
+                            <!-- Hold status, so this report agrees with the payment pages
+                                 and the Professional Payments Report (#22483) -->
+                            <p:column headerText="Hold Status">
+                                <f:facet name="header">
+                                    <p:outputLabel value="Hold Status"/>
+                                </f:facet>
+                                <h:panelGroup layout="block" rendered="#{bf.professionalPaymentHeld}">
+                                    <span class="ui-tag ui-tag-danger"
+                                          title="#{bf.professionalPaymentHoldDetails}">#{bf.professionalPaymentHoldStatus}</span>
+                                </h:panelGroup>
+                                <h:panelGroup layout="block" rendered="#{not bf.professionalPaymentHeld}">
+                                    <span class="ui-tag ui-tag-success">Payable</span>
+                                </h:panelGroup>
                             </p:column>
 
                         </p:dataTable>

--- a/src/main/webapp/inward/inward_search_professional_payment_due.xhtml
+++ b/src/main/webapp/inward/inward_search_professional_payment_due.xhtml
@@ -63,8 +63,9 @@
                                              paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
                                              rowsPerPageTemplate="5,10,25,50">
                                     <f:facet name="header">
-                                        <h:outputLabel value=" #{searchController.total}"/>
-
+                                        <h:outputLabel value="Payable: #{searchController.total}"/>
+                                        <h:outputLabel value=" | On Hold: #{searchController.totalOnHold}" styleClass="text-danger"
+                                                       rendered="#{searchController.totalOnHold gt 0}"/>
                                     </f:facet>
                                     <p:column headerText="No" styleClass="alignTop">
                                         <h:outputLabel value="#{i+1}"/>
@@ -142,6 +143,20 @@
                                             <h:outputLabel value="Charge"  />
                                         </f:facet>
                                         <h:outputLabel value="#{bf.feeValue}" />
+                                    </p:column>
+                                    <!-- Hold status, so this list agrees with the payment pages
+                                         and the Professional Payments Report (#22483) -->
+                                    <p:column headerText="Hold Status">
+                                        <f:facet name="header">
+                                            <h:outputLabel value="Hold Status"  />
+                                        </f:facet>
+                                        <h:panelGroup layout="block" rendered="#{bf.professionalPaymentHeld}">
+                                            <span class="ui-tag ui-tag-danger"
+                                                  title="#{bf.professionalPaymentHoldDetails}">#{bf.professionalPaymentHoldStatus}</span>
+                                        </h:panelGroup>
+                                        <h:panelGroup layout="block" rendered="#{not bf.professionalPaymentHeld}">
+                                            <span class="ui-tag ui-tag-success">Payable</span>
+                                        </h:panelGroup>
                                     </p:column>
                                     <p:column headerText="Action">
                                         <p:commandButton ajax="false" icon="fas fa-eye" value="Pay" action="#{inwardStaffPaymentBillController.calculateDueFees()}"  >


### PR DESCRIPTION
Closes #22483
Closes #22484

## The root cause

Two hold levels shipped separately and never learned about each other:

| Hold level | Field | Introduced |
|---|---|---|
| Whole BHT | `PatientEncounter.professionalPaymentsOnHold` | #16473 / PR #22225 |
| Individual fee | `BillFee.feePaymentOnHold` | #22383 / PR #22398 |

Every page read only the half it knew about, so the same fee looked held on one screen and payable on the next. Verified on a local deployment before changing anything:

| Surface | Behaviour before | Issue |
|---|---|---|
| Professional Payments Report | Whole BHT on hold, yet all 5 rows showed **"Payable"** | #22483 Sc.1 |
| Search Outstanding Professional Payments | **No hold column at all**; a held fee sat in the list and in the outstanding total | #22483 Sc.2 |
| Ward / surgery payment pages | Per-fee-held rows were **excluded from the query** → a doctor whose only due fee was held saw *"No records found."* | #22484 |
| Inward professional payment due report | No hold information (not named in either issue, same blind spot) | — |

On "held payments can still be processed": the guard added in #16473 **does** work. It is bypassed only by the intentional `InwardPayProfessionalFeesWhileOnHold` privilege, which the reporting user holds — so the settle passed the hold check silently. Confirmed by retiring that privilege and getting the expected block.

## What changed

**One source of truth.** `BillFee.isProfessionalPaymentHeld()` (plus `getProfessionalPaymentHoldStatus()` / `getProfessionalPaymentHoldDetails()`) — held if the fee itself is held *or* its whole BHT is. All listings and both payment guards read this. No schema change; these are `@Transient` helpers over the existing columns.

**Held fees are shown, not hidden.** The `feePaymentOnHold` exclusion is removed from the ward and surgery due-fee queries; the rows appear with a Hold Status column instead.

**Hold status is everywhere.** Hold Status column added to both payment pages, Search Outstanding Professional Payments, and the inward due report. The Professional Payments Report now reflects both levels and carries a banner explaining that releasing one fee will not help while the BHT is held.

**Totals split.** "Total Due (Payable)" and "Total On Hold" on the payment pages; `Payable: … | On Hold: …` on the search and report headers. The payable figure is no longer inflated by money that cannot be paid.

**The override is explicit, not silent.** Without the privilege: blocked, with a message naming the BHT. With it: a warning panel lists the held rows, and settling requires ticking a confirmation **and** giving a reason. The override is then written to the payment bill's comments and logged as a `Professional Fee Paid While On Hold` audit event on the admission. Changing the selection invalidates an earlier acknowledgement.

## Verification

Built (`mvn clean package`, 185 tests pass), deployed locally, and driven with Playwright against BHT/56552:

- Whole-BHT hold → report shows `On Hold (Whole BHT)` on all rows; the combined case shows `On Hold (This Fee + Whole BHT)`.
- Search Outstanding → Hold Status per row, header `Payable: 0.0 | On Hold: 32000.0`.
- The doctor who previously showed "No records found." now shows his held 1,500 fee with its hold status.
- Split totals correct on the payment page: `Payable 40,000.00 / On Hold 20,000.00`.
- Settle with a held fee selected but **not** acknowledged → blocked, *"Tick the override confirmation and give a reason before settling."*
- Acknowledged + reason → paid, and the DB confirms both the bill comment (`Paid while on hold (BHT/56552) by … Reason: …`) and the `Professional Fee Paid While On Hold` audit event.
- With the override privilege retired → held fee still listed, no acknowledgement UI, hard block on settle.
- Due report → Hold Status column, header `Payable: 4772300.0 | On Hold: 12000.0`.

A `NullPointerException` on the payment page (null selection list on first render) was found by this testing and fixed before the final run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clear “Payable” and “On Hold” totals and status indicators for professional fee payments.
  * Added hold details and tooltips for individual fees and whole-admission holds.
  * Authorized staff can override payment holds by acknowledging the override and providing a reason.
  * Hold overrides are recorded with audit details and updated payment notes.

* **Bug Fixes**
  * Held fees now appear in payment selections while remaining excluded from payable totals.
  * Payment and surgery settlement flows now consistently validate hold conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->