### PR TITLE
feat(pharmacy): show ordering-store available qty on transfer request approval

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -1345,6 +1345,57 @@ Item" dialog). The working counterpart,
 submitted form field — worth checking as the reference pattern before
 assuming `appendTo` itself needs to be removed.
 
+## 52. A non-AJAX search that looks "hung" in Playwright may actually be a real, still-running N+1 query — check a Payara thread dump before assuming the button is broken
+
+Clicking a date-filtered `ajax="false"` Search button (e.g.
+`SearchController.fillSavedTranserRequestBills()` behind
+`pharmacy_transfer_request_list_search_for_approval.xhtml`'s "Search") can
+time out on `browser_click` ("waiting for scheduled navigations to finish"),
+and every subsequent `browser_snapshot`/`browser_evaluate`/`browser_tabs`
+call on that page then also times out — indistinguishable, from Playwright's
+side, from a broken client-side handler that never reaches the server (the
+symptom described in §37). Opening a **fresh tab** in the same browser
+context can even reproduce the identical hang on the very first click,
+which looks like confirmation the page itself is broken.
+
+It isn't, necessarily. Check `server.log` first for whether the request even
+arrived — but a wide date range that doesn't filter by `billTypeAtomic`
+(only by `billType`, so it pulls every PRE **and** approved/downstream bill
+over the range) can trigger a classic EclipseLink N+1: one `ReadAllQuery` for
+the bill list, then a lazy `OneToOneMapping`/`ForeignReferenceMapping` round
+trip **per row per relationship** (`fromDepartment`, `toDepartment`,
+`creater`, `checkedBy`, …). Over hundreds of matching rows this is genuinely
+slow (multiple minutes), not stuck — but produces no new `server.log` lines
+if that code path (unlike the heavily-instrumented login flow) has no
+`LOGGER.log(...)` trace statements, making "no new log output" look like
+proof the request never arrived when it actually is just quiet.
+
+**Definitive diagnostic**: `asadmin generate-jvm-report --type=thread`,
+then `grep -A3 'http-thread-pool.*RUNNABLE'` in the output. A thread whose
+stack shows your controller method (e.g.
+`TransferRequestController.navigateToApproveRequest`) blocked in
+`SocketInputStream.socketRead0` under
+`com.mysql.cj.protocol...`/`EclipseLink` frames is **genuinely executing** —
+not stuck. `SELECT ... FROM information_schema.PROCESSLIST WHERE
+COMMAND='Query' AND ID != CONNECTION_ID()` corroborates this (a short-lived
+but constantly-refreshing row is the N+1 loop grinding through rows, not a
+single frozen query).
+
+**Fix for testing purposes**: don't fight the browser hang — stop issuing
+more clicks/tabs (each retry adds another slow in-flight request, and
+Chrome's per-origin connection cap means enough of these queued up will
+eventually make *every* tab/request against that origin appear to hang, even
+unrelated ones). Instead, narrow the date filter to the single day the
+target record was created before searching, which keeps the row count (and
+therefore the N+1 fan-out) small enough to return in a couple of seconds.
+The wide-range search's result **does** eventually land in the session-scoped
+searchController.bills once it finishes, so a plain navigate-away-and-back
+on a fresh tab can pick up the now-populated list without re-submitting.
+Verified while testing issue #22455 (Pharmacy Transfer Request Approval —
+`pharmacy_transfer_request_list_search_for_approval.xhtml` and its twin
+`pharmacy_transfer_request_list_to_approve.xhtml`, both driven by the same
+session-scoped `SearchController`).
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.

--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -1370,9 +1370,13 @@ if that code path (unlike the heavily-instrumented login flow) has no
 `LOGGER.log(...)` trace statements, making "no new log output" look like
 proof the request never arrived when it actually is just quiet.
 
-**Definitive diagnostic**: `asadmin generate-jvm-report --type=thread`,
-then `grep -A3 'http-thread-pool.*RUNNABLE'` in the output. A thread whose
-stack shows your controller method (e.g.
+**Definitive diagnostic**: `asadmin generate-jvm-report --type=thread` prints
+straight to stdout (no file to locate). Payara's report format — unlike a raw
+`jstack` dump — puts each thread's name and state on one physical line (e.g.
+`Thread "http-thread-pool::http-listener-1(2)" thread-id: 75 thread-state:
+RUNNABLE Running in native`), so a single-line `grep -A3
+'http-thread-pool.*RUNNABLE'` reliably catches it and the frames below. A
+thread whose stack shows your controller method (e.g.
 `TransferRequestController.navigateToApproveRequest`) blocked in
 `SocketInputStream.socketRead0` under
 `com.mysql.cj.protocol...`/`EclipseLink` frames is **genuinely executing** —
