### PR TITLE
Add Custom Bill 2 (5x5 impact printer) to Inward Final Bill

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -516,6 +516,58 @@ public class BhtSummeryController implements Serializable {
         return new ArrayList<>(totals.entrySet());
     }
 
+    /**
+     * Charges grouped by inward charge type, alphabetical by display name,
+     * for the Custom3 5x5 impact-printer bill ("Custom Bill 2" in the UI).
+     * Unlike getCustom2CategoryTotals, ProfessionalCharge (doctor/consultant
+     * fee) is NOT excluded — Custom3 is a single-page format with no separate
+     * Professional Bill page, so it must appear as its own particulars line.
+     */
+    public List<Map.Entry<String, Double>> getCustom3CategoryTotals(Bill bill) {
+        Map<String, Double> totals = new TreeMap<>();
+        if (bill == null || bill.getBillItems() == null) {
+            return new ArrayList<>(totals.entrySet());
+        }
+        for (BillItem bi : bill.getBillItems()) {
+            if (bi.getAdjustedValue() == 0.0) {
+                continue;
+            }
+            String label = getChargeTypeLabel(bi.getInwardChargeType());
+            totals.merge(label, bi.getAdjustedValue(), Double::sum);
+        }
+        return new ArrayList<>(totals.entrySet());
+    }
+
+    /**
+     * Sum of prior payments/receipts recorded against this admission — the
+     * Custom3 bill's "Deposit" line. Same backwardReferenceBills source and
+     * qualifying filter as the Custom2 receipts table (finalBillCustom2.xhtml
+     * lines 280-291), just summed instead of rendered row by row.
+     */
+    public double getCustom3DepositTotal(Bill bill) {
+        if (bill == null) {
+            return 0.0;
+        }
+        List<Bill> receipts = (bill.getPatientEncounter() != null && bill.getPatientEncounter().getFinalBill() != null)
+                ? bill.getPatientEncounter().getFinalBill().getBackwardReferenceBills()
+                : bill.getBackwardReferenceBills();
+        double total = 0.0;
+        if (receipts == null) {
+            return total;
+        }
+        for (Bill b : receipts) {
+            if (b.getNetTotal() == 0.0) {
+                continue;
+            }
+            boolean qualifies = (!b.isCancelled() && "class com.divudi.core.entity.BilledBill".equals(b.getBillClass()))
+                    || (!b.isCancelled() && b.getRefundedBill() == null && "class com.divudi.core.entity.RefundBill".equals(b.getBillClass()));
+            if (qualifies) {
+                total += b.getNetTotal();
+            }
+        }
+        return total;
+    }
+
     public boolean isCustom2ShowAddress() {
         return custom2ShowAddress;
     }

--- a/src/main/webapp/inward/inward_reprint_bill_final.xhtml
+++ b/src/main/webapp/inward/inward_reprint_bill_final.xhtml
@@ -664,6 +664,55 @@
                                         </div>
                                     </div>
 
+                                    <div class="row mt-3">
+                                        <div class="col-lg-6">
+                                            <p:panel>
+                                                <f:facet name="header">
+                                                    <div class="d-flex justify-content-between">
+                                                        <div><h:outputLabel value="Original" class="mt-2"/></div>
+                                                        <div>
+                                                            <p:commandButton
+                                                                icon="fa fa-print"
+                                                                value="Custom Bill 2"
+                                                                class="ui-button-info"
+                                                                ajax="false">
+                                                                <p:printer target="originalCustom3BillPriview" ></p:printer>
+                                                            </p:commandButton>
+                                                        </div>
+                                                    </div>
+                                                </f:facet>
+
+                                                <h:panelGroup id="originalCustom3BillPriview">
+                                                    <bi:finalBillCustom3 bill="#{inwardSearch.showOrginalBill ? inwardSearch.bill.referenceBill : inwardSearch.bill}" duplicate="false"/>
+                                                </h:panelGroup>
+
+                                            </p:panel>
+                                        </div>
+                                        <div class="col-lg-6">
+                                            <p:panel>
+                                                <f:facet name="header">
+                                                    <div class="d-flex justify-content-between">
+                                                        <div><h:outputLabel value="Duplicate" class="mt-2"/></div>
+                                                        <div>
+                                                            <p:commandButton
+                                                                icon="fa fa-print"
+                                                                value="Custom Bill 2"
+                                                                class="ui-button-info"
+                                                                ajax="false">
+                                                                <p:printer target="duplicateCustom3BillPriview" ></p:printer>
+                                                            </p:commandButton>
+                                                        </div>
+                                                    </div>
+                                                </f:facet>
+
+                                                <h:panelGroup id="duplicateCustom3BillPriview">
+                                                    <bi:finalBillCustom3 bill="#{inwardSearch.showOrginalBill ? inwardSearch.bill.referenceBill : inwardSearch.bill}" duplicate="true"/>
+                                                </h:panelGroup>
+
+                                            </p:panel>
+                                        </div>
+                                    </div>
+
                                     <p:dialog id="custom2ConfigDialog"
                                               header="Custom Bills Printer Configuration"
                                               widgetVar="custom2ConfigDialog"

