### PR TITLE
fix(inward): correct interim gross total, final bill cancel nav and dashboard visibility

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -4682,6 +4682,10 @@ public class BhtSummeryController implements Serializable {
                     cit.setMargin(docMargin);
                     cit.setVat(docVat);
                 }
+            } else if (cit.getInwardChargeType() == InwardChargeType.AdmissionFee) {
+                cit.setGross(cit.getTotal());
+                cit.setMargin(0.0);
+                cit.setVat(0.0);
             }
         }
     }

--- a/src/main/java/com/divudi/bean/inward/InwardSearch.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSearch.java
@@ -667,6 +667,13 @@ public class InwardSearch implements Serializable {
         return getBillFacade().findByJpql(jpql, params);
     }
 
+    public boolean hasAnyFinalBillVersion(PatientEncounter admission) {
+        if (admission == null) {
+            return false;
+        }
+        return !fetchFinalBillVersions(admission).isEmpty();
+    }
+
     /**
      * User-facing action to mark {@code newConfirmed} as the confirmed final
      * bill version for its admission. Privilege checks are done in the XHTML

--- a/src/main/webapp/inward/admission_profile.xhtml
+++ b/src/main/webapp/inward/admission_profile.xhtml
@@ -439,7 +439,7 @@
                                 </div>
                                 <div class="col-12">
                                     <p:commandButton
-                                        rendered="#{admissionController.current.discharged and admissionController.current.paymentFinalized and webUserController.hasPrivilege('InwardSettleFinalBill')}"
+                                        rendered="#{admissionController.current.discharged and inwardSearch.hasAnyFinalBillVersion(admissionController.current) and webUserController.hasPrivilege('InwardSettleFinalBill')}"
                                         value="Manage Final Bills"
                                         ajax="false"
                                         action="#{inwardSearch.navigateToManageFinalBills}"

--- a/src/main/webapp/inward/inward_cancel_bill_final.xhtml
+++ b/src/main/webapp/inward/inward_cancel_bill_final.xhtml
@@ -171,7 +171,22 @@
                         <p:panel>
                             <f:facet name="header">
                                 <h:outputLabel value="Cancel Bill Preview" class="mt-2"/>
-                                <p:commandButton 
+                                <p:commandButton
+                                    ajax="false"
+                                    immediate="true"
+                                    value="Inpatient Dashboard"
+                                    icon="fas fa-id-card"
+                                    styleClass="ui-button-info ui-button-outlined"
+                                    style="float: right;"
+                                    action="#{bhtSummeryController.navigateToInpatientProfile()}">
+                                    <f:setPropertyActionListener
+                                        value="#{inwardSearch.bill.patientEncounter}"
+                                        target="#{bhtSummeryController.patientEncounter}"/>
+                                    <f:setPropertyActionListener
+                                        value="#{inwardSearch.bill.patientEncounter}"
+                                        target="#{admissionController.current}"/>
+                                </p:commandButton>
+                                <p:commandButton
                                     icon="fa fa-print"
                                     class="ui-button-info"
                                     style="float: right;"

--- a/src/main/webapp/inward/inward_cancel_bill_final.xhtml
+++ b/src/main/webapp/inward/inward_cancel_bill_final.xhtml
@@ -178,10 +178,7 @@
                                     icon="fas fa-id-card"
                                     styleClass="ui-button-info ui-button-outlined"
                                     style="float: right;"
-                                    action="#{bhtSummeryController.navigateToInpatientProfile()}">
-                                    <f:setPropertyActionListener
-                                        value="#{inwardSearch.bill.patientEncounter}"
-                                        target="#{bhtSummeryController.patientEncounter}"/>
+                                    action="#{admissionController.navigateToAdmissionProfilePage()}">
                                     <f:setPropertyActionListener
                                         value="#{inwardSearch.bill.patientEncounter}"
                                         target="#{admissionController.current}"/>


### PR DESCRIPTION
## Summary

Fixes three related bugs in the Inward billing flow, found during a live QA3 demo and filed together in #22588:

1. **Interim Bill "Gross Total" undercounted by the admission fee.** `BhtSummeryController.setGrossMarginVatBreakdown()` relied on an implicit fallback to give `AdmissionFee` its gross value; any coincidental `BillItem` sharing that charge type could silently zero it out. Now explicitly set (mirroring the existing `ProfessionalCharge`/`DoctorAndNurses` pattern).
2. **Cancel Bill Preview page had no way back to the Inpatient Dashboard.** Added an "Inpatient Dashboard" button to `inward_cancel_bill_final.xhtml`, routed through the established `AdmissionController.navigateToAdmissionProfilePage()` flow (per CodeRabbit review) so the encounter, child admissions, and provisional-bill state are all initialized correctly rather than via a hand-rolled shortcut.
3. **"Manage Final Bills" disappeared once all final bills for an admission were cancelled.** The `paymentFinalized` flag already correctly reverts to `false` in that case (existing logic), but the dashboard button's `rendered` condition incorrectly tied "Manage Final Bills" visibility to that same flag. Decoupled it via a new `InwardSearch.hasAnyFinalBillVersion()` check so cancelled-bill history stays reachable.

## Test plan

Full end-to-end pass on local Payara, using a fresh synthetic OPD Card admission (BHT `OPDCARD/43472`, admission fee 500):

- [x] Local build (`mvn clean package -DskipTests`) succeeds, redeployed to local Payara.
- [x] **Bug 1 verified**: Interim Bill's Gross Total showed `500.00`, matching Total Charges (the admission-fee-only charge now flows into Gross Total via the explicit override).
- [x] Discharged the admission, created + saved its Final Bill; confirmed baseline dashboard state — **Final Bill** + **Manage Final Bills** both visible, **Interim Bill** hidden (correct pre-cancellation state).
- [x] **Bug 2 + 3 verified**: cancelled the final bill via the Cancel Bill Preview flow. Confirmed:
  - The new **Inpatient Dashboard** button appears on the Cancel Bill Preview and, when clicked, navigates to `admission_profile.xhtml` for the **correct** patient (BHT `OPDCARD/43472`, not a stale session patient).
  - Dashboard now shows **Interim Bill** active again, **Final Bill** hidden, **Manage Final Bills** still visible — clicking it lists the cancelled version via `inward_final_bill_list.xhtml`.
  - DB cross-check: `PATIENTENCOUNTER.paymentFinalized = 0`, `finalBill_id = NULL`, and the cancelled `BILL` row shows `confirmedFinalBill = 0`, `cancelled = 1`.
- [x] Addressed CodeRabbit review comment: switched the new nav button to use `admissionController.navigateToAdmissionProfilePage()` (the pattern used by 60+ other pages) instead of a hand-rolled listener pair that skipped setting `patientEncounterHasProvisionalBill`.

No schema/entity changes — no DDL regeneration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an **Inpatient Dashboard** button to the final-bill cancellation preview for faster navigation back to the patient’s inpatient profile.
  - Improved access to final-bill management for discharged admissions with available final bill versions and appropriate permissions.

- **Bug Fixes**
  - Corrected admission-fee breakdowns so the total is shown as gross, with margin and VAT correctly reported as zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->