### PR TITLE
fix(inward): show bold Due Amount on Custom Bill 2 print

### DIFF
--- a/src/main/webapp/resources/inward/bill/finalBillCustom3.xhtml
+++ b/src/main/webapp/resources/inward/bill/finalBillCustom3.xhtml
@@ -144,10 +144,18 @@
                         </h:outputLabel>
                     </td>
                 </tr>
-                <tr style="font-weight: bold; font-size: 13px; border-top: 1px solid #000;">
+                <tr style="font-size: 13px; border-top: 1px solid #000;">
                     <td style="text-align: left;">Net Amount (LKR)</td>
                     <td style="text-align: right;">
                         <h:outputLabel value="#{cc.attrs.bill.netTotal}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputLabel>
+                    </td>
+                </tr>
+                <tr style="font-weight: bold; font-size: 13px;">
+                    <td style="text-align: left;">Due Amount</td>
+                    <td style="text-align: right;">
+                        <h:outputLabel value="#{cc.attrs.bill.netTotal - cc.attrs.bill.paidAmount}">
                             <f:convertNumber pattern="#,##0.00" />
                         </h:outputLabel>
                     </td>


### PR DESCRIPTION
## Summary
- Custom Bill 2 (`finalBillCustom3.xhtml`, the composite behind the "Custom Bill 2" button in the Final Bill page's Custom Bills tab) had no Due/outstanding-balance line at all.
- Added a **Due Amount** row (`bill.netTotal - bill.paidAmount`, the same formula the sibling "Custom Bill" template uses for its "Balance To Pay" line) and made it bold.
- Removed bold from the "Net Amount (LKR)" row — it no longer needs emphasis now that Due Amount is the highlighted figure.
- Applies to both Original and Duplicate copies since they share this one composite template.

Closes #22602

## Test plan

**Local Playwright + DB verification** (JSF-only change, hot-copied into the local exploded Payara deployment — no Java recompile needed):
- Queried the local `coop` DB for an Inward Final Bill with a partial payment: `Inward/INWFINAL/154` — Net Total 53,756.29, Paid 10,000.00, Due 43,756.29.
- Logged into local HMIS (`localhost:9080/rh`), department Inward, searched and opened that bill, opened the Custom Bills tab.
- Confirmed both Original and Duplicate Custom Bill 2 copies now render a bold **Due Amount: 43,756.29** row, and **Net Amount (LKR)** is no longer bold. 43,756.29 = 53,756.29 − 10,000.00 ✓.
- Before/after screenshots and full detail posted on issue #22602: https://github.com/hmislk/hmis/issues/22602#issuecomment-5156409377

![after](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/22602-02-after-custom-bill-2-bold-due.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)