--- a/src/main/webapp/resources/inward/bill/finalBillCustom3.xhtml
+++ b/src/main/webapp/resources/inward/bill/finalBillCustom3.xhtml
@@ -1,0 +1,186 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
+
+    <!--
+        5 inch wide Inward Final Bill ("Custom Bill 2" in the Custom Bills tab).
+        Tuned for impact / dot-matrix printers (e.g. Epson LX/FX series):
+        a single clean sans-serif font, solid black text, no background fills.
+        Replicates tmp/COOP/OPD CARD.pdf — see
+        docs/superpowers/specs/2026-08-01-inward-final-bill-custom3-five-five-design.md
+    -->
+    <cc:interface>
+        <cc:attribute name="bill" type="com.divudi.core.entity.Bill" required="true" />
+        <cc:attribute name="duplicate" type="java.lang.Boolean" default="false" />
+    </cc:interface>
+
+    <cc:implementation>
+        <style>
+            .custom3-bill {
+                width: 12.7cm; /* 5 inch */
+                font-family: Arial, "Liberation Sans", sans-serif;
+                color: #000;
+                font-size: 12px;
+                line-height: 1.35;
+                padding: 0.3cm;
+                box-sizing: border-box;
+            }
+            .custom3-bill table { width: 100%; border-collapse: collapse; }
+            .custom3-bill .sep { border-top: 1px solid #000; margin: 4px 0; }
+            .custom3-bill .title { text-align: center; font-weight: bold; font-size: 14px; }
+            .custom3-bill .dept-name { text-align: center; font-weight: bold; font-size: 15px; }
+            .custom3-bill .items th, .custom3-bill .items td { padding: 2px 0; }
+            @media print {
+                .custom3-bill {
+                    width: 12.7cm !important;
+                    min-height: 12.7cm; /* 5 inch */
+                    page-break-after: always;
+                }
+            }
+        </style>
+
+        <div class="custom3-bill">
+
+            <div class="dept-name">
+                <h:outputLabel value="#{cc.attrs.bill.department.printingName}" />
+            </div>
+            <div style="text-align: center; font-size: 11px;">
+                <h:outputLabel value="#{cc.attrs.bill.department.address}" />
+            </div>
+            <div style="text-align: center; font-size: 11px;">
+                <h:outputLabel value="#{cc.attrs.bill.department.telephone1}" />
+                <h:outputLabel value=" / " rendered="#{cc.attrs.bill.department.telephone2 ne null}" />
+                <h:outputLabel value="#{cc.attrs.bill.department.telephone2}" />
+            </div>
+
+            <div class="title" style="margin-top: 4px;">
+                <h:outputLabel value="FINAL BILL" />
+                <h:outputLabel value=" **Duplicate**" rendered="#{cc.attrs.duplicate eq true}" />
+                <h:outputLabel value=" **Cancelled**" rendered="#{cc.attrs.bill.cancelled eq true}" />
+            </div>
+
+            <div class="sep"></div>
+
+            <table>
+                <tr>
+                    <td style="width: 28%;">Bill No</td>
+                    <td style="width: 3%;">:</td>
+                    <td style="width: 69%;"><h:outputLabel value="#{cc.attrs.bill.deptId}" /></td>
+                </tr>
+                <tr>
+                    <td>Bill Date</td>
+                    <td>:</td>
+                    <td>
+                        <h:outputLabel value="#{cc.attrs.bill.createdAt}">
+                            <f:convertDateTime pattern="yyyy-MM-dd hh:mm a" timeZone="Asia/Colombo" />
+                        </h:outputLabel>
+                    </td>
+                </tr>
+                <tr>
+                    <td>Patient Name</td>
+                    <td>:</td>
+                    <td><h:outputLabel value="#{cc.attrs.bill.patientEncounter.patient.person.nameWithTitle}" /></td>
+                </tr>
+                <tr>
+                    <td>OPD Card</td>
+                    <td>:</td>
+                    <td><h:outputLabel value="#{cc.attrs.bill.patientEncounter.bhtNo}" /></td>
+                </tr>
+            </table>
+
+            <div class="sep"></div>
+
+            <table class="items">
+                <thead>
+                    <tr style="font-weight: bold; border-bottom: 1px solid #000;">
+                        <th style="text-align: left;">Particular</th>
+                        <th style="text-align: right; width: 28%;">Amount</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <ui:repeat value="#{bhtSummeryController.getCustom3CategoryTotals(cc.attrs.bill)}" var="entry">
+                        <tr>
+                            <td style="text-align: left;"><h:outputLabel value="#{entry.key}" /></td>
+                            <td style="text-align: right;">
+                                <h:outputLabel value="#{entry.value}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                    </ui:repeat>
+                </tbody>
+            </table>
+
+            <div class="sep"></div>
+
+            <table>
+                <tr>
+                    <td style="text-align: left;">Total Amount</td>
+                    <td style="text-align: right;">
+                        <h:outputLabel value="#{cc.attrs.bill.total}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputLabel>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left;">Discounts</td>
+                    <td style="text-align: right;">
+                        <h:outputLabel value="#{cc.attrs.bill.discount}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputLabel>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: left;">Deposit</td>
+                    <td style="text-align: right;">
+                        <h:outputLabel value="#{bhtSummeryController.getCustom3DepositTotal(cc.attrs.bill)}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputLabel>
+                    </td>
+                </tr>
+                <tr style="font-weight: bold; font-size: 13px; border-top: 1px solid #000;">
+                    <td style="text-align: left;">Net Amount (LKR)</td>
+                    <td style="text-align: right;">
+                        <h:outputLabel value="#{cc.attrs.bill.netTotal}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputLabel>
+                    </td>
+                </tr>
+            </table>
+
+            <div class="sep"></div>
+
+            <table>
+                <tr style="font-weight: bold;">
+                    <td style="text-align: left;">Pay Type</td>
+                    <td style="text-align: right;">Amount Rs.</td>
+                </tr>
+                <tr>
+                    <td style="text-align: left;"><h:outputLabel value="#{cc.attrs.bill.paymentMethod}" /></td>
+                    <td style="text-align: right;">
+                        <h:outputLabel value="#{cc.attrs.bill.paidAmount}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputLabel>
+                    </td>
+                </tr>
+            </table>
+
+            <div class="sep"></div>
+
+            <table style="margin-top: 4px;">
+                <tr>
+                    <td style="text-align: left;">Bill Prepared By : <h:outputLabel value="#{cc.attrs.bill.creater.name}" /></td>
+                </tr>
+            </table>
+
+            <div style="text-align: center; font-size: 10px; margin-top: 8px;">
+                <h:outputLabel value="Powered by CareCode (Pvt) Ltd." />
+            </div>
+
+        </div>
+    </cc:implementation>
+</html>


### PR DESCRIPTION
## Summary
- Adds a second custom print format ("Custom Bill 2") to the Inward Final Bill screen's Custom Bills tab: a single-page, 5-inch-wide bill for impact/dot-matrix printers, replicating a customer-supplied sample bill (COOP OPD Card admission bill).
- New `BhtSummeryController.getCustom3CategoryTotals`/`getCustom3DepositTotal` helpers; new `finalBillCustom3.xhtml` composite; existing Custom2 format untouched.
- Design spec: `docs/superpowers/specs/2026-08-01-inward-final-bill-custom3-five-five-design.md`
- Implementation plan: `docs/superpowers/plans/2026-08-01-inward-final-bill-custom-bill-2-five-five.md`

## Test plan
- [x] Task-level review of each commit (spec compliance + code quality) passed clean for all 3 tasks
- [ ] Local build + deploy + rendered-page verification against a real final bill — **not yet performed**, opening this PR ahead of that step by request; QA to verify functionally once deployed to the development environment
- [ ] Confirm the existing "Custom Bill" (Custom2) panel is unaffected (regression check)
- [ ] Confirm doctor/professional fee appears as its own line in the new format's particulars table

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Custom Bill 2 print preview for original and duplicate inward bills.
  * Introduced a compact 5-inch bill layout with patient details, categorized charges, payments, totals, status, and branding.
  * Added categorized charge totals, including professional charges, and deposit totals to the bill.
  * Added conditional display of duplicate, cancellation, and telephone information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->