### PR TITLE
fix(inward): reorder Custom Bill 2 totals, drop Pay Type, itemize professional fees

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -517,11 +517,10 @@ public class BhtSummeryController implements Serializable {
     }
 
     /**
-     * Charges grouped by inward charge type, alphabetical by display name,
-     * for the Custom3 5x5 impact-printer bill ("Custom Bill 2" in the UI).
-     * Unlike getCustom2CategoryTotals, ProfessionalCharge (doctor/consultant
-     * fee) is NOT excluded — Custom3 is a single-page format with no separate
-     * Professional Bill page, so it must appear as its own particulars line.
+     * Charges grouped by inward charge type (excluding Professional Charge,
+     * which is now listed as individual per-doctor fee lines), alphabetical
+     * by display name, for the Custom3 5x5 impact-printer bill ("Custom Bill
+     * 2" in the UI).
      */
     public List<Map.Entry<String, Double>> getCustom3CategoryTotals(Bill bill) {
         Map<String, Double> totals = new TreeMap<>();
@@ -529,6 +528,9 @@ public class BhtSummeryController implements Serializable {
             return new ArrayList<>(totals.entrySet());
         }
         for (BillItem bi : bill.getBillItems()) {
+            if (bi.getInwardChargeType() == InwardChargeType.ProfessionalCharge) {
+                continue;
+            }
             if (bi.getAdjustedValue() == 0.0) {
                 continue;
             }

--- a/src/main/webapp/resources/inward/bill/finalBillCustom3.xhtml
+++ b/src/main/webapp/resources/inward/bill/finalBillCustom3.xhtml
@@ -114,6 +114,25 @@
                             </td>
                         </tr>
                     </ui:repeat>
+                    <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
+                        <h:panelGroup rendered="#{bip.inwardChargeType eq 'ProfessionalCharge'}">
+                            <ui:repeat value="#{bip.proFees}" var="fe">
+                                <h:panelGroup rendered="#{fe.feeAdjusted ne 0 and fe.bill.cancelled eq false and fe.bill.billClass eq 'class com.divudi.core.entity.BilledBill'}">
+                                    <tr>
+                                        <td style="text-align: left;">
+                                            <h:outputLabel value="#{fe.staff.person.nameWithTitle}" />
+                                            <h:outputText value=" (#{fe.staff.speciality.name})" rendered="#{fe.staff.speciality ne null}" />
+                                        </td>
+                                        <td style="text-align: right;">
+                                            <h:outputLabel value="#{fe.feeAdjusted}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                        </td>
+                                    </tr>
+                                </h:panelGroup>
+                            </ui:repeat>
+                        </h:panelGroup>
+                    </ui:repeat>
                 </tbody>
             </table>
 
@@ -136,26 +155,10 @@
                         </h:outputLabel>
                     </td>
                 </tr>
-                <tr>
-                    <td style="text-align: left;">Deposit</td>
-                    <td style="text-align: right;">
-                        <h:outputLabel value="#{bhtSummeryController.getCustom3DepositTotal(cc.attrs.bill)}">
-                            <f:convertNumber pattern="#,##0.00" />
-                        </h:outputLabel>
-                    </td>
-                </tr>
                 <tr style="font-size: 13px; border-top: 1px solid #000;">
                     <td style="text-align: left;">Net Amount (LKR)</td>
                     <td style="text-align: right;">
                         <h:outputLabel value="#{cc.attrs.bill.netTotal}">
-                            <f:convertNumber pattern="#,##0.00" />
-                        </h:outputLabel>
-                    </td>
-                </tr>
-                <tr style="font-weight: bold; font-size: 13px;">
-                    <td style="text-align: left;">Due Amount</td>
-                    <td style="text-align: right;">
-                        <h:outputLabel value="#{cc.attrs.bill.netTotal - cc.attrs.bill.paidAmount}">
                             <f:convertNumber pattern="#,##0.00" />
                         </h:outputLabel>
                     </td>
@@ -165,14 +168,18 @@
             <div class="sep"></div>
 
             <table>
-                <tr style="font-weight: bold;">
-                    <td style="text-align: left;">Pay Type</td>
-                    <td style="text-align: right;">Amount Rs.</td>
-                </tr>
                 <tr>
-                    <td style="text-align: left;"><h:outputLabel value="#{cc.attrs.bill.paymentMethod}" /></td>
+                    <td style="text-align: left;">Deposit</td>
                     <td style="text-align: right;">
-                        <h:outputLabel value="#{cc.attrs.bill.paidAmount}">
+                        <h:outputLabel value="#{bhtSummeryController.getCustom3DepositTotal(cc.attrs.bill)}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputLabel>
+                    </td>
+                </tr>
+                <tr style="font-weight: bold; font-size: 13px;">
+                    <td style="text-align: left;">Due Amount</td>
+                    <td style="text-align: right;">
+                        <h:outputLabel value="#{cc.attrs.bill.netTotal - cc.attrs.bill.paidAmount}">
                             <f:convertNumber pattern="#,##0.00" />
                         </h:outputLabel>
                     </td>


### PR DESCRIPTION
## Summary
Follow-up to #22602 / #22603 on the same "Custom Bill 2" print (`finalBillCustom3.xhtml`):

- **Reordered totals**: Total Amount, Discounts, Net Amount (grouped as the bill subtotal), then a separator, then Deposit, Due Amount (grouped as the payment/balance figures). Previously the order was Total, Discount, Deposit, Net Amount, Due Amount.
- **Removed the Pay Type block** — it duplicated the payment method already shown elsewhere on the bill and wasn't needed on this print.
- **Itemized professional fees**: the single lump "Professional Charge" line is replaced with one line per doctor (`Doctor Name (Speciality)` — `Amount`), matching the breakdown already used on the "Custom Bill" (1) Professional Bill page (`finalBillCustom2.xhtml`). `getCustom3CategoryTotals` in `BhtSummeryController.java` now excludes `ProfessionalCharge` from the aggregated totals to avoid double-counting now that it's itemized separately.

## Test plan
Rebuilt (`mvn clean package`) and redeployed locally, since this touches Java (not JSF-only). Logged into local HMIS, department Inward, opened `Inward/INWFINAL/154` — a bill with two professional-fee doctors (Dr. Champika Yapa, Dr. (Mrs) R.R Weerakoon) — and opened the Custom Bills tab:

- [x] Items table no longer shows a single "Professional Charge" line; instead shows both doctors individually with their fees, and the line items still sum to Total Amount (53,756.29).
- [x] Totals table order is now Total Amount → Discounts → Net Amount → (separator) → Deposit → Due Amount, confirmed in both Original and Duplicate copies.
- [x] Pay Type block is gone; "Bill Prepared By" now follows directly after the Deposit/Due Amount table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Professional fee details now appear in the final bill, including staff names, specialties, and adjusted fees.
  * Deposit information is presented in a separate payment summary before the amount due.

* **Bug Fixes**
  * Category totals now accurately exclude professional charges, aligning totals with displayed professional fees.
  * Cancelled professional charges are excluded from the bill.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->