### PR TITLE
fix(opd): stop Generate PHN button from wiping existing PHN

### DIFF
--- a/src/main/java/com/divudi/bean/common/PatientController.java
+++ b/src/main/java/com/divudi/bean/common/PatientController.java
@@ -489,7 +489,12 @@ public class PatientController implements Serializable, ControllerWithPatient {
             JsfUtil.addErrorMessage("No patient selected");
             return;
         }
-        current.setPhn(applicationController.createNewPersonalHealthNumber(sessionController.getInstitution()));
+        String newPhn = applicationController.createNewPersonalHealthNumber(sessionController.getInstitution());
+        if (newPhn != null) {
+            current.setPhn(newPhn);
+        } else {
+            JsfUtil.addErrorMessage("PHN generation failed. Please check PHN configuration (POI Number must be 4 characters).");
+        }
     }
 
     public void downloadAllPatients() {

--- a/src/main/webapp/opd/patient_edit.xhtml
+++ b/src/main/webapp/opd/patient_edit.xhtml
@@ -301,11 +301,11 @@
                                                 <span class="input-group-btn">
                                                     <p:commandButton
                                                         id="btnPhn"
-                                                        value="Generate" 
-                                                        process="btnPhn" 
+                                                        value="Generate"
+                                                        process="btnPhn"
                                                         disabled="#{not patientController.reGenerateePhn}"
-                                                        update="txtPhn" 
-                                                        action="#{patientController.generateNewPhnAndAssignToCurrentPatient()}" 
+                                                        update="txtPhn :growl"
+                                                        action="#{patientController.generateNewPhnAndAssignToCurrentPatient()}"
                                                         class="mx-1" />
                                                 </span>
                                             </div>


### PR DESCRIPTION
## Summary
- `PatientController.generateNewPhnAndAssignToCurrentPatient()` unconditionally overwrote `current.phn` with the result of `createNewPersonalHealthNumber(...)`, which legitimately returns `null` when PHN configuration is incomplete (no `PHN POI Number` global config and no per-institution `pointOfIssueNo`, or POI not exactly 4 chars, etc.). This silently wiped a patient's existing PHN when clicking Generate.
- Fixed to only overwrite the PHN on a successful (non-null) generation; otherwise the existing PHN is left untouched and an error message is shown.
- `opd/patient_edit.xhtml`'s Generate button `update` attribute was extended from `txtPhn` to `txtPhn :growl` — previously the error message was added to the JSF response but never rendered because the growl component (in the shared template, outside the button's original update scope) was never refreshed.

Fixes #21508

## Test plan
- [x] Rebuilt and redeployed locally (Maven `clean package` + Payara `redeploy`)
- [x] Verified with Playwright against a patient with an existing PHN (`PHN22147TEST01`):
  - Department with unconfigured PHN POI (`OPD - Diagnostic Centre`): clicking Generate leaves the PHN untouched and shows `PHN generation failed. Please check PHN configuration (POI Number must be 4 characters).` in the growl toast. Confirmed via the raw AJAX partial-response body that both the preserved field value and the growl message round-trip correctly.
  - Department with a valid PHN POI config (`OPD`, POI = `COOP`): clicking Generate replaces the old PHN with a newly generated, well-formed one (`COOP57KVVFQ6HX6`).
- [x] Verified the new PHN was correctly persisted to the database after Save (cold read via `mysql`, not a cached session value), then restored the shared test patient's original PHN afterward.
- [x] See screenshot evidence and detailed verification notes in the [issue comment](https://github.com/hmislk/hmis/issues/21508#issuecomment-5134428961).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved PHN generation handling by preventing invalid values from being assigned when generation fails.
  - Added a clear error notification when PHN generation is unsuccessful, including configuration guidance.
  - PHN generation errors now appear immediately in the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->