### PR TITLE
fix(inward): block Hold on already-paid professional payments

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -1265,6 +1265,56 @@ Two traps found verifying issue #19168's Transfer Issue Department Type filter f
   `TransferIssueDirectController`) instead — it doesn't require a prior
   approved request and reaches the same `Bill.departmentType` stamping logic.
 
+## 50. `p:calendar`/`p:selectOneMenu` widgets can silently ignore a plain Playwright `fill()`/`click()` — drive the PrimeFaces widget JS API directly when the visible value won't stick
+
+Hit while verifying issue #22414 (blocking Hold on an already-paid professional
+fee), which needed a specific old BHT found by widening a search page's date
+filter and switching its payment-method dropdown off "Cash" (no cash-drawer
+balance locally):
+
+- **`p:calendar`**: `browser_type`/`.fill()` on the visible text input updates
+  the DOM, but on some pages the value silently reverts to today's date after
+  the next postback (`inward_search_professional_payment_due.xhtml` did this;
+  `inpatient_search.xhtml`'s calendar accepted `.fill()` normally — behavior
+  isn't consistent across pages, so don't assume either way). If a submitted
+  search comes back with unexpectedly narrow/empty results right after typing
+  a date, suspect this before suspecting the query. Fix: drive the widget
+  directly via `browser_evaluate`:
+  ```js
+  const w = PrimeFaces.widgets['widget_<id_with_colons_as_underscores>'];
+  w.setDate(new Date(2020,0,1,0,0,0));
+  w.input.val('01 Jan 2020 00:00:00').trigger('change');
+  ```
+  Find the widget name with
+  `Object.keys(PrimeFaces.widgets).filter(k => k.includes('<idFragment>'))`.
+- **`p:selectOneMenu`**: setting the underlying native `<select>`'s `.value`
+  directly (even to a matching `<option value>`) does not reliably update the
+  PrimeFaces display label — it can silently resync to a stale/wrong option.
+  What actually works is clicking the real `<li>` inside the (JS-rendered,
+  `display:none` until opened) `..._panel` element:
+  ```js
+  const panel = document.getElementById('<id_with_colons>_panel');
+  const li = Array.from(panel.querySelectorAll('li')).find(li => li.textContent.trim() === 'Cheque');
+  li.click();
+  ```
+  This fires the widget's real `itemClick` handler, which updates both the
+  hidden select and the visible label consistently.
+- Both patterns require the target element to actually exist in
+  `PrimeFaces.widgets` first — a plain `browser_click` to open the dropdown
+  panel beforehand isn't necessary once you're driving it via JS, but doing a
+  quick `browser_snapshot` after any of this is worth it to confirm the
+  visible label actually changed before submitting the form.
+- Separately: local test data can have **zero** BillFee rows with
+  `paidValue == feeValue` (nobody has ever settled a professional payment
+  through this exact local DB copy) — check with a quick SQL count before
+  assuming a "must find an already-paid row" test fixture exists; if it
+  doesn't, settle one through the real UI first (Search Outstanding
+  Professional Payments → select one row only → Settle) rather than writing
+  `paidValue` via raw SQL, so the whole flow is genuinely exercised. Settling
+  with "Cash" fails locally with "Not enough cash in your drawer" — switch
+  Payment Method to Cheque/Card/Slip/ewallet (whichever needs no drawer
+  balance) to unblock the settlement without needing a funded cash drawer.
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.

--- a/src/main/java/com/divudi/bean/inward/ProfessionalFeeHoldController.java
+++ b/src/main/java/com/divudi/bean/inward/ProfessionalFeeHoldController.java
@@ -103,7 +103,12 @@ public class ProfessionalFeeHoldController implements Serializable {
             return;
         }
         int held = 0;
