### PR TITLE
fix(pharmacy): fix Pharmacy Return Without Traising bill search returning zero results

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -1345,6 +1345,23 @@ Item" dialog). The working counterpart,
 submitted form field — worth checking as the reference pattern before
 assuming `appendTo` itself needs to be removed.
 
+## 52. "Pharmacy Bill Search by Bill Type" has two different pages — pick the one keyed on `billType`, not `billTypeAtomic`
+
+Two separate JSF pages both claim to be the pharmacy bill-type search: `pharmacy/pharmacy_search.xhtml`
+(dropdown bound to `searchController.billType`, the plain `BillType` enum) and
+`pharmacy/pharmacy_search_by_bill_type_atomic.xhtml` (dropdown bound to `searchController.billTypeAtomic`,
+the finer-grained `BillTypeAtomic` enum). Both render a "Pharmacy Bill Search" panel with a Bill Type
+dropdown, so it's easy to land on the wrong one and see misleading results. For
+`PHARMACY_RETURN_WITHOUT_TREASING`/`PharmacyReturnWithoutTraising` specifically, the atomic-driven page is
+**dead for this bill type**: `BillTypeAtomic.PHARMACY_RETURN_WITHOUT_TREASING`'s constructor declares its
+associated `BillType` as `PharmacySale` (not `PharmacyReturnWithoutTraising`), so the atomic page's
+`rendered="#{searchController.billTypeAtomic.billType eq 'PharmacyReturnWithoutTraising'}"` panel can never
+match — selecting "Pharmacy Return without a Receipt" there silently falls through to an unrelated stale
+"SALE BILL SEARCH" panel showing "No Bills Found", with no error. Grep
+`BillTypeAtomic.java` for other atomics whose declared `BillType` doesn't match their own name before trusting
+the atomic-based search page for a given bill type — `pharmacy_search.xhtml`'s plain-`billType` dropdown is
+the reliable one when in doubt. Found verifying issue #22563.
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -5837,7 +5837,7 @@ public class PharmacyBillSearch implements Serializable {
                 + "b.refunded, rb.createdAt, COALESCE(refunderPerson.name, ''), "
                 + "COALESCE(cb.comments, rb.comments, ''), "
                 + "b.netTotal, b.pharmacyBill.saleValue, COALESCE(b.comments, '')) "
-                + "FROM BilledBill b "
+                + "FROM PreBill b "
                 + "LEFT JOIN b.creater creater LEFT JOIN creater.webUserPerson creatorPerson "
                 + "LEFT JOIN b.cancelledBill cb LEFT JOIN cb.creater canceller "
                 + "LEFT JOIN canceller.webUserPerson cancellerPerson "


### PR DESCRIPTION
## Summary
- `PharmacyBillSearch.fetchReturnWithoutTraisingSearchDtos()` queried `FROM BilledBill b`, but bills of type `PharmacyReturnWithoutTraising` are always persisted as `PreBill` (`PharmacyReturnwithouttresing` always calls `new PreBill()`). `BilledBill` and `PreBill` are sibling subclasses of `Bill`, so the DTYPE filter could never match — the search always returned zero rows for every one of the 252 existing bills of this type.
- Fixed by changing the query to `FROM PreBill b`, matching the existing pattern already used by the sibling `fetchPreBillSearchDtos()` method in the same file.
- Documented a related but out-of-scope finding in the Playwright E2E workflow doc: `pharmacy_search_by_bill_type_atomic.xhtml`'s `BillTypeAtomic`-driven dropdown can never reach this composite for this bill type, since `PHARMACY_RETURN_WITHOUT_TREASING` declares `BillType.PharmacySale` in its own metadata (a separate, pre-existing issue not touched here).

## Test plan
- [x] Rebuilt and redeployed to local Payara.
- [x] Logged in as `Main Pharmacy`, created a fresh test bill `MPPHDIRRET/280` (id 13988508) via the "Return without Receipt" flow; confirmed `DTYPE='PreBill'` in the DB.
- [x] Reproduced the bug pre-fix: Pharmacy → Pharmacy Bill Search by Bill Type → "Pharmacy Return Without Traising" → "No Return Without Receipt Bills Found" for any date range.
- [x] After the fix: same search correctly returns `MPPHDIRRET/280` with supplier, billed-at date, biller, net return value, retail sale value, and comments populated.
- [x] Cross-checked against the DB directly — exactly 1 matching row for the department/date range used, matching the 1 row shown in the UI.
- [x] Verified no other `FROM BilledBill` query in `PharmacyBillSearch.java` matches this bill type (isolated fix).

Verification evidence and screenshot: hmislk/hmis#22563 (comment)

Closes #22563

🤖 Generated with [Claude Code](https://claude.com/claude-code)