### PR TITLE
fix(pharmacy): include cancelled retail sale atomic in COGS Sale rows

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -1417,6 +1417,24 @@ match — selecting "Pharmacy Return without a Receipt" there silently falls thr
 the atomic-based search page for a given bill type — `pharmacy_search.xhtml`'s plain-`billType` dropdown is
 the reliable one when in doubt. Found verifying issue #22563.
 
+## 54. `pharmacy_fast_retail_sale_for_cashier.xhtml` "Settle Bill At Cashier" 500s with a Patient cascade error if the Patient Name field is left blank
+
+`PharmacyFastRetailSaleForCashierController.settlePreBill()` → `settlePharmacyToken()` creates a `Token`
+referencing an in-memory `Patient` placeholder when no patient is selected/entered. Committing that
+transaction throws `IllegalStateException: During synchronization a new object was found through a
+relationship that was not marked cascade PERSIST: com.divudi.core.entity.Patient[ id=null ]`, rolling back
+the whole "Settle Bill At Cashier" action with an HTTP 500 (unrelated to whatever feature is actually under
+test). Always type something into "Enter the Name of the patient" before clicking "Settle Bill At Cashier"
+on this page — a walk-in placeholder name is enough. Found verifying issue #21419.
+
+Also for this page: "Settle Bill At Cashier" only creates a `PHARMACY_RETAIL_SALE_PRE_TO_SETTLE_AT_CASHIER`
+pre-bill and deducts stock — it does **not** create the final sale bill. To reach the actual
+`PHARMACY_RETAIL_SALE_PREBILL_SETTLED_AT_CASHIER` bill (the one with a cancellable "To Cancel" button on
+`pharmacy_reprint_bill_sale_cashier.xhtml`), separately go to `pharmacy_search_pre_bill.xhtml` → **Search
+Not Paid Tokens** → **Call Customer** → **Accept Payment** → enter Tendered amount → **Accept Payment and
+Settle**. Then from `pharmacy_search_pre_bill.xhtml` → **Search Paid Only Tokens** → **View Payment Bill**
+lands on the reprint/cancel page for that bill.
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.

