### PR TITLE
feat(pharmacy): add substitute option to Direct Issue to BHT

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/InpatientDirectIssueNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/InpatientDirectIssueNativeSqlController.java
@@ -27,6 +27,7 @@ import com.divudi.core.util.JsfUtil;
 import com.divudi.ejb.BillNumberGenerator;
 import com.divudi.ejb.PharmacyService;
 import com.divudi.service.pharmacy.InpatientDirectIssueNativeSqlService;
+import com.divudi.service.pharmacy.PharmacySubstituteService;
 import com.divudi.service.pharmacy.PriceMatrixNativeSqlService;
 import com.divudi.core.util.CommonFunctions;
 
@@ -88,6 +89,8 @@ public class InpatientDirectIssueNativeSqlController implements Serializable {
     @EJB
     private PriceMatrixNativeSqlService priceMatrixNativeSqlService;
     @EJB
+    private PharmacySubstituteService pharmacySubstituteService;
+    @EJB
     private com.divudi.core.facade.BillItemFacade billItemFacade;
     @EJB
     private com.divudi.core.facade.InpatientPackageItemFacade inpatientPackageItemFacade;
@@ -109,6 +112,11 @@ public class InpatientDirectIssueNativeSqlController implements Serializable {
     private String errorMessage = "";
     private double marginTotal = 0.0;
     private Bill sourceItemRequest;
+
+    // ---- On-demand substitute (alternative) medicines (issue #22482) ----
+    private BillItemData itemDataForSubstitution;
+    private StockDTO selectedSubstituteStock;
+    private List<StockDTO> substituteStocks;
 
     @PostConstruct
     public void init() {
@@ -475,26 +483,12 @@ public class InpatientDirectIssueNativeSqlController implements Serializable {
         double discountPct = 0.0;
         double discountValue = 0.0;
         if (!isPackageRate) {
-            try {
-                long itemId = selectedStockDto.getItemId();
-                Department matrixDept = determineMatrixDepartment();
-                if (matrixDept == null) matrixDept = sessionController.getDepartment();
-                long matrixDeptId = matrixDept.getId();
-                double marginPct = priceMatrixNativeSqlService.getInwardMarginPct(itemId, matrixDeptId, grossValue);
-                if (marginPct != 0.0) {
-                    marginRate = (marginPct / 100.0) * lineRetailRate;
-                    marginValue = marginRate * absQty;
-                }
-                if (priceMatrixNativeSqlService.isDiscountAllowed(itemId)) {
-                    Long schemeId = patientEncounter.getPaymentScheme() != null ? patientEncounter.getPaymentScheme().getId() : null;
-                    Long admTypeId = patientEncounter.getAdmissionType() != null ? patientEncounter.getAdmissionType().getId() : null;
-                    String pmName = patientEncounter.getPaymentMethod() != null ? patientEncounter.getPaymentMethod().name() : null;
-                    discountPct = priceMatrixNativeSqlService.getInwardDiscountPct(itemId, pmName, schemeId, admTypeId, matrixDeptId);
-                    discountValue = (discountPct / 100.0) * grossValue;
-                }
-            } catch (Exception e) {
-                LOGGER.log(Level.WARNING, "[addBillItem] margin/discount lookup failed, using retail rate only", e);
-            }
+            long itemId = selectedStockDto.getItemId();
+            double[] marginAndDiscount = computeMarginAndDiscount(itemId, lineRetailRate, absQty);
+            marginRate = marginAndDiscount[0];
+            marginValue = marginAndDiscount[1];
+            discountPct = marginAndDiscount[2];
+            discountValue = marginAndDiscount[3];
         }
         double netRate = lineRetailRate + marginRate - (absQty > 0 ? discountValue / absQty : 0.0);
         double netValue = grossValue + marginValue - discountValue;
@@ -519,6 +513,45 @@ public class InpatientDirectIssueNativeSqlController implements Serializable {
         calTotal();
         clearBillItem();
         errorMessage = "";
+    }
+
+    /**
+     * Computes inward price-matrix margin and discount for a bill line, given
+     * the resolved item id, its retail rate, and the absolute quantity.
+     * Extracted from {@link #addBillItem()} so the same lookup logic can be
+     * reused by {@link #replaceSelectedSubstitute()} without duplicating the
+     * price-matrix calls (issue #22482). On any lookup failure, falls back to
+     * retail-rate-only pricing (all zeros) exactly as the original inline
+     * try/catch in addBillItem() did.
+     *
+     * @return {marginRate, marginValue, discountPct, discountValue}
+     */
+    private double[] computeMarginAndDiscount(long itemId, double lineRetailRate, double absQty) {
+        double grossValue = lineRetailRate * absQty;
+        double marginRate = 0.0;
+        double marginValue = 0.0;
+        double discountPct = 0.0;
+        double discountValue = 0.0;
+        try {
+            Department matrixDept = determineMatrixDepartment();
+            if (matrixDept == null) matrixDept = sessionController.getDepartment();
+            long matrixDeptId = matrixDept.getId();
+            double marginPct = priceMatrixNativeSqlService.getInwardMarginPct(itemId, matrixDeptId, grossValue);
+            if (marginPct != 0.0) {
+                marginRate = (marginPct / 100.0) * lineRetailRate;
+                marginValue = marginRate * absQty;
+            }
+            if (priceMatrixNativeSqlService.isDiscountAllowed(itemId)) {
+                Long schemeId = patientEncounter.getPaymentScheme() != null ? patientEncounter.getPaymentScheme().getId() : null;
+                Long admTypeId = patientEncounter.getAdmissionType() != null ? patientEncounter.getAdmissionType().getId() : null;
+                String pmName = patientEncounter.getPaymentMethod() != null ? patientEncounter.getPaymentMethod().name() : null;
+                discountPct = priceMatrixNativeSqlService.getInwardDiscountPct(itemId, pmName, schemeId, admTypeId, matrixDeptId);
+                discountValue = (discountPct / 100.0) * grossValue;
+            }
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "[computeMarginAndDiscount] margin/discount lookup failed, using retail rate only", e);
+        }
+        return new double[]{marginRate, marginValue, discountPct, discountValue};
     }
 
     private double[] fetchBatchRates(Long itemBatchId) {
@@ -791,6 +824,89 @@ public class InpatientDirectIssueNativeSqlController implements Serializable {
     }
 
     // -----------------------------------------------------------------------
+    // On-demand substitute (alternative) medicines (issue #22482)
+    // -----------------------------------------------------------------------
+
+    public void prepareSubstitute(BillItemData bid) {
+        itemDataForSubstitution = bid;
+        selectedSubstituteStock = null;
+        substituteStocks = new ArrayList<>();
+        if (bid == null || bid.getItemId() == null) {
+            return;
+        }
+        if (bid.isFromPackage()) {
+            JsfUtil.addErrorMessage("Package-priced items cannot be substituted.");
+            return;
+        }
+        Item item = itemFacade.find(bid.getItemId());
+        if (item == null) {
+            return;
+        }
+        double requiredQty = Math.abs(bid.getQty());
+        substituteStocks = pharmacySubstituteService.findSubstituteStocks(item, sessionController.getDepartment(), requiredQty);
+    }
+
+    public void replaceSelectedSubstitute() {
+        if (itemDataForSubstitution == null || selectedSubstituteStock == null
+                || selectedSubstituteStock.getStockId() == null) {
+            JsfUtil.addErrorMessage("Please select a substitute stock.");
+            return;
+        }
+        if (itemDataForSubstitution.isFromPackage()) {
+            JsfUtil.addErrorMessage("Package-priced items cannot be substituted.");
+            return;
+        }
+
+        StockDTO sub = selectedSubstituteStock;
+        BillItemData bid = itemDataForSubstitution;
+        double qty = Math.abs(bid.getQty());
+
+        double batchRetailRate = sub.getRetailRate() != null ? sub.getRetailRate() : 0.0;
+        double batchPurchaseRate = sub.getPurchaseRate() != null ? sub.getPurchaseRate() : 0.0;
+        double batchWholesaleRate = sub.getWholesaleRate() != null ? sub.getWholesaleRate() : 0.0;
+        Double batchCostRate = (sub.getCostRate() != null && sub.getCostRate() > 0) ? sub.getCostRate() : null;
+
+        long ampItemId = resolveAmpItemId(sub.getItemId());
+
+        bid.setItemId(sub.getItemId());
+        bid.setItemName(sub.getItemName());
+        bid.setAmpItemId(ampItemId);
+        bid.setStockId(sub.getStockId());
+        bid.setItemBatchId(sub.getItemBatchId());
+        bid.setPbiQty(-Math.abs(qty));
+        bid.setRetailRate(batchRetailRate);
+        bid.setPurchaseRate(batchPurchaseRate);
+        bid.setWholesaleRate(batchWholesaleRate);
+        bid.setCostRate(batchCostRate != null ? batchCostRate : batchPurchaseRate);
+        bid.setBatchRetailRate(batchRetailRate);
+        bid.setBatchPurchaseRate(batchPurchaseRate);
+        bid.setBatchWholesaleRate(batchWholesaleRate);
+        bid.setBatchCostRate(batchCostRate);
+        bid.setDoe(sub.getDateOfExpire());
+        bid.setDescription(sub.getItemName());
+
+        double grossValue = batchRetailRate * qty;
+        double[] marginAndDiscount = computeMarginAndDiscount(sub.getItemId(), batchRetailRate, qty);
+        double marginRate = marginAndDiscount[0];
+        double marginValue = marginAndDiscount[1];
+        double discountPct = marginAndDiscount[2];
+        double discountValue = marginAndDiscount[3];
+        double netRate = batchRetailRate + marginRate - (qty > 0 ? discountValue / qty : 0.0);
+        double netValue = grossValue + marginValue - discountValue;
+
+        bid.setRate(batchRetailRate);
+        bid.setNetRate(netRate);
+        bid.setDiscountPercent(discountPct);
+        bid.setDiscountValue(discountValue);
+        bid.setMarginValue(marginValue);
+        bid.setNetValue(-netValue);
+        bid.setGrossValue(-grossValue);
+
+        calTotal();
+        JsfUtil.addSuccessMessage("Stock replaced successfully.");
+    }
+
+    // -----------------------------------------------------------------------
     // Getters / setters
     // -----------------------------------------------------------------------
 
@@ -911,6 +1027,30 @@ public class InpatientDirectIssueNativeSqlController implements Serializable {
 
     public double getMarginTotal() {
         return marginTotal;
+    }
+
+    public BillItemData getItemDataForSubstitution() {
+        return itemDataForSubstitution;
+    }
+
+    public void setItemDataForSubstitution(BillItemData itemDataForSubstitution) {
+        this.itemDataForSubstitution = itemDataForSubstitution;
+    }
+
+    public StockDTO getSelectedSubstituteStock() {
+        return selectedSubstituteStock;
+    }
+
+    public void setSelectedSubstituteStock(StockDTO selectedSubstituteStock) {
+        this.selectedSubstituteStock = selectedSubstituteStock;
+    }
+
+    public List<StockDTO> getSubstituteStocks() {
+        return substituteStocks;
+    }
+
+    public void setSubstituteStocks(List<StockDTO> substituteStocks) {
+        this.substituteStocks = substituteStocks;
     }
 
     public StockDtoConverter getStockDtoConverter() {

--- a/src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml
+++ b/src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml
@@ -432,6 +432,20 @@
                                     </p:column>
                                     <p:column headerText="Item" style="min-width: 20em;">
                                         <h:outputText value="#{bid.itemName}"></h:outputText>
+                                        <p:commandButton
+                                            rendered="#{!bid.fromPackage}"
+                                            id="btnSelectSubstitute"
+                                            icon="pi pi-refresh"
+                                            title="Select a Substitute"
+                                            action="#{inpatientDirectIssueNativeSqlController.prepareSubstitute(bid)}"
+                                            update=":#{p:resolveFirstComponentWithId('substituteDlg',view).clientId}"
+                                            oncomplete="PF('substituteDialog').show();"
+                                            process="@this"
+                                            styleClass="ui-button-warning ui-button-icon-only mx-1" />
+                                        <h:outputText
+                                            rendered="#{bid.fromPackage}"
+                                            styleClass="pi pi-lock mx-1 text-muted"
+                                            title="Package-priced item — substitution not available" />
                                     </p:column>
                                     <p:column headerText="Quantity" width="8em" class="text-end">
                                         <p:inputText
@@ -512,6 +526,64 @@
                                         </p:commandButton>
                                     </p:column>
                                 </p:dataTable>
+
+                                <p:dialog
+                                    id="substituteDlg"
+                                    widgetVar="substituteDialog"
+                                    modal="true"
+                                    position="top"
+                                    fitViewport="true"
+                                    appendTo="@(body)"
+                                    header="Alternatives"
+                                    width="60%">
+                                    <div class="mb-3 p-3 bg-light border rounded">
+                                        <h:outputLabel value="Selected Item: " styleClass="fw-bold text-primary"/>
+                                        <h:outputText value="#{inpatientDirectIssueNativeSqlController.itemDataForSubstitution.itemName}" styleClass="fw-bold text-dark"/>
+                                    </div>
+                                    <p:dataTable
+                                        id="substituteTable"
+                                        value="#{inpatientDirectIssueNativeSqlController.substituteStocks}"
+                                        var="sStock"
+                                        rowKey="#{sStock.stockId}"
+                                        paginator="true"
+                                        rows="10"
+                                        paginatorPosition="bottom"
+                                        emptyMessage="No substitute stocks found"
+                                        styleClass="table-striped">
+                                        <p:column headerText="Item">
+                                            <h:outputText value="#{sStock.itemName}"/>
+                                        </p:column>
+                                        <p:column headerText="Code">
+                                            <h:outputText value="#{sStock.code}"/>
+                                        </p:column>
+                                        <p:column headerText="Rate" style="text-align: right;">
+                                            <h:outputText value="#{sStock.retailRate}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputText>
+                                        </p:column>
+                                        <p:column headerText="Stock" style="text-align: right;">
+                                            <h:outputText value="#{sStock.stockQty}">
+                                                <f:convertNumber pattern="#,###.#"/>
+                                            </h:outputText>
+                                        </p:column>
+                                        <p:column headerText="Expiry">
+                                            <h:outputText value="#{sStock.dateOfExpire}">
+                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"/>
+                                            </h:outputText>
+                                        </p:column>
+                                        <p:column headerText="Action" style="width: 8em;">
+                                            <p:commandButton
+                                                id="btnReplace"
+                                                value="Replace"
+                                                action="#{inpatientDirectIssueNativeSqlController.replaceSelectedSubstitute}"
+                                                update=":bill:pBillItems :bill:pBillDetails panelErrorMsg"
+                                                oncomplete="PF('substituteDialog').hide();"
+                                                process="@this">
+                                                <f:setPropertyActionListener value="#{sStock}" target="#{inpatientDirectIssueNativeSqlController.selectedSubstituteStock}" />
+                                            </p:commandButton>
+                                        </p:column>
+                                    </p:dataTable>
+                                </p:dialog>
                             </p:panel>
 
                             <p:panel header="Bill Details" id="pBillDetails" class="my-1" rendered="#{webUserController.hasPrivilege('ShowDrugCharges')}">


### PR DESCRIPTION
## Summary
- Adds a "Select a Substitute" action to `inward/pharmacy_bill_issue_bht.xhtml` (Direct Issue to BHTs — reached from both the Pharmacy and Inward menus, a single screen not two separate implementations), matching the alternatives feature already available on Retail Sale. Closes #22482.
- `InpatientDirectIssueNativeSqlController` gains `prepareSubstitute()` / `replaceSelectedSubstitute()`, reusing the shared native-SQL `PharmacySubstituteService.findSubstituteStocks()` lookup (FEFO-ordered, in-stock, non-expired sibling AMPs under the same VMP) already powering Retail Sale's substitute feature — no new business logic for stock resolution, just wiring this DTO-based controller into the existing shared service.
- Price-matrix margin/discount computation was extracted from `addBillItem()` into a small `computeMarginAndDiscount()` helper so the substitute swap recalculates pricing exactly the way a normal add does (this controller needs both margin *and* discount, unlike Retail Sale's simpler discount-only substitute logic).
- Package-priced lines (`bid.fromPackage`) are excluded from substitution — button is replaced with a lock icon/tooltip, and the Java methods reject the action defensively too — since the package quota was reserved for the original item specifically and swapping items would silently orphan that reservation.
- No config toggle (unlike Retail Sale's) — the button always renders; the page is already privilege-gated. No entity/DTO/schema changes; `BillItemData` already carried every field the swap needed.

## Test plan
Verified end-to-end with Playwright against the local dev DB (Main Pharmacy department, BHT/56750):
- [x] Added a bill line for an item with in-stock sibling brands under the same VMP — substitute button appeared on the row.
- [x] Opened the Alternatives dialog — FEFO-ordered sibling brands listed with stock/rate/expiry, paginated.
- [x] Replaced the line with a different sibling brand — item name, rate, gross/service-charge/discount/net values, and expiry all updated correctly in the UI, bill totals recalculated.
- [x] Settled the bill and confirmed directly in the database: the `PHARMACEUTICALBILLITEM` row for the line points at the substituted item's stock/batch (not the original), that batch's stock was decremented by the issued quantity, and the original item's stock was untouched.
- [x] Reviewed the package-priced exclusion via code (both the XHTML `rendered` conditions and the Java `isFromPackage()` guards) — did not stand up a full inpatient-package test encounter locally since that would be a large detour for a two-line boolean guard.

Screenshots and full verification notes: https://github.com/hmislk/hmis/issues/22482#issuecomment-5127461790

🤖 Generated with [Claude Code](https://claude.ai/code)