### PR TITLE
fix(ward-pharmacy): edit/substitute dialog silently drops form values on save

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -1337,7 +1337,7 @@ just typed silently reverts, with no error unless you also check the
 Confirmed by injecting an `XMLHttpRequest.prototype.send` hook via
 `javascript_tool` to capture the real request body and diffing the parameter
 names against a known-good submission from the same form (see issue
-#22352's `ward_pharmacy_bht_issue_request_bill.xhtml` "Edit / Substitute
+`#22352`'s `ward_pharmacy_bht_issue_request_bill.xhtml` "Edit / Substitute
 Item" dialog). The working counterpart,
 `pharmacy_bill_retail_sale_native.xhtml`'s `substituteDlg`, also uses
 `appendTo="@(body)"` but avoids the problem entirely by using

--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -1315,6 +1315,36 @@ balance locally):
   Payment Method to Cheque/Card/Slip/ewallet (whichever needs no drawer
   balance) to unblock the settlement without needing a funded cash drawer.
 
+## 51. `p:dialog appendTo="@(body)"` silently drops that dialog's own bound inputs from every AJAX submission
+
+A `p:dialog` with `appendTo="@(body)"` gets physically relocated by PrimeFaces
+to be a direct child of `<body>` in the DOM — taking it **outside** whatever
+`<h:form>` it's declared inside in the JSF source. Any `p:selectOneMenu`/
+`p:inputText` inside that dialog that's bound via a normal `value="#{...}"`
+expression (rather than captured through
+`<f:setPropertyActionListener>`/an iteration var on a `p:dataTable` row) will
+never have its value included in the form's AJAX POST body, because
+PrimeFaces serializes the enclosing `<form>`'s actual DOM subtree, and the
+dialog's inputs are no longer part of it. The request still looks legitimate
+— `javax.faces.partial.execute` correctly lists the dialog's component IDs,
+and the response comes back `200` with no exception — but the parameter
+names for those specific inputs are simply absent from the POST body, so the
+server-side bean properties they're bound to never get updated. Symptom:
+"nothing happens" when clicking Save inside the dialog — a value the user
+just typed silently reverts, with no error unless you also check the
+`update` target's message component actually renders (see #32).
+
+Confirmed by injecting an `XMLHttpRequest.prototype.send` hook via
+`javascript_tool` to capture the real request body and diffing the parameter
+names against a known-good submission from the same form (see issue
+#22352's `ward_pharmacy_bht_issue_request_bill.xhtml` "Edit / Substitute
+Item" dialog). The working counterpart,
+`pharmacy_bill_retail_sale_native.xhtml`'s `substituteDlg`, also uses
+`appendTo="@(body)"` but avoids the problem entirely by using
+`f:setPropertyActionListener` on the row's own "Replace" button instead of a
+submitted form field — worth checking as the reference pattern before
+assuming `appendTo` itself needs to be removed.
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.

--- a/src/main/webapp/ward/ward_pharmacy_bht_issue_request_bill.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_bht_issue_request_bill.xhtml
@@ -716,7 +716,6 @@
                                             widgetVar="editBillItemDialog"
                                             header="Edit / Substitute Item"
                                             modal="true"
-                                            appendTo="@(body)"
                                             width="40%"
                                             fitViewport="true">
                                             <h:panelGrid columns="2" cellpadding="6" styleClass="w-100"
@@ -750,7 +749,7 @@
                                                     class="ui-button-success"
                                                     action="#{pharmacyRequestForBhtController.saveEditedBillItem}"
                                                     process="@this cmbSubstitute txtEditQty"
-                                                    update=":#{p:resolveFirstComponentWithId('tblBillItem',view).clientId} @(.ui-messages)"
+                                                    update=":#{p:resolveFirstComponentWithId('tblBillItem',view).clientId} :#{p:resolveFirstComponentWithId('growl',view).clientId}"
                                                     oncomplete="if (args &amp;&amp; args.editSaved) { PF('editBillItemDialog').hide(); }" />
                                             </f:facet>
                                         </p:dialog>


### PR DESCRIPTION
## Summary
- Fixes #22352: after editing or substituting an item in the BHT Issue Request ("Edit / Substitute Item" dialog on `ward_pharmacy_bht_issue_request_bill.xhtml`), the change could not be saved.
- **Root cause**: the dialog used `appendTo="@(body)"`, which makes PrimeFaces physically relocate the dialog's DOM to be a direct child of `<body>` — outside the enclosing `<h:form id="bill">`. This silently excluded the `Substitute` dropdown and `Quantity` input from every AJAX submission (confirmed by intercepting the actual POST body: every other field in the form was present except these two). The request came back `200` with no exception, so the failure was invisible.
- A secondary bug compounded the "nothing happens" symptom: the Save button's `update` attribute targeted a `@(.ui-messages)` selector that matches nothing on this page (the only messages component is a `p:growl`, which renders with class `ui-growl`, not `ui-messages`), so success/error feedback was never shown to the user.
- **Fix**: removed `appendTo="@(body)"` so the dialog's inputs stay inside the form and get submitted normally, and pointed the message update target at the page's actual growl.
- Documented the `appendTo` pitfall in the Playwright E2E workflow guide (`developer_docs/testing/playwright-e2e-workflow.md`) for future reference, since a similar dialog on Retail Sale native avoids the problem entirely via `f:setPropertyActionListener` instead of bound form fields.

No Java changes were needed — `PharmacyRequestForBhtController` was already correct; this was purely an XHTML wiring bug.

## Test plan
Verified end-to-end with Playwright against the local dev DB (Main Pharmacy department, BHT/56280):
- [x] Added a bill line (Paracetamol 1.0 ml Syrup, qty 5), saved as draft.
- [x] Opened the Edit/Substitute dialog, changed quantity to 9 — dialog closed automatically, "Item updated" success message appeared, and the Bill Items table updated immediately to show qty 9.
- [x] Confirmed directly in the `coop` MySQL database that `BILLITEM.QTY` was persisted as `9` (previously it silently remained unchanged at `5` no matter what was saved).
- [x] Re-tested the validation-failure path (cleared quantity) — "Please enter a valid quantity." now displays visibly, and the dialog correctly stays open without corrupting the row.

Screenshots (patient details redacted): https://github.com/hmislk/hmis/issues/22352#issuecomment-5133776017

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the edit-substitute dialog so entered values are included in the AJAX save request.
  * Improved the post-save UI refresh to reliably update the growl notifications and the bill-item table.

* **Documentation**
  * Added Playwright end-to-end workflow troubleshooting guidance for dialog behavior with `appendTo="@(body)"`, including how to confirm missing AJAX POST parameters and a safer dialog parameter pattern reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->