@@ -1382,10 +1386,10 @@ but constantly-refreshing row is the N+1 loop grinding through rows, not a
 single frozen query).
 
 **Fix for testing purposes**: don't fight the browser hang — stop issuing
-more clicks/tabs (each retry adds another slow in-flight request, and
-Chrome's per-origin connection cap means enough of these queued up will
-eventually make *every* tab/request against that origin appear to hang, even
-unrelated ones). Instead, narrow the date filter to the single day the
+more clicks/tabs. Each retry adds another slow in-flight request; enough of
+these piling up can exhaust server thread-pool, session, or DB connection
+capacity, making *every* tab/request against that origin appear to hang, even
+unrelated ones. Instead, narrow the date filter to the single day the
 target record was created before searching, which keeps the row count (and
 therefore the N+1 fan-out) small enough to return in a couple of seconds.
 The wide-range search's result **does** eventually land in the session-scoped

--- a/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
@@ -56,6 +56,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.WeakHashMap;
 import javax.annotation.PostConstruct;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
@@ -323,11 +324,26 @@ public class TransferRequestController implements Serializable {
         getPharmacyController().fillItemDetails(bi.getItem());
     }
 
+    private final Map<BillItem, Double> availableQtyAtOrderingStoreCache = new WeakHashMap<>();
+
     public double getAvailableQtyAtOrderingStore(BillItem bi) {
         if (bi == null || bi.getItem() == null || getToDepartment() == null) {
             return 0.0;
         }
-        return stockService.findDepartmentStock(getToDepartment(), bi.getItem());
+        return availableQtyAtOrderingStoreCache.computeIfAbsent(bi, this::calculateAvailableQtyAtOrderingStore);
+    }
+
+    private double calculateAvailableQtyAtOrderingStore(BillItem bi) {
+        Item item = bi.getItem();
+        double stock = stockService.findDepartmentStock(getToDepartment(), item);
+        if ((item instanceof Ampp || item instanceof Vmpp) && item.getDblValue() > 0) {
+            return stock / item.getDblValue();
+        }
+        return stock;
+    }
+
+    public boolean isAvailableQtyShortAtOrderingStore(BillItem bi) {
+        return getAvailableQtyAtOrderingStore(bi) < bi.getQty();
     }
 
     public void saveBill() {

--- a/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
@@ -40,6 +40,7 @@ import com.divudi.core.util.JsfUtil;
 import com.divudi.core.entity.pharmacy.Amp;
 import com.divudi.core.entity.pharmacy.Vmp;
 import com.divudi.service.BillService;
+import com.divudi.service.StockService;
 
 import java.text.DecimalFormat;
 import java.util.logging.Level;
@@ -94,6 +95,8 @@ public class TransferRequestController implements Serializable {
     private DepartmentFacade departmentFacade;
     @EJB
     BillService billService;
+    @EJB
+    private StockService stockService;
     // </editor-fold>
 
     // <editor-fold defaultstate="collapsed" desc="Controllers">
@@ -318,6 +321,13 @@ public class TransferRequestController implements Serializable {
 
     public void displayItemDetails(BillItem bi) {
         getPharmacyController().fillItemDetails(bi.getItem());
+    }
+
+    public double getAvailableQtyAtOrderingStore(BillItem bi) {
+        if (bi == null || bi.getItem() == null || getToDepartment() == null) {
+            return 0.0;
+        }
+        return stockService.findDepartmentStock(getToDepartment(), bi.getItem());
     }
 
     public void saveBill() {

--- a/src/main/java/com/divudi/service/StockService.java
+++ b/src/main/java/com/divudi/service/StockService.java
@@ -4,7 +4,9 @@ import com.divudi.core.entity.Item;
 import com.divudi.core.entity.Institution;
 import com.divudi.core.entity.Department;
 import com.divudi.core.entity.pharmacy.Amp;
+import com.divudi.core.entity.pharmacy.Ampp;
 import com.divudi.core.entity.pharmacy.Vmp;
+import com.divudi.core.entity.pharmacy.Vmpp;
 import com.divudi.core.entity.pharmacy.Stock;
 import com.divudi.core.data.StockValueRow;
 import com.divudi.core.entity.Department;
@@ -170,9 +172,21 @@ public class StockService {
             List<Amp> amps = new ArrayList<>();
             amps.add(amp);
             return findStock(department, amps);
+        } else if (item instanceof Ampp) {
+            Amp amp = ((Ampp) item).getAmp();
+            if (amp == null) {
+                return 0.0;
+            }
+            return findDepartmentStock(department, amp);
         } else if (item instanceof Vmp) {
             List<Amp> amps = ampsOfVmp(item);
             return findStock(department, amps);
+        } else if (item instanceof Vmpp) {
+            Vmp vmp = ((Vmpp) item).getVmp();
+            if (vmp == null) {
+                return 0.0;
+            }
+            return findDepartmentStock(department, vmp);
         } else {
             return 0.0;
         }

--- a/src/main/webapp/pharmacy/pharmacy_transfer_request_approval.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_request_approval.xhtml
@@ -98,7 +98,7 @@
                                     <p:column headerText="Available Qty (Ordering Store)" class="text-end" width="10em">
                                         <h:outputText
                                             value="#{transferRequestController.getAvailableQtyAtOrderingStore(bi)}"
-                                            styleClass="#{transferRequestController.getAvailableQtyAtOrderingStore(bi) lt bi.qty ? 'text-danger fw-bold' : ''}">
+                                            styleClass="#{transferRequestController.isAvailableQtyShortAtOrderingStore(bi) ? 'text-danger fw-bold' : ''}">
                                             <f:convertNumber pattern="#,##0.#"/>
                                         </h:outputText>
                                     </p:column>

--- a/src/main/webapp/pharmacy/pharmacy_transfer_request_approval.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_request_approval.xhtml
@@ -95,6 +95,14 @@
                                         </p:inputText>
                                     </p:column>
 
+                                    <p:column headerText="Available Qty (Ordering Store)" class="text-end" width="10em">
+                                        <h:outputText
+                                            value="#{transferRequestController.getAvailableQtyAtOrderingStore(bi)}"
+                                            styleClass="#{transferRequestController.getAvailableQtyAtOrderingStore(bi) lt bi.qty ? 'text-danger fw-bold' : ''}">
+                                            <f:convertNumber pattern="#,##0.#"/>
+                                        </h:outputText>
+                                    </p:column>
+
                                     <p:column headerText="Transfer Rate" class="text-end" width="8em">
                                         <p:inputText value="#{bi.billItemFinanceDetails.lineGrossRate}" class="w-100 text-end">
                                             <f:convertNumber pattern="#,##0.00" />


### PR DESCRIPTION
## Summary
- Adds an "Available Qty (Ordering Store)" column to the Pharmacy Transfer Request Approval item table (`pharmacy_transfer_request_approval.xhtml`), between "Qty" and "Transfer Rate", showing live stock at the ordering/supplying department via a new `TransferRequestController.getAvailableQtyAtOrderingStore(BillItem)` method backed by the already-injected-for-this-PR `StockService`.
- Rows where available stock is less than the requested Qty render in red/bold so approvers can spot shortages at a glance without opening History for every item.
- Fixes `StockService.findDepartmentStock` to resolve `Ampp`/`Vmpp` pack items (previously fell through to `return 0.0` for these types, unlike `Amp`/`Vmp` — misleading for the new column since pack items are common in transfer requests).

Closes #22455

## Test plan
- [x] `mvn clean package` — build green, unit tests pass (185 tests, 0 failures).
- [x] Local redeploy to Payara; verified via Playwright against a real pending transfer request (OPD Pharmacy → Main Pharmacy, request `MP/OP/26/000105`, 17 items):
  - New column renders with correct live stock numbers for every row (Amp items).
  - Shortage rows (e.g. requested qty 10 vs 0 available) render in red/bold; sufficiently-stocked rows render as plain text.
  - Cross-checked displayed numbers against the `Stock` table for the ordering department.
  - Confirmed no approval action was taken — bill left untouched (`referenceBill_id`/`approveUser` still `NULL`) since this was a read-only verification pass.
- [x] Verification screenshot and details posted to issue #22455.

![Available Qty column screenshot](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/transfer_request_approval_available_qty_column.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an “Available Qty (Ordering Store)” column to pharmacy transfer request approvals.
  - Quantities are clearly formatted and highlighted when stock is below the requested amount.
  - Availability is now supported for additional wrapped product types.

- **Documentation**
  - Added troubleshooting guidance for diagnosing slow, seemingly hung Playwright searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->