### PR TITLE
fix(pharmacy): exclude never-paid GRN/DP bills from Settled Bills list

### DIFF
--- a/src/main/java/com/divudi/bean/common/BillController.java
+++ b/src/main/java/com/divudi/bean/common/BillController.java
@@ -3766,7 +3766,7 @@ public class BillController implements Serializable, ControllerWithMultiplePayme
         hm.put("to", toDate);
 
         if (balanceGraterThan != null) {
-            jpql += " and (abs(b.balance) < :val) ";
+            jpql += " and (abs(b.balance) < :val) and (abs(b.paidAmount) > :val) ";
             hm.put("val", balanceGraterThan);
         }
         if (pm != null) {

--- a/src/main/java/com/divudi/bean/pharmacy/SupplierPaymentController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/SupplierPaymentController.java
@@ -2392,6 +2392,10 @@ public class SupplierPaymentController implements Serializable {
         hm.put("bta", BillTypeAtomic.SUPPLIER_PAYMENT_PREPERATION);
         hm.put("bill", b);
         BillItem supBillItem = getBillItemFacade().findFirstByJpql(jpql, hm);
+        if (supBillItem == null) {
+            JsfUtil.addErrorMessage("No supplier payment voucher found for this bill.");
+            return null;
+        }
         Bill supplierPaymentBill = supBillItem.getBill();
 
         if (supplierPaymentBill == null) {


### PR DESCRIPTION
## Summary

- `Supplier Payment Management → Settled Bills` (Pharmacy/Store/All Credit Bills Settled) listed GRN/Direct Purchase bills that were never actually paid, because `BillController.findPaidBills()` only filtered on `abs(balance) < 0.01` — a condition also matched by bills whose `balance` was simply left at its default `0` (never processed for payment at all). Added an `abs(paidAmount) > 0.01` check alongside it so only genuinely settled bills appear.
- Clicking "View Voucher" on one of these never-paid bills threw a `NullPointerException` because `findAndnavigateToViewSupplierPaymentVoucher()` dereferenced the result of a `BillItem` lookup without a null check. Added a guard that shows a friendly error message instead, matching the existing guard pattern used elsewhere in the same method.

## Test plan

- [x] Rebuilt and redeployed locally (`mvn clean package -DskipTests` + `asadmin redeploy`), no errors in `server.log`.
- [x] Identified a live local-DB reproduction: a `PHARMACY_DIRECT_PURCHASE` bill with `paidAmount=0, balance=0` (matches the bug pattern exactly) alongside a genuinely settled `PHARMACY_GRN` bill (`paidAmount=28331.71, balance=0`) in the same date range.
- [x] Verified via Playwright against the local app: "Pharmacy Credit Bills Settled" and "All Credit Bills Settled" now show only the genuinely settled bill — the never-paid bill is correctly excluded.
- [x] Regression check: "View Voucher" on the genuinely settled bill still navigates correctly to the payment voucher page with no error.
- [x] Cross-checked against the local DB directly: re-running the old vs. new query logic for the same date range returns 3 rows (old, incorrectly including 2 never-paid bills) vs. 1 row (new, correct) — matching what the UI showed.

Closes #18592

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved paid bill filtering so results accurately reflect bills with payments above the specified balance threshold.
  * Added a clear error message when a supplier payment voucher cannot be found.
  * Prevented navigation errors when supplier payment details are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->