### PR TITLE
fix(inward): keep encounter credit company in sync when editing payment details

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtEditController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtEditController.java
@@ -266,6 +266,7 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
         if (removingPrimary) {
             current.setCreditCompany(encounterCreditCompanys.isEmpty()
                     ? null : encounterCreditCompanys.get(0).getInstitution());
+            getEjbFacade().edit(current);
         }
     }
 
@@ -301,6 +302,7 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
         encounterCreditCompanys.add(newEncounterCreditCompany);
         if (current.getCreditCompany() == null) {
             current.setCreditCompany(newEncounterCreditCompany.getInstitution());
+            getEjbFacade().edit(current);
         }
         newEncounterCreditCompany = new EncounterCreditCompany();
         JsfUtil.addSuccessMessage("Credit company added");

--- a/src/main/java/com/divudi/bean/inward/BhtEditController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtEditController.java
@@ -249,6 +249,9 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
     }
 
     public void removeCreditCompany(EncounterCreditCompany ecc) {
+        boolean removingPrimary = current.getCreditCompany() != null
+                && ecc.getInstitution() != null
+                && current.getCreditCompany().equals(ecc.getInstitution());
         for (EncounterCreditCompany e : encounterCreditCompanys) {
             if (e == ecc) {
                 Map<String, Object> before = creditCompanyAuditMap(e);
@@ -259,9 +262,11 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
                         "EncounterCreditCompany", e.getId());
             }
         }
-        current.setCreditCompany(null);
         fillCreditCompaniesByPatient();
-//        current.setCreditCompany(encounterCreditCompanys.get(0).getInstitution());
+        if (removingPrimary) {
+            current.setCreditCompany(encounterCreditCompanys.isEmpty()
+                    ? null : encounterCreditCompanys.get(0).getInstitution());
+        }
     }
 
     public void fillCreditCompaniesByPatient() {
@@ -294,6 +299,9 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
                 sessionController.getLoggedUser(),
                 "EncounterCreditCompany", newEncounterCreditCompany.getId());
         encounterCreditCompanys.add(newEncounterCreditCompany);
+        if (current.getCreditCompany() == null) {
+            current.setCreditCompany(newEncounterCreditCompany.getInstitution());
+        }
         newEncounterCreditCompany = new EncounterCreditCompany();
         JsfUtil.addSuccessMessage("Credit company added");
     }
@@ -572,6 +580,11 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
     public void saveCurrent() {
         if (getCurrent() == null) {
             JsfUtil.addErrorMessage("No admission record to save");
+            return;
+        }
+
+        if (getCurrent().getPaymentMethod() == PaymentMethod.Credit && getCurrent().getCreditCompany() == null) {
+            JsfUtil.addErrorMessage("Please add a credit company before saving a Credit admission");
             return;
         }
 


### PR DESCRIPTION
## Summary
- A cashier can switch a BHT's payment method from Cash to Credit and add a credit company via the dashboard's "Edit Payment Details" screen (`inward_edit_admission_payment.xhtml`, backed by `BhtEditController`), but `patientEncounter.creditCompany` never got set — the only method that set it (`setSelectedCompany`) was unreachable from any page. The final bill print reads `bill.creditCompany` directly, so it silently showed no credit company name.
- `addNewCreditCompany()` now auto-selects the newly added company as the encounter's primary credit company when none is set yet (mirroring the logic the initial-admission flow already had).
- `removeCreditCompany()` previously always nulled the primary company on any removal; it now only clears it when the removed row was the primary, falling back to a remaining company if one exists.
- `saveCurrent()` now blocks saving a Credit-payment-method admission with no credit company set, with a clear error message, as a safety net.

Confirmed against a real production incident (BHT/57198, Galle Co-Operative Hospital): cash admission was cancelled, edited to Credit, credit company added, but final bill printed with no credit company. Root cause matched exactly; data was corrected directly, and this PR fixes the underlying gap so it can't recur.

## Test plan
- [x] `mvn compile` passes
- [ ] Manually verify on local deploy: create/edit a BHT, switch payment method to Credit, add a credit company via "Edit Payment Details", save, confirm `patientEncounter.creditCompany` is set and final bill print shows the credit company name
- [ ] Verify removing the only credit company clears the primary, and removing one of several falls back to another
- [ ] Verify saving a Credit admission with zero credit companies added is blocked with the new error message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credit-company selection when removing companies from an admission.
  * Automatically assigns a remaining or newly added company as the primary company when needed.
  * Prevents saving Credit admissions without a primary credit company.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->