### PR TITLE
fix(pharmacy): separate Approved By and Printed At on GRN return note

### DIFF
--- a/src/main/webapp/resources/pharmacy/pharmacyReturnWithoutTresingA4.xhtml
+++ b/src/main/webapp/resources/pharmacy/pharmacyReturnWithoutTresingA4.xhtml
@@ -272,8 +272,12 @@
             </div>
 
             <div class="mb-4">
-                <h:outputLabel value="Approved By : #{cc.attrs.bill.approveUser.webUserPerson.nameWithTitle}" style="text-align: right!important;" rendered="#{!empty cc.attrs.bill.approveAt}"/>
-                <h:outputLabel value="Printed At : #{sessionController.currentDate}" style="text-align: right!important;"/>
+                <div>
+                    <h:outputLabel value="Approved By : #{cc.attrs.bill.approveUser.webUserPerson.nameWithTitle}" style="text-align: right!important;" rendered="#{!empty cc.attrs.bill.approveAt}"/>
+                </div>
+                <div>
+                    <h:outputLabel value="Printed At : #{sessionController.currentDate}" style="text-align: right!important;"/>
+                </div>
             </div>
 
 


### PR DESCRIPTION
## Summary
- Fixes the remaining layout issue from #18570: **Approved By** and **Printed At** now render on separate lines in the Purchase Return Note (Pharmacy Return Without Tracing print view), matching the pattern already used in `grn_return_receipt_with_costing_custom_1.xhtml`
- The header fax/email/telephone fixes mentioned in the issue were already present in the file from a prior fix and are untouched here
- JSF-only change (`pharmacyReturnWithoutTresingA4.xhtml`), no Java touched

## Test plan
- [x] Verified locally on Payara (Main Pharmacy department): created a new "Return without Receipt" bill (`MPPHDIRRET/280`) via Pharmacy → Returns and Cancellations → Return items without tracing purchase details, then confirmed the Purchase Return Note shows Approved By and Printed At on separate lines
- [x] Verified the bill was correctly persisted in the local DB (id 13988508, PHARMACY_RETURN_WITHOUT_TREASING, department 485)
- [x] Screenshot published to wiki and posted on issue #18570: https://github.com/hmislk/hmis/issues/18570#issuecomment-5134563325

Closes #18570

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the footer layout by placing the “Approved By” and “Printed At” fields in separate containers.
  * Existing visibility conditions and displayed information remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->