### PR TITLE
fix(inward): compare BHT/OPD-card text against load-time snapshot, not a fresh peek

### DIFF
--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -189,6 +189,12 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
     String selectText = "";
     private String ageText = "";
     private String bhtText = "";
+    // Snapshot of the suggested BHT/OPD-card text at the moment the admission
+    // form loaded it into bhtText. Used at save time to detect whether the
+    // user actually edited the field, instead of comparing against a fresh
+    // peek (which can drift if another admission consumes the counter while
+    // this form is still open, wrongly looking like a manual override). (#22583)
+    private String suggestedBhtAtLoad = "";
     private String patientTabId = "tabNewPt";
     private int patientSearchTab;
     private Patient patient;
@@ -2651,9 +2657,13 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         savePatientAllergies();
         saveGuardian();
         boolean bhtCanBeEdited = configOptionApplicationController.getBooleanValueByKey("BHT Number can be edited at the time of admission");
-        String suggestedBht = getInwardBean().getBhtTextPreview(getCurrent().getAdmissionType());
+        // Compare against the snapshot taken when the form loaded, not a fresh
+        // peek — the counter may have moved on since then (another admission
+        // saved while this form sat open), which would make an untouched
+        // field look like a manual override and bypass the counter/lock,
+        // silently colliding with a number already issued elsewhere. (#22583)
         boolean userOverrodeBht = bhtCanBeEdited && bhtText != null && !bhtText.trim().isEmpty()
-                && !bhtText.trim().equals(suggestedBht);
+                && !bhtText.trim().equals(suggestedBhtAtLoad.trim());
 
         long oldBhtLong = getCurrent().getBhtLong();
         String oldBhtNo = getCurrent().getBhtNo();
@@ -3146,6 +3156,7 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         }
 
         bhtText = getInwardBean().getBhtTextPreview(getCurrent().getAdmissionType());
+        suggestedBhtAtLoad = bhtText;
 
         // Baby admissions never get a room of their own — the baby stays in the
         // mother's room. Skip applying the admission type's default/package room


### PR DESCRIPTION
## Summary
- Fixes a root cause of duplicate OPD Card / BHT numbers being assigned to two different patients (#22583)
- `AdmissionController.saveSelected()` decided whether staff manually overrode the suggested BHT/OPD-card number by comparing the on-screen text against a **freshly re-peeked** suggestion at save time. If another admission consumed the counter while this form sat open (e.g. a form left open/idle), the untouched field would no longer match the fresh peek, get misclassified as a manual override, and be written straight to `bhtNo` — completely bypassing the counter/lock and colliding with a number already issued to another patient.
- Adds `suggestedBhtAtLoad`, a snapshot of the suggested text taken when the form loads it into `bhtText` (`bhtNumberCalculation()`), and compares against that frozen snapshot at save time instead of a fresh peek, so only an actual staff edit is treated as an override.

## Root cause
See investigation notes on #22583. This is a regression introduced by the July 23 fix for #22336 (commit `0fb9b381a8`), which correctly stopped overrides from "burning" counter numbers but introduced this new bypass path that isn't safe when the suggested value goes stale between form load and save.

## Test plan
- [x] `mvn compile` succeeds with no errors
- [ ] Manually verify: open two admission forms (or one left open while another admission is saved elsewhere) for the same admission type/institution, confirm the second save still draws a fresh, unique counter number when the BHT field was left untouched
- [ ] Confirm a genuine manual edit of the BHT field is still respected as an override and does not draw a counter number

Fixes #22583

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved BHT override detection to accurately identify whether the entered value was changed.
  * Prevented unchanged BHT fields from being incorrectly flagged after the counter advances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->