### PR TITLE
fix(pharmacy): add non-mutating Bill.peekCreatedAt() to avoid getter side effect

### DIFF
--- a/src/main/java/com/divudi/core/data/dto/PharmacyBhtIssueRequestDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/PharmacyBhtIssueRequestDTO.java
@@ -50,12 +50,12 @@ public class PharmacyBhtIssueRequestDTO implements Serializable {
                 && bill.getPatientEncounter().getCurrentPatientRoom().getRoomFacilityCharge() != null
                 && bill.getPatientEncounter().getCurrentPatientRoom().getRoomFacilityCharge().getRoom() != null)
                 ? bill.getPatientEncounter().getCurrentPatientRoom().getRoomFacilityCharge().getRoom().getName() : null;
-        this.requestedAt = bill.getCreatedAt();
+        this.requestedAt = bill.peekCreatedAt();
         this.requestedByName = (bill.getCreater() != null && bill.getCreater().getWebUserPerson() != null)
                 ? bill.getCreater().getWebUserPerson().getName() : null;
         this.cancelled = bill.isCancelled();
         this.cancelledAt = (bill.isCancelled() && bill.getCancelledBill() != null)
-                ? bill.getCancelledBill().getCreatedAt() : null;
+                ? bill.getCancelledBill().peekCreatedAt() : null;
         this.cancelledByName = (bill.isCancelled() && bill.getCancelledBill() != null
                 && bill.getCancelledBill().getCreater() != null
                 && bill.getCancelledBill().getCreater().getWebUserPerson() != null)

--- a/src/main/java/com/divudi/core/data/dto/PharmacyBhtIssuedBillDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/PharmacyBhtIssuedBillDTO.java
@@ -30,10 +30,10 @@ public class PharmacyBhtIssuedBillDTO implements Serializable {
         this.bill = bill;
         this.billId = bill.getId();
         this.deptId = bill.getDeptId();
-        this.createdAt = bill.getCreatedAt();
+        this.createdAt = bill.peekCreatedAt();
         this.cancelled = bill.isCancelled();
         this.cancelledAt = (bill.isCancelled() && bill.getCancelledBill() != null)
-                ? bill.getCancelledBill().getCreatedAt() : null;
+                ? bill.getCancelledBill().peekCreatedAt() : null;
         this.cancelledByName = (bill.isCancelled() && bill.getCancelledBill() != null
                 && bill.getCancelledBill().getCreater() != null
                 && bill.getCancelledBill().getCreater().getWebUserPerson() != null)

--- a/src/main/java/com/divudi/core/entity/Bill.java
+++ b/src/main/java/com/divudi/core/entity/Bill.java
@@ -1653,6 +1653,15 @@ public class Bill implements Serializable, RetirableEntity {
         this.createdAt = createdAt;
     }
 
+    /**
+     * Read-only accessor for createdAt. Unlike getCreatedAt(), never computes or
+     * persists a fallback value - returns null if createdAt was never set. Use
+     * for display/reporting where triggering a backfill write is undesirable.
+     */
+    public Date peekCreatedAt() {
+        return createdAt;
+    }
+
     public boolean isRetired() {
         return retired;
     }


### PR DESCRIPTION
## Summary

`Bill.getCreatedAt()` lazily computes and **writes** `this.createdAt` on first access when the field is null (deriving it from `billDate`/`billTime`, or falling back to `new Date()`). Any display-only read of a bill's created-at timestamp can silently mutate a managed JPA entity, causing an unintended `UPDATE BILL SET CREATEDAT=...` at the next transaction flush.

Flagged by CodeRabbit during review of #22532, which relocated an existing `getCreatedAt()` call from XHTML EL into a DTO constructor — not a regression, but it surfaced that the underlying getter is unsafe for many display-only call sites across the codebase (~550 total `getCreatedAt()` calls, 66+ on `Bill`-typed variables across 38 files).

## Changes

- Added `Bill.peekCreatedAt()` — a genuinely non-mutating accessor that returns the raw `createdAt` field, never computing or persisting a fallback. `getCreatedAt()` itself is **unchanged**, fully backward compatible.
- Migrated the two DTOs from PR #22532 to use `peekCreatedAt()` for their display-only reads:
  - `PharmacyBhtIssueRequestDTO` (`requestedAt`, `cancelledAt`)
  - `PharmacyBhtIssuedBillDTO` (`createdAt`, `cancelledAt`)

Per the issue's own scoping note, a blanket migration of all ~550 `getCreatedAt()` call sites is explicitly out of scope — some callers may rely on the backfill-on-read behavior, and that audit is a separate effort.

## Test plan

Built and redeployed locally, then verified end-to-end via Playwright against `ward_pharmacy_bht_issue_request_list_for_issue.xhtml` (Main Pharmacy department, BHT/53360, CareCode Model Hospital demo data):

![BHT issue request list](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/22534-01-bht-issue-request-list.png)

- [x] `mvn clean package` — 185 tests pass, build succeeds
- [x] List page renders `Requested At` / `Issued` timestamps correctly for both migrated DTOs — no visual regression
- [x] "View Request" detail page shows the same Date/Time sourced through the new `peekCreatedAt()` path
- [x] **DB verification (the core bug)**: captured `BILL.CREATEDAT` for the displayed bills before and after loading both pages — all values identical before/after, confirming the page view no longer triggers an unintended `UPDATE`

Full verification detail posted on the issue: https://github.com/hmislk/hmis/issues/22534#issuecomment-5129243411

Closes #22534

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the accuracy and consistency of request, issue, and cancellation timestamps.
  * Prevented timestamp values from being implicitly derived when no original creation time is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->