### PR TITLE
Fix Inward Payment gaps in Cashier Summary/Details/All Cashier Summary reports

### DIFF
--- a/src/main/java/com/divudi/bean/report/CashierReportController.java
+++ b/src/main/java/com/divudi/bean/report/CashierReportController.java
@@ -2343,10 +2343,13 @@ public class CashierReportController implements Serializable {
                 + sumInwardPayment(w, new RefundBill(), PaymentMethod.Slip, own));
     }
 
+    private static final List<BillType> INWARD_PAYMENT_BILL_TYPES
+            = Arrays.asList(BillType.InwardPaymentBill, BillType.PostFinalBillInwardPayment);
+
     private double sumInwardPayment(WebUser w, Bill billClass, PaymentMethod pm, boolean own) {
-        double total = own ? calTotOwn(w, billClass, pm, BillType.InwardPaymentBill) : calTot(w, billClass, pm, BillType.InwardPaymentBill);
-        total += own ? calTotOwn(w, billClass, pm, BillType.PostFinalBillInwardPayment) : calTot(w, billClass, pm, BillType.PostFinalBillInwardPayment);
-        return total;
+        return own
+                ? calTotOwn(w, billClass, pm, INWARD_PAYMENT_BILL_TYPES)
+                : calTot(w, billClass, pm, INWARD_PAYMENT_BILL_TYPES);
     }
 
     double calTotOwn(WebUser w, Bill billClass, PaymentMethod pM, BillType billType) {
@@ -2382,6 +2385,37 @@ public class CashierReportController implements Serializable {
         }
         return tot;
 
+    }
+
+    /**
+     * Same as calTotOwn(WebUser, Bill, PaymentMethod, BillType) but sums
+     * across several bill types in one query (b.billType IN :billTps)
+     * instead of one query per type.
+     */
+    private double calTotOwn(WebUser w, Bill billClass, PaymentMethod pM, List<BillType> billTypes) {
+        if (getSessionController().getInstitution() == null) {
+            return 0.0;
+        }
+
+        String sql = "select b from Bill b where type(b)=:bill and b.creater=:cret and "
+                + " b.paymentMethod=:payMethod  and b.institution=:ins"
+                + " and b.billType in :billTps and b.createdAt between :fromDate and :toDate ";
+
+        Map temMap = new HashMap();
+        temMap.put("toDate", getToDate());
+        temMap.put("fromDate", getFromDate());
+        temMap.put("billTps", billTypes);
+        temMap.put("payMethod", pM);
+        temMap.put("bill", billClass.getClass());
+        temMap.put("cret", w);
+        temMap.put("ins", getSessionController().getInstitution());
+
+        List<Bill> bills = getBillFacade().findByJpql(sql, temMap, TemporalType.TIMESTAMP);
+        double tot = 0;
+        for (Bill b : bills) {
+            tot += b.getNetTotal();
+        }
+        return tot;
     }
 
     public Date getFromDate() {
@@ -2599,6 +2633,30 @@ public class CashierReportController implements Serializable {
         temMap.put("toDate", getToDate());
         temMap.put("fromDate", getFromDate());
         temMap.put("billTp", billType);
+        temMap.put("pm", paymentMethod);
+        temMap.put("bill", bill.getClass());
+        temMap.put("web", w);
+        List<Bill> bills = getBillFacade().findByJpql(sql, temMap, TemporalType.TIMESTAMP);
+        double tot = 0;
+        for (Bill b : bills) {
+            tot += b.getNetTotal();
+        }
+        return tot;
+    }
+
+    /**
+     * Same as calTot(WebUser, Bill, PaymentMethod, BillType) but sums across
+     * several bill types in one query (b.billType IN :billTps) instead of
+     * one query per type.
+     */
+    private double calTot(WebUser w, Bill bill, PaymentMethod paymentMethod, List<BillType> billTypes) {
+        String sql = "select b from Bill b  where b.retired=false and type(b)=:bill and b.creater=:web and "
+                + "b.paymentMethod= :pm "
+                + " and b.billType in :billTps and b.createdAt between :fromDate and :toDate";
+        Map temMap = new HashMap();
+        temMap.put("toDate", getToDate());
+        temMap.put("fromDate", getFromDate());
+        temMap.put("billTps", billTypes);
         temMap.put("pm", paymentMethod);
         temMap.put("bill", bill.getClass());
         temMap.put("web", w);

--- a/src/main/java/com/divudi/bean/report/CashierReportController.java
+++ b/src/main/java/com/divudi/bean/report/CashierReportController.java
@@ -2316,25 +2316,37 @@ public class CashierReportController implements Serializable {
         c.setAgentCancelCheque(calTotOwn(w, new CancelledBill(), PaymentMethod.Cheque, BillType.AgentPaymentReceiveBill));
         c.setAgentCancelSlip(calTotOwn(w, new CancelledBill(), PaymentMethod.Slip, BillType.AgentPaymentReceiveBill));
 
-        c.setInwardPaymentCash(
-                calTotOwn(w, new BilledBill(), PaymentMethod.Cash, BillType.InwardPaymentBill)
-                + calTotOwn(w, new BilledBill(), PaymentMethod.Cash, BillType.PostFinalBillInwardPayment));
-        c.setInwardPaymentCheque(
-                calTotOwn(w, new BilledBill(), PaymentMethod.Cheque, BillType.InwardPaymentBill)
-                + calTotOwn(w, new BilledBill(), PaymentMethod.Cheque, BillType.PostFinalBillInwardPayment));
-        c.setInwardPaymentSlip(
-                calTotOwn(w, new BilledBill(), PaymentMethod.Slip, BillType.InwardPaymentBill)
-                + calTotOwn(w, new BilledBill(), PaymentMethod.Slip, BillType.PostFinalBillInwardPayment));
+        setInwardPaymentFields(c, w, true);
+    }
+
+    /**
+     * Shared by findSummeryOwn() and findSummery(). Sums both
+     * BillType.InwardPaymentBill (pre-final deposit) and
+     * BillType.PostFinalBillInwardPayment (#22617) into the same "Inward
+     * Payment" bucket, and folds RefundBill amounts into the cancel/reversal
+     * totals alongside CancelledBill (issue #22629 — refunds were previously
+     * never counted in either report).
+     */
+    private void setInwardPaymentFields(CashierSummeryData c, WebUser w, boolean own) {
+        c.setInwardPaymentCash(sumInwardPayment(w, new BilledBill(), PaymentMethod.Cash, own));
+        c.setInwardPaymentCheque(sumInwardPayment(w, new BilledBill(), PaymentMethod.Cheque, own));
+        c.setInwardPaymentSlip(sumInwardPayment(w, new BilledBill(), PaymentMethod.Slip, own));
 
         c.setInwardCancelCash(
-                calTotOwn(w, new CancelledBill(), PaymentMethod.Cash, BillType.InwardPaymentBill)
-                + calTotOwn(w, new CancelledBill(), PaymentMethod.Cash, BillType.PostFinalBillInwardPayment));
+                sumInwardPayment(w, new CancelledBill(), PaymentMethod.Cash, own)
+                + sumInwardPayment(w, new RefundBill(), PaymentMethod.Cash, own));
         c.setInwardCancelCheque(
-                calTotOwn(w, new CancelledBill(), PaymentMethod.Cheque, BillType.InwardPaymentBill)
-                + calTotOwn(w, new CancelledBill(), PaymentMethod.Cheque, BillType.PostFinalBillInwardPayment));
+                sumInwardPayment(w, new CancelledBill(), PaymentMethod.Cheque, own)
+                + sumInwardPayment(w, new RefundBill(), PaymentMethod.Cheque, own));
         c.setInwardCancelSlip(
-                calTotOwn(w, new CancelledBill(), PaymentMethod.Slip, BillType.InwardPaymentBill)
-                + calTotOwn(w, new CancelledBill(), PaymentMethod.Slip, BillType.PostFinalBillInwardPayment));
+                sumInwardPayment(w, new CancelledBill(), PaymentMethod.Slip, own)
+                + sumInwardPayment(w, new RefundBill(), PaymentMethod.Slip, own));
+    }
+
+    private double sumInwardPayment(WebUser w, Bill billClass, PaymentMethod pm, boolean own) {
+        double total = own ? calTotOwn(w, billClass, pm, BillType.InwardPaymentBill) : calTot(w, billClass, pm, BillType.InwardPaymentBill);
+        total += own ? calTotOwn(w, billClass, pm, BillType.PostFinalBillInwardPayment) : calTot(w, billClass, pm, BillType.PostFinalBillInwardPayment);
+        return total;
     }
 
     double calTotOwn(WebUser w, Bill billClass, PaymentMethod pM, BillType billType) {
@@ -2574,6 +2586,7 @@ public class CashierReportController implements Serializable {
         c.setAgentCancelCheque(calTot(w, new CancelledBill(), PaymentMethod.Cheque, BillType.AgentPaymentReceiveBill));
         c.setAgentCancelSlip(calTot(w, new CancelledBill(), PaymentMethod.Slip, BillType.AgentPaymentReceiveBill));
 
+        setInwardPaymentFields(c, w, false);
     }
 
     double calTot(WebUser w, Bill bill, PaymentMethod paymentMethod, BillType billType) {


### PR DESCRIPTION
## Summary

Follow-up to PR #22623 (found during that PR's CodeRabbit review). `CashierReportController` had two related gaps in Inward Payment reporting, both pre-existing (not introduced by #22623 — that PR only extended the existing, already-incomplete `findSummeryOwn()` pattern to the new `PostFinalBillInwardPayment` bill type):

1. **`findSummery()`** (backs `getCashierDatas()` — the all-cashiers view used by Cashier Summary / Cashier Details / All Cashier Summary for *other* cashiers) never set any Inward Payment cash/cheque/slip/cancel fields at all. Only `findSummeryOwn()` (the logged-in cashier's own summary) ever populated them.
2. **Refunds were never counted** — neither method folded `RefundBill` amounts into the Inward Payment cancel/reversal totals, so an Inward Payment refund never reduced the reported Inward Payment total in *any* cashier report.

## Fix

Extracted a shared `setInwardPaymentFields()` / `sumInwardPayment()` helper, called from both `findSummeryOwn()` and `findSummery()`, covering both `BillType.InwardPaymentBill` (pre-final deposit) and `BillType.PostFinalBillInwardPayment` (#22617), and folding `RefundBill` into the cancel/reversal sums alongside `CancelledBill`.

## Verification

Local Payara, Inward department, BHT/56753 (already had a confirmed final bill with an outstanding balance):

1. Baseline: All Cashier Summary "Cash" column for `buddhika` = 400.00 (pre-existing test data, unrelated).
2. Recorded a new Post Final Bill Payment of 100.00 (Cash) via `payments/pay_index.xhtml` → Post Final Bill Payment tab. All Cashier Summary "Cash" column updated to **500.00** — confirms `findSummery()` now includes Inward Payment (previously it would have stayed at 400.00, since that method ignored Inward Payment entirely).
3. Refunded 50.00 of that payment via the new Refund flow. All Cashier Summary "Cash" column correctly netted to **450.00** — confirms `RefundBill` amounts are now included.

`mvn -o -q compile` clean before and after.

Closes #22629

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cashier reports by consistently combining inward-payment totals across summary types.
  - Included post-final bill inward payments in reported totals.
  - Updated inward-payment cancellation totals to include refunds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->