### PR TITLE
perf(pharmacy): fix N+1 lazy-loading on transfer-request approval search pages

### DIFF
--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -324,6 +324,10 @@ public class SearchController implements Serializable {
     private Map<Long, List<PharmacyPreBillSearchDTO>> returnBillsByParentBillId;
     // DTO list for pharmacy transfer requests
     private List<PharmacyTransferRequestListDTO> transferRequestDtos;
+    // DTO list for the transfer-request search-for-approval page (issue #22567)
+    private List<PharmacyTransferRequestListDTO> transferRequestApprovalSearchDtos;
+    // DTO list for the transfer-request "to approve" list page (issue #22567)
+    private List<PharmacyTransferRequestListDTO> transferRequestsToApproveDtos;
     // DTO list for pharmacy transfer issued list (pharmacy_transfer_issued_list.xhtml)
     private List<PharmacyTransferIssuedListDTO> transferIssuedListDtos = new ArrayList<>();
     // DTO lists for disposal issue search results
@@ -1081,23 +1085,32 @@ public class SearchController implements Serializable {
     }
 
     public void fillSavedTranserRequestBills() {
-
-        String sql = "Select bill from Bill bill where bill.retired =false "
-                + " and bill.billType = :billType "
-                + " and bill.institution = :institution "
-                + " and bill.fromDepartment = :fromDepartment "
-                + " and bill.createdAt between :fromDate and :toDate"
-                + " order by bill.createdAt desc";
-
-        Map parametersForSearching = new HashMap();
-        parametersForSearching.put("billType", BillType.PharmacyTransferRequest);
-        parametersForSearching.put("institution", sessionController.getInstitution());
-        parametersForSearching.put("fromDepartment", sessionController.getDepartment());
-        parametersForSearching.put("fromDate", getFromDate());
-        parametersForSearching.put("toDate", getToDate());
-
-        bills = getBillFacade().findByJpql(sql, parametersForSearching, TemporalType.TIMESTAMP);
-
+        String jpql = "SELECT new com.divudi.core.data.dto.PharmacyTransferRequestListDTO("
+                + "b.id, b.deptId, b.createdAt, b.department.name, "
+                + "COALESCE(creatorPerson.name, ''), b.cancelled, "
+                + "canBill.createdAt, COALESCE(canCreatorPerson.name, ''), "
+                + "CASE WHEN b.checkedBy IS NOT NULL THEN true ELSE false END, "
+                + "CASE WHEN b.approveUser IS NOT NULL THEN true ELSE false END) "
+                + "FROM Bill b "
+                + "LEFT JOIN b.creater creator "
+                + "LEFT JOIN creator.webUserPerson creatorPerson "
+                + "LEFT JOIN b.cancelledBill canBill "
+                + "LEFT JOIN canBill.creater canCreator "
+                + "LEFT JOIN canCreator.webUserPerson canCreatorPerson "
+                + "WHERE b.retired = false "
+                + "AND b.billType = :billType "
+                + "AND b.institution = :institution "
+                + "AND b.fromDepartment = :fromDepartment "
+                + "AND b.createdAt BETWEEN :fromDate AND :toDate "
+                + "ORDER BY b.createdAt DESC";
+        Map<String, Object> params = new HashMap<>();
+        params.put("billType", BillType.PharmacyTransferRequest);
+        params.put("institution", sessionController.getInstitution());
+        params.put("fromDepartment", sessionController.getDepartment());
+        params.put("fromDate", getFromDate());
+        params.put("toDate", getToDate());
+        transferRequestApprovalSearchDtos = (List<PharmacyTransferRequestListDTO>)
+                getBillFacade().findLightsByJpql(jpql, params, TemporalType.TIMESTAMP);
     }
     
     public String navigateToApproveRequests() {
@@ -6866,27 +6879,33 @@ public class SearchController implements Serializable {
     }
 
     public void fillPharmacyTransferRequestsToApprove() {
-        bills = null;
-        HashMap tmp = new HashMap();
-        String sql;
-        sql = "Select b From Bill b where "
-                + " b.checkedBy is not null "
-                + " and (b.completed = false or b.completed is null) "
-                + " and b.institution = :ins "
-                + " and b.fromDepartment = :fromDep "
-                + " and b.createdAt between :fromDate and :toDate "
-                + " and b.retired=false "
-                + " and b.billTypeAtomic= :bTp";
-
-        sql += " order by b.createdAt desc  ";
-        tmp.put("toDate", getToDate());
-        tmp.put("fromDate", getFromDate());
-        tmp.put("ins", sessionController.getInstitution());
-        tmp.put("fromDep", sessionController.getDepartment());
-        tmp.put("bTp", BillTypeAtomic.PHARMACY_TRANSFER_REQUEST_PRE);
-
-        bills = getBillFacade().findByJpql(sql, tmp, TemporalType.TIMESTAMP, maxResult);
-
+        String jpql = "SELECT new com.divudi.core.data.dto.PharmacyTransferRequestListDTO("
+                + "b.id, b.deptId, b.createdAt, COALESCE(toDept.name, ''), "
+                + "COALESCE(creatorPerson.name, ''), b.cancelled, "
+                + "canBill.createdAt, COALESCE(canCreatorPerson.name, ''), b.netTotal) "
+                + "FROM Bill b "
+                + "LEFT JOIN b.toDepartment toDept "
+                + "LEFT JOIN b.creater creator "
+                + "LEFT JOIN creator.webUserPerson creatorPerson "
+                + "LEFT JOIN b.cancelledBill canBill "
+                + "LEFT JOIN canBill.creater canCreator "
+                + "LEFT JOIN canCreator.webUserPerson canCreatorPerson "
+                + "WHERE b.checkedBy IS NOT NULL "
+                + "AND (b.completed = false OR b.completed IS NULL) "
+                + "AND b.institution = :ins "
+                + "AND b.fromDepartment = :fromDep "
+                + "AND b.createdAt BETWEEN :fromDate AND :toDate "
+                + "AND b.retired = false "
+                + "AND b.billTypeAtomic = :bTp "
+                + "ORDER BY b.createdAt DESC";
+        Map<String, Object> params = new HashMap<>();
+        params.put("ins", sessionController.getInstitution());
+        params.put("fromDep", sessionController.getDepartment());
+        params.put("fromDate", getFromDate());
+        params.put("toDate", getToDate());
+        params.put("bTp", BillTypeAtomic.PHARMACY_TRANSFER_REQUEST_PRE);
+        transferRequestsToApproveDtos = (List<PharmacyTransferRequestListDTO>)
+                getBillFacade().findLightsByJpql(jpql, params, TemporalType.TIMESTAMP, maxResult);
     }
 
     public void fillApprovedPharmacyTransferRequests() {
@@ -23585,6 +23604,22 @@ public class SearchController implements Serializable {
 
     public void setTransferRequestDtos(List<PharmacyTransferRequestListDTO> transferRequestDtos) {
         this.transferRequestDtos = transferRequestDtos;
+    }
+
+    public List<PharmacyTransferRequestListDTO> getTransferRequestApprovalSearchDtos() {
+        return transferRequestApprovalSearchDtos;
+    }
+
+    public void setTransferRequestApprovalSearchDtos(List<PharmacyTransferRequestListDTO> transferRequestApprovalSearchDtos) {
+        this.transferRequestApprovalSearchDtos = transferRequestApprovalSearchDtos;
+    }
+
+    public List<PharmacyTransferRequestListDTO> getTransferRequestsToApproveDtos() {
+        return transferRequestsToApproveDtos;
+    }
+
+    public void setTransferRequestsToApproveDtos(List<PharmacyTransferRequestListDTO> transferRequestsToApproveDtos) {
+        this.transferRequestsToApproveDtos = transferRequestsToApproveDtos;
     }
 
     public List<PharmacyTransferIssuedListDTO> getTransferIssuedListDtos() {

--- a/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
@@ -122,6 +122,9 @@ public class TransferRequestController implements Serializable {
     // <editor-fold defaultstate="collapsed" desc="Class Variables">
     private Bill bill;
     private Bill transferRequestBillPre;
+    // Bill id used for navigation from DTO-driven tables (issue #22567) that
+    // only have the bill id available, not the full Bill entity.
+    private Long billId;
     private Institution dealor;
     private BillItem currentBillItem;
     private List<BillItem> billItems;
@@ -779,6 +782,39 @@ public class TransferRequestController implements Serializable {
         return "/pharmacy/pharmacy_transfer_request_approval?faces-redirect=true";
     }
 
+    /**
+     * Navigation helper for DTO-driven tables that only have the bill id
+     * (not the full entity) available.
+     */
+    public String navigateToEditRequestById() {
+        if (billId == null) {
+            JsfUtil.addErrorMessage("No Bill Selected");
+            return "";
+        }
+        transferRequestBillPre = billFacade.find(billId);
+        return navigateToEditRequest();
+    }
+
+    // synchronized for the same double-click defense-in-depth reason as navigateToApproveRequest()
+    public synchronized String navigateToApproveRequestById() {
+        if (billId == null) {
+            JsfUtil.addErrorMessage("No Bill Selected");
+            return "";
+        }
+        transferRequestBillPre = billFacade.find(billId);
+        return navigateToApproveRequest();
+    }
+
+    public String navigateToViewApprovedRequestById() {
+        if (billId == null) {
+            JsfUtil.addErrorMessage("No Bill Selected");
+            return "";
+        }
+        bill = billFacade.find(billId);
+        printPreview = true;
+        return "/pharmacy/pharmacy_transfer_request_approval?faces-redirect=true";
+    }
+
     public void finalizeTranserRequestPreBill() {
         if (!isAuthorized("FINALIZE_REQUEST", "PharmacyDisbursementFinalizeRequest")) {
             return;
@@ -927,6 +963,14 @@ public class TransferRequestController implements Serializable {
 
     public void setBill(Bill bill) {
         this.bill = bill;
+    }
+
+    public Long getBillId() {
+        return billId;
+    }
+
+    public void setBillId(Long billId) {
+        this.billId = billId;
     }
 
     public BillItemFacade getBillItemFacade() {

--- a/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
@@ -811,6 +811,10 @@ public class TransferRequestController implements Serializable {
             return "";
         }
         bill = billFacade.find(billId);
+        if (bill == null) {
+            JsfUtil.addErrorMessage("Selected bill is no longer available");
+            return "";
+        }
         printPreview = true;
         return "/pharmacy/pharmacy_transfer_request_approval?faces-redirect=true";
     }

--- a/src/main/java/com/divudi/core/data/dto/PharmacyTransferRequestListDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/PharmacyTransferRequestListDTO.java
@@ -26,6 +26,10 @@ public class PharmacyTransferRequestListDTO implements Serializable {
     private String cancellerName;
     private Boolean completed;
     private Boolean fullyIssued;
+    private String toDepartmentName;
+    private Boolean checked;
+    private Boolean approved;
+    private Double netTotal;
     private List<PharmacyTransferRequestIssueDTO> issuedBills = new ArrayList<>();
 
     // ------------------------------------------------------------------
@@ -134,6 +138,38 @@ public class PharmacyTransferRequestListDTO implements Serializable {
         this.cancellerName = "";
     }
 
+    /**
+     * Constructor for the transfer-request search-for-approval page, adding
+     * checked/approved flags on top of the existing 8-arg constructor.
+     */
+    public PharmacyTransferRequestListDTO(Long billId, String deptId, Date createdAt,
+            String fromDepartmentName, String creatorName, Boolean cancelled,
+            Date cancelledAt, String cancellerName, Boolean checked, Boolean approved) {
+        this(billId, deptId, createdAt, fromDepartmentName, creatorName, cancelled, cancelledAt, cancellerName);
+        this.checked = checked;
+        this.approved = approved;
+    }
+
+    /**
+     * Constructor for the transfer-request "to approve" list page, which shows
+     * the destination department and requested value instead of the requester's
+     * own department name.
+     */
+    public PharmacyTransferRequestListDTO(Long billId, String deptId, Date createdAt,
+            String toDepartmentName, String creatorName, Boolean cancelled,
+            Date cancelledAt, String cancellerName, Double netTotal) {
+        this.billId = billId;
+        this.deptId = deptId;
+        this.createdAt = createdAt;
+        this.toDepartmentName = toDepartmentName;
+        this.creatorName = creatorName;
+        this.cancelled = cancelled;
+        this.cancelledAt = cancelledAt;
+        this.cancellerName = cancellerName;
+        this.completed = false;
+        this.netTotal = netTotal;
+    }
+
     // ------------------------------------------------------------------
     // Getters & Setters
     // ------------------------------------------------------------------
@@ -200,6 +236,38 @@ public class PharmacyTransferRequestListDTO implements Serializable {
 
     public void setFullyIssued(Boolean fullyIssued) {
         this.fullyIssued = fullyIssued;
+    }
+
+    public String getToDepartmentName() {
+        return toDepartmentName;
+    }
+
+    public void setToDepartmentName(String toDepartmentName) {
+        this.toDepartmentName = toDepartmentName;
+    }
+
+    public Boolean getChecked() {
+        return checked;
+    }
+
+    public void setChecked(Boolean checked) {
+        this.checked = checked;
+    }
+
+    public Boolean getApproved() {
+        return approved;
+    }
+
+    public void setApproved(Boolean approved) {
+        this.approved = approved;
+    }
+
+    public Double getNetTotal() {
+        return netTotal;
+    }
+
+    public void setNetTotal(Double netTotal) {
+        this.netTotal = netTotal;
     }
 
     public Date getCancelledAt() {

--- a/src/main/webapp/pharmacy/pharmacy_transfer_request_list_search_for_approval.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_request_list_search_for_approval.xhtml
@@ -53,8 +53,8 @@
                     </div>
 
                     <div class="col-md-10">
-                        <p:dataTable 
-                            value="#{searchController.bills}" 
+                        <p:dataTable
+                            value="#{searchController.transferRequestApprovalSearchDtos}"
                             var="p"
                             rows="10"
                             paginator="true"
@@ -100,35 +100,34 @@
                                     title="Edit Request" 
                                     icon="fas fa-edit"
                                     class="ui-button-warning m-1"
-                                    disabled="#{p.checkedBy ne null or p.cancelled eq true}"
-                                    action="#{transferRequestController.navigateToEditRequest}">
-                                    <f:setPropertyActionListener 
-                                        target="#{transferRequestController.transferRequestBillPre}"
-                                        value="#{p}"/>
+                                    disabled="#{p.checked or p.cancelled}"
+                                    action="#{transferRequestController.navigateToEditRequestById}">
+                                    <f:setPropertyActionListener
+                                        target="#{transferRequestController.billId}"
+                                        value="#{p.billId}"/>
                                 </p:commandButton>
-                                <p:commandButton 
+                                <p:commandButton
                                     id="approve"
                                     ajax="false"
-                                    title="To Approve" 
+                                    title="To Approve"
                                     icon="fas fa-check-circle"
                                     class="ui-button-success m-1"
-                                    disabled="#{p.checkedBy eq null or p.approveUser ne null or p.cancelled eq true or not webUserController.hasPrivilege('PharmacyDisbursementRequestApproval')}"
-                                    action="#{transferRequestController.navigateToApproveRequest()}"
+                                    disabled="#{not p.checked or p.approved or p.cancelled or not webUserController.hasPrivilege('PharmacyDisbursementRequestApproval')}"
+                                    action="#{transferRequestController.navigateToApproveRequestById}"
                                     onclick="return confirm('Proceed to review and approve this transfer request?');">
                                     <f:setPropertyActionListener
-                                        target="#{transferRequestController.transferRequestBillPre}"
-                                        value="#{p}"/>
+                                        target="#{transferRequestController.billId}"
+                                        value="#{p.billId}"/>
                                 </p:commandButton>
 
-                                <p:commandButton  
-                                    class="m-1"  
+                                <p:commandButton
+                                    class="m-1"
                                     icon="fa fa-eye"
-                                    title="View Bill" 
+                                    title="View Bill"
                                     ajax="false"
-                                    action="/pharmacy/pharmacy_transfer_request_approval?faces-redirect=true" 
-                                    disabled="#{p.approveUser eq null}">
-                                    <f:setPropertyActionListener target="#{transferRequestController.bill}" value="#{p}"/>
-                                    <f:setPropertyActionListener target="#{transferRequestController.printPreview}" value="true"/>
+                                    action="#{transferRequestController.navigateToViewApprovedRequestById}"
+                                    disabled="#{not p.approved}">
+                                    <f:setPropertyActionListener target="#{transferRequestController.billId}" value="#{p.billId}"/>
                                 </p:commandButton>
                             </p:column>
                         </p:dataTable>

--- a/src/main/webapp/pharmacy/pharmacy_transfer_request_list_to_approve.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_request_list_to_approve.xhtml
@@ -31,7 +31,7 @@
                         <p:inputText class="w-100" autocomplete="off" value="#{searchController.searchKeyword.department}"/>
                     </div>
                     <div class="col-md-10">
-                        <p:dataTable value="#{searchController.bills}" var="b" rows="10"
+                        <p:dataTable value="#{searchController.transferRequestsToApproveDtos}" var="b" rows="10"
                                      paginator="true"
                                      paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
                                      rowsPerPageTemplate="5,10,15" paginatorPosition="bottom">
@@ -39,7 +39,7 @@
                                 <h:outputLabel value="#{b.deptId}"/>
                             </p:column>
                             <p:column headerText="To Department" >
-                                <h:outputLabel value="#{b.toDepartment.name}"/>
+                                <h:outputLabel value="#{b.toDepartmentName}"/>
                             </p:column>
                             <p:column headerText="Requested At" >
                                 <h:outputLabel value="#{b.createdAt}">
@@ -75,10 +75,10 @@
                                     value="Approve Request"
                                     title="Approve Request"
                                     icon="fas fa-check-double" styleClass="ui-button-stage-approve mx-2"
-                                    action="#{transferRequestController.navigateToApproveRequest}"
+                                    action="#{transferRequestController.navigateToApproveRequestById}"
                                     onclick="return confirm('Proceed to review and approve this transfer request?');"
                                     disabled="#{b.cancelled eq true}">
-                                    <f:setPropertyActionListener target="#{transferRequestController.transferRequestBillPre}" value="#{b}"/>
+                                    <f:setPropertyActionListener target="#{transferRequestController.billId}" value="#{b.billId}"/>
                                 </p:commandButton>
                             </p:column>
                         </p:dataTable>


### PR DESCRIPTION
## Summary
- Replace the full-entity `Bill` queries in `SearchController.fillSavedTranserRequestBills()` and `.fillPharmacyTransferRequestsToApprove()` with a single JPQL `PharmacyTransferRequestListDTO` projection using explicit `LEFT JOIN`s (creator, cancelled-bill + its creator, to-department) — eliminates the per-row lazy loads that made a ~20-row search take multiple minutes.
- Extend `PharmacyTransferRequestListDTO` with `toDepartmentName`, `checked`, `approved`, `netTotal` via two new constructors (existing constructors untouched, per repo convention).
- Both pages' Edit/Approve/View buttons previously passed the full `Bill` entity into `TransferRequestController` via `f:setPropertyActionListener` — switched to passing just the bill id, with three new `*ById()` navigation methods (`navigateToEditRequestById()`, `navigateToApproveRequestById()`, `navigateToViewApprovedRequestById()`) that resolve the entity via `billFacade.find(billId)`, mirroring the existing pattern from #21006. The original entity-based `navigateToEditRequest()`/`navigateToApproveRequest()` are untouched — still used by `pharmacy_transfer_request_list_to_finalize.xhtml`.

## Test plan
Verified locally against the `coop` dev DB, logged in as **OPD Pharmacy**, date range covering all local test data:
- [x] `pharmacy_transfer_request_list_search_for_approval.xhtml` renders 770 matching rows instantly (previously multi-minute), with `Edit`/`To Approve`/`View` button enabled/disabled states correctly driven by the new `checked`/`approved` DTO flags for not-checked, checked-not-approved, and approved bills.
- [x] `pharmacy_transfer_request_list_to_approve.xhtml` renders `toDepartmentName` ("Main Pharmacy") and `netTotal` (108,984.10) correctly for a checked-not-approved bill.
- [x] Clicked "To Approve" on that bill — new `navigateToApproveRequestById()` correctly loaded the full `Bill` (all 10 line items, correct from/to department, correct transfer value) via `billFacade.find(billId)`.
- [x] No `SEVERE`/`Exception` entries in `server.log` across all searches and navigations (the boolean `CASE WHEN` inside the JPQL constructor expression compiled and executed correctly).

Screenshots and full verification notes: https://github.com/hmislk/hmis/issues/22567#issuecomment-5137612847

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added streamlined pharmacy transfer-request workflows for editing, approving, and viewing approved requests.
  * Approval and search lists now display destination departments, approval status, checked status, and net totals.
* **Bug Fixes**
  * Improved action availability based on each request’s current status.
  * Preserved approval permissions and existing search filters, sorting, and result limits.
  * Improved handling of missing or invalid transfer-request references during navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->