### PR TITLE
fix(inward): render selection checkboxes and live refund total in service bill refund

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardSearch.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSearch.java
@@ -2458,12 +2458,14 @@ public class InwardSearch implements Serializable {
     }
 
     public List<BillItem> getBillItems() {
-        HashMap hm = new HashMap();
-        String sql = "SELECT b FROM BillItem b WHERE b.retired=false and b.bill=:b ";
-        hm.put("b", getBill());
-        billItems = getBillItemFacede().findByJpql(sql, hm);
         if (billItems == null) {
-            billItems = new ArrayList<>();
+            HashMap hm = new HashMap();
+            String sql = "SELECT b FROM BillItem b WHERE b.retired=false and b.bill=:b ";
+            hm.put("b", getBill());
+            billItems = getBillItemFacede().findByJpql(sql, hm);
+            if (billItems == null) {
+                billItems = new ArrayList<>();
+            }
         }
 
         return billItems;

--- a/src/main/java/com/divudi/bean/inward/InwardSearch.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSearch.java
@@ -371,6 +371,7 @@ public class InwardSearch implements Serializable {
             return "";
         }
         bill = b;
+        billItems = null;
         printPreview = true;
         return "/inward/inward_deposit_cancel_bill_payment?faces-redirect=true";
     }
@@ -617,6 +618,7 @@ public class InwardSearch implements Serializable {
 
         if (versions.size() == 1) {
             bill = versions.get(0);
+            billItems = null;
             withProfessionalFee = false;
             return "/inward/inward_reprint_bill_final?faces-redirect=true";
         }
@@ -939,6 +941,7 @@ public class InwardSearch implements Serializable {
 
         // bill = getBillFacade().findFirstByJpql(jpql, temMap, TemporalType.TIMESTAMP);
         bill = getBillFacade().findFirstByJpql(jpql, temMap);
+        billItems = null;
 
         if (bill == null) {
             JsfUtil.addErrorMessage("No Provisional Bill Created");

--- a/src/main/webapp/inward/inward_bill_service_refund.xhtml
+++ b/src/main/webapp/inward/inward_bill_service_refund.xhtml
@@ -94,17 +94,18 @@
 
                             <p:panel header="Bill Item Detail">
                                 <p:dataTable id="dtF" rowIndexVar="rowIndex" value="#{inwardSearch.billItems}" var="b"
+                                             selectionMode="multiple"
                                              rowKey="#{b.id}"
                                              selection="#{inwardServiceRefundController.refundingItems}" >
 
                                     <p:ajax event="rowSelectCheckbox" listener="#{inwardServiceRefundController.calculateRefundTotal()}"
-                                            update=":refundForm:txtTotal" />
+                                            update=":refundForm:txtTotal" process="colSelect dtF" />
                                     <p:ajax event="rowUnselectCheckbox" listener="#{inwardServiceRefundController.calculateRefundTotal()}"
-                                            update=":refundForm:txtTotal" />
+                                            update=":refundForm:txtTotal" process="colSelect dtF" />
                                     <p:ajax event="toggleSelect" listener="#{inwardServiceRefundController.calculateRefundTotal()}"
-                                            update=":refundForm:txtTotal" />
+                                            update=":refundForm:txtTotal" process="colSelect dtF" />
 
-                                    <p:column selectionMode="multiple" style="width: 3em; text-align: center;" disabledSelection="#{b.refunded}" />
+                                    <p:column selectionBox="true" id="colSelect" style="width: 3em; text-align: center;" disabledSelection="#{b.refunded}" />
 
                                     <p:column headerText="Item Name">
                                         <h:outputLabel value="#{b.item.name}"/>


### PR DESCRIPTION
## Summary

- Fixes #22597 — the Inward Bill Service Refund page (`inward_bill_service_refund.xhtml`) rendered no row-selection checkboxes at all, and "Total Refund" never updated on selection.
- Root cause 1: the selection column used `p:column selectionMode="multiple"`, which is not a valid checkbox-rendering attribute for `p:column` in PrimeFaces — the checkbox widget requires `selectionBox="true"` on the column (`selectionMode` belongs on `p:dataTable`). Fixed to match the working pattern already used by `collecting_centre/bill_refund.xhtml` and `agency_management/bill_refund.xhtml`.
- Root cause 2: `InwardSearch.getBillItems()` re-ran its JPQL query and reassigned the field on every call (including mid-AJAX-request re-evaluations), handing PrimeFaces a fresh set of `BillItem` instances each time — this breaks selection tracking. Now cached (`if (billItems == null) { ...query... }`), matching the existing pattern in the sibling `getBillFees()` getter on the same class.

## Test plan

Verified end-to-end locally via Playwright against the local `coop` DB (bill `OPDL1//26/042475`, BHT/57238, 3 unrefunded items):

- [x] Checkbox column now renders — header "select all" plus one checkbox per row.
- [x] Selecting one item updates "Total Refund" live via AJAX to that item's Fee Value (no full postback).
- [x] Selecting a second item sums both values correctly.
- [x] Deselecting an item drops the total back down correctly.
- [x] Submitted a refund with 1 of 3 items selected — confirmed in the DB that only the selected `BillItem` was flagged `REFUNDED=1`/`BILLITEMREFUNDED=1`, the other two items were untouched, and a new `RefundBill` was created with a single inverted line item matching the selected item's value.
- [x] Refund print preview shows only the returned item.

Screenshots (before/after + DB-verified refund):

![Checkboxes visible](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/22597-01-checkboxes-visible.png)
![Live total update on selection](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/22597-02-live-total-update.png)
![Refund submitted successfully](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/22597-03-refund-success.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading performance when viewing bill items by reusing previously loaded results.
  * Enhanced refund bill selection behavior, including reliable checkbox selection, unselection, and toggling.
  * Prevented already refunded items from being selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->