### PR TITLE
fix(pharmacy): stop Disposal Issue Return FK violation on save/finalize/settle

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/IssueReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/IssueReturnController.java
@@ -300,14 +300,17 @@ public class IssueReturnController implements Serializable {
      * not-yet-persisted draft as part of a Finalize action already
      * authorized under FinalizeDisposalReturn.
      */
-    private void doSaveDisposalIssueReturnBill() {
+    private boolean doSaveDisposalIssueReturnBill() {
         if (disposalReturnAlreadyProcessed()) {
-            return;
+            return false;
         }
         // No validation required for saving drafts - users can save incomplete data
-        saveBill();
+        if (!saveBill()) {
+            return false;
+        }
         saveBillComponents();
         JsfUtil.addSuccessMessage("Saved");
+        return true;
     }
 
     // synchronized: no double-click guard exists on the Finalize action. Although
@@ -344,7 +347,9 @@ public class IssueReturnController implements Serializable {
             return;
         }
 
-        doSaveDisposalIssueReturnBill();
+        if (!doSaveDisposalIssueReturnBill()) {
+            return;
+        }
         // Reload from DB so we don't trigger orphan-removal on billItems
         returnBill = billService.reloadBill(getReturnBill());
         if (returnBill != null) {
@@ -398,8 +403,12 @@ public class IssueReturnController implements Serializable {
             return;
         }
         calculateBillTotal();
-        saveSettlingBill();
-        saveSettlingBillComponents();
+        if (!saveSettlingBill()) {
+            return;
+        }
+        if (!saveSettlingBillComponents()) {
+            return;
+        }
 
         // Reload both bills so EclipseLink doesn't orphan-remove existing billItems
         Bill freshReturn = billService.reloadBill(getReturnBill());
@@ -574,7 +583,7 @@ public class IssueReturnController implements Serializable {
         originalBillItems = null;
     }
 
-    private void saveBill() {
+    private boolean saveBill() {
         if (getReturnBill().getReferenceBill() == null) {
             getReturnBill().setReferenceBill(originalBill);
         }
@@ -597,20 +606,39 @@ public class IssueReturnController implements Serializable {
             // before the reload replaces the entity, or they'd be silently lost.
             Bill referenceBill = getReturnBill().getReferenceBill();
             String comments = getReturnBill().getComments();
-            returnBill = billService.reloadBill(getReturnBill());
+            Bill fresh = billService.reloadBill(getReturnBill());
+            if (fresh == null) {
+                JsfUtil.addErrorMessage("This return bill no longer exists. Please reload the page and try again.");
+                return false;
+            }
+            returnBill = fresh;
+            // Recompute bill-level totals onto the fresh entity - calculateBillItemTotals()
+            // (the per-item Return Qty ajax handler) writes total/netTotal/billFinanceDetails
+            // directly onto the in-memory bill, which the reload above just replaced.
+            calculateBillTotal();
             getReturnBill().setReferenceBill(referenceBill);
             getReturnBill().setComments(comments);
             getBillFacade().edit(getReturnBill());
         }
+        return true;
     }
 
-    private void saveSettlingBill() {
+    private boolean saveSettlingBill() {
         // Reload from DB so we don't trigger orphan-removal on billItems.
         // Bill items are managed independently by saveSettlingBillComponents() / billItemFacade.
         // Capture comments (bound directly to returnBill by the UI) before the reload
         // replaces the entity, or the user's typed comment would be silently lost.
         String comments = getReturnBill().getComments();
-        returnBill = billService.reloadBill(getReturnBill());
+        Bill fresh = billService.reloadBill(getReturnBill());
+        if (fresh == null) {
+            JsfUtil.addErrorMessage("This return bill no longer exists. Please reload the page and try again.");
+            return false;
+        }
+        returnBill = fresh;
+        // Recompute bill-level totals onto the fresh entity - calculateBillTotal() was just
+        // called by settleDisposalIssueReturnBill() before this method, and the reload above
+        // discarded whatever it had computed onto the previous in-memory bill.
+        calculateBillTotal();
 
         getReturnBill().setBillType(BillType.PharmacyIssue);
         getReturnBill().setBillTypeAtomic(BillTypeAtomic.PHARMACY_DISPOSAL_ISSUE_RETURN);
@@ -669,9 +697,10 @@ public class IssueReturnController implements Serializable {
         getReturnBill().setDeptId(deptId);
         getReturnBill().setInsId(insId);
         billFacade.edit(returnBill);
+        return true;
     }
 
-    private void saveSettlingBillComponents() {
+    private boolean saveSettlingBillComponents() {
         boolean fullyReturned = true;
         List<BillItem> itemsToProcess = new ArrayList<>(getReturnBillItems());
         for (BillItem i : itemsToProcess) {
@@ -900,16 +929,27 @@ public class IssueReturnController implements Serializable {
         }
         if (fullyReturned) {
             // Reload from DB so we don't trigger orphan-removal on billItems.
-            originalBill = billService.reloadBill(getOriginalBill());
+            Bill freshOriginal = billService.reloadBill(getOriginalBill());
+            if (freshOriginal == null) {
+                JsfUtil.addErrorMessage("The original disposal issue bill no longer exists. Please reload the page and try again.");
+                return false;
+            }
+            originalBill = freshOriginal;
             getOriginalBill().setFullReturned(true);
             getOriginalBill().setFullReturnedAt(new Date());
             getOriginalBill().setFullReturnedBy(sessionController.getLoggedUser());
             getBillFacade().edit(getOriginalBill());
         }
         // Reload from DB so we don't trigger orphan-removal on billItems.
-        returnBill = billService.reloadBill(getReturnBill());
+        Bill freshReturn = billService.reloadBill(getReturnBill());
+        if (freshReturn == null) {
+            JsfUtil.addErrorMessage("This return bill no longer exists. Please reload the page and try again.");
+            return false;
+        }
+        returnBill = freshReturn;
         getBillFacade().edit(getReturnBill());
 
+        return true;
     }
 
     private void saveBillComponents() {

--- a/src/main/java/com/divudi/bean/pharmacy/IssueReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/IssueReturnController.java
@@ -591,15 +591,26 @@ public class IssueReturnController implements Serializable {
             getReturnBill().setCreater(sessionController.getLoggedUser());
             getBillFacade().create(getReturnBill());
         } else {
-            // Null out the billItems collection before merge so EclipseLink does not treat
-            // the in-memory empty ArrayList as an authoritative orphan-removal signal.
+            // Reload from DB so we don't trigger orphan-removal on billItems.
             // Bill items are managed independently by saveBillComponents() / billItemFacade.
-            getReturnBill().setBillItems(null);
+            // Capture in-memory fields set directly by the UI (JSF binds returnBill.comments)
+            // before the reload replaces the entity, or they'd be silently lost.
+            Bill referenceBill = getReturnBill().getReferenceBill();
+            String comments = getReturnBill().getComments();
+            returnBill = billService.reloadBill(getReturnBill());
+            getReturnBill().setReferenceBill(referenceBill);
+            getReturnBill().setComments(comments);
             getBillFacade().edit(getReturnBill());
         }
     }
 
     private void saveSettlingBill() {
+        // Reload from DB so we don't trigger orphan-removal on billItems.
+        // Bill items are managed independently by saveSettlingBillComponents() / billItemFacade.
+        // Capture comments (bound directly to returnBill by the UI) before the reload
+        // replaces the entity, or the user's typed comment would be silently lost.
+        String comments = getReturnBill().getComments();
+        returnBill = billService.reloadBill(getReturnBill());
 
         getReturnBill().setBillType(BillType.PharmacyIssue);
         getReturnBill().setBillTypeAtomic(BillTypeAtomic.PHARMACY_DISPOSAL_ISSUE_RETURN);
@@ -622,7 +633,7 @@ public class IssueReturnController implements Serializable {
 
         // Copy reference information from original bill for traceability
         getReturnBill().setReferenceNumber(originalBill.getReferenceNumber());
-        getReturnBill().setComments(returnBill.getComments());
+        getReturnBill().setComments(comments);
 
         // Handle Department ID generation (independent)
         String deptId;
@@ -657,7 +668,6 @@ public class IssueReturnController implements Serializable {
         }
         getReturnBill().setDeptId(deptId);
         getReturnBill().setInsId(insId);
-        getReturnBill().setBillItems(null);
         billFacade.edit(returnBill);
     }
 
@@ -889,13 +899,15 @@ public class IssueReturnController implements Serializable {
 
         }
         if (fullyReturned) {
+            // Reload from DB so we don't trigger orphan-removal on billItems.
+            originalBill = billService.reloadBill(getOriginalBill());
             getOriginalBill().setFullReturned(true);
             getOriginalBill().setFullReturnedAt(new Date());
             getOriginalBill().setFullReturnedBy(sessionController.getLoggedUser());
-            getOriginalBill().setBillItems(null);
             getBillFacade().edit(getOriginalBill());
         }
-        getReturnBill().setBillItems(null);
+        // Reload from DB so we don't trigger orphan-removal on billItems.
+        returnBill = billService.reloadBill(getReturnBill());
         getBillFacade().edit(getReturnBill());
 
     }


### PR DESCRIPTION
## Summary

Fixes issue #21407 — finalizing/settling a Disposal Issue Return threw `SQLIntegrityConstraintViolationException` because EclipseLink tried to `DELETE FROM BILLITEM` for rows still referenced by `PHARMACEUTICALBILLITEM`.

**Root cause**: `Bill.billItems` is mapped `orphanRemoval = true`. Four call sites in `IssueReturnController` (`saveBill()`, `saveSettlingBill()`, `saveSettlingBillComponents()`) called `xxxBill.setBillItems(null)` on an **already-persisted** bill right before `getBillFacade().edit(xxxBill)`. EclipseLink interpreted the nulled collection as "all children removed" and issued the destructive delete — even though nothing in this flow ever intends to delete a `BillItem` (row-level deletion is always a soft-delete via `retired=true`, done independently through `billItemFacade`, per this project's rule that we never hard-delete `BillItem`s).

Note: a prior comment on #21407 proposed the *opposite* fix (adding `setBillItems(null)`, matching the exact anti-pattern above). That was incorrect — see the corrected root-cause writeup posted as an issue comment, cross-referencing the more detailed analysis in #21724 on this same controller.

**Fix**: replaced each `setBillItems(null)` site with `billService.reloadBill(...)` before `.edit()`, so EclipseLink always merges a freshly-loaded managed entity whose `billItems` collection is left untouched — mirroring the pattern already used correctly in this same file's `finalizeDisposalIssueReturnBill()`/`settleDisposalIssueReturnBill()` tail sections. Also preserved `comments` (and `referenceBill` where applicable) across the reload, since the UI binds the Return Comment field directly onto the Bill entity and the reload would otherwise silently discard whatever the user just typed.

## Test plan

Verified end-to-end locally via Playwright + direct DB checks:
- [x] Create a Disposal Issue (Main Pharmacy → Inward), finalize, approve
- [x] Create a Disposal Issue Return against it, save as draft (create path)
- [x] Re-save the draft (edit path — this is exactly where the bug fired)
- [x] Finalize the return
- [x] Approve/settle the return
- [x] Confirm in DB: `BillItem` row never deleted (`RETIRED=0`), still linked to its `PharmaceuticalBillItem` via FK; original bill `fullReturned=1`/`refunded=1`; return bill `completed=1`/`checked=1`
- [x] Server log clean — zero exceptions across the whole flow
- [x] Cross-checked F15 Daily Stock Value report: Issue (-22.09 cost value) and Return (+22.09 cost value) both recorded and net to zero, Opening Stock Value == Closing Stock Value

See screenshots and full writeup in the [issue #21407 comment](https://github.com/hmislk/hmis/issues/21407#issuecomment-5137518329).

Closes #21407

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pharmacy issue-return processing to prevent bill items from being unintentionally removed during edits.
  * Preserved reference bill details and comments when updating bills and settlements.
  * Improved completion processing for original and return bills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->