### PR TITLE
fix(pharmacy): Transfer Issue cancellation adds values instead of reducing report totals

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -2368,6 +2368,14 @@ public class PharmacyBillSearch implements Serializable {
             b.copy(nB);
             b.invertValue(nB);
 
+            if (nB.getBillItemFinanceDetails() != null) {
+                BillItemFinanceDetails invertedFinanceDetails = new BillItemFinanceDetails();
+                invertedFinanceDetails.invertValue(nB.getBillItemFinanceDetails());
+                invertedFinanceDetails.setBillItem(b);
+                invertedFinanceDetails.setCreatedAt(new Date());
+                b.setBillItemFinanceDetails(invertedFinanceDetails);
+            }
+
             b.setReferanceBillItem(nB);
 
             b.setCreatedAt(new Date());

--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueDirectController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueDirectController.java
@@ -661,9 +661,13 @@ public class TransferIssueDirectController implements Serializable {
             // reversal (TransferIssueCancellationController) read these fields; leaving
             // them null makes the issue contribute nothing to report totals, so a later
             // cancellation's positive reversal has no negative to offset (issue #21438).
-            f.setValueAtCostRate(BigDecimal.ZERO.subtract(costRate.multiply(absQtyByUnits)));
-            f.setValueAtPurchaseRate(BigDecimal.ZERO.subtract(BigDecimal.valueOf(batch.getPurcahseRate()).multiply(absQtyByUnits)));
-            f.setValueAtRetailRate(BigDecimal.ZERO.subtract(BigDecimal.valueOf(batch.getRetailsaleRate()).multiply(absQtyByUnits)));
+            // Use PharmaceuticalBillItem.qty directly (not absQtyByUnits) so this stays
+            // consistent with PharmacyReportController's COGS query, which multiplies
+            // pharmaceuticalBillItem.qty by the batch rate as-is.
+            BigDecimal absPhQty = BigDecimal.valueOf(Math.abs(b.getPharmaceuticalBillItem().getQty()));
+            f.setValueAtCostRate(BigDecimal.ZERO.subtract(costRate.multiply(absPhQty)));
+            f.setValueAtPurchaseRate(BigDecimal.ZERO.subtract(BigDecimal.valueOf(batch.getPurcahseRate()).multiply(absPhQty)));
+            f.setValueAtRetailRate(BigDecimal.ZERO.subtract(BigDecimal.valueOf(batch.getRetailsaleRate()).multiply(absPhQty)));
         }
 
         // For AMPP items: record pack quantity as negative (user's input in packs, stock going out)

--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueDirectController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueDirectController.java
@@ -655,6 +655,15 @@ public class TransferIssueDirectController implements Serializable {
             // Use absQtyByUnits so AMPP items are costed in units, not packs
             f.setLineCost(BigDecimal.ZERO.subtract(costRate.multiply(absQtyByUnits)));
             f.setTotalCost(BigDecimal.ZERO.subtract(costRate.multiply(absQtyByUnits)));
+
+            // Value estimates: negative for stock-out (stock valuation reduces).
+            // Disbursement reports (e.g. Detailed Transfer Listing) and cancellation
+            // reversal (TransferIssueCancellationController) read these fields; leaving
+            // them null makes the issue contribute nothing to report totals, so a later
+            // cancellation's positive reversal has no negative to offset (issue #21438).
+            f.setValueAtCostRate(BigDecimal.ZERO.subtract(costRate.multiply(absQtyByUnits)));
+            f.setValueAtPurchaseRate(BigDecimal.ZERO.subtract(BigDecimal.valueOf(batch.getPurcahseRate()).multiply(absQtyByUnits)));
+            f.setValueAtRetailRate(BigDecimal.ZERO.subtract(BigDecimal.valueOf(batch.getRetailsaleRate()).multiply(absQtyByUnits)));
         }
 
         // For AMPP items: record pack quantity as negative (user's input in packs, stock going out)

--- a/src/main/java/com/divudi/bean/store/StoreBillSearch.java
+++ b/src/main/java/com/divudi/bean/store/StoreBillSearch.java
@@ -21,6 +21,7 @@ import com.divudi.core.entity.BillComponent;
 import com.divudi.core.entity.BillEntry;
 import com.divudi.core.entity.BillFee;
 import com.divudi.core.entity.BillItem;
+import com.divudi.core.entity.BillItemFinanceDetails;
 import com.divudi.core.entity.CancelledBill;
 import com.divudi.core.entity.PaymentScheme;
 import com.divudi.core.entity.RefundBill;
@@ -873,6 +874,14 @@ public class StoreBillSearch implements Serializable {
             b.setBill(can);
             b.copy(nB);
             b.invertValue(nB);
+
+            if (nB.getBillItemFinanceDetails() != null) {
+                BillItemFinanceDetails invertedFinanceDetails = new BillItemFinanceDetails();
+                invertedFinanceDetails.invertValue(nB.getBillItemFinanceDetails());
+                invertedFinanceDetails.setBillItem(b);
+                invertedFinanceDetails.setCreatedAt(new Date());
+                b.setBillItemFinanceDetails(invertedFinanceDetails);
+            }
 
             b.setReferanceBillItem(nB);
 


### PR DESCRIPTION
## Summary

Fixes #21438. Root cause was in two places, not one:

- **`TransferIssueDirectController`** (the current "Direct Issue"
  creation flow) never populated `BillItemFinanceDetails.valueAtCostRate`
  / `valueAtPurchaseRate` / `valueAtRetailRate` on the original issue
  bill — confirmed via DB, these were `NULL`, and the Detailed
  Transfer Listing report showed **0.00** totals for a real
  transaction.
- **`PharmacyBillSearch`/`StoreBillSearch.pharmacyCancelIssuedItems()`**
  (a legacy cancellation path still reachable via
  `pharmacy_cancel_transfer_issue.xhtml`) never created/inverted
  `BillItemFinanceDetails` on the cancellation bill at all — unlike
  its sibling `pharmacyCancelReceivedItems()`, which already does this
  correctly.

Together these explain the reported symptom: because the original
issue contributed nothing to the report, a cancellation (via the
already-correct `TransferIssueCancellationController`) added a
positive value with no negative to offset — totals only ever grew.

## Changes

- `TransferIssueDirectController.updateBillItemRateAndValueForDirectIssue()`:
  set `valueAtCostRate`/`valueAtPurchaseRate`/`valueAtRetailRate`
  negative (stock-out), matching the convention already used in
  `TransferIssueController`.
- `PharmacyBillSearch.pharmacyCancelIssuedItems()` and
  `StoreBillSearch`'s equivalent: invert `BillItemFinanceDetails`
  using the existing `BillItemFinanceDetails.invertValue()` helper,
  mirroring `pharmacyCancelReceivedItems()`.

No changes to `TransferIssueCancellationController`,
`ReportsTransfer`, or `PharmacyReportController` — those were already
correct.

## COGS impact: none

`PharmacyReportController.retrievePurchaseAndCostValues()` (the Cost
of Goods Sold engine) never reads `BillItemFinanceDetails` — it sums
`pharmaceuticalBillItem.qty * itemBatch.rate` directly, and that field
was already correctly signed on both the create and cancel paths.
Verified: original issue (-2,871.78 cost) + cancellation (+2,871.78
cost) = exactly 0. COGS Variance row showed **-0.00 / -0.00 / 0.00**
before and is structurally unaffected by this change since it doesn't
touch the fields COGS reads.

## Test plan

- [x] `mvn clean package` — 185 tests pass, 0 failures
- [x] Created a fresh Transfer Issue (Main Pharmacy → Endoscopy) via
  the current "Direct Issue" flow; Detailed Transfer Listing report
  correctly showed the transaction (3,360.00 retail / 2,871.78
  purchase) instead of 0.00
- [x] Cancelled the same bill via the modern cancellation flow
  (`TransferIssueCancellationController`); report totals correctly
  returned to 0.00 (net zero)
- [x] Verified via direct DB query that both bills'
  `BillItemFinanceDetails.valueAtCostRate/valueAtPurchaseRate/valueAtRetailRate`
  are exact positive/negative mirrors of each other
- [x] Confirmed COGS report shows no variance for the affected
  department/period before the test transaction

Screenshots (before/after fix, cancellation preview, report
netting to zero): see the [issue comment](https://github.com/hmislk/hmis/issues/21438#issuecomment-5137196706).

Closes #21438

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cancellation handling for pharmacy and store-issued items by preserving and reversing associated financial details.
  - Corrected valuation for direct transfer issues by applying negative cost, purchase, and retail rates based on quantities and batch pricing.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->