### PR TITLE
fix(inward): net cancelled Direct Issue to BHT bills out of Interim Bill totals

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyBillSearch.java
@@ -3102,19 +3102,31 @@ public class PharmacyBillSearch implements Serializable {
                 ? BillTypeAtomic.DIRECT_ISSUE_INWARD_DISCHARGE_MEDICINE_CANCELLATION
                 : BillTypeAtomic.DIRECT_ISSUE_INWARD_MEDICINE_CANCELLATION;
         String deptId = billNumberBean.departmentBillNumberGeneratorYearly(sessionController.getDepartment(), cancellationAtomic);
-        Bill newlyCreatedCancellationBill = getPharmacyBean().reAddToStock(getBill(), getSessionController().getLoggedUser(), getSessionController().getDepartment(), BillNumberSuffix.PHISSCAN);
-        newlyCreatedCancellationBill.setForwardReferenceBill(getBill().getForwardReferenceBill());
+        // Bills settled through InpatientDirectIssueNativeSqlService write their real netTotal
+        // and BillItem rows via native SQL after this session-scoped bean's `bill` reference was
+        // already populated from an earlier (now stale) query, so getBill() here can still show
+        // netTotal=0 and an empty item list even though the database row is correct. Bypassing the
+        // cache guarantees the reversal is built from the real billed amount (#22599).
+        Bill billToCancel = getBillFacade().findWithoutCache(getBill().getId());
+        Bill originalForwardReferenceBill = billToCancel.getForwardReferenceBill();
+        Bill newlyCreatedCancellationBill = getPharmacyBean().reAddToStock(billToCancel, getSessionController().getLoggedUser(), getSessionController().getDepartment(), BillNumberSuffix.PHISSCAN);
+        newlyCreatedCancellationBill.setForwardReferenceBill(originalForwardReferenceBill);
         newlyCreatedCancellationBill.setBillTypeAtomic(cancellationAtomic);
         newlyCreatedCancellationBill.setDeptId(deptId);
-        newlyCreatedCancellationBill.setReferenceBill(getBill());
+        newlyCreatedCancellationBill.setReferenceBill(billToCancel);
         getBillFacade().edit(newlyCreatedCancellationBill);
         // REMOVED: Finance details already correctly created by reAddToStock() method
         // Fixes #18144 - This redundant call was overwriting correct positive values with incorrect negative values
         // billService.createBillFinancialDetailsForPharmacyBill(newlyCreatedCancellationBill);
 
-        getBill().setCancelled(true);
-        getBill().setCancelledBill(newlyCreatedCancellationBill);
-        getBillFacade().edit(getBill());
+        // Merge through billToCancel (not the stale getBill()): its billItems collection is
+        // empty on the stale reference, and Bill.billItems cascades ALL/orphanRemoval, so
+        // merging the stale bill here would delete the original BillItem rows the reversal
+        // above just linked to via referanceBillItem_ID.
+        billToCancel.setCancelled(true);
+        billToCancel.setCancelledBill(newlyCreatedCancellationBill);
+        getBillFacade().edit(billToCancel);
+        setBill(billToCancel);
         JsfUtil.addSuccessMessage("Cancelled");
 
         printPreview = true;


### PR DESCRIPTION
## Summary
- Fixes #22599 — cancelling a "Direct Issue to BHTs" pharmacy bill did not deduct its amount from Interim Bill → Charges → Inward Medicine.
- Root cause: bills settled through `InpatientDirectIssueNativeSqlService` write their real `netTotal` and `BillItem` rows via native SQL, after the request that populated `PharmacyBillSearch`'s session-scoped `bill` field with an earlier (now stale) query result. `cancelPharmacyDirectIssueToBht()` built the reversal from that stale in-memory `Bill` (`netTotal=0`, empty `billItems`), so the reversal bill was persisted with `netTotal=0` and never actually offset the original charge — even though the original bill's real `netTotal` was correct in the database the whole time.
- Fix: reload the bill via the existing `AbstractFacade.findWithoutCache()` (cache-bypass + refresh) before building the reversal, and merge the `cancelled` flag through that same fresh reference — merging through the stale reference triggered a second, related bug where `Bill.billItems`' `orphanRemoval` cascade would try to delete the original bill's real `BillItem` rows (since the stale in-memory collection was empty), causing a hard FK violation once the reversal's item legitimately referenced them via `referanceBillItem_ID`.

## Verification
Reproduced end-to-end against a local Payara + MySQL deployment (issue medicine → settle → cancel), confirmed via direct DB inspection before/after the fix:

**Before fix:**
```
Bill 13861742 (original):  netTotal=8.9526  cancelled=1
Bill 13861743 (reversal):  netTotal=0        <- bug: should be -8.9526
```

**After fix:**
```
Bill 13861746 (original):  netTotal=4.4763  cancelled=1  cancelledBill_ID=13861747
Bill 13861747 (reversal):  netTotal=-4.4763                <- correct

BillItem 13865847 (original): qty=1  netValue=4.4763
BillItem 13865848 (reversal): qty=-1 netValue=-4.4763  referanceBillItem_ID=13865847
```
Original + reversal now nets to 0, and the original `BillItem` row survives cancellation (previously at risk of being silently deleted by the orphan-removal cascade even in the pre-fix code, just without an FK reference to surface it as an error).

## Test plan
- [x] Rebuilt and redeployed locally after each change
- [x] Reproduced the bug live (qa4, then locally) before fixing
- [x] Verified fix end-to-end: issue → settle → cancel → confirmed reversal `netTotal` and linked `BillItem` in the database
- [x] `mvn clean package` — 185 existing tests pass, no regressions
- [ ] No new automated test added — the bug is specific to native-SQL-settle cache staleness across separate HTTP requests, which isn't practical to reproduce in the existing unit-test harness (no live Payara/EclipseLink L2 cache). Verified manually instead; flagging for reviewer awareness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved direct BHT issue cancellation by refreshing bill information before creating reversals.
  * Ensured cancellations use the latest bill totals and item details.
  * Updated cancellation status and relationships consistently after processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->