### PR TITLE
fix(pharmacy): add GRN visibility to DTO PO-receive list page

### DIFF
--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -92,6 +92,7 @@ import com.divudi.core.data.dto.PharmacyPreBillSearchDTO;
 import com.divudi.core.data.dto.PharmacyTransferRequestIssueDTO;
 import com.divudi.core.data.dto.PharmacyTransferRequestListDTO;
 import com.divudi.core.data.dto.channel.ChannelIncomeDTO;
+import com.divudi.core.data.dto.PharmacyGrnSummaryDTO;
 import com.divudi.core.data.dto.PharmacyPurchaseOrderDTO;
 import com.divudi.core.data.dto.PharmacyTransferIssuedListDTO;
 import com.divudi.core.data.dto.PharmacyTransferReceivedListDTO;
@@ -7678,6 +7679,14 @@ public class SearchController implements Serializable {
             logger.info("createPoTablePharmacyDto: Result size = {}", (pharmacyPurchaseOrderDtos != null ? pharmacyPurchaseOrderDtos.size() : "null"));
             if (pharmacyPurchaseOrderDtos != null && !pharmacyPurchaseOrderDtos.isEmpty()) {
                 logger.debug("createPoTablePharmacyDto: First DTO = {}", pharmacyPurchaseOrderDtos.get(0));
+
+                // Bulk-load GRNs already raised against each PO (issue #22612)
+                // so the DTO page can show/reopen them like the legacy page.
+                List<BillTypeAtomic> grnBillTypesAtomicsToList = new ArrayList<>();
+                grnBillTypesAtomicsToList.add(BillTypeAtomic.PHARMACY_GRN);
+                grnBillTypesAtomicsToList.add(BillTypeAtomic.PHARMACY_GRN_PRE);
+                grnBillTypesAtomicsToList.add(BillTypeAtomic.PHARMACY_GRN_CANCELLED);
+                fillGrnDtosByBulkQuery(pharmacyPurchaseOrderDtos, grnBillTypesAtomicsToList);
             }
         } catch (Exception e) {
             logger.error("createPoTablePharmacyDto: ERROR while executing DTO query", e);
@@ -7860,6 +7869,78 @@ public class SearchController implements Serializable {
 
         for (Bill po : poList) {
             po.setListOfBill(grnsByPoId.getOrDefault(po.getId(), new ArrayList<>()));
+        }
+    }
+
+    /**
+     * DTO-page counterpart of fillGrnsByBulkQuery: bulk-loads GRN summaries
+     * for every PO in the list using 2 queries (same 2 relationship paths as
+     * fillGrnsByBulkQuery), projecting a lightweight DTO instead of loading
+     * full Bill entities, then assigns the results to each PO DTO's
+     * listOfGrnDtos (issue #22612).
+     */
+    private void fillGrnDtosByBulkQuery(List<PharmacyPurchaseOrderDTO> poDtos, List<BillTypeAtomic> grnBillTypesAtomicsToList) {
+        Map<Long, List<PharmacyGrnSummaryDTO>> grnsByPoId = new HashMap<>();
+        List<Long> poIds = new ArrayList<>();
+        for (PharmacyPurchaseOrderDTO po : poDtos) {
+            poIds.add(po.getBillId());
+            grnsByPoId.put(po.getBillId(), new ArrayList<>());
+        }
+
+        // Path 1: GRN.referenceBill is the PO
+        String jpql1 = "SELECT g.referenceBill.id, g.id, g.deptId, g.createdAt, g.netTotal, g.billTypeAtomic, g.cancelled, g.refunded "
+                + "FROM Bill g "
+                + "WHERE g.retired = false "
+                + "AND g.billTypeAtomic IN :btas "
+                + "AND g.referenceBill.id IN :poIds";
+        Map<String, Object> params1 = new HashMap<>();
+        params1.put("btas", grnBillTypesAtomicsToList);
+        params1.put("poIds", poIds);
+        List<Object> rows1 = getBillFacade().findObjects(jpql1, params1);
+        if (rows1 != null) {
+            for (Object row : rows1) {
+                Object[] cols = (Object[]) row;
+                Long poId = ((Number) cols[0]).longValue();
+                PharmacyGrnSummaryDTO grnDto = new PharmacyGrnSummaryDTO(
+                        (Long) cols[1], (String) cols[2], (Date) cols[3], (Double) cols[4], cols[5], cols[6], cols[7]);
+                grnsByPoId.computeIfAbsent(poId, k -> new ArrayList<>()).add(grnDto);
+            }
+        }
+
+        // Path 2: GRN.billedBill.referenceBill is the PO
+        String jpql2 = "SELECT g.billedBill.referenceBill.id, g.id, g.deptId, g.createdAt, g.netTotal, g.billTypeAtomic, g.cancelled, g.refunded "
+                + "FROM Bill g "
+                + "WHERE g.retired = false "
+                + "AND g.billTypeAtomic IN :btas "
+                + "AND g.billedBill IS NOT NULL "
+                + "AND g.billedBill.referenceBill.id IN :poIds";
+        Map<String, Object> params2 = new HashMap<>();
+        params2.put("btas", grnBillTypesAtomicsToList);
+        params2.put("poIds", poIds);
+        List<Object> rows2 = getBillFacade().findObjects(jpql2, params2);
+        if (rows2 != null) {
+            for (Object row : rows2) {
+                Object[] cols = (Object[]) row;
+                Long poId = ((Number) cols[0]).longValue();
+                Long grnBillId = (Long) cols[1];
+                List<PharmacyGrnSummaryDTO> grnList = grnsByPoId.computeIfAbsent(poId, k -> new ArrayList<>());
+                boolean alreadyPresent = false;
+                for (PharmacyGrnSummaryDTO existing : grnList) {
+                    if (existing.getBillId().equals(grnBillId)) {
+                        alreadyPresent = true;
+                        break;
+                    }
+                }
+                if (!alreadyPresent) {
+                    PharmacyGrnSummaryDTO grnDto = new PharmacyGrnSummaryDTO(
+                            grnBillId, (String) cols[2], (Date) cols[3], (Double) cols[4], cols[5], cols[6], cols[7]);
+                    grnList.add(grnDto);
+                }
+            }
+        }
+
+        for (PharmacyPurchaseOrderDTO po : poDtos) {
+            po.setListOfGrnDtos(grnsByPoId.getOrDefault(po.getBillId(), new ArrayList<>()));
         }
     }
 

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -1485,6 +1485,10 @@ public class PharmacyBillSearch implements Serializable {
             return null;
         }
         bill = billService.reloadBill(billId);
+        if (bill == null) {
+            JsfUtil.addErrorMessage("Bill not found");
+            return null;
+        }
         return navigateToEditSavedGrn();
     }
 
