### PR TITLE
fix(pharmacy): show all users' bills in Return Without Tracing report

### DIFF
--- a/developer_docs/dto/implementation-guidelines.md
+++ b/developer_docs/dto/implementation-guidelines.md
@@ -439,6 +439,8 @@ String jpql = "SELECT new DTO("
 
 **Note:** Even with LEFT JOIN, you must join EACH level of the relationship chain separately.
 
+**🚨 An explicit `LEFT JOIN` without an alias is a hard compile error, not a silent failure.** Unlike the silent-zero-rows case above, writing `LEFT JOIN b.toInstitution` (no alias) and then still referencing `b.toInstitution.name` in SELECT/WHERE throws `EclipseLink-0 JPQLException: An identification variable must be defined for a JOIN expression` at query-build time — every call fails, wrapped in an `EJBTransactionRolledbackException`. If the caller catches and swallows the exception (`catch (Exception e) { e.printStackTrace(); return new ArrayList<>(); }`), this looks identical to "no matching rows" from the UI, with the real error only visible in `server.log`. Once you add an explicit `LEFT JOIN x.y alias`, every reference to that path in the rest of the query must go through `alias`, not `x.y` again. (Found in issue #18579 — `BillService.fetchPharmacyReturnWithoutTrasingBillDTOs`/`...BillItemDTOs` had four such unaliased joins.)
+
 ### ✅ SOLUTION 3 (Standard): COALESCE on every nullable LEFT JOIN String — always apply this
 
 Even when LEFT JOINs are present, a `null` value flowing into a `String` DTO constructor

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyReturnWithoutTrasingReportController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyReturnWithoutTrasingReportController.java
@@ -6,7 +6,6 @@ package com.divudi.bean.pharmacy;
 
 import com.divudi.bean.common.DepartmentController;
 import com.divudi.bean.common.InstitutionController;
-import com.divudi.bean.common.SessionController;
 import com.divudi.core.data.ReportViewType;
 import com.divudi.core.data.dto.PharmacyReturnWithoutTrasingBillDTO;
 import com.divudi.core.data.dto.PharmacyReturnWithoutTrasingBillItemDTO;
@@ -57,8 +56,6 @@ public class PharmacyReturnWithoutTrasingReportController implements Serializabl
     // Injected services
     @EJB
     private BillService billService;
-    @Inject
-    private SessionController sessionController;
     @Inject
     private InstitutionController institutionController;
     @Inject
@@ -126,7 +123,7 @@ public class PharmacyReturnWithoutTrasingReportController implements Serializabl
 
             // Fetch bill-level data
             billReportData = billService.fetchPharmacyReturnWithoutTrasingBillDTOs(
-                    fromDate, toDate, institution, site, department, sessionController.getLoggedUser());
+                    fromDate, toDate, institution, site, department);
 
             calculateBillSummary();
 
@@ -154,7 +151,7 @@ public class PharmacyReturnWithoutTrasingReportController implements Serializabl
 
             // Fetch item-level data
             billItemReportData = billService.fetchPharmacyReturnWithoutTrasingBillItemDTOs(
-                    fromDate, toDate, institution, site, department, sessionController.getLoggedUser());
+                    fromDate, toDate, institution, site, department);
 
             calculateBillItemSummary();
 