+        List<String> alreadyPaidStaffNames = new ArrayList<>();
         for (BillFee bf : selectedFees) {
+            if (Boolean.TRUE.equals(bf.getCompletedPayment())) {
+                alreadyPaidStaffNames.add(bf.getStaff() != null ? bf.getStaff().getPerson().getNameWithTitle() : "Unknown");
+                continue;
+            }
             if (bf.isFeePaymentOnHold()) {
                 continue;
             }
@@ -122,7 +127,11 @@ public class ProfessionalFeeHoldController implements Serializable {
         loadProfessionalFees();
         if (held > 0) {
             JsfUtil.addSuccessMessage(held + " professional payment(s) held.");
-        } else {
+        }
+        if (!alreadyPaidStaffNames.isEmpty()) {
+            JsfUtil.addErrorMessage("Cannot hold payment(s) for " + String.join(", ", alreadyPaidStaffNames)
+                    + " because payment has already been completed.");
+        } else if (held == 0) {
             JsfUtil.addErrorMessage("Selected payment(s) are already on hold.");
         }
     }


### PR DESCRIPTION
Closes #22414

## The problem

`inward_professional_fee_hold.xhtml` (Professional Payments Report) let a
user select a `BillFee` row that had already been fully paid and click
**Hold Selected** — the fee's `feePaymentOnHold` flag was flipped to `true`
with no check on payment status at all. `BillFee` already has
`getCompletedPayment()` (paidValue == feeValue), used elsewhere to
distinguish due vs. settled fees (e.g. the `(bf.feeValue - bf.paidValue) > 0`
condition in `InwardStaffPaymentBillController`/`InwardSurgeryPaymentBillController`),
but `ProfessionalFeeHoldController.holdSelected()` never consulted it.

## The fix

In `ProfessionalFeeHoldController.holdSelected()`: skip any selected
`BillFee` where `getCompletedPayment()` is `true` (don't mutate it), and
show a growl error naming the affected doctor(s), e.g. *"Cannot hold
payment(s) for Mrs. L.P Colombage because payment has already been
completed."* This sits alongside the existing "already on hold" skip in
the same loop — no entity, JPQL, or XHTML changes needed.
`releaseHoldSelected()` is untouched; releasing a hold on a paid fee isn't
harmful and isn't part of this issue.

## Verification

Built and redeployed locally against the `coop` DB, then drove the real
flow with Playwright (BHT/56505, a fully-discharged inward admission with
one due professional fee, Dr. L.P Colombage, Rs 8,000):

1. Settled the fee for real through **Search Outstanding Professional
   Payments → Pay → Settle Professional Payment** (Cheque, since the local
   cash drawer had no balance). Confirmed in the DB: `BILLFEE.PAIDVALUE`
   went from `0` to `8000` (== `FEEVALUE`), `FEEPAYMENTONHOLD` stayed `0`.
2. Opened **Professional Payments Report** for the same BHT, selected the
   now-paid row (Hold Status still showed "Payable"), clicked **Hold
   Selected**.
   - **Before this fix**: would have set `feePaymentOnHold=1` silently.
   - **After this fix**: blocked with growl *"Cannot hold payment(s) for
     Mrs. L.P Colombage because payment has already been completed."*
     Confirmed in the DB: `FEEPAYMENTONHOLD` stayed `0`,
     `FEEPAYMENTHOLDDATETIME`/`FEEPAYMENTHOLDBY_ID` stayed `NULL`.
3. Regression-checked the happy path on a different BHT (BHT/56112, a
   still-due Rs 4,000 fee): **Hold Selected** succeeded normally
   (`FEEPAYMENTONHOLD=1`, hold-by/hold-at populated), then released the
   test hold to restore clean state.

No screenshots are attached to this PR/issue — the local test DB (`coop`)
contains real-looking patient/doctor names, and this verification pass is
documented in text only to avoid publishing any PII to a public repo.

Also recorded the PrimeFaces `p:calendar`/`p:selectOneMenu` widget-API
workaround needed to drive date filters and payment-method dropdowns
during this Playwright pass (`developer_docs/testing/playwright-e2e-workflow.md` §50).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guidance for reliably testing calendar and dropdown interactions in end-to-end workflows.
* **Bug Fixes**
  * Prevented completed professional fee payments from being placed on hold.
  * Added clearer error messages identifying staff whose completed payments cannot be held.
  * Improved handling when selected payments are already on hold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->