### PR TITLE
fix(inward): make nursing discharge optional as administrative discharge prerequisite

### DIFF
--- a/developer_docs/configuration/application-options.md
+++ b/developer_docs/configuration/application-options.md
@@ -45,6 +45,12 @@ This document lists the configuration options used in the application and their 
 | `OPD Billing - Clear Referring Doctor on New Bill`              | Boolean   | `true`  | When true, clears the referring doctor and referring institution when starting a new OPD bill. When false, the values are preserved across consecutive bills. |
 | `Show Mark Foreigner and Mark Local Buttons in Billing`         | Boolean   | `true`  | Controls visibility of the Mark Foreigner / Mark Local buttons across OPD Billing, Channel Booking, Clinic Sessions, and Inward Service Bill screens. Independent of `Save the Patient with Patient Status` (which only controls the read-only status badge/toggle shown during patient registration). See issue #22311. |
 
+## Inward Discharge
+
+| Key                                                              | Type      | Default | Description                                                                                             |
+| ---------------------------------------------------------------- | --------- | ------- | ------------------------------------------------------------------------------------------------------- |
+| `Inward Administrative Discharge - Require Nursing Discharge`   | Boolean   | `true`  | Controls whether `BhtSummeryController.checkDischargeTime()` requires `PatientEncounter.isNursingDischarged()` before allowing administrative discharge (the "Discharge" action on the Interim Bill) for room-charged admissions. Some hospitals do not use the nursing discharge workflow; setting this to `false` for those institutions lets administrative discharge proceed without it. See issue #22607. |
+
 ## Pharmacy Procurement
 
 | Key                                                              | Type      | Default | Description                                                                                             |

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -2112,7 +2112,9 @@ public class BhtSummeryController implements Serializable {
 
         if (getPatientEncounter().getAdmissionType() != null
                 && getPatientEncounter().getAdmissionType().isRoomChargesAllowed()) {
-            if (!getPatientEncounter().isNursingDischarged()) {
+            boolean nursingDischargeRequired = configOptionApplicationController.getBooleanValueByKey(
+                    "Inward Administrative Discharge - Require Nursing Discharge", true);
+            if (nursingDischargeRequired && !getPatientEncounter().isNursingDischarged()) {
                 JsfUtil.addErrorMessage("Nursing discharge must be completed before the bill can be settled.");
                 return true;
             }


### PR DESCRIPTION
## Summary
- `BhtSummeryController.checkDischargeTime()` unconditionally required `PatientEncounter.isNursingDischarged()` before allowing administrative discharge (the "Discharge" action on the Interim Bill) for room-charged admissions.
- Some hospitals do not use the nursing discharge workflow, so `nursingDischarged` stays `false` forever, permanently blocking discharge for those institutions.
- Adds a new boolean config option `Inward Administrative Discharge - Require Nursing Discharge` (default `true`, preserving current behaviour) so those institutions can opt out.

## Test plan
- [x] Build succeeds (`mvn clean package`, 185 tests passed)
- [x] With the config option left at its default (`true`), attempting Discharge on the Interim Bill for a room-charged, not-yet-nursing-discharged BHT still shows "Nursing discharge must be completed before the bill can be settled." (no regression) — verified end-to-end against local Payara with a synthetic test admission
- [x] With the config option set to `false` (via Admin → Application Options), the same BHT can complete administrative discharge without nursing discharge — verified end-to-end, patient successfully discharged (`DISCHARGED=1`, `NURSINGDISCHARGED=0`)
- [x] Documented in `developer_docs/configuration/application-options.md`

Closes #22607

🤖 Generated with [Claude Code](https://claude.com/claude-code)