@@ -1525,6 +1529,10 @@ public class PharmacyBillSearch implements Serializable {
             return null;
         }
         bill = billService.reloadBill(billId);
+        if (bill == null) {
+            JsfUtil.addErrorMessage("Bill not found");
+            return null;
+        }
         return navigateToEditSavedGrnCosting();
     }
 

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -1474,6 +1474,20 @@ public class PharmacyBillSearch implements Serializable {
         return grnController.navigateToEditGrn();
     }
 
+    /**
+     * Id-based counterpart of navigateToEditSavedGrn(), for pages (e.g. the
+     * DTO PO-receive list, issue #22612) that only carry a lightweight GRN
+     * summary DTO rather than a preloaded Bill entity.
+     */
+    public String navigateToEditSavedGrnByBillId(Long billId) {
+        if (billId == null) {
+            JsfUtil.addErrorMessage("No Bill Selected");
+            return null;
+        }
+        bill = billService.reloadBill(billId);
+        return navigateToEditSavedGrn();
+    }
+
     public String navigateToEditSavedDirectPurchase() {
         if (bill == null) {
             JsfUtil.addErrorMessage("No Bill Selected");
@@ -1498,6 +1512,20 @@ public class PharmacyBillSearch implements Serializable {
         bill = billService.reloadBill(bill);
         grnCostingController.setCurrentGrnBillPre(bill);
         return grnCostingController.navigateToEditGrnCosting();
+    }
+
+    /**
+     * Id-based counterpart of navigateToEditSavedGrnCosting(), for pages
+     * (e.g. the DTO PO-receive list, issue #22612) that only carry a
+     * lightweight GRN summary DTO rather than a preloaded Bill entity.
+     */
+    public String navigateToEditSavedGrnCostingByBillId(Long billId) {
+        if (billId == null) {
+            JsfUtil.addErrorMessage("No Bill Selected");
+            return null;
+        }
+        bill = billService.reloadBill(billId);
+        return navigateToEditSavedGrnCosting();
     }
 
 //    public String navigateToApproveGrn() {

--- a/src/main/java/com/divudi/core/data/dto/PharmacyGrnSummaryDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/PharmacyGrnSummaryDTO.java
@@ -1,0 +1,96 @@
+package com.divudi.core.data.dto;
+
+import java.io.Serializable;
+import java.util.Date;
+
+/**
+ * Lightweight GRN-row projection nested under a PO row on the DTO/optimized
+ * "Create GRN from PO" page (pharmacy_purchase_order_list_for_recieve_dto.xhtml).
+ * Mirrors what the legacy page shows via Bill.listOfBill, without loading the
+ * full Bill entity graph.
+ */
+public class PharmacyGrnSummaryDTO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Long billId;
+    private String deptId;
+    private Date createdAt;
+    private Double netTotal;
+    private String billTypeAtomic;
+    private Boolean cancelled;
+    private Boolean refunded;
+
+    public PharmacyGrnSummaryDTO(
+            Long billId,
+            String deptId,
+            Date createdAt,
+            Double netTotal,
+            Object billTypeAtomic,
+            Object cancelled,
+            Object refunded) {
+        this.billId = billId;
+        this.deptId = deptId;
+        this.createdAt = createdAt;
+        this.netTotal = netTotal;
+        this.billTypeAtomic = billTypeAtomic != null ? billTypeAtomic.toString() : null;
+        this.cancelled = cancelled != null ? (Boolean) cancelled : false;
+        this.refunded = refunded != null ? (Boolean) refunded : false;
+    }
+
+    public Long getBillId() {
+        return billId;
+    }
+
+    public void setBillId(Long billId) {
+        this.billId = billId;
+    }
+
+    public String getDeptId() {
+        return deptId;
+    }
+
+    public void setDeptId(String deptId) {
+        this.deptId = deptId;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Double getNetTotal() {
+        return netTotal;
+    }
+
+    public void setNetTotal(Double netTotal) {
+        this.netTotal = netTotal;
+    }
+
+    public String getBillTypeAtomic() {
+        return billTypeAtomic;
+    }
+
+    public void setBillTypeAtomic(String billTypeAtomic) {
+        this.billTypeAtomic = billTypeAtomic;
+    }
+
+    public Boolean getCancelled() {
+        return cancelled;
+    }
+
+    public void setCancelled(Boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+
+    public Boolean getRefunded() {
+        return refunded;
+    }
+
+    public void setRefunded(Boolean refunded) {
+        this.refunded = refunded;
+    }
+}

--- a/src/main/java/com/divudi/core/data/dto/PharmacyPurchaseOrderDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/PharmacyPurchaseOrderDTO.java
@@ -1,7 +1,9 @@
 package com.divudi.core.data.dto;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 /**
  * DTO for Pharmacy Purchase Order list display optimization
@@ -56,6 +58,10 @@ public class PharmacyPurchaseOrderDTO implements Serializable {
     // Bill status fields (for GRN page actions)
     private Boolean billClosed;
     private Boolean fullyIssued;
+
+    // GRNs already raised against this PO (issue #22612), populated separately
+    // via a bulk query after the main DTO list query, mirrors Bill.listOfBill
+    private List<PharmacyGrnSummaryDTO> listOfGrnDtos;
 
     // Default constructor required for JPA
     public PharmacyPurchaseOrderDTO() {
@@ -656,6 +662,17 @@ public class PharmacyPurchaseOrderDTO implements Serializable {
 
     public void setFullyIssued(Boolean fullyIssued) {
         this.fullyIssued = fullyIssued;
+    }
+
+    public List<PharmacyGrnSummaryDTO> getListOfGrnDtos() {
+        if (listOfGrnDtos == null) {
+            listOfGrnDtos = new ArrayList<>();
+        }
+        return listOfGrnDtos;
+    }
+
+    public void setListOfGrnDtos(List<PharmacyGrnSummaryDTO> listOfGrnDtos) {
+        this.listOfGrnDtos = listOfGrnDtos;
     }
 
     @Override

--- a/src/main/webapp/pharmacy/pharmacy_purchase_order_list_for_recieve_dto.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purchase_order_list_for_recieve_dto.xhtml
@@ -148,7 +148,12 @@
                                     resizableColumns="true"
                                     reflow="true"
                                     stripedRows="true"
+                                    rowExpandMode="multiple"
+                                    rowKey="#{p.billId}"
                                     size="small">
+                                    <p:column width="30" exportable="false">
+                                        <p:rowToggler />
+                                    </p:column>
                                     <p:column headerText="Request Details" sortBy="#{p.createdAt}" styleClass="text-nowrap" width="200">
                                         <div class="d-flex flex-column">
                                             <div class="d-flex align-items-center mb-1">
@@ -202,6 +207,15 @@
                                         <h:outputLabel value="#{p.netTotal}">
                                             <f:convertNumber pattern="#,##0.00" />
                                         </h:outputLabel>
+                                    </p:column>
+
+                                    <p:column headerText="GRNs" styleClass="text-center" exportable="false" width="60">
+                                        <h:panelGroup rendered="#{not empty p.listOfGrnDtos}">
+                                            <span class="badge bg-success">#{p.listOfGrnDtos.size()}</span>
+                                        </h:panelGroup>
+                                        <h:panelGroup rendered="#{empty p.listOfGrnDtos}">
+                                            <span class="badge bg-secondary">0</span>
+                                        </h:panelGroup>
                                     </p:column>
 
                                     <p:column headerText="Actions" styleClass="text-center" exportable="false" width="160">
@@ -273,6 +287,80 @@
                                             </p:commandButton>
                                         </div>
                                     </p:column>
+                                    <p:rowExpansion>
+                                        <div class="p-2">
+                                            <p:dataTable
+                                                var="g"
+                                                value="#{p.listOfGrnDtos}"
+                                                styleClass="ui-datatable-borderless table-sm border"
+                                                emptyMessage="No GRNs created yet"
+                                                size="small">
+                                                <f:facet name="header">
+                                                    <span class="fw-bold text-secondary">Goods Received Notes for PO #{p.deptId}</span>
+                                                </f:facet>
+
+                                                <p:column headerText="GRN Number">
+                                                    <h:outputText
+                                                        value="#{g.deptId}"
+                                                        styleClass="#{g.cancelled ? 'text-danger' :
+                                                                      g.refunded ? 'text-warning' : 'text-success'}" />
+                                                    <h:panelGroup rendered="#{g.cancelled}">
+                                                        <span class="ui-icon ui-icon-circle-close" title="Cancelled" style="margin-left:5px;"></span>
+                                                    </h:panelGroup>
+                                                    <h:panelGroup rendered="#{g.refunded}">
+                                                        <span class="ui-icon ui-icon-arrowreturnthick-1-w" title="Refunded" style="margin-left:5px;"></span>
+                                                    </h:panelGroup>
+                                                </p:column>
+
+                                                <p:column headerText="GRN Date" width="8em">
+                                                    <h:outputText
+                                                        value="#{g.createdAt}"
+                                                        styleClass="#{g.cancelled ? 'text-danger' :
+                                                                      g.refunded ? 'text-warning' : 'text-success'}">
+                                                        <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                                                    </h:outputText>
+                                                </p:column>
+
+                                                <p:column headerText="Value" width="8em" styleClass="text-end">
+                                                    <h:outputText
+                                                        value="#{g.netTotal lt 0 ? g.netTotal * -1 : g.netTotal}"
+                                                        styleClass="fw-bold #{g.cancelled ? 'text-danger' :
+                                                                              g.refunded ? 'text-warning' : 'text-success'}">
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputText>
+                                                </p:column>
+
+                                                <p:column headerText="Actions" width="6em">
+                                                    <h:panelGroup layout="block" styleClass="d-flex gap-1">
+                                                        <p:commandButton
+                                                            class="ui-button-info"
+                                                            icon="fas fa-eye"
+                                                            title="View Finalized GRN"
+                                                            ajax="false"
+                                                            rendered="#{g.billTypeAtomic eq 'PHARMACY_GRN'}"
+                                                            action="#{billSearch.navigateToViewBillByAtomicBillTypeByBillId(g.billId)}">
+                                                        </p:commandButton>
+                                                        <p:commandButton
+                                                            class="ui-button-warning"
+                                                            icon="fas fa-edit"
+                                                            title="Edit Saved GRN"
+                                                            ajax="false"
+                                                            rendered="#{g.billTypeAtomic eq 'PHARMACY_GRN_PRE' and !configOptionApplicationController.getBooleanValueByKey('Manage Costing', true)}"
+                                                            action="#{pharmacyBillSearch.navigateToEditSavedGrnByBillId(g.billId)}">
+                                                        </p:commandButton>
+                                                        <p:commandButton
+                                                            class="ui-button-warning"
+                                                            icon="fas fa-edit"
+                                                            title="Edit Saved GRN with Costing"
+                                                            ajax="false"
+                                                            rendered="#{g.billTypeAtomic eq 'PHARMACY_GRN_PRE' and configOptionApplicationController.getBooleanValueByKey('Manage Costing', true)}"
+                                                            action="#{pharmacyBillSearch.navigateToEditSavedGrnCostingByBillId(g.billId)}">
+                                                        </p:commandButton>
+                                                    </h:panelGroup>
+                                                </p:column>
+                                            </p:dataTable>
+                                        </div>
+                                    </p:rowExpansion>
                                 </p:dataTable>
                             </p:panel>
                         </div>


### PR DESCRIPTION
## Summary

- The DTO/optimized "Create GRN from PO" list page (`pharmacy_purchase_order_list_for_recieve_dto.xhtml`) had no way to see or reopen a GRN already created against a PO, unlike the legacy list page's "GRNs" column + row-expansion (View Finalized GRN / Edit Saved GRN). This blocked retiring the legacy page per #22595.
- Adds a lightweight `PharmacyGrnSummaryDTO` projection (no full `Bill` entity load) and a bulk 2-query GRN loader (`SearchController.fillGrnDtosByBulkQuery`) mirroring the legacy `fillGrnsByBulkQuery` pattern, so the DTO page keeps its performance characteristics (exactly 2 extra bulk queries regardless of PO count).
- Adds two new id-based navigation methods on `PharmacyBillSearch` (`navigateToEditSavedGrnByBillId`, `navigateToEditSavedGrnCostingByBillId`) so "Edit Saved GRN" works from a lightweight DTO row instead of requiring a preloaded `Bill` entity; "View Finalized GRN" reuses the existing id-based `billSearch.navigateToViewBillByAtomicBillTypeByBillId(...)`.
- XHTML: adds the "GRNs" badge column + `p:rowToggler`/`p:rowExpansion` nested table matching the legacy page's layout and status coloring (cancelled/refunded).

No entity/schema changes.

## Test plan

Verified locally end-to-end (Playwright + local `coop` DB, Main Pharmacy department, Manage Costing enabled):

- [x] `mvn clean package` — build succeeds, 185 tests pass
- [x] Redeployed to local Payara, no errors in `server.log`
- [x] GRNs badge/column now shows on the DTO page and matches legacy page count for the same PO (`MP/PO/26/043280` → GRNs: 1)
- [x] Row expansion shows the finalized GRN (`MP/GRN/26/043326`), date, and value
- [x] "View Finalized GRN" navigates to the correct native GRN view for that exact GRN/PO pair
- [x] For a PO with a saved-not-finalized GRN (`PHARMACY_GRN_PRE`, `MP/PO/26/039614`), the "Edit Saved GRN with Costing" button renders (Manage Costing enabled) and correctly reloads the saved bill by id, landing on the costing edit page pre-populated with the right item/invoice/supplier

Screenshots and detailed verification notes posted to https://github.com/hmislk/hmis/issues/22612#issuecomment-5159319800

Closes #22612

🤖 Generated with [Claude Code](https://claude.ai/code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Purchase-order listings now show the number of associated goods received notes (GRNs).
  * Expand purchase orders to view GRN dates, values, statuses, and available actions.
  * Added navigation for editing saved GRNs and GRN costing records using bill IDs.

* **Improvements**
  * GRN details are automatically linked to the relevant purchase orders.
  * Empty GRN results are handled cleanly without disrupting the purchase-order view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->