### PR TITLE
Fix legacy GRN list/count for POs linked via original PO bill (#22630)

### DIFF
--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -7842,6 +7842,12 @@ public class SearchController implements Serializable {
      *   1. g.referenceBill = po
      *   2. g.billedBill.referenceBill = po
      */
+    /**
+     * Legacy-page counterpart of fillGrnDtosByBulkQuery. Both methods check
+     * the same 3 GRN-to-PO relationship paths; the 3rd catches GRNs linked
+     * one hop further up the approval chain, to the original PHARMACY_ORDER
+     * bill instead of its PHARMACY_ORDER_APPROVAL bill (issue #22624/#22630).
+     */
     private void fillGrnsByBulkQuery(List<Bill> poList, List<BillTypeAtomic> grnBillTypesAtomicsToList) {
         Map<Long, List<Bill>> grnsByPoId = new HashMap<>();
         for (Bill po : poList) {
@@ -7888,6 +7894,50 @@ public class SearchController implements Serializable {
             }
         }
 
+        // Path 3: GRN.referenceBill is the PO's own originating PHARMACY_ORDER bill
+        // instead of its PHARMACY_ORDER_APPROVAL bill (issue #22624/#22630). Some GRNs
+        // end up linked one hop further up the approval chain than expected, so resolve
+        // each approval bill's own referenceBill (the original PO) and match on that
+        // too, mirroring Path 1/2's tolerance for an alternate linking path.
+        Map<Long, List<Long>> approvalIdsByOriginalPoId = new HashMap<>();
+        String originalPoJpql = "SELECT b.id, b.referenceBill.id FROM Bill b "
+                + "WHERE b IN :pos AND b.referenceBill IS NOT NULL";
+        Map<String, Object> originalPoParams = new HashMap<>();
+        originalPoParams.put("pos", poList);
+        List<Object> originalPoRows = getBillFacade().findObjects(originalPoJpql, originalPoParams);
+        if (originalPoRows != null) {
+            for (Object row : originalPoRows) {
+                Object[] cols = (Object[]) row;
+                Long approvalId = ((Number) cols[0]).longValue();
+                Long originalPoId = ((Number) cols[1]).longValue();
+                approvalIdsByOriginalPoId.computeIfAbsent(originalPoId, k -> new ArrayList<>()).add(approvalId);
+            }
+        }
+
+        if (!approvalIdsByOriginalPoId.isEmpty()) {
+            String jpql3 = "SELECT g.referenceBill.id, g FROM Bill g "
+                    + "WHERE g.retired = false "
+                    + "AND g.billTypeAtomic IN :btas "
+                    + "AND g.referenceBill.id IN :originalPoIds";
+            Map<String, Object> params3 = new HashMap<>();
+            params3.put("btas", grnBillTypesAtomicsToList);
+            params3.put("originalPoIds", approvalIdsByOriginalPoId.keySet());
+            List<Object> rows3 = getBillFacade().findObjects(jpql3, params3);
+            if (rows3 != null) {
+                for (Object row : rows3) {
+                    Object[] cols = (Object[]) row;
+                    Long originalPoId = ((Number) cols[0]).longValue();
+                    Bill grn = (Bill) cols[1];
+                    for (Long approvalId : approvalIdsByOriginalPoId.getOrDefault(originalPoId, new ArrayList<>())) {
+                        List<Bill> grnList = grnsByPoId.computeIfAbsent(approvalId, k -> new ArrayList<>());
+                        if (!grnList.contains(grn)) {
+                            grnList.add(grn);
+                        }
+                    }
+                }
+            }
+        }
+
         for (Bill po : poList) {
             po.setListOfBill(grnsByPoId.getOrDefault(po.getId(), new ArrayList<>()));
         }
@@ -7897,10 +7947,10 @@ public class SearchController implements Serializable {
      * DTO-page counterpart of fillGrnsByBulkQuery: bulk-loads GRN summaries
      * for every PO in the list, projecting a lightweight DTO instead of
      * loading full Bill entities, then assigns the results to each PO DTO's
-     * listOfGrnDtos (issue #22612). Checks 3 relationship paths: the first 2
-     * match fillGrnsByBulkQuery; the 3rd additionally catches GRNs linked one
-     * hop further up the approval chain, to the original PHARMACY_ORDER bill
-     * instead of its PHARMACY_ORDER_APPROVAL bill (issue #22624).
+     * listOfGrnDtos (issue #22612). Both methods check the same 3
+     * relationship paths; the 3rd catches GRNs linked one hop further up the
+     * approval chain, to the original PHARMACY_ORDER bill instead of its
+     * PHARMACY_ORDER_APPROVAL bill (issue #22624/#22630).
      */
     private void fillGrnDtosByBulkQuery(List<PharmacyPurchaseOrderDTO> poDtos, List<BillTypeAtomic> grnBillTypesAtomicsToList) {
         Map<Long, List<PharmacyGrnSummaryDTO>> grnsByPoId = new HashMap<>();


### PR DESCRIPTION
## Summary

- Fixes #22630: the legacy "Purchase Orders for Receiving" page (`pharmacy_purchase_order_list_for_recieve.xhtml`) showed GRN count = 0 and an empty GRN sub-grid for a PO whose GRN was linked one hop further up the approval chain — i.e. `GRN.referenceBill` points at the original `PHARMACY_ORDER` bill instead of the `PHARMACY_ORDER_APPROVAL` bill the page queries by. This is the same root cause as #22624, which was previously fixed only on the DTO-optimized sibling page (`pharmacy_purchase_order_list_for_recieve_dto.xhtml`, PR #22626).
- `fillGrnsByBulkQuery()` (`SearchController.java`) only implemented Path 1 (`g.referenceBill IN :pos`) and Path 2 (`g.billedBill.referenceBill IN :pos`). Its DTO sibling `fillGrnDtosByBulkQuery()` already had a third path added for #22624/PR #22626, which resolves each approval PO's own `referenceBill` (the original PO bill) and also matches GRNs linked to that. This Path 3 was never ported back to the legacy `Bill`-based method.
- Ported the same Path 3 lookup into `fillGrnsByBulkQuery()`, mirroring the DTO method's logic but working with `Bill` entities/`poList` instead of DTOs/`poIds`, and reusing Path 2's existing `grnList.contains(grn)` dedupe pattern.
- Updated the doc comments on both methods to reflect that they now check the same 3 relationship paths, to avoid this kind of fix drift recurring.

## Changes

- `src/main/java/com/divudi/bean/common/SearchController.java`
  - `fillGrnsByBulkQuery()`: added Path 3 (original-PO resolution + GRN match), same JPQL shape as the already-proven DTO version.
  - Doc comments on `fillGrnsByBulkQuery()` / `fillGrnDtosByBulkQuery()` updated for parity.

No entity/schema or XHTML changes — pure Java query-logic fix reusing the exact JPQL pattern already verified correct by #22624/PR #22626, adapted from projection columns to whole `Bill` entities.

## Testing

- `mvn compile` succeeds with no errors (verified in this session).
- This session runs in a cloud/remote environment without the local Windows NetBeans/Payara/Playwright toolchain, so a live redeploy + Playwright UI pass against the actual repro data (PO `MP/PO/26/037966`, GRN `MP/GRN/26/037967`) was not performed here. The query logic is a direct, unmodified port of the Path 3 logic already live-verified on the DTO page for #22624/PR #22626 — same params, same JPQL shape, same map-merging semantics — so behavioral parity is expected. Recommend a quick manual re-check on the legacy page with the same repro data before/after deploy to confirm.

Closes #22630


---
_Generated by [Claude Code](https://claude.ai/code/session_012qkUNq6Vhtm4yXHmj9jR9G)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GRN bulk loading for approval bills linked through pharmacy orders.
  * Prevented duplicate GRN entries in search results.
  * Added support for all supported purchase-order relationship paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->