### PR TITLE
fix(inward): fix Custom Bill 2 print margins and drop redundant header

### DIFF
--- a/src/main/webapp/resources/inward/bill/finalBillCustom3.xhtml
+++ b/src/main/webapp/resources/inward/bill/finalBillCustom3.xhtml
@@ -7,11 +7,13 @@
       xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
 
     <!--
-        5 inch wide Inward Final Bill ("Custom Bill 2" in the Custom Bills tab).
-        Tuned for impact / dot-matrix printers (e.g. Epson LX/FX series):
-        a single clean sans-serif font, solid black text, no background fills.
-        Replicates tmp/COOP/OPD CARD.pdf — see
-        docs/superpowers/specs/2026-08-01-inward-final-bill-custom3-five-five-design.md
+        Inward Final Bill ("Custom Bill 2" in the Custom Bills tab), printed
+        on the same pre-printed continuous stationery as the Inward Deposit
+        Receipt (five_five_custom_3_inward_payments.xhtml /
+        sale_bill_five_five_custom_3.css) — that receipt is the proven-good
+        reference for this printer's actual printable area. No institution
+        header is printed here: the letterhead paper already has it
+        pre-printed, so the bill starts directly with the FINAL BILL title.
     -->
     <cc:interface>
         <cc:attribute name="bill" type="com.divudi.core.entity.Bill" required="true" />
@@ -21,7 +23,7 @@
     <cc:implementation>
         <style>
             .custom3-bill {
-                width: 12.7cm; /* 5 inch */
+                width: 10cm;
                 font-family: Arial, "Liberation Sans", sans-serif;
                 color: #000;
                 font-size: 12px;
@@ -32,34 +34,22 @@
             .custom3-bill table { width: 100%; border-collapse: collapse; }
             .custom3-bill .sep { border-top: 1px solid #000; margin: 4px 0; }
             .custom3-bill .title { text-align: center; font-weight: bold; font-size: 14px; }
-            .custom3-bill .dept-name { text-align: center; font-weight: bold; font-size: 15px; }
             .custom3-bill .items th, .custom3-bill .items td { padding: 2px 0; }
             @media print {
                 .custom3-bill {
-                    width: 12.7cm !important;
+                    width: 10cm !important;
+                    margin-left: 0cm !important;
+                    margin-right: 2.5cm !important;
+                    margin-top: 2.5cm !important;
+                    margin-bottom: 1.0cm !important;
+                    padding-left: 0.25cm;
                 }
-            }
-            @page {
-                size: 12.7cm auto; /* 5 inch wide continuous stationery */
-                margin: 0;
             }
         </style>
 
         <div class="custom3-bill">
 
-            <div class="dept-name">
-                <h:outputLabel value="#{cc.attrs.bill.department.printingName}" />
-            </div>
-            <div style="text-align: center; font-size: 11px;">
-                <h:outputLabel value="#{cc.attrs.bill.department.address}" />
-            </div>
-            <div style="text-align: center; font-size: 11px;">
-                <h:outputLabel value="#{cc.attrs.bill.department.telephone1}" />
-                <h:outputLabel value=" / " rendered="#{cc.attrs.bill.department.telephone2 ne null}" />
-                <h:outputLabel value="#{cc.attrs.bill.department.telephone2}" />
-            </div>
-
-            <div class="title" style="margin-top: 4px;">
+            <div class="title">
                 <h:outputLabel value="FINAL BILL" />
                 <h:outputLabel value=" **Duplicate**" rendered="#{cc.attrs.duplicate eq true}" />
                 <h:outputLabel value=" **Cancelled**" rendered="#{cc.attrs.bill.cancelled eq true}" />


### PR DESCRIPTION
## Summary
Fixes #22613 — Custom Bill 2 (`finalBillCustom3.xhtml`) was printing off the right edge of the pre-printed continuous stationery.

**Root cause**: the print CSS used `width: 12.7cm` with a `margin: 0` `@page` override, which exceeds this dot-matrix printer's actual printable width, cutting off the amount column on the right.

**Fix**: replaced the geometry with the proven-good values already used by the Inward Deposit Receipt on the same paper (`five_five_custom_3_inward_payments.xhtml` / `sale_bill_five_five_custom_3.css`, referenced directly in the issue as the correctly-printing example):
- `width: 10cm`, `margin-right: 2.5cm`, `margin-left: 0cm`, `margin-top: 2.5cm`, `margin-bottom: 1.0cm`
- Dropped the `@page` override entirely (the working reference template doesn't use one)

**Also per the issue**: removed the printed institution name/address/phone header block. The letterhead paper already has the institution details pre-printed, so the bill now starts directly with the "FINAL BILL" title, matching the deposit receipt's pattern.

## Test plan
JSF-only change — hot-copied into the local exploded Payara deployment (no Java touched, no recompile needed).

- [x] Confirmed the institution header block no longer renders; the print starts directly with "FINAL BILL" / "FINAL BILL**Duplicate**".
- [x] Force-applied the `@media print` rules in the browser (temporarily overriding without the media query) against `Inward/INWFINAL/154`, a bill with long particular labels ("Dr. (MRS) R.R WEERAKOON (PHYSICIAN )", "Laboratory Charges", etc.) and confirmed the narrower 10cm width causes no line wrapping or overflow — all content stays within bounds.
- [ ] Actual physical print test on the dot-matrix printer still recommended before/after merge, since this is calibrated to real printer hardware I don't have access to — but the geometry is a direct copy of the already-verified-working Deposit Receipt template on the same paper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the custom inward final bill for pre-printed stationery.
  * The bill now starts directly with the “FINAL BILL” title.
  * Reduced the content width for a more compact printed layout.
  * Added print-specific margins and padding.
  * Removed the department header, address, telephone details, and explicit page sizing.
  * Adjusted title spacing for improved print presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->