--- a/src/main/java/com/divudi/bean/report/PharmacyReportController.java
+++ b/src/main/java/com/divudi/bean/report/PharmacyReportController.java
@@ -13867,9 +13867,16 @@ public class PharmacyReportController implements Serializable {
             creditTypePaymentMethods.add(PaymentMethod.Credit);
             creditTypePaymentMethods.add(PaymentMethod.Staff);
 
+            // FIX (#21419 COGS variance after cancellation): a cancelled retail sale bill
+            // gets billTypeAtomic=PHARMACY_RETAIL_SALE_CANCELLED with correctly negated
+            // PharmaceuticalBillItem qty/rates (see PharmacyBillSearch.pharmacyCancelBillItems()).
+            // Without this atomic in the list, the reversal is invisible to this row while the
+            // original sale (bills are immutable, never retired on cancellation) stays counted
+            // forever, permanently overstating this row by the cancelled bill's value.
             List<BillTypeAtomic> billTypes = Arrays.asList(
                     BillTypeAtomic.PHARMACY_RETAIL_SALE,
-                    BillTypeAtomic.PHARMACY_RETAIL_SALE_PREBILL_SETTLED_AT_CASHIER
+                    BillTypeAtomic.PHARMACY_RETAIL_SALE_PREBILL_SETTLED_AT_CASHIER,
+                    BillTypeAtomic.PHARMACY_RETAIL_SALE_CANCELLED
             );
 
             Map<String, Double> saleCreditValues = retrievePurchaseAndCostValues(" bi.bill.billTypeAtomic ", billTypes, creditTypePaymentMethods);
@@ -13950,9 +13957,13 @@ public class PharmacyReportController implements Serializable {
                     .filter(pm -> pm != PaymentMethod.Credit && pm != PaymentMethod.Staff)
                     .collect(Collectors.toList());
 
+            // FIX (#21419 COGS variance after cancellation): see the matching comment in
+            // calculateSaleCreditValue() — PHARMACY_RETAIL_SALE_CANCELLED must be included
+            // here too so a cancelled non-credit retail sale nets back out of this row.
             List<BillTypeAtomic> billTypes = Arrays.asList(
                     BillTypeAtomic.PHARMACY_RETAIL_SALE,
-                    BillTypeAtomic.PHARMACY_RETAIL_SALE_PREBILL_SETTLED_AT_CASHIER
+                    BillTypeAtomic.PHARMACY_RETAIL_SALE_PREBILL_SETTLED_AT_CASHIER,
+                    BillTypeAtomic.PHARMACY_RETAIL_SALE_CANCELLED
             );
 
             Map<String, Double> saleWithoutCreditValues = retrievePurchaseAndCostValues(billTypes, nonCreditPaymentMethods);


### PR DESCRIPTION
## Summary

Fixes #21419 — Cost of Goods Sold (COGS) report variance after bill cancellation.

Root cause: the COGS report's **"Sale"** and **"Sale Credit"** rows (`calculateSaleCreditValue()` / `calculateSaleWithoutCreditPaymentMethod()` in `PharmacyReportController.java`) filtered by `billTypeAtomic IN [PHARMACY_RETAIL_SALE, PHARMACY_RETAIL_SALE_PREBILL_SETTLED_AT_CASHIER]`. When a Cashier Sale bill is cancelled, the reversal bill is created with `billTypeAtomic = PHARMACY_RETAIL_SALE_CANCELLED` — correctly inverted via `invertValue()`, but **not included in either filter list** — so the reversal was invisible to the report while the original sale stayed fully counted forever (bills are immutable, never retired on cancellation). Net effect: cancelling a retail sale never reduced the COGS report, permanently overstating it by the cancelled amount.

- Added `PHARMACY_RETAIL_SALE_CANCELLED` to both rows' `billTypes` lists, mirroring the existing pattern already used for GRN cancellations in `calculatePurchaseReturn()`.
- Confirmed Transfer Receive (also named in the related investigation issue #21421) does **not** have this bug: that row filters by the broader `billType` (not `billTypeAtomic`), and the cancellation bill shares the same `billType` as the original, so it already nets to zero correctly — no change needed there.
- #21421's "zero the original bill's BillFinanceDetails/BillItemFinanceDetails on cancellation" theory was investigated and found **not** to be the actual cause of this report bug (confirmed with the codebase owner — bills are immutable once created, matching the pattern used by every other cancellation flow), and was intentionally left out of scope.
- #21340 (GRN/Direct-Purchase double-count in this same report) was already fixed on `development` prior to this work — verified present.

## Test plan

- [x] `mvn clean package` — BUILD SUCCESS, all existing tests pass.
- [x] Playwright, local Payara, OPD Pharmacy department: created a fresh retail sale (Panadol 500mg tab, qty 1, value 3.49), ran the COGS report — baseline "Sale" row = `-3.20 / -3.20 / -3.49` (purchase/cost/retail).
- [x] Cancelled the bill via "To Cancel" on `pharmacy_reprint_bill_sale_cashier.xhtml`.
- [x] Re-ran the COGS report — "Sale" row now `0.00 / 0.00 / 0.00`, confirming the cancellation nets against the original sale.
- [x] DB cross-check: original bill's `PharmaceuticalBillItem` values summed to `-3.2018 / -3.2018 / -3.49`; cancellation bill summed to `+3.2018 / +3.2018 / +3.49` — exact netting.
- [x] Verification screenshot and full before/after detail posted on hmislk/hmis#21419.

Screenshot: https://raw.githubusercontent.com/wiki/hmislk/hmis/images/21419-01-cogs-report-after-cancellation.png

🤖 Generated with [Claude Code](https://claude.com/claude-code)