### PR TITLE
fix(session): invalidate HTTP session on logout, refresh TimedItem list per request

### DIFF
--- a/src/main/java/com/divudi/bean/common/SessionController.java
+++ b/src/main/java/com/divudi/bean/common/SessionController.java
@@ -353,6 +353,8 @@ public class SessionController implements Serializable, HttpSessionListener {
         } catch (Exception e) {
             e.printStackTrace();
         }
+
+        thisLogin = null;
     }
 
     @Override

--- a/src/main/java/com/divudi/bean/common/SessionController.java
+++ b/src/main/java/com/divudi/bean/common/SessionController.java
@@ -83,6 +83,7 @@ import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.servlet.http.HttpSession;
 import javax.servlet.http.HttpSessionEvent;
 import javax.servlet.http.HttpSessionListener;
 import javax.faces.context.FacesContext;
@@ -2178,6 +2179,40 @@ public class SessionController implements Serializable, HttpSessionListener {
         paymentManagementAfterShiftStart = null;
         availableDepartmentTypesForPharmacyTransactions = null;
         financialTransactionController.resetForLogout();
+        invalidateHttpSession();
+    }
+
+    /**
+     * Invalidates the underlying HttpSession so all @SessionScoped beans
+     * (including their cached reference lists, e.g. #22509) are destroyed
+     * on logout instead of surviving into the next login on the same
+     * browser session (#22508).
+     *
+     * Skips the redirect when already on logout.xhtml (session-timeout
+     * flow) so that page's own "session timed out, please log in again"
+     * message and Login button still render instead of being bounced
+     * straight to the index page.
+     */
+    private void invalidateHttpSession() {
+        FacesContext ctx = FacesContext.getCurrentInstance();
+        if (ctx == null) {
+            return;
+        }
+        Object session = ctx.getExternalContext().getSession(false);
+        if (session instanceof HttpSession) {
+            ((HttpSession) session).invalidate();
+        }
+        String viewId = ctx.getViewRoot() != null ? ctx.getViewRoot().getViewId() : null;
+        if (viewId != null && viewId.contains("logout.xhtml")) {
+            return;
+        }
+        try {
+            String redirectUrl = ctx.getExternalContext().getRequestContextPath() + "/faces/index.xhtml";
+            ctx.getExternalContext().redirect(redirectUrl);
+            ctx.responseComplete();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
 
     public WebUser getCurrent() {

--- a/src/main/java/com/divudi/bean/inward/TimedItemController.java
+++ b/src/main/java/com/divudi/bean/inward/TimedItemController.java
@@ -382,9 +382,7 @@ public class TimedItemController implements Serializable {
     }
 
     public List<TimedItem> getItems() {
-        if (items == null) {
-            fillItems();
-        }
+        fillItems();
         return items;
     }
 


### PR DESCRIPTION
## Summary
- `SessionController.logout()` cleared its own bean fields but never invalidated the underlying `HttpSession`, so every `@SessionScoped` bean (and any list it cached) survived unchanged into the next login on the same browser session. `logout()` now invalidates the session and redirects to the login page, except when already on `logout.xhtml` (the session-timeout flow keeps its own "session timed out" message and Login button instead of being redirected away mid-render).
- `TimedItemController.getItems()` cached its `TimedItem` list on first access and served it for the life of the session; it now re-queries on every call, so items created after the session started (e.g. via the REST API or another user) show up immediately. This was the confirmed reproduction case in #22509; the issue's broader ask to audit every `@SessionScoped` "cache on first read" controller is left for future follow-up since the fixes are unrelated by file/entity.

## Test plan
- [x] `mvn clean package -DskipTests` — compiles cleanly
- [x] Rebuilt and redeployed to local Payara; verified via Playwright:
  - Logged in, selected department, clicked the logout icon button on an inner page (`home.xhtml`) → correctly redirected to the login page (`index1.xhtml`) instead of re-rendering the previous page with nulled-out session state
  - No exceptions in `server.log` around the logout/redirect
  - Logged back in successfully afterward (session cleanly re-established)
  - Opened `inward/inward_timed_item.xhtml` (Manage Timed Item) — the Timed Item list box still populates correctly (`CSSD Charges`, `ICU Hourly Charge`) after the `getItems()` caching change

Closes #22508
Closes #22509

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logout handling to fully terminate the active session and ensure users are redirected correctly after signing out.
  * Ensured timed item lists refresh on every access, avoiding stale results and keeping displayed information up to date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->