### PR TITLE
Add categoryId support to TimedItem API create/update

### DIFF
--- a/src/main/java/com/divudi/core/data/dto/timeditem/TimedItemCreateRequestDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/timeditem/TimedItemCreateRequestDTO.java
@@ -20,6 +20,7 @@ public class TimedItemCreateRequestDTO {
     private String inwardChargeType; // required
     private Long departmentId; // optional
     private Long institutionId; // optional
+    private Long categoryId; // optional (TimedItemCategory / Service Group)
     private boolean inactive = false;
 
     public TimedItemCreateRequestDTO() {
@@ -100,6 +101,14 @@ public class TimedItemCreateRequestDTO {
 
     public void setInstitutionId(Long institutionId) {
         this.institutionId = institutionId;
+    }
+
+    public Long getCategoryId() {
+        return categoryId;
+    }
+
+    public void setCategoryId(Long categoryId) {
+        this.categoryId = categoryId;
     }
 
     public boolean isInactive() {

--- a/src/main/java/com/divudi/core/data/dto/timeditem/TimedItemResponseDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/timeditem/TimedItemResponseDTO.java
@@ -30,6 +30,8 @@ public class TimedItemResponseDTO {
     private String departmentName;
     private Long institutionId;
     private String institutionName;
+    private Long categoryId;
+    private String categoryName;
     private Date createdAt;
     private List<TimedItemFeeDTO> fees;
     private String message;
@@ -155,6 +157,22 @@ public class TimedItemResponseDTO {
 
     public void setInstitutionName(String institutionName) {
         this.institutionName = institutionName;
+    }
+
+    public Long getCategoryId() {
+        return categoryId;
+    }
+
+    public void setCategoryId(Long categoryId) {
+        this.categoryId = categoryId;
+    }
+
+    public String getCategoryName() {
+        return categoryName;
+    }
+
+    public void setCategoryName(String categoryName) {
+        this.categoryName = categoryName;
     }
 
     public Date getCreatedAt() {

--- a/src/main/java/com/divudi/core/data/dto/timeditem/TimedItemUpdateRequestDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/timeditem/TimedItemUpdateRequestDTO.java
@@ -20,6 +20,7 @@ public class TimedItemUpdateRequestDTO {
     private String inwardChargeType;
     private Long departmentId;
     private Long institutionId;
+    private Long categoryId;
     private Boolean inactive;
 
     public TimedItemUpdateRequestDTO() {
@@ -28,7 +29,7 @@ public class TimedItemUpdateRequestDTO {
     public boolean isValid() {
         return hasText(name) || hasText(code) || printName != null || fullName != null
                 || hasText(departmentType) || hasText(inwardChargeType)
-                || departmentId != null || institutionId != null || inactive != null;
+                || departmentId != null || institutionId != null || categoryId != null || inactive != null;
     }
 
     private boolean hasText(String value) {
@@ -97,6 +98,14 @@ public class TimedItemUpdateRequestDTO {
 
     public void setInstitutionId(Long institutionId) {
         this.institutionId = institutionId;
+    }
+
+    public Long getCategoryId() {
+        return categoryId;
+    }
+
+    public void setCategoryId(Long categoryId) {
+        this.categoryId = categoryId;
     }
 
     public Boolean getInactive() {

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -5854,7 +5854,7 @@ public class AnthropicApiService implements Serializable {
           .append("Use LIST to search items (filter by departmentType e.g. Inward or Theatre). ")
           .append("Use GET to fetch a single item with its fees. ")
           .append("Use POST to create a new timed item — required: name, departmentType, inwardChargeType. ")
-          .append("Use PUT to update name, code, departmentType, inwardChargeType, departmentId, institutionId, or inactive flag. ")
+          .append("Use PUT to update name, code, departmentType, inwardChargeType, departmentId, institutionId, categoryId, or inactive flag. ")
           .append("Use DELETE to soft-retire an item. Use ACTIVATE / DEACTIVATE to toggle availability without retiring. ")
           .append("For tiered fee management: LIST_FEES lists all fees ordered by sortOrder. ")
           .append("POST_FEE creates a fee tier — required: name, durationHours (> 0). fee, ffee, overShootHours, sortOrder, repeating are optional. ")

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -1755,6 +1755,9 @@ public class AnthropicApiService implements Serializable {
                                 .add("institutionId", Json.createObjectBuilder()
                                         .add("type", "string")
                                         .add("description", "Institution id. Optional."))
+                                .add("categoryId", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "TimedItemCategory (Service Group) id. Optional."))
                                 .add("inactive", Json.createObjectBuilder()
                                         .add("type", "string")
                                         .add("description", "true or false — whether item is inactive. Optional."))
@@ -2391,6 +2394,7 @@ public class AnthropicApiService implements Serializable {
                     String chargeType   = toolInput.containsKey("inwardChargeType")  ? toolInput.getString("inwardChargeType", "")  : "";
                     String departmentId = toolInput.containsKey("departmentId")      ? toolInput.getString("departmentId", "")      : "";
                     String institutionId= toolInput.containsKey("institutionId")     ? toolInput.getString("institutionId", "")     : "";
+                    String categoryId   = toolInput.containsKey("categoryId")        ? toolInput.getString("categoryId", "")        : "";
                     String inactive     = toolInput.containsKey("inactive")          ? toolInput.getString("inactive", "")          : "";
                     String fee          = toolInput.containsKey("fee")               ? toolInput.getString("fee", "")               : "";
                     String ffee         = toolInput.containsKey("ffee")              ? toolInput.getString("ffee", "")              : "";
@@ -2403,7 +2407,7 @@ public class AnthropicApiService implements Serializable {
                     String size         = toolInput.containsKey("size")              ? toolInput.getString("size", "")              : "";
                     String retireComments = toolInput.containsKey("retireComments")  ? toolInput.getString("retireComments", "")    : "";
                     return callTimedItemsApi(method, id, feeId, name, code, deptType, chargeType,
-                            departmentId, institutionId, inactive,
+                            departmentId, institutionId, categoryId, inactive,
                             fee, ffee, durationHrs, overShoot, durationDays, sortOrder, repeating,
                             query, size, retireComments, hmisBaseUrl, hmisApiKey);
                 }
@@ -5507,7 +5511,7 @@ public class AnthropicApiService implements Serializable {
 
     private String callTimedItemsApi(String method, String id, String feeId, String name, String code,
             String departmentType, String inwardChargeType, String departmentId, String institutionId,
-            String inactive, String fee, String ffee, String durationHours, String overShootHours,
+            String categoryId, String inactive, String fee, String ffee, String durationHours, String overShootHours,
             String durationDaysForMoCharge, String sortOrder, String repeating,
             String query, String size, String retireComments,
             String hmisBaseUrl, String hmisApiKey) {
@@ -5548,6 +5552,7 @@ public class AnthropicApiService implements Serializable {
                     if (!code.isEmpty()) b.add("code", code);
                     if (!departmentId.isEmpty()) b.add("departmentId", Long.parseLong(departmentId));
                     if (!institutionId.isEmpty()) b.add("institutionId", Long.parseLong(institutionId));
+                    if (!categoryId.isEmpty()) b.add("categoryId", Long.parseLong(categoryId));
                     if (!inactive.isEmpty()) b.add("inactive", Boolean.parseBoolean(inactive));
                     HttpRequest req = HttpRequest.newBuilder().uri(URI.create(baseUrl))
                             .timeout(Duration.ofSeconds(15)).header("Finance", hmisApiKey)
@@ -5564,6 +5569,7 @@ public class AnthropicApiService implements Serializable {
                     if (!inwardChargeType.isEmpty()) b.add("inwardChargeType", inwardChargeType);
                     if (!departmentId.isEmpty()) b.add("departmentId", Long.parseLong(departmentId));
                     if (!institutionId.isEmpty()) b.add("institutionId", Long.parseLong(institutionId));
+                    if (!categoryId.isEmpty()) b.add("categoryId", Long.parseLong(categoryId));
                     if (!inactive.isEmpty()) b.add("inactive", Boolean.parseBoolean(inactive));
                     HttpRequest req = HttpRequest.newBuilder().uri(URI.create(baseUrl + "/" + id))
                             .timeout(Duration.ofSeconds(15)).header("Finance", hmisApiKey)
@@ -6489,8 +6495,8 @@ public class AnthropicApiService implements Serializable {
                 new String[][]{
                     {"GET",    "/timed-items/search?query=&departmentType=&limit=", "Search timed items"},
                     {"GET",    "/timed-items/{id}",          "Fetch one timed item with fees"},
-                    {"POST",   "/timed-items",               "Create timed item. Body: name, departmentType, inwardChargeType (all required); code, departmentId, institutionId, inactive optional"},
-                    {"PUT",    "/timed-items/{id}",          "Update timed item (all fields optional)"},
+                    {"POST",   "/timed-items",               "Create timed item. Body: name, departmentType, inwardChargeType (all required); code, departmentId, institutionId, categoryId, inactive optional"},
+                    {"PUT",    "/timed-items/{id}",          "Update timed item (all fields optional, including categoryId)"},
                     {"DELETE", "/timed-items/{id}",          "Soft-retire timed item"},
                     {"PATCH",  "/timed-items/{id}/activate", "Set inactive=false"},
                     {"PATCH",  "/timed-items/{id}/deactivate", "Set inactive=true"},

--- a/src/main/java/com/divudi/service/inward/TimedItemApiService.java
+++ b/src/main/java/com/divudi/service/inward/TimedItemApiService.java
@@ -14,12 +14,15 @@ import com.divudi.core.data.dto.timeditem.TimedItemResponseDTO;
 import com.divudi.core.data.dto.timeditem.TimedItemSearchResultDTO;
 import com.divudi.core.data.dto.timeditem.TimedItemUpdateRequestDTO;
 import com.divudi.core.data.inward.InwardChargeType;
+import com.divudi.core.entity.Category;
 import com.divudi.core.entity.Department;
 import com.divudi.core.entity.Institution;
 import com.divudi.core.entity.Item;
 import com.divudi.core.entity.WebUser;
 import com.divudi.core.entity.inward.TimedItem;
+import com.divudi.core.entity.inward.TimedItemCategory;
 import com.divudi.core.entity.inward.TimedItemFee;
+import com.divudi.core.facade.CategoryFacade;
 import com.divudi.core.facade.DepartmentFacade;
 import com.divudi.core.facade.InstitutionFacade;
 import com.divudi.core.facade.TimedItemFacade;
@@ -56,6 +59,9 @@ public class TimedItemApiService implements Serializable {
 
     @EJB
     private InstitutionFacade institutionFacade;
+
+    @EJB
+    private CategoryFacade categoryFacade;
 
     // =========================================================================
     // Search
@@ -167,6 +173,10 @@ public class TimedItemApiService implements Serializable {
             item.setInstitution(inst);
         }
 
+        if (request.getCategoryId() != null) {
+            item.setCategory(resolveCategory(request.getCategoryId()));
+        }
+
         item.setCreater(user);
         item.setCreatedAt(Calendar.getInstance().getTime());
 
@@ -233,6 +243,9 @@ public class TimedItemApiService implements Serializable {
                 throw new Exception("Institution not found with ID: " + request.getInstitutionId());
             }
             item.setInstitution(inst);
+        }
+        if (request.getCategoryId() != null) {
+            item.setCategory(resolveCategory(request.getCategoryId()));
         }
 
         item.setEditer(user);
@@ -390,6 +403,14 @@ public class TimedItemApiService implements Serializable {
     // Private helpers
     // =========================================================================
 
+    private TimedItemCategory resolveCategory(Long categoryId) throws Exception {
+        Category category = categoryFacade.find(categoryId);
+        if (category == null || !(category instanceof TimedItemCategory)) {
+            throw new Exception("TimedItemCategory not found with ID: " + categoryId);
+        }
+        return (TimedItemCategory) category;
+    }
+
     private TimedItem loadAndValidate(Long id) throws Exception {
         if (id == null) {
             throw new Exception("TimedItem ID is required");
@@ -486,6 +507,10 @@ public class TimedItemApiService implements Serializable {
         if (item.getInstitution() != null) {
             dto.setInstitutionId(item.getInstitution().getId());
             dto.setInstitutionName(item.getInstitution().getName());
+        }
+        if (item.getCategory() != null) {
+            dto.setCategoryId(item.getCategory().getId());
+            dto.setCategoryName(item.getCategory().getName());
         }
         dto.setCreatedAt(item.getCreatedAt());
 

--- a/src/main/java/com/divudi/service/inward/TimedItemApiService.java
+++ b/src/main/java/com/divudi/service/inward/TimedItemApiService.java
@@ -405,7 +405,7 @@ public class TimedItemApiService implements Serializable {
 
     private TimedItemCategory resolveCategory(Long categoryId) throws Exception {
         Category category = categoryFacade.find(categoryId);
-        if (category == null || !(category instanceof TimedItemCategory)) {
+        if (category == null || !(category instanceof TimedItemCategory) || category.isRetired()) {
             throw new Exception("TimedItemCategory not found with ID: " + categoryId);
         }
         return (TimedItemCategory) category;


### PR DESCRIPTION
## Summary
- `TimedItemApi` could create timed items and `TimedItemCategory` service groups, but had no way to link the two — `CATEGORY_ID` always stayed `NULL` for API-driven items.
- Added optional `categoryId` to `TimedItemCreateRequestDTO` and `TimedItemUpdateRequestDTO`.
- `TimedItemApiService.createTimedItem`/`updateTimedItem` resolve `categoryId` via `CategoryFacade`, validating it's a `TimedItemCategory` (following the existing `departmentId`/`institutionId` pattern, including the "not found" 404 error path).
- `TimedItemResponseDTO` now returns `categoryId`/`categoryName`.
- Threaded `categoryId` through the `manage_timed_items` AI chat tool (`AnthropicApiService`: tool schema, `executeToolCall`, `callTimedItemsApi`, and the system-prompt module description) so AI Chat can also set the category.
- The create response already includes the new item's `id` (`TimedItemResponseDTO.id` was already populated), so no change was needed there.

## Test plan
- [ ] `POST /api/timed-items/categories` to create a category, then `POST /api/timed-items` with `categoryId` set — verify `CATEGORY_ID` is populated and the response includes `categoryId`/`categoryName`.
- [ ] `PUT /api/timed-items/{id}` with `categoryId` — verify the category updates.
- [ ] `PUT`/`POST` with an invalid `categoryId` (non-existent or non-`TimedItemCategory` id) — verify a 404/400 error is returned.
- [ ] AI Chat: prompt `manage_timed_items` tool with a `categoryId` on create/update and confirm the category is set.

Closes #22507

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTzYEMaWkFBACtirX7xVXx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Timed items can now be assigned to a category when created or updated.
  * Timed item responses now include the associated category ID and name.
  * AI-assisted timed item management now supports an optional category parameter.
* **Validation**
  * Category assignments are validated against valid timed-item categories, and retired categories are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->