### PR TITLE
fix(pharmacy): rename Discard Category labels to Issue Category

### DIFF
--- a/src/main/java/com/divudi/bean/common/UserPrivilageController.java
+++ b/src/main/java/com/divudi/bean/common/UserPrivilageController.java
@@ -903,7 +903,7 @@ public class UserPrivilageController implements Serializable {
         new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDisposalIssueFinalize, "Pharmacy Disposal Issue Finalize"), pharmacyDisposalNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDisposalIssueApprove, "Pharmacy Disposal Issue Approve"), pharmacyDisposalNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDisposalIssueCancel, "Pharmacy Disposal Issue Cancel"), pharmacyDisposalNode);
-        new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDiscardCategoryManage, "Pharmacy Discard Category Manage"), pharmacyDisposalNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDiscardCategoryManage, "Pharmacy Issue Category Manage"), pharmacyDisposalNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDisposalSearchIssueBill, "Pharmacy Disposal Search Issue Bill"), pharmacyDisposalNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDisposalSearchIssueBillItems, "Pharmacy Disposal Search Issue Bill Items"), pharmacyDisposalNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDisposalSearchIssueReturnBill, "Pharmacy Disposal Search Issue Return Bill"), pharmacyDisposalNode);

--- a/src/main/java/com/divudi/bean/pharmacy/DiscardCategoryController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/DiscardCategoryController.java
@@ -65,7 +65,7 @@ public class DiscardCategoryController implements Serializable {
 
     public void saveSelected() {
         if (!webUserController.hasPrivilege("PharmacyDiscardCategoryManage")) {
-            JsfUtil.addErrorMessage("You do not have the privilege to manage discard categories.");
+            JsfUtil.addErrorMessage("You do not have the privilege to manage issue categories.");
             return;
         }
 
@@ -119,7 +119,7 @@ public class DiscardCategoryController implements Serializable {
 
     public void delete() {
         if (!webUserController.hasPrivilege("PharmacyDiscardCategoryManage")) {
-            JsfUtil.addErrorMessage("You do not have the privilege to manage discard categories.");
+            JsfUtil.addErrorMessage("You do not have the privilege to manage issue categories.");
             return;
         }
 

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyIssueController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyIssueController.java
@@ -1214,6 +1214,7 @@ public class PharmacyIssueController implements Serializable {
             preBill.setCompleted(draft.isCompleted());
             preBill.setComments(draft.getComments());
             preBill.setInvoiceNumber(draft.getInvoiceNumber());
+            preBill.setReferenceNumber(draft.getReferenceNumber());
             preBill.setDepartmentType(draft.getDepartmentType());
             preBill.setBillTypeAtomic(draft.getBillTypeAtomic());
             preBill.setBillType(draft.getBillType());

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -632,7 +632,7 @@ public enum Privileges {
     PharmacyDisposalIssueFinalize("Pharmacy Disposal Issue Finalize"),
     PharmacyDisposalIssueApprove("Pharmacy Disposal Issue Approve"),
     PharmacyDisposalIssueCancel("Pharmacy Disposal Issue Cancel"),
-    PharmacyDiscardCategoryManage("Pharmacy Discard Category Manage"),
+    PharmacyDiscardCategoryManage("Pharmacy Issue Category Manage"),
     PharmacyDisposalSearchIssueBill("Pharmacy Disposal Search Issue Bill"),
     PharmacyDisposalSearchIssueBillItems("Pharmacy Disposal Search Issue Bill Items"),
     PharmacyDisposalSearchIssueReturnBill("Pharmacy Disposal Search Issue Return Bill"),

--- a/src/main/webapp/pharmacy/admin/index.xhtml
+++ b/src/main/webapp/pharmacy/admin/index.xhtml
@@ -45,7 +45,7 @@
                                                 ajax="false" 
                                                 value="Manage Units" 
                                                 action="#{measurementUnitController.navigateToManageMeasurementUnit()}"  ></p:commandButton>
-                                            <p:commandButton class="w-100" ajax="false" value="Discard Categories" action="#{pharmacyController.navigateToDiscardCategory()}" rendered="#{webUserController.hasPrivilege('PharmacyDiscardCategoryManage')}" ></p:commandButton>
+                                            <p:commandButton class="w-100" ajax="false" value="Issue Categories" action="#{pharmacyController.navigateToDiscardCategory()}" rendered="#{webUserController.hasPrivilege('PharmacyDiscardCategoryManage')}" ></p:commandButton>
                                             <p:commandButton class="w-100" ajax="false" value="Adjustment Categories" action="/pharmacy/pharmacy_adjustment_category" ></p:commandButton>
                                         </div>
                                     </p:tab>

--- a/src/main/webapp/pharmacy/pharmacy_discard_category.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_discard_category.xhtml
@@ -19,7 +19,7 @@
             <p:focus id="selectFocus" for="lstSelect" />
             <p:focus id="detailFocus" for="gpDetail" />
 
-            <p:panel header="Manage Discard Category" >
+            <p:panel header="Manage Issue Category" >
                 <div class="row">
                     <div class="col-5">
                         <p:commandButton id="btnAdd" value="Add"
@@ -49,7 +49,7 @@
                         </p:selectOneListbox>
                     </div>
                     <div class="col-7">
-                        <p:panel header="Discard Category Details">
+                        <p:panel header="Issue Category Details">
                             <h:panelGrid id="gpDetail" columns="2" class="w-100">
                                 <h:outputText id="lblName" value="Name" ></h:outputText>
                                 <p:inputText autocomplete="off" id="txtName" value="#{discardCategoryController.current.name}" class="w-100"></p:inputText>

--- a/src/main/webapp/pharmacy/pharmacy_issue.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_issue.xhtml
@@ -542,7 +542,7 @@
                                             <p:inputTextarea class="w-100" value="#{pharmacyIssueController.preBill.comments}" id="comment"
                                                              readonly="#{pharmacyIssueController.preBill.checkedBy ne null}"/>
 
-                                            <h:outputLabel value="Discard Category"/>
+                                            <h:outputLabel value="Issue Category"/>
                                             <p:inputText class="w-100" value="#{pharmacyIssueController.preBill.referenceNumber}" id="discardCategory"
                                                          readonly="#{pharmacyIssueController.preBill.checkedBy ne null}"/>
 


### PR DESCRIPTION
## Summary
- Renames leftover "Discard Category" UI labels to "Issue Category" to match the earlier Disposal → Consumption/Issue terminology rename (menu button, admin panel headers, the Pharmacy Issue bill field label, the privilege display name in Administration → User Privileges, and the related error messages).
- Entity class (`DiscardCategory`), table/discriminator, and privilege key (`PharmacyDiscardCategoryManage`) are left unchanged — only user-facing text changed, per backward-compatibility rules.
- Fixes a real (if narrow) data-loss bug found while investigating #3923: `PharmacyIssueController.loadDraftForEdit()` rebuilds a `PreBill` from a previously-saved draft when the persisted row isn't already resolved as a `PreBill` instance, and copied `comments`/`invoiceNumber`/etc. but **not** `referenceNumber` (the Issue Category value) — so it was silently dropped on the next save. Added the missing copy, matching the existing pattern for the other fields.
- Updated the HMIS wiki (`Manage-Discard-Category`, `Discard-Categories`, `Pharmaceutical-Fundamentals`, `Pharmaceutical-Management`, `Pharmacy-Issue`, `Pharmacy-Batch-Management-and-Expiry-Tracking`) with the current label, a verified click-through nav path, and screenshots.

## Investigation notes on #3923
The original 2023-era report ("Not Saving Discard Category in Pharmaceutical Management") does **not** reproduce on the current code for the category-metadata admin screen itself — verified live via Playwright: created a category, edited its name, and confirmed both persisted correctly across a full page reload and a direct DB check. The `loadDraftForEdit` bug above is a different, still-live gap that happens to match the same symptom ("Issue Category value silently not saved") on the *bill* field of the same name, so it's fixed here defensively even though it wasn't independently reproduced end-to-end (would require seeded local stock data to run the full save → reload-draft → finalize cycle).

## Test plan
- [x] Built with `mvn clean package -DskipTests` and redeployed to local Payara (`rh`)
- [x] Verified via Playwright, logged in as `buddhika` / Main Pharmacy department:
  - [x] Pharmacy → Administration → Pharmaceutical Fundamentals → **Issue Categories** button renders (was "Discard Categories")
  - [x] Panel header reads **Manage Issue Category**, detail panel reads **Issue Category Details**
  - [x] Added a new category, saved, confirmed "Saved Successfully" and persisted after a fresh page load and a direct DB query
  - [x] Edited the category name, saved, confirmed "Updated Successfully" and persisted (single row updated, not duplicated) via DB query
  - [x] Pharmacy → Consumption → Issue bill: **Issue Category** field label renders correctly (was "Discard Category")
- [ ] Full save-draft → reload-draft → finalize cycle for the `loadDraftForEdit` fix (not run — needs seeded local stock/item data; the fix mirrors the existing, already-tested pattern for sibling fields on the same line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)