--- a/src/main/java/com/divudi/service/BillService.java
+++ b/src/main/java/com/divudi/service/BillService.java
@@ -1937,8 +1937,7 @@ public class BillService {
             Date toDate,
             Institution institution,
             Institution site,
-            Department department,
-            WebUser webUser) {
+            Department department) {
 
         String jpql = "SELECT COUNT(b) FROM Bill b "
                 + " WHERE b.retired = false "
@@ -1953,11 +1952,6 @@ public class BillService {
         if (institution != null) {
             jpql += " AND b.institution = :ins ";
             params.put("ins", institution);
-        }
-
-        if (webUser != null) {
-            jpql += " AND b.creater = :user ";
-            params.put("user", webUser);
         }
 
         if (department != null) {
@@ -1978,11 +1972,10 @@ public class BillService {
             Date toDate,
             Institution institution,
             Institution site,
-            Department department,
-            WebUser webUser) {
+            Department department) {
 
         // First, debug with count query
-        Long count = countPharmacyReturnWithoutTrasingBills(fromDate, toDate, institution, site, department, webUser);
+        Long count = countPharmacyReturnWithoutTrasingBills(fromDate, toDate, institution, site, department);
 
         if (count == 0) {
             return new ArrayList<>();
@@ -1998,11 +1991,11 @@ public class BillService {
                 + " coalesce(b.invoiceNumber,''), "
                 + " b.createdAt, "
                 + " b.billDate, "
-                + " coalesce(b.toInstitution.name,''), " // ✅ SAFE: Using COALESCE with direct property
-                + " b.toInstitution.id, " // ✅ SAFE: Left join handles null
-                + " coalesce(b.department.name,''), " // ✅ SAFE: Using COALESCE with direct property
-                + " b.department.id, " // ✅ SAFE: Left join handles null
-                + " coalesce(b.creater.webUserPerson.name,''), " // ⚠️ POTENTIAL ISSUE: Nested relationship
+                + " coalesce(toIns.name,''), "
+                + " toIns.id, "
+                + " coalesce(dept.name,''), "
+                + " dept.id, "
+                + " coalesce(createrPerson.name,''), "
                 + " coalesce(b.comments,''), "
                 + " coalesce(b.paymentMethod,''), "
                 + " coalesce(b.total,0.0), "
@@ -2013,10 +2006,10 @@ public class BillService {
                 + " coalesce(bfd.totalRetailSaleValue,0.0) ) "
                 + " from Bill b "
                 + " left join b.billFinanceDetails bfd "
-                + " left join b.toInstitution " // ✅ Explicit LEFT JOIN for safety
-                + " left join b.department " // ✅ Explicit LEFT JOIN for safety
-                + " left join b.creater " // ✅ Explicit LEFT JOIN for safety
-                + " left join b.creater.webUserPerson " // ✅ Explicit LEFT JOIN for nested relationship
+                + " left join b.toInstitution toIns "
+                + " left join b.department dept "
+                + " left join b.creater creater "
+                + " left join creater.webUserPerson createrPerson "
                 + " where b.retired=:ret "
                 + " and b.billTypeAtomic = :billTypeAtomic "
                 + " and b.createdAt between :fromDate and :toDate ";
@@ -2029,11 +2022,6 @@ public class BillService {
         if (institution != null) {
             jpql += " and b.institution = :ins ";
             params.put("ins", institution);
-        }
-
-        if (webUser != null) {
-            jpql += " and b.creater = :user ";
-            params.put("user", webUser);
         }
 
         if (department != null) {
@@ -2065,8 +2053,7 @@ public class BillService {
             Date toDate,
             Institution institution,
             Institution site,
-            Department department,
-            WebUser webUser) {
+            Department department) {
 
         // First verify bill items exist
         String countJpql = "SELECT COUNT(bi) FROM Bill b "
@@ -2084,11 +2071,6 @@ public class BillService {
         if (institution != null) {
             countJpql += " AND b.institution = :ins ";
             countParams.put("ins", institution);
-        }
-
-        if (webUser != null) {
-            countJpql += " AND b.creater = :user ";
-            countParams.put("user", webUser);
         }
 
         if (department != null) {
@@ -2115,7 +2097,7 @@ public class BillService {
                 + " b.id, "
                 + " coalesce(b.deptId,''), "
                 + " b.createdAt, "
-                + " coalesce(b.toInstitution.name,''), " // Direct property access with COALESCE
+                + " coalesce(toIns.name,''), "
                 + " coalesce(b.paymentMethod,''), "
                 + " coalesce(item.id,0), " // Handle null item
                 + " coalesce(item.name,''), "
@@ -2124,7 +2106,7 @@ public class BillService {
                 + " coalesce(batch.batchNo,''), "
                 + " batch.dateOfExpire, " // May be null from LEFT JOIN
                 + " coalesce(bi.qty,0.0), "
-                + " coalesce(pbi.qtyInUnit,0.0), "
+                + " coalesce(pbi.qty,0.0), "
                 + " coalesce(bifd.costRate,0.0), "
                 + " coalesce(bifd.purchaseRate,0.0), "
                 + " coalesce(bifd.retailSaleRate,0.0), "
@@ -2139,7 +2121,7 @@ public class BillService {
                 + " left join pbi.stock stock "
                 + " left join stock.itemBatch batch "
                 + " left join batch.item item "
-                + " left join b.toInstitution " // Explicit LEFT JOIN
+                + " left join b.toInstitution toIns "
                 + " where b.retired = false and bi.retired = false "
                 + " and b.billTypeAtomic = :billTypeAtomic "
                 + " and b.createdAt between :fromDate and :toDate ";
@@ -2151,11 +2133,6 @@ public class BillService {
         if (institution != null) {
             jpql += " and b.institution = :ins ";
             params.put("ins", institution);
-        }
-
-        if (webUser != null) {
-            jpql += " and b.creater = :user ";
-            params.put("user", webUser);
         }
 
         if (department != null) {


### PR DESCRIPTION
## Summary
- Fixes #18579: the Pharmacy Analytics → Procurement Reports → **Pharmacy Return Without Tracing** report was silently restricted to bills created by the currently logged-in user, even though the UI has no per-user filter (only date range / institution / site / department).
- Root cause was two compounding bugs in `BillService.java`:
  1. `countPharmacyReturnWithoutTrasingBills()`, `fetchPharmacyReturnWithoutTrasingBillDTOs()`, and `fetchPharmacyReturnWithoutTrasingBillItemDTOs()` all added `AND b.creater = :user` whenever a `webUser` was passed — and the controller always passed `sessionController.getLoggedUser()`. Removed the filter and the now-unused `webUser` parameter/import.
  2. Independently, both DTO fetch queries declared explicit `LEFT JOIN`s with **no alias** (e.g. `left join b.toInstitution`) while still referencing the original path (`b.toInstitution.name`) in SELECT/WHERE — invalid JPQL that EclipseLink rejects with `An identification variable must be defined for a JOIN expression`. The exception was caught and swallowed by the calling code, so it looked identical to "no matching rows" from the UI. Fixed by aliasing every join and referencing the alias consistently. Also fixed `pbi.qtyInUnit` (a deprecated, non-persisted getter-only alias) to the real `qty` field, which was failing to compile for the same reason.
- Added a note to `developer_docs/dto/implementation-guidelines.md` documenting the unaliased-explicit-JOIN failure mode, since it's a distinct (hard-exception, not silent-zero-rows) pitfall from what was already documented there.

## Test plan
Verified end-to-end on local Payara against the `coop` dev DB (CareCode Model Hospital demo data):
- Logged in as `buddhika`; all 41 return-without-tracing bills in the test date range (01 Oct 2025 – 31 Dec 2025, Main Pharmacy) were created by a different user (`weroshani`) — exercises the cross-user visibility fix directly.
- **By Bill** view: 41 bills, Rs 872,204.24 net total — matches a direct DB query (`SELECT COUNT(*), SUM(NETTOTAL) FROM BILL WHERE BILLTYPEATOMIC='PHARMACY_RETURN_WITHOUT_TREASING' ...`) exactly.

  ![By Bill view](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/issue_18579_return_without_tracing_by_bill_fixed.png)

- **By Bill Items** view: 99 bill items — matches a direct DB query exactly.

  ![By Bill Item view](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/issue_18579_return_without_tracing_by_bill_item_fixed.png)

- [x] Confirmed both report views previously threw a swallowed `EJBTransactionRolledbackException` / returned 0 rows before this fix (via `server.log`), and now return correct, DB-matching results.
- [x] Local build (`mvn clean package -DskipTests`) succeeds; no other callers of the changed `BillService` methods exist (`git grep` confirmed only this controller references them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)