### PR TITLE
fix(reports): skip Payment record for Collecting Centre Agent Payment (hotfix)

### DIFF
--- a/developer_docs/configuration/application-options.md
+++ b/developer_docs/configuration/application-options.md
@@ -44,3 +44,9 @@ This document lists the configuration options used in the application and their 
 | ---------------------------------------------------------------- | --------- | ------- | ------------------------------------------------------------------------------------------------------- |
 | `Cost of Goods Sold Report - Display Stock Correction Section`  | Boolean   | `true`  | Controls whether the Stock Correction section is displayed and calculated in the Cost of Goods Sold report. |
 
+## Collecting Centre
+
+| Key                                                              | Type      | Default | Description                                                                                             |
+| ----------------------------------------------------------------  | --------- | ------- | ------------------------------------------------------------------------------------------------------- |
+| `Collecting Centre Agent Payment - Skip Payment Record`         | Boolean   | `true`  | When true, `CollectingCentrePaymentController.createPayment()` does not create a `Payment` record for Collecting Centre Agent Payment / Cancellation bills (`CC_AGENT_PAYMENT`, `CC_AGENT_PAYMENT_CANCELLATION`). These are agent/collecting-centre commission payouts, not cashier cash collections, and should not appear in cashier reports (All Cashier Summary, Cashier Summary, Cashier Details). The `Bill` itself is still created for agent-balance history and printing. See issue #21840. |
+

--- a/src/main/java/com/divudi/bean/common/CollectingCentrePaymentController.java
+++ b/src/main/java/com/divudi/bean/common/CollectingCentrePaymentController.java
@@ -64,6 +64,8 @@ public class CollectingCentrePaymentController implements Serializable {
     SessionController sessionController;
     @Inject
     AgentAndCcApplicationController agentAndCcApplicationController;
+    @Inject
+    ConfigOptionApplicationController configOptionApplicationController;
 // </editor-fold>
 
 // <editor-fold defaultstate="collapsed" desc="Variables">
@@ -587,6 +589,9 @@ public class CollectingCentrePaymentController implements Serializable {
     }
 
     public Payment createPayment(Bill bill, PaymentMethod pm) {
+        if (configOptionApplicationController.getBooleanValueByKey("Collecting Centre Agent Payment - Skip Payment Record", true)) {
+            return null;
+        }
         Payment p = new Payment();
         p.setBill(bill);
         setPaymentMethodData(p, pm);


### PR DESCRIPTION
## Summary
- Cherry-pick of the config-skip half of #21842 (already on `development`/`rh-stg`) onto `ruhunu-prod`.
- The report-level exclusion from All Cashier Summary (PR #21841) is already live on `ruhunu-prod`; this PR adds the second, more durable part of the fix: a config option so `CollectingCentrePaymentController.createPayment()` no longer creates a `Payment` record at all for Collecting Centre Agent Payment / Cancellation bills (`CC_AGENT_PAYMENT`, `CC_AGENT_PAYMENT_CANCELLATION`).
- New config key: **`Collecting Centre Agent Payment - Skip Payment Record`** (Boolean, default `true`). The `Bill` itself is still created for agent-balance history and printing — only the `Payment` row that feeds cashier reports is skipped.

## Why
Reported by Ruhunu Hospital (Dushan Maduranga) — Agency Commission Payment transactions were inflating the All Cashier Summary report for cashiers who never touched cash. Confirmed on production: 74 such bills since Jan 2026. Discussed with Dushan: these payouts should never appear in any cashier report; not generating the `Payment` record is the more robust fix vs. relying on every report to filter the bill type out downstream.

Closes #21840

## Test plan
- [x] Cherry-picked cleanly from `9016fa9844` (already merged to `development` via #21842, and live on `rh-stg`/`rh-local-staging`) — no conflicts
- [ ] Deploy to RH Production, make a Collecting Centre Agent Payment, confirm no `Payment` row is created and the Bill still shows correctly in agent history/print
- [ ] Confirm All Cashier Summary still excludes these bills (already the case via #21841)