### PR TITLE
fix(pharmacy): deprecate legacy GRN direct-settle approval flow

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/GrnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnController.java
@@ -287,14 +287,18 @@ public class GrnController implements Serializable {
 
     /**
      * @deprecated Entry point into the legacy non-costing approval flow
-     * (issue #21289), reached from the now-unreachable
+     * (issue #21289), reached from
      * {@code pharmacy_purchase_order_list_for_recieve_with_approval.xhtml}.
      * Navigates to {@code pharmacy_grn_with_approval.xhtml} whose
      * Save/Finalize buttons call {@link #request()} /
      * {@link #requestFinalize()}; the flow's terminal Approve step
      * ({@link #navigateToApproveRecieveGrnPreBill()} / {@link #settle()})
-     * always fails with "Please select a payment method". No longer
-     * reachable from the UI.
+     * always fails with "Please select a payment method". No longer linked
+     * from any navigation menu (the home tile and Procurement &gt; GRN button
+     * were removed), but the backing XHTML pages and their JSF action
+     * bindings are intentionally left in place — not deleted — until the QA
+     * comparison in #22595 confirms the DTO/costing flow has full parity,
+     * at which point this whole flow will be removed.
      */
     @Deprecated
     public String navigateToRecieveGrnPreBill() {
@@ -320,8 +324,10 @@ public class GrnController implements Serializable {
      * {@code GrnCostingController}'s Save/Finalize/Approve flow
      * ({@code requestWithSaveApprove()} / {@code finalizeGrnWithSaveApprove()}
      * / {@code approveGrnWithSaveApprove()}), which is already the sole path
-     * for GRN creation whenever "Manage Costing" is enabled. No longer
-     * reachable from the UI as of #21289.
+     * for GRN creation whenever "Manage Costing" is enabled. No longer linked
+     * from any navigation menu, but the backing XHTML pages and their JSF
+     * action bindings are intentionally left in place until the QA
+     * comparison in #22595 confirms the DTO/costing flow has full parity.
      */
     @Deprecated
     public String navigateToApproveRecieveGrnPreBill() {
@@ -533,7 +539,10 @@ public class GrnController implements Serializable {
 
     /**
      * @deprecated Part of the legacy non-costing approval flow (issue
-     * #21289), no longer reachable from the UI. See
+     * #21289), no longer linked from any navigation menu. The backing XHTML
+     * page ({@code pharmacy_grn_with_approval.xhtml}) and its JSF action
+     * binding are intentionally left in place until the QA comparison in
+     * #22595 confirms the DTO/costing flow has full parity. See
      * {@link #navigateToApproveRecieveGrnPreBill()} for details.
      */
     @Deprecated
@@ -647,7 +656,10 @@ public class GrnController implements Serializable {
 
     /**
      * @deprecated Part of the legacy non-costing approval flow (issue
-     * #21289), no longer reachable from the UI. See
+     * #21289), no longer linked from any navigation menu. The backing XHTML
+     * page ({@code pharmacy_grn_with_approval.xhtml}) and its JSF action
+     * binding are intentionally left in place until the QA comparison in
+     * #22595 confirms the DTO/costing flow has full parity. See
      * {@link #navigateToApproveRecieveGrnPreBill()} for details.
      */
     @Deprecated
@@ -759,7 +771,12 @@ public class GrnController implements Serializable {
      * {@link #navigateToApproveRecieveGrnPreBill()} and lazily creates a
      * disconnected empty {@code Bill} — the real payment method lives on
      * {@code currentGrnBillPre}, so Settle always fails with "Please select
-     * a payment method". No longer reachable from the UI. Superseded by
+     * a payment method", unconditionally — this does not depend on the
+     * "Manage Costing" config flag. No longer linked from any navigation
+     * menu, but the backing XHTML page
+     * ({@code pharmacy_grn_approval_finalized.xhtml}) and its JSF action
+     * binding are intentionally left in place until the QA comparison in
+     * #22595 confirms the DTO/costing flow has full parity. Superseded by
      * {@code GrnCostingController.approveGrnWithSaveApprove()}.
      */
     @Deprecated

--- a/src/main/java/com/divudi/bean/pharmacy/GrnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnController.java
@@ -299,6 +299,19 @@ public class GrnController implements Serializable {
         return "/pharmacy/pharmacy_grn_with_approval?faces-redirect=true";
     }
 
+    /**
+     * @deprecated Legacy non-costing approval flow (issue #21289). Never
+     * assigns {@code grnBill}, so {@link #settle()} operates on a
+     * disconnected, lazily-created empty {@code Bill} instead of
+     * {@code currentGrnBillPre} where the real payment method lives — Settle
+     * always fails with "Please select a payment method". Superseded by
+     * {@code GrnCostingController}'s Save/Finalize/Approve flow
+     * ({@code requestWithSaveApprove()} / {@code finalizeGrnWithSaveApprove()}
+     * / {@code approveGrnWithSaveApprove()}), which is already the sole path
+     * for GRN creation whenever "Manage Costing" is enabled. No longer
+     * reachable from the UI as of #21289.
+     */
+    @Deprecated
     public String navigateToApproveRecieveGrnPreBill() {
         clear();
         billItems = getCurrentGrnBillPre().getBillItems();
@@ -506,6 +519,12 @@ public class GrnController implements Serializable {
         return fromDate;
     }
 
+    /**
+     * @deprecated Part of the legacy non-costing approval flow (issue
+     * #21289), no longer reachable from the UI. See
+     * {@link #navigateToApproveRecieveGrnPreBill()} for details.
+     */
+    @Deprecated
     public void request() {
         if (!isAuthorized("REQUEST", "PharmacyGrnSave")) {
             return;
@@ -614,6 +633,12 @@ public class GrnController implements Serializable {
 
     }
 
+    /**
+     * @deprecated Part of the legacy non-costing approval flow (issue
+     * #21289), no longer reachable from the UI. See
+     * {@link #navigateToApproveRecieveGrnPreBill()} for details.
+     */
+    @Deprecated
     public void requestFinalize() {
         if (!isAuthorized("REQUEST_FINALIZE", "PharmacyGrnFinalize")) {
             return;
@@ -716,6 +741,16 @@ public class GrnController implements Serializable {
 
     }
 
+    /**
+     * @deprecated Legacy non-costing approval flow (issue #21289). Operates
+     * on {@code getGrnBill()}, which is never populated by
+     * {@link #navigateToApproveRecieveGrnPreBill()} and lazily creates a
+     * disconnected empty {@code Bill} — the real payment method lives on
+     * {@code currentGrnBillPre}, so Settle always fails with "Please select
+     * a payment method". No longer reachable from the UI. Superseded by
+     * {@code GrnCostingController.approveGrnWithSaveApprove()}.
+     */
+    @Deprecated
     public void settle() {
         if (!isAuthorized("SETTLE", "PharmacyGrnFinalize")) {
             return;

--- a/src/main/java/com/divudi/bean/pharmacy/GrnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnController.java
@@ -285,6 +285,18 @@ public class GrnController implements Serializable {
         insTotal = 0;
     }
 
+    /**
+     * @deprecated Entry point into the legacy non-costing approval flow
+     * (issue #21289), reached from the now-unreachable
+     * {@code pharmacy_purchase_order_list_for_recieve_with_approval.xhtml}.
+     * Navigates to {@code pharmacy_grn_with_approval.xhtml} whose
+     * Save/Finalize buttons call {@link #request()} /
+     * {@link #requestFinalize()}; the flow's terminal Approve step
+     * ({@link #navigateToApproveRecieveGrnPreBill()} / {@link #settle()})
+     * always fails with "Please select a payment method". No longer
+     * reachable from the UI.
+     */
+    @Deprecated
     public String navigateToRecieveGrnPreBill() {
         clear();
         currentGrnBillPre = null;

--- a/src/main/webapp/home.xhtml
+++ b/src/main/webapp/home.xhtml
@@ -1176,7 +1176,15 @@
                     </h:form>
                 </h:panelGroup>
 
-                <!-- Goods Receipt With Approval -->
+                <!-- Goods Receipt With Approval: deprecated, issue #21289.
+                     Routed into the legacy GrnController approval flow, whose
+                     settle() always fails with "Please select a payment
+                     method" (never assigns grnBill). "Goods Receipt" above
+                     already routes every GRN through GrnCostingController's
+                     Save/Finalize/Approve pipeline whenever "Manage Costing"
+                     is enabled, making this tile a redundant, broken
+                     duplicate. -->
+                <!--
                 <h:panelGroup layout="block" class="col-1 p-1"  rendered="#{ui.icon eq 'Goods_Receipt_With_Approval' and configOptionApplicationController.getBooleanValueByKey('Pharmacy Good Recipt With Approval') and webUserController.hasPrivilege('GoodsRecipt')}">
                     <h:form>
                         <p:tooltip for="Goods_Receipt_With_Approval" value="Goods Receipt With Approval"  showDelay="0" hideDelay="0"></p:tooltip>
@@ -1190,6 +1198,7 @@
                         </p:commandLink>
                     </h:form>
                 </h:panelGroup>
+                -->
 
                 <!-- Goods Receipt Costing -->
                 <h:panelGroup layout="block" class="col-1 p-1"  rendered="#{ui.icon eq 'Goods_Receipt_Costing' and configOptionApplicationController.getBooleanValueByKey('Manage Costing', true)}">

--- a/src/main/webapp/pharmacy/procurement_index.xhtml
+++ b/src/main/webapp/pharmacy/procurement_index.xhtml
@@ -117,7 +117,7 @@
                             <div class="d-grid gap-2">
                                 <p:commandButton
                                     id="btnGrn"
-                                    value="GRN"
+                                    value="Create GRN from PO (Legacy)"
                                     ajax="false"
                                     action="#{searchController.navigateToListPurchaseOrdersToReceive()}"
                                     styleClass="ui-button-stage-save w-100"
@@ -126,7 +126,7 @@
                                     rendered="#{webUserController.hasPrivilege('GoodsRecipt')}" />
                                 <p:commandButton
                                     id="btnApprovedPOsToGrn"
-                                    value="Approved POs to Create GRN"
+                                    value="Create GRN from PO"
                                     ajax="false"
                                     action="#{searchController.navigateToListPurchaseOrdersToReceiveDto()}"
                                     styleClass="ui-button-stage-save w-100"
@@ -151,6 +151,15 @@
                                     style="text-align: left"
                                     icon="fas fa-check-double"
                                     rendered="#{webUserController.hasPrivilege('PharmacyGrnApprove')}" />
+                                <!-- Goods Receipt With Approval: deprecated, issue #21289.
+                                     Routed into the legacy GrnController approval flow, whose
+                                     settle() always fails with "Please select a payment
+                                     method" (never assigns grnBill). The "GRN Finalize" /
+                                     "GRN Approval" buttons above already cover the same
+                                     receive/approve separation via GrnCostingController's
+                                     Save/Finalize/Approve pipeline, making this button a
+                                     redundant, broken duplicate. -->
+                                <!--
                                 <p:commandButton
                                     id="btnGoodsReceiptWithApproval"
                                     value="Goods Receipt With Approval"
@@ -161,6 +170,7 @@
                                     style="text-align: left"
                                     icon="fas fa-dolly-flatbed"
                                     rendered="#{webUserController.hasPrivilege('GoodsRecipt') and configOptionApplicationController.getBooleanValueByKey('Pharmacy Good Recipt With Approval')}" />
+                                -->
                             </div>
                         </p:tab>
 


### PR DESCRIPTION
## Summary

- Fixes #21289. What started as a request for a "Back to PO List" button on the legacy GRN approval page uncovered the real bug: `GrnController.settle()` never gets a populated `grnBill` from `navigateToApproveRecieveGrnPreBill()`, so it operates on a disconnected, lazily-created empty `Bill` instead of `currentGrnBillPre` — where the real payment method actually lives. Settle always fails with **"Please select a payment method"**, no matter what the user picks. Reproduced independently on both localhost/coop and qa1/ruhunu-backup databases, confirming it's a code defect, not data/tenant-specific.
- Production now exclusively uses the Save → Finalize → Approve pipeline (`GrnCostingController`), and the plain "GRN" PO-receive button already routes into that same pipeline whenever "Manage Costing" is enabled — confirmed by tracing `pharmacy_purchase_order_list_for_recieve.xhtml`'s "Create GRN" button, which is wired to `navigateToResiveCostingWithSaveApprove()` and has the old non-costing button already commented out. This makes "Goods Receipt With Approval" a redundant, broken duplicate rather than a distinct feature.
- Changes:
  - `GrnController.java`: mark `navigateToApproveRecieveGrnPreBill()`, `request()`, `requestFinalize()`, `settle()` as `@Deprecated` with Javadoc explaining the root cause and the superseding `GrnCostingController` methods. Not deleted, in case of unforeseen callers.
  - `home.xhtml` / `procurement_index.xhtml`: comment out the "Goods Receipt With Approval" tile/button (the only UI entry points into the broken flow).
  - `procurement_index.xhtml`: relabel the two remaining GRN-receive buttons to **"Create GRN from PO (Legacy)"** (non-DTO, `navigateToListPurchaseOrdersToReceive()`) and **"Create GRN from PO"** (DTO, `navigateToListPurchaseOrdersToReceiveDto()`) to make the pending consolidation explicit — a QA comparison of the two is tracked separately (linked to #21893) before the legacy one is removed.

## Test plan

- [x] `mvn -q -o clean package -DskipTests` compiles cleanly
- [x] Rebuilt and redeployed to local Payara; verified via Playwright:
  - [x] Procurement → GRN tab no longer shows "Goods Receipt With Approval"
  - [x] "Create GRN from PO" (DTO) still creates a GRN via the working costing pipeline end-to-end (confirm dialog explicitly says "start a new Goods Receipt with costing"), landing on `pharmacy_grn_costing_with_save_approve.xhtml` with Payment Method / Save / Finalize present
  - [x] No new server-side exceptions in `server.log` tied to the changed pages
- [ ] QA to run the full legacy-vs-DTO comparison plan (separate issue, linked to #21893) before removing the legacy method entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Removed access to the deprecated “Goods Receipt With Approval” workflow from the home page and procurement menu.
  * Updated goods receipt menu labels to clarify the available purchase-order workflows.
  * Marked legacy non-costing goods receipt actions as deprecated and directed users toward the current costing process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->