### PR TITLE
fix(lab): microbiology memo alignment, order-list spacing, and antibiotic sort

### DIFF
--- a/src/main/java/com/divudi/core/entity/lab/PatientReport.java
+++ b/src/main/java/com/divudi/core/entity/lab/PatientReport.java
@@ -920,36 +920,68 @@ public class PatientReport implements Serializable, RetirableEntity {
 
         @Override
         public int compare(PatientReportItemValue o1, PatientReportItemValue o2) {
+            if (o1 == null && o2 == null) {
+                return 0;
+            }
             if (o1 == null) {
-                return 1;
-            }
-            if (o1.getInvestigationItem() == null) {
-                return 1;
-            }
-            if (o1.getInvestigationItem().getRiTop() == 0.0) {
                 return 1;
             }
             if (o2 == null) {
                 return -1;
             }
-            if (o2.getInvestigationItem() == null) {
-                return -1;
+            InvestigationItem ii1 = o1.getInvestigationItem();
+            InvestigationItem ii2 = o2.getInvestigationItem();
+            if (ii1 == null && ii2 == null) {
+                return compareByIdNullSafe(o1, o2);
             }
-            if (o2.getInvestigationItem().getRiTop() == 0.0) {
-                return -1;
-            }
-            if (o1.getInvestigationItem().getRiTop() == o2.getInvestigationItem().getRiTop()) {
-                if (o1.getId() > o2.getId()) {
-                    return 1;
-                } else {
-                    return -1;
-                }
-
-            }
-            if (o1.getInvestigationItem().getRiTop() > o2.getInvestigationItem().getRiTop()) {
+            if (ii1 == null) {
                 return 1;
             }
-            return -1;
+            if (ii2 == null) {
+                return -1;
+            }
+            boolean top1Unset = ii1.getRiTop() == 0.0;
+            boolean top2Unset = ii2.getRiTop() == 0.0;
+            if (top1Unset && top2Unset) {
+                // riTop is never configured for items such as antibiotics, so
+                // fall back to a stable, alphabetical order instead of an
+                // unconditional "greater than", which is not a valid
+                // comparator (violates antisymmetry and breaks
+                // Collections.sort with an IllegalArgumentException).
+                String n1 = ii1.getName() == null ? "" : ii1.getName();
+                String n2 = ii2.getName() == null ? "" : ii2.getName();
+                int nameCompare = n1.compareToIgnoreCase(n2);
+                if (nameCompare != 0) {
+                    return nameCompare;
+                }
+                return compareByIdNullSafe(o1, o2);
+            }
+            if (top1Unset) {
+                return 1;
+            }
+            if (top2Unset) {
+                return -1;
+            }
+            int topCompare = Double.compare(ii1.getRiTop(), ii2.getRiTop());
+            if (topCompare != 0) {
+                return topCompare;
+            }
+            return compareByIdNullSafe(o1, o2);
+        }
+
+        private int compareByIdNullSafe(PatientReportItemValue o1, PatientReportItemValue o2) {
+            Long id1 = o1.getId();
+            Long id2 = o2.getId();
+            if (id1 == null && id2 == null) {
+                return 0;
+            }
+            if (id1 == null) {
+                return 1;
+            }
+            if (id2 == null) {
+                return -1;
+            }
+            return id1.compareTo(id2);
         }
     }
 

--- a/src/main/java/com/divudi/core/entity/lab/PatientReportItemValue.java
+++ b/src/main/java/com/divudi/core/entity/lab/PatientReportItemValue.java
@@ -153,10 +153,16 @@ public class PatientReportItemValue implements Serializable, RetirableEntity {
 
         final List<Node> nodes;
         final String extraClass;
+        final boolean noSplit;
 
         MicLine(List<Node> nodes, String extraClass) {
+            this(nodes, extraClass, false);
+        }
+
+        MicLine(List<Node> nodes, String extraClass, boolean noSplit) {
             this.nodes = nodes;
             this.extraClass = extraClass;
+            this.noSplit = noSplit;
         }
     }
 
@@ -179,7 +185,7 @@ public class PatientReportItemValue implements Serializable, RetirableEntity {
                     }
                     List<Node> single = new ArrayList<>();
                     single.add(el);
-                    lines.add(new MicLine(single, null));
+                    lines.add(new MicLine(single, null, true));
                     continue;
                 }
                 if ("p".equals(tag) || "div".equals(tag)) {
@@ -188,10 +194,8 @@ public class PatientReportItemValue implements Serializable, RetirableEntity {
                         current = new ArrayList<>();
                     }
                     String indentClass = extractIndentClass(el);
-                    boolean first = true;
                     for (List<Node> sub : splitOnBr(new ArrayList<>(el.childNodes()))) {
-                        lines.add(new MicLine(sub, first ? indentClass : null));
-                        first = false;
+                        lines.add(new MicLine(sub, indentClass));
                     }
                     continue;
                 }
@@ -233,7 +237,7 @@ public class PatientReportItemValue implements Serializable, RetirableEntity {
             out.append("<div class=\"micLineFull\"></div>");
             return;
         }
-        ColonSplit split = splitAtColon(line.nodes);
+        ColonSplit split = line.noSplit ? new ColonSplit() : splitAtColon(line.nodes);
         String cls = line.extraClass == null ? "" : " " + line.extraClass;
         if (split.found) {
             out.append("<div class=\"micLineLabel").append(cls).append("\">")

--- a/src/main/java/com/divudi/core/entity/lab/PatientReportItemValue.java
+++ b/src/main/java/com/divudi/core/entity/lab/PatientReportItemValue.java
@@ -248,7 +248,16 @@ public class PatientReportItemValue implements Serializable, RetirableEntity {
     }
 
     private static String renderNodes(List<Node> nodes) {
-        Element wrapper = new Element("span");
+        // A detached Element has no owner Document, so it falls back to
+        // Jsoup's default OutputSettings, which pretty-prints block tags
+        // (e.g. ol/li) with indentation newlines between them. .micMemoValue
+        // renders with white-space: pre-wrap to preserve intentional
+        // spacing, so those injected newlines were showing up as a big gap
+        // between list lines. Giving the wrapper an owner Document with
+        // prettyPrint disabled avoids that.
+        Document shell = Document.createShell("");
+        shell.outputSettings().prettyPrint(false);
+        Element wrapper = shell.body().appendElement("span");
         for (Node n : nodes) {
             wrapper.appendChild(n);
         }

--- a/src/main/java/com/divudi/core/entity/lab/PatientReportItemValue.java
+++ b/src/main/java/com/divudi/core/entity/lab/PatientReportItemValue.java
@@ -10,7 +10,14 @@ import com.divudi.core.entity.PatientEncounter;
 import com.divudi.core.entity.WebUser;
 import java.io.Serializable;
 import java.text.DecimalFormat;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.nodes.Node;
+import org.jsoup.nodes.TextNode;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -110,6 +117,207 @@ public class PatientReportItemValue implements Serializable, RetirableEntity {
         String trimmed = lobValue.replaceAll("(?i)^(?:" + LOB_VALUE_BLANK_UNIT + ")+", "");
         trimmed = trimmed.replaceAll("(?i)(?:" + LOB_VALUE_BLANK_UNIT + ")+$", "");
         return trimmed;
+    }
+
+    /**
+     * lobValuePrintable restructured into an auto-aligned label/value grid.
+     * Each line is split on its first top-level ":" into a label (before)
+     * and a value (after); rendered with the .micLineGrid CSS rules in
+     * microbiology_patient_report.xhtml, the colons of every line in this
+     * memo line up in one column no matter how long the longest label is -
+     * the column width is not hardcoded, it is sized by the browser to the
+     * widest label actually present. Lines without a ":" are left as a
+     * single full-width line, untouched. List blocks (ol/ul) are left
+     * unsplit since their marker layout is not compatible with the
+     * label/value column split.
+     */
+    public String getLobValueLinesAligned() {
+        String html = getLobValuePrintable();
+        if (html == null) {
+            return null;
+        }
+        // Normalize legacy plain "\n" (real or literal backslash-n), typed
+        // before the rich-text editor existed, into <br/> line breaks.
+        String normalized = html.replaceAll("\\\\n|\\r\\n|\\r|\\n", "<br/>");
+        Document doc = Jsoup.parseBodyFragment(normalized);
+
+        StringBuilder out = new StringBuilder("<div class=\"micLineGrid\">");
+        for (MicLine line : splitIntoLines(new ArrayList<>(doc.body().childNodes()))) {
+            appendLine(out, line);
+        }
+        out.append("</div>");
+        return out.toString();
+    }
+
+    private static final class MicLine {
+
+        final List<Node> nodes;
+        final String extraClass;
+
+        MicLine(List<Node> nodes, String extraClass) {
+            this.nodes = nodes;
+            this.extraClass = extraClass;
+        }
+    }
+
+    private static List<MicLine> splitIntoLines(List<Node> topLevelNodes) {
+        List<MicLine> lines = new ArrayList<>();
+        List<Node> current = new ArrayList<>();
+        for (Node node : topLevelNodes) {
+            if (node instanceof Element) {
+                Element el = (Element) node;
+                String tag = el.tagName().toLowerCase();
+                if ("br".equals(tag)) {
+                    lines.add(new MicLine(current, null));
+                    current = new ArrayList<>();
+                    continue;
+                }
+                if ("ol".equals(tag) || "ul".equals(tag)) {
+                    if (!current.isEmpty()) {
+                        lines.add(new MicLine(current, null));
+                        current = new ArrayList<>();
+                    }
+                    List<Node> single = new ArrayList<>();
+                    single.add(el);
+                    lines.add(new MicLine(single, null));
+                    continue;
+                }
+                if ("p".equals(tag) || "div".equals(tag)) {
+                    if (!current.isEmpty()) {
+                        lines.add(new MicLine(current, null));
+                        current = new ArrayList<>();
+                    }
+                    String indentClass = extractIndentClass(el);
+                    boolean first = true;
+                    for (List<Node> sub : splitOnBr(new ArrayList<>(el.childNodes()))) {
+                        lines.add(new MicLine(sub, first ? indentClass : null));
+                        first = false;
+                    }
+                    continue;
+                }
+            }
+            current.add(node);
+        }
+        if (!current.isEmpty()) {
+            lines.add(new MicLine(current, null));
+        }
+        return lines;
+    }
+
+    private static List<List<Node>> splitOnBr(List<Node> nodes) {
+        List<List<Node>> result = new ArrayList<>();
+        List<Node> current = new ArrayList<>();
+        for (Node node : nodes) {
+            if (node instanceof Element && "br".equalsIgnoreCase(((Element) node).tagName())) {
+                result.add(current);
+                current = new ArrayList<>();
+            } else {
+                current.add(node);
+            }
+        }
+        result.add(current);
+        return result;
+    }
+
+    private static String extractIndentClass(Element el) {
+        for (String cls : el.classNames()) {
+            if (cls.startsWith("ql-indent-")) {
+                return cls;
+            }
+        }
+        return null;
+    }
+
+    private static void appendLine(StringBuilder out, MicLine line) {
+        if (line.nodes.isEmpty()) {
+            out.append("<div class=\"micLineFull\"></div>");
+            return;
+        }
+        ColonSplit split = splitAtColon(line.nodes);
+        String cls = line.extraClass == null ? "" : " " + line.extraClass;
+        if (split.found) {
+            out.append("<div class=\"micLineLabel").append(cls).append("\">")
+                    .append(renderNodes(split.before)).append("</div>");
+            out.append("<div class=\"micLineSep\">:</div>");
+            out.append("<div class=\"micLineValue\">")
+                    .append(renderNodes(split.after)).append("</div>");
+        } else {
+            out.append("<div class=\"micLineFull").append(cls).append("\">")
+                    .append(renderNodes(line.nodes)).append("</div>");
+        }
+    }
+
+    private static String renderNodes(List<Node> nodes) {
+        Element wrapper = new Element("span");
+        for (Node n : nodes) {
+            wrapper.appendChild(n);
+        }
+        return wrapper.html();
+    }
+
+    private static final class ColonSplit {
+
+        final List<Node> before = new ArrayList<>();
+        final List<Node> after = new ArrayList<>();
+        boolean found;
+    }
+
+    /**
+     * Splits a line's node list at the first top-level ":" text character,
+     * recursing into inline elements (strong/em/span/...) so formatting
+     * that wraps the split point (e.g. "&lt;strong&gt;Organism:&lt;/strong&gt; E.coli")
+     * is preserved on both sides rather than producing unbalanced HTML.
+     */
+    private static ColonSplit splitAtColon(List<Node> nodes) {
+        ColonSplit split = new ColonSplit();
+        for (Node node : nodes) {
+            if (split.found) {
+                split.after.add(node.clone());
+                continue;
+            }
+            if (node instanceof TextNode) {
+                String text = ((TextNode) node).getWholeText();
+                int idx = text.indexOf(':');
+                if (idx >= 0) {
+                    split.found = true;
+                    String beforeText = text.substring(0, idx);
+                    String afterText = text.substring(idx + 1);
+                    if (!beforeText.isEmpty()) {
+                        split.before.add(new TextNode(beforeText));
+                    }
+                    if (!afterText.isEmpty()) {
+                        split.after.add(new TextNode(afterText));
+                    }
+                } else {
+                    split.before.add(node.clone());
+                }
+            } else if (node instanceof Element) {
+                Element el = (Element) node;
+                ColonSplit childSplit = splitAtColon(new ArrayList<>(el.childNodes()));
+                if (childSplit.found) {
+                    split.found = true;
+                    Element beforeEl = el.shallowClone();
+                    for (Node c : childSplit.before) {
+                        beforeEl.appendChild(c);
+                    }
+                    if (beforeEl.childNodeSize() > 0) {
+                        split.before.add(beforeEl);
+                    }
+                    Element afterEl = el.shallowClone();
+                    for (Node c : childSplit.after) {
+                        afterEl.appendChild(c);
+                    }
+                    if (afterEl.childNodeSize() > 0) {
+                        split.after.add(afterEl);
+                    }
+                } else {
+                    split.before.add(node.clone());
+                }
+            } else {
+                split.before.add(node.clone());
+            }
+        }
+        return split;
     }
 
     public byte[] getBaImage() {

--- a/src/main/webapp/resources/ezcomp/lab/microbiology_patient_report.xhtml
+++ b/src/main/webapp/resources/ezcomp/lab/microbiology_patient_report.xhtml
@@ -47,10 +47,13 @@
                ":" (.micLineFull) just span the full row untouched. */
             .micMemoValue .micLineGrid {
                 display: grid;
-                grid-template-columns: max-content max-content 1fr;
+                grid-template-columns: minmax(0, max-content) max-content 1fr;
                 column-gap: 0;
             }
-            .micMemoValue .micLineLabel { grid-column: 1; }
+            .micMemoValue .micLineLabel {
+                grid-column: 1;
+                overflow-wrap: break-word;
+            }
             .micMemoValue .micLineSep { grid-column: 2; padding: 0 16px; }
             .micMemoValue .micLineValue { grid-column: 3; }
             .micMemoValue .micLineFull { grid-column: 1 / -1; }

--- a/src/main/webapp/resources/ezcomp/lab/microbiology_patient_report.xhtml
+++ b/src/main/webapp/resources/ezcomp/lab/microbiology_patient_report.xhtml
@@ -38,6 +38,22 @@
                so the indent is lost. The longhand padding-left overrides the
                padding:0 reset above (higher specificity). Values match Quill's
                default of 3em per indent level. */
+            /* Auto-aligned label:value grid for memo lines split by
+               PatientReportItemValue#getLobValueLinesAligned(). Grid's first
+               two columns size themselves to the widest label/colon
+               actually present in this memo block, so every line's colon
+               lines up without a hardcoded width - the alignment holds
+               however long the longest label turns out to be. Lines with no
+               ":" (.micLineFull) just span the full row untouched. */
+            .micMemoValue .micLineGrid {
+                display: grid;
+                grid-template-columns: max-content max-content 1fr;
+                column-gap: 0;
+            }
+            .micMemoValue .micLineLabel { grid-column: 1; }
+            .micMemoValue .micLineSep { grid-column: 2; padding: 0 16px; }
+            .micMemoValue .micLineValue { grid-column: 3; }
+            .micMemoValue .micLineFull { grid-column: 1 / -1; }
             .micMemoValue .ql-indent-1 { padding-left: 3em; }
             .micMemoValue .ql-indent-2 { padding-left: 6em; }
             .micMemoValue .ql-indent-3 { padding-left: 9em; }
@@ -81,7 +97,7 @@
                                     </div>
                                     <div style="display: inline-block; float: left; width: 3%; " ></div>
                                     <div class="micMemoValue" style="display: inline-block; text-align: left; float:left; width: 60%; padding-top: 0.1%; padding-bottom: 0.1%; ">
-                                        <h:outputLabel value="#{fn:replace(prv.lobValuePrintable,'\\n','&lt;br/&gt;')}"   escape="false"   />
+                                        <h:outputLabel value="#{prv.lobValueLinesAligned}"   escape="false"   />
                                     </div>
                                 </h:panelGroup>
                             </ui:repeat>
@@ -229,7 +245,7 @@
                                 </h:panelGroup>
                                 <h:panelGroup layout="block" style="display: block; clear: left; float: left; width: 100%; margin-bottom: 12px;" rendered="#{prv.investigationItem.ixItemType eq 'Value' and prv.investigationItem.ixItemValueType eq 'Memo' and prv.investigationItem.retired ne true and prv.lobValuePrintable ne '' and prv.lobValuePrintable ne null and prv.investigationItem.riTop gt 50 }" >
                                     <div class="micMemoValue" style=" text-align: left; float:left; margin-left: 5%; width: 90%;padding-left: 1px; padding-right: 1px; padding-top: 1px; vertical-align: top;">
-                                        <h:outputLabel value="#{fn:replace(prv.lobValuePrintable,'\\n','&lt;br/&gt;')}"    escape="false" />
+                                        <h:outputLabel value="#{prv.lobValueLinesAligned}"    escape="false" />
                                     </div>
                                 </h:panelGroup>
                             </ui:repeat>


### PR DESCRIPTION
Closes #22590

## Summary

Hotfix for the microbiology memo/comment rendering in the patient report view:

- Adds `PatientReportItemValue#getLobValueLinesAligned()`, a Jsoup-based splitter that breaks each memo line on its first top-level `:` into label/value node lists.
- Renders memo lines as an auto-aligned label:value CSS grid (`.micLineGrid`) in `microbiology_patient_report.xhtml`, replacing the old raw `\n` → `<br/>` replace, so colons line up across lines without a hardcoded width.
- Fixes the antibiotic sensitivity list sort: the comparator fell back to `InvestigationItem.riTop`, which is unset (0.0) for antibiotic items, always returning 1 and violating the `Comparator` contract — `Collections.sort` threw `IllegalArgumentException`, silently swallowed, leaving the list in JPA's unordered load order. Now falls back to a case-insensitive name compare with a null-safe id tiebreaker when `riTop` is unset.
- Fixes a large visual gap between order-list (`<ol>/<li>`) lines in the report: `renderNodes()` serialized memo nodes via a detached `span` Element, which falls back to Jsoup's default `OutputSettings` and pretty-prints block tags with indentation newlines; since `.micMemoValue` uses `white-space: pre-wrap`, those newlines rendered as a visible gap. The wrapper now gets an owner `Document` with pretty-print disabled.

## Test plan

- [ ] Add a microbiology memo result containing a `Label: value` line and confirm colons align across multiple lines
- [ ] Add an ordered/bulleted order list to a memo comment and confirm no extra gap appears between list lines in the report view
- [ ] Reload an antibiotic sensitivity report page (not just right after entry) and confirm the antibiotic list stays sorted A-Z


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved laboratory memo formatting for printed reports.
  * Added aligned label-and-value columns with dynamic separators.
  * Preserved paragraphs, indentation, inline formatting, and list content.
  * Displayed empty or colonless lines across the full report width.

* **Bug Fixes**
  * Improved report item ordering with consistent handling of missing values.
  * Added case-insensitive ordering and deterministic tie-breaking for matching entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->