### PR TITLE
Link Inward refunds to a specific payment bill to close double-cancel gap

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardRefundController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardRefundController.java
@@ -24,6 +24,7 @@ import com.divudi.core.facade.BillItemFacade;
 import com.divudi.service.PaymentService;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -64,11 +65,15 @@ public class InwardRefundController implements Serializable {
     private boolean printPreview;
     @Inject
     private InwardBeanController inwardBean;
+    private List<Bill> eligiblePaymentBills;
+    private Bill originalBillToRefund;
 
     public void makeNull() {
         current = null;
         paidAmount = 0.0;
         printPreview = false;
+        eligiblePaymentBills = null;
+        originalBillToRefund = null;
     }
 
     /**
@@ -99,6 +104,12 @@ public class InwardRefundController implements Serializable {
             JsfUtil.addErrorMessage("Select BHT");
             return true;
         }
+
+        if (getOriginalBillToRefund() == null) {
+            JsfUtil.addErrorMessage("Select a Payment Bill to Refund");
+            return true;
+        }
+
         if (getCurrent().getPaymentMethod() == null) {
             JsfUtil.addErrorMessage("Select Payment Method");
             return true;
@@ -108,8 +119,10 @@ public class InwardRefundController implements Serializable {
             return true;
         }
 
-        if ((Math.abs(getPaidAmount()) < getCurrent().getTotal())) {
-            double different = Math.abs(Math.abs((getPaidAmount()) - Math.abs(getCurrent().getTotal())));
+        double remaining = getRemainingRefundableAmount(getOriginalBillToRefund());
+
+        if (Math.abs(remaining) < getCurrent().getTotal()) {
+            double different = Math.abs(Math.abs(remaining) - Math.abs(getCurrent().getTotal()));
 
             if (different > 0.1) {
                 JsfUtil.addErrorMessage("Check Refuning Amount");
@@ -132,6 +145,10 @@ public class InwardRefundController implements Serializable {
         getCurrent().setBillTypeAtomic(BillTypeAtomic.INWARD_DEPOSIT_REFUND);
         getBillFacade().edit(getCurrent());
         saveBillItem();
+
+        getOriginalBillToRefund().setRefunded(true);
+        getBillFacade().edit(getOriginalBillToRefund());
+
         printPreview = true;
 
         List<Payment> payments = paymentService.createPayment(getCurrent(), paymentMethodData);
@@ -161,7 +178,7 @@ public class InwardRefundController implements Serializable {
         getCurrent().setBillTime(new Date());
         getCurrent().setInstitution(getSessionController().getInstitution());
         getCurrent().setDepartment(getSessionController().getDepartment());
-        // getCurrent().setForwardReferenceBill(getCurrent().getPatientEncounter().getFinalBill());
+        getCurrent().setReferenceBill(getOriginalBillToRefund());
         getCurrent().setDeptId(getBillNumberBean().institutionBillNumberGenerator(getSessionController().getDepartment(), getCurrent().getBillType(), BillClassType.RefundBill, BillNumberSuffix.INWREF));
         getCurrent().setInsId(getBillNumberBean().institutionBillNumberGenerator(getSessionController().getInstitution(), getCurrent().getBillType(), BillClassType.RefundBill, BillNumberSuffix.INWREF));
 
@@ -270,7 +287,76 @@ public class InwardRefundController implements Serializable {
         } else {
             calculatePaidAmount();
         }
+        loadEligiblePaymentBills();
+    }
 
+    /**
+     * Loads the encounter's payment bills that still have a nonzero
+     * remaining refundable amount (issue #22627 - refund must be linked to
+     * one specific original bill, not an encounter-wide aggregate).
+     */
+    private void loadEligiblePaymentBills() {
+        eligiblePaymentBills = new ArrayList<>();
+        originalBillToRefund = null;
+        for (Bill b : getInwardBean().fetchPaymentBill(getCurrent().getPatientEncounter(), null)) {
+            if (b instanceof BilledBill && !b.isCancelled() && getRemainingRefundableAmount(b) > 0.01) {
+                eligiblePaymentBills.add(b);
+            }
+        }
+    }
+
+    /**
+     * Sum of netTotal of every RefundBill already linked to originalBill via
+     * referenceBill (always <= 0), added to the bill's own netTotal. Do NOT
+     * use Bill.refundBills/getRefundBills() here - that collection is
+     * mappedBy="billedBill", which no refund flow in this codebase populates,
+     * so it never reflects referenceBill-linked refunds.
+     */
+    public double getRemainingRefundableAmount(Bill originalBill) {
+        if (originalBill == null) {
+            return 0.0;
+        }
+        String sql = "select sum(b.netTotal) from Bill b where b.referenceBill=:orig and b.retired=false";
+        HashMap hm = new HashMap();
+        hm.put("orig", originalBill);
+        double refundedSoFar = getBillFacade().findDoubleByJpql(sql, hm);
+        return originalBill.getNetTotal() + refundedSoFar;
+    }
+
+    public void selectBillToRefundListener() {
+        if (getOriginalBillToRefund() == null) {
+            JsfUtil.addErrorMessage("Select a Payment Bill to Refund");
+            return;
+        }
+        getCurrent().setTotal(getRemainingRefundableAmount(getOriginalBillToRefund()));
+    }
+
+    /**
+     * Lets the cashier pick a different bill without losing the BHT
+     * selection or re-querying eligiblePaymentBills.
+     */
+    public void clearSelectedBillToRefund() {
+        originalBillToRefund = null;
+        getCurrent().setTotal(0);
+    }
+
+    public List<Bill> getEligiblePaymentBills() {
+        if (eligiblePaymentBills == null) {
+            eligiblePaymentBills = new ArrayList<>();
+        }
+        return eligiblePaymentBills;
+    }
+
+    public void setEligiblePaymentBills(List<Bill> eligiblePaymentBills) {
+        this.eligiblePaymentBills = eligiblePaymentBills;
+    }
+
+    public Bill getOriginalBillToRefund() {
+        return originalBillToRefund;
+    }
+
+    public void setOriginalBillToRefund(Bill originalBillToRefund) {
+        this.originalBillToRefund = originalBillToRefund;
     }
 
     public void calculteFinalBillMax() {

--- a/src/main/java/com/divudi/bean/inward/InwardRefundController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardRefundController.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.faces.context.FacesContext;
@@ -67,6 +68,7 @@ public class InwardRefundController implements Serializable {
     private InwardBeanController inwardBean;
     private List<Bill> eligiblePaymentBills;
     private Bill originalBillToRefund;
+    private Map<Long, Double> remainingRefundableAmountCache;
 
     public void makeNull() {
         current = null;
@@ -74,6 +76,7 @@ public class InwardRefundController implements Serializable {
         printPreview = false;
         eligiblePaymentBills = null;
         originalBillToRefund = null;
+        remainingRefundableAmountCache = null;
     }
 
     /**
@@ -298,11 +301,33 @@ public class InwardRefundController implements Serializable {
     private void loadEligiblePaymentBills() {
         eligiblePaymentBills = new ArrayList<>();
         originalBillToRefund = null;
+        remainingRefundableAmountCache = new HashMap<>();
         for (Bill b : getInwardBean().fetchPaymentBill(getCurrent().getPatientEncounter(), null)) {
-            if (b instanceof BilledBill && !b.isCancelled() && getRemainingRefundableAmount(b) > 0.01) {
+            if (b instanceof BilledBill && !b.isCancelled() && computeRemainingRefundableAmount(b) > 0.01) {
                 eligiblePaymentBills.add(b);
             }
         }
+    }
+
+    /**
+     * Cached per-bill remaining-refundable amount, populated once per bill
+     * by loadEligiblePaymentBills(). The bill picker table calls this once
+     * per row through EL on every render/postback, so without the cache it
+     * would re-run computeRemainingRefundableAmount()'s JPQL SUM query for
+     * every row on every render, on top of the same query already run for
+     * every bill while building eligiblePaymentBills.
+     */
+    public double getRemainingRefundableAmount(Bill originalBill) {
+        if (originalBill == null) {
+            return 0.0;
+        }
+        if (remainingRefundableAmountCache != null && originalBill.getId() != null) {
+            Double cached = remainingRefundableAmountCache.get(originalBill.getId());
+            if (cached != null) {
+                return cached;
+            }
+        }
+        return computeRemainingRefundableAmount(originalBill);
     }
 
     /**
@@ -312,15 +337,16 @@ public class InwardRefundController implements Serializable {
      * mappedBy="billedBill", which no refund flow in this codebase populates,
      * so it never reflects referenceBill-linked refunds.
      */
-    public double getRemainingRefundableAmount(Bill originalBill) {
-        if (originalBill == null) {
-            return 0.0;
-        }
+    private double computeRemainingRefundableAmount(Bill originalBill) {
         String sql = "select sum(b.netTotal) from Bill b where b.referenceBill=:orig and b.retired=false";
         HashMap hm = new HashMap();
         hm.put("orig", originalBill);
         double refundedSoFar = getBillFacade().findDoubleByJpql(sql, hm);
-        return originalBill.getNetTotal() + refundedSoFar;
+        double remaining = originalBill.getNetTotal() + refundedSoFar;
+        if (remainingRefundableAmountCache != null && originalBill.getId() != null) {
+            remainingRefundableAmountCache.put(originalBill.getId(), remaining);
+        }
+        return remaining;
     }
 
     public void selectBillToRefundListener() {

--- a/src/main/java/com/divudi/bean/inward/PostFinalBillInwardPaymentController.java
+++ b/src/main/java/com/divudi/bean/inward/PostFinalBillInwardPaymentController.java
@@ -39,6 +39,7 @@ import com.divudi.core.facade.BilledBillFacade;
 import com.divudi.core.facade.PatientFacade;
 import com.divudi.service.PaymentService;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -109,6 +110,8 @@ public class PostFinalBillInwardPaymentController implements Serializable, Contr
     private double total;
     private Patient patient;
     private PaymentMethodData paymentMethodData;
+    private List<Bill> eligiblePostFinalPaymentBills;
+    private Bill originalBillToRefund;
     // </editor-fold>
 
     public PaymentMethod[] getPaymentMethods() {
@@ -757,6 +760,10 @@ public class PostFinalBillInwardPaymentController implements Serializable, Contr
         getRefundCurrent().setBillTypeAtomic(BillTypeAtomic.POST_FINAL_BILL_INWARD_PAYMENT_REFUND);
         getBillFacade().edit(getRefundCurrent());
         saveRefundBillItem();
+
+        getOriginalBillToRefund().setRefunded(true);
+        getBillFacade().edit(getOriginalBillToRefund());
+
         printPreview = true;
 
         List<Payment> payments = paymentService.createPayment(getRefundCurrent(), paymentMethodData);
@@ -775,6 +782,8 @@ public class PostFinalBillInwardPaymentController implements Serializable, Contr
         refundCurrent = null;
         paidAmount = 0.0;
         printPreview = false;
+        eligiblePostFinalPaymentBills = null;
+        originalBillToRefund = null;
         financialTransactionController.findNonClosedShiftStartFundBillIsAvailable();
         if (financialTransactionController.getNonClosedShiftStartFundBill() == null) {
             JsfUtil.addErrorMessage("Start Your Shift First !");
@@ -797,6 +806,78 @@ public class PostFinalBillInwardPaymentController implements Serializable, Contr
             return;
         }
         paidAmount = getPostFinalPaymentTotal(getRefundCurrent().getPatientEncounter());
+        loadEligiblePostFinalPaymentBills();
+    }
+
+    /**
+     * Loads the encounter's post-final payment bills that still have a
+     * nonzero remaining refundable amount (issue #22627 - refund must be
+     * linked to one specific original bill, not an encounter-wide
+     * aggregate). Mirrors {@code InwardRefundController.loadEligiblePaymentBills()}.
+     */
+    private void loadEligiblePostFinalPaymentBills() {
+        eligiblePostFinalPaymentBills = new ArrayList<>();
+        originalBillToRefund = null;
+        for (Bill b : getInwardBean().fetchPostFinalPaymentBill(getRefundCurrent().getPatientEncounter(), null)) {
+            if (b instanceof BilledBill && !b.isCancelled() && getRemainingRefundableAmount(b) > 0.01) {
+                eligiblePostFinalPaymentBills.add(b);
+            }
+        }
+    }
+
+    /**
+     * Sum of netTotal of every RefundBill already linked to originalBill via
+     * referenceBill (always <= 0), added to the bill's own netTotal. Do NOT
+     * use Bill.refundBills/getRefundBills() here - that collection is
+     * mappedBy="billedBill", which no refund flow in this codebase
+     * populates, so it never reflects referenceBill-linked refunds. Mirrors
+     * {@code InwardRefundController.getRemainingRefundableAmount()}.
+     */
+    public double getRemainingRefundableAmount(Bill originalBill) {
+        if (originalBill == null) {
+            return 0.0;
+        }
+        String sql = "select sum(b.netTotal) from Bill b where b.referenceBill=:orig and b.retired=false";
+        HashMap hm = new HashMap();
+        hm.put("orig", originalBill);
+        double refundedSoFar = getBillFacade().findDoubleByJpql(sql, hm);
+        return originalBill.getNetTotal() + refundedSoFar;
+    }
+
+    public void selectBillToRefundListener() {
+        if (getOriginalBillToRefund() == null) {
+            JsfUtil.addErrorMessage("Select a Payment Bill to Refund");
+            return;
+        }
+        getRefundCurrent().setTotal(getRemainingRefundableAmount(getOriginalBillToRefund()));
+    }
+
+    /**
+     * Lets the cashier pick a different bill without losing the BHT
+     * selection or re-querying eligiblePostFinalPaymentBills.
+     */
+    public void clearSelectedBillToRefund() {
+        originalBillToRefund = null;
+        getRefundCurrent().setTotal(0);
+    }
+
+    public List<Bill> getEligiblePostFinalPaymentBills() {
+        if (eligiblePostFinalPaymentBills == null) {
+            eligiblePostFinalPaymentBills = new ArrayList<>();
+        }
+        return eligiblePostFinalPaymentBills;
+    }
+
+    public void setEligiblePostFinalPaymentBills(List<Bill> eligiblePostFinalPaymentBills) {
+        this.eligiblePostFinalPaymentBills = eligiblePostFinalPaymentBills;
+    }
+
+    public Bill getOriginalBillToRefund() {
+        return originalBillToRefund;
+    }
+
+    public void setOriginalBillToRefund(Bill originalBillToRefund) {
+        this.originalBillToRefund = originalBillToRefund;
     }
 
     private boolean errorCheckForRefund() {
@@ -804,6 +885,12 @@ public class PostFinalBillInwardPaymentController implements Serializable, Contr
             JsfUtil.addErrorMessage("Select BHT");
             return true;
         }
+
+        if (getOriginalBillToRefund() == null) {
+            JsfUtil.addErrorMessage("Select a Payment Bill to Refund");
+            return true;
+        }
+
         if (getRefundCurrent().getPaymentMethod() == null) {
             JsfUtil.addErrorMessage("Select Payment Method");
             return true;
@@ -813,8 +900,10 @@ public class PostFinalBillInwardPaymentController implements Serializable, Contr
             return true;
         }
 
-        if (Math.abs(getPaidAmount()) < getRefundCurrent().getTotal()) {
-            double different = Math.abs(Math.abs(getPaidAmount()) - Math.abs(getRefundCurrent().getTotal()));
+        double remaining = getRemainingRefundableAmount(getOriginalBillToRefund());
+
+        if (Math.abs(remaining) < getRefundCurrent().getTotal()) {
+            double different = Math.abs(Math.abs(remaining) - Math.abs(getRefundCurrent().getTotal()));
             if (different > 0.1) {
                 JsfUtil.addErrorMessage("Check Refunding Amount");
                 return true;
@@ -831,6 +920,7 @@ public class PostFinalBillInwardPaymentController implements Serializable, Contr
         getRefundCurrent().setBillTime(new Date());
         getRefundCurrent().setInstitution(getSessionController().getInstitution());
         getRefundCurrent().setDepartment(getSessionController().getDepartment());
+        getRefundCurrent().setReferenceBill(getOriginalBillToRefund());
         getRefundCurrent().setDeptId(getBillNumberBean().institutionBillNumberGenerator(getSessionController().getDepartment(), getRefundCurrent().getBillType(), BillClassType.RefundBill, BillNumberSuffix.INWREF));
         getRefundCurrent().setInsId(getBillNumberBean().institutionBillNumberGenerator(getSessionController().getInstitution(), getRefundCurrent().getBillType(), BillClassType.RefundBill, BillNumberSuffix.INWREF));
 

--- a/src/main/java/com/divudi/bean/inward/PostFinalBillInwardPaymentController.java
+++ b/src/main/java/com/divudi/bean/inward/PostFinalBillInwardPaymentController.java
@@ -43,6 +43,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Inject;
@@ -112,6 +113,7 @@ public class PostFinalBillInwardPaymentController implements Serializable, Contr
     private PaymentMethodData paymentMethodData;
     private List<Bill> eligiblePostFinalPaymentBills;
     private Bill originalBillToRefund;
+    private Map<Long, Double> remainingRefundableAmountCache;
     // </editor-fold>
 
     public PaymentMethod[] getPaymentMethods() {
@@ -784,6 +786,7 @@ public class PostFinalBillInwardPaymentController implements Serializable, Contr
         printPreview = false;
         eligiblePostFinalPaymentBills = null;
         originalBillToRefund = null;
+        remainingRefundableAmountCache = null;
         financialTransactionController.findNonClosedShiftStartFundBillIsAvailable();
         if (financialTransactionController.getNonClosedShiftStartFundBill() == null) {
             JsfUtil.addErrorMessage("Start Your Shift First !");
@@ -818,11 +821,34 @@ public class PostFinalBillInwardPaymentController implements Serializable, Contr
     private void loadEligiblePostFinalPaymentBills() {
         eligiblePostFinalPaymentBills = new ArrayList<>();
         originalBillToRefund = null;
+        remainingRefundableAmountCache = new HashMap<>();
         for (Bill b : getInwardBean().fetchPostFinalPaymentBill(getRefundCurrent().getPatientEncounter(), null)) {
-            if (b instanceof BilledBill && !b.isCancelled() && getRemainingRefundableAmount(b) > 0.01) {
+            if (b instanceof BilledBill && !b.isCancelled() && computeRemainingRefundableAmount(b) > 0.01) {
                 eligiblePostFinalPaymentBills.add(b);
             }
         }
+    }
+
+    /**
+     * Cached per-bill remaining-refundable amount, populated once per bill
+     * by loadEligiblePostFinalPaymentBills(). The bill picker table calls
+     * this once per row through EL on every render/postback, so without the
+     * cache it would re-run computeRemainingRefundableAmount()'s JPQL SUM
+     * query for every row on every render, on top of the same query already
+     * run for every bill while building eligiblePostFinalPaymentBills.
+     * Mirrors {@code InwardRefundController.getRemainingRefundableAmount()}.
+     */
+    public double getRemainingRefundableAmount(Bill originalBill) {
+        if (originalBill == null) {
+            return 0.0;
+        }
+        if (remainingRefundableAmountCache != null && originalBill.getId() != null) {
+            Double cached = remainingRefundableAmountCache.get(originalBill.getId());
+            if (cached != null) {
+                return cached;
+            }
+        }
+        return computeRemainingRefundableAmount(originalBill);
     }
 
     /**
@@ -830,18 +856,18 @@ public class PostFinalBillInwardPaymentController implements Serializable, Contr
      * referenceBill (always <= 0), added to the bill's own netTotal. Do NOT
      * use Bill.refundBills/getRefundBills() here - that collection is
      * mappedBy="billedBill", which no refund flow in this codebase
-     * populates, so it never reflects referenceBill-linked refunds. Mirrors
-     * {@code InwardRefundController.getRemainingRefundableAmount()}.
+     * populates, so it never reflects referenceBill-linked refunds.
      */
-    public double getRemainingRefundableAmount(Bill originalBill) {
-        if (originalBill == null) {
-            return 0.0;
-        }
+    private double computeRemainingRefundableAmount(Bill originalBill) {
         String sql = "select sum(b.netTotal) from Bill b where b.referenceBill=:orig and b.retired=false";
         HashMap hm = new HashMap();
         hm.put("orig", originalBill);
         double refundedSoFar = getBillFacade().findDoubleByJpql(sql, hm);
-        return originalBill.getNetTotal() + refundedSoFar;
+        double remaining = originalBill.getNetTotal() + refundedSoFar;
+        if (remainingRefundableAmountCache != null && originalBill.getId() != null) {
+            remainingRefundableAmountCache.put(originalBill.getId(), remaining);
+        }
+        return remaining;
     }
 
     public void selectBillToRefundListener() {

--- a/src/main/webapp/inward/inward_bill_post_final_payment_refund.xhtml
+++ b/src/main/webapp/inward/inward_bill_post_final_payment_refund.xhtml
@@ -89,58 +89,119 @@
                                 </p:panel>
                             </div>
                             <div class="col-md-6">
-                                <p:panel id="paid">
+                                <p:panel id="billPicker" rendered="#{postFinalBillInwardPaymentController.originalBillToRefund eq null}">
                                     <f:facet name="header">
-                                        <h:outputText styleClass="fas fa-file-invoice"></h:outputText>
-                                        <h:outputLabel value="Post Final Payments Made" class="mx-4"></h:outputLabel>
+                                        <h:outputText styleClass="fas fa-list"></h:outputText>
+                                        <h:outputLabel value="Select Payment Bill to Refund" class="mx-4"></h:outputLabel>
                                     </f:facet>
-                                    <h:panelGrid columns="3" class="w-100">
-                                        <h:outputLabel value="Available to Refund" style="color: green"/>
-                                        <h:outputLabel value=":" ></h:outputLabel>
-                                        <h:outputLabel value="#{postFinalBillInwardPaymentController.paidAmount}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputLabel>
-                                    </h:panelGrid>
+                                    <p:dataTable
+                                        id="tblEligiblePostFinalPaymentBills"
+                                        widgetVar="wvEligiblePostFinalPaymentBills"
+                                        rowKey="#{eb.id}"
+                                        value="#{postFinalBillInwardPaymentController.eligiblePostFinalPaymentBills}"
+                                        var="eb"
+                                        styleClass="table table-sm"
+                                        emptyMessage="No refundable payment bills found for this BHT.">
+                                        <p:column headerText="Bill No">
+                                            <h:outputText value="#{eb.deptId}"/>
+                                        </p:column>
+                                        <p:column headerText="Paid At">
+                                            <h:outputText value="#{eb.createdAt}">
+                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                            </h:outputText>
+                                        </p:column>
+                                        <p:column headerText="Payment Method">
+                                            <h:outputText value="#{eb.paymentMethod}"/>
+                                        </p:column>
+                                        <p:column headerText="Net Total" styleClass="text-end">
+                                            <h:outputText value="#{eb.netTotal}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                                        </p:column>
+                                        <p:column headerText="Remaining Refundable" styleClass="text-end">
+                                            <h:outputText value="#{postFinalBillInwardPaymentController.getRemainingRefundableAmount(eb)}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                                        </p:column>
+                                        <p:column headerText="Action">
+                                            <p:commandButton
+                                                ajax="false"
+                                                value="Select"
+                                                icon="fas fa-check"
+                                                title="Refund payment bill #{eb.deptId}"
+                                                action="#{postFinalBillInwardPaymentController.selectBillToRefundListener}">
+                                                <f:setPropertyActionListener value="#{eb}" target="#{postFinalBillInwardPaymentController.originalBillToRefund}"/>
+                                            </p:commandButton>
+                                        </p:column>
+                                    </p:dataTable>
                                 </p:panel>
-                                <p:panel id="amount" class="my-2">
-                                    <f:facet name="header" >
-                                        <h:outputText styleClass="fas fa-money-bill-wave"></h:outputText>
-                                        <h:outputLabel value="Payment Details" class="mx-4"></h:outputLabel>
-                                    </f:facet>
 
-                                    <h:panelGrid columns="3" class="w-100" columnClasses="col-label,col-colon,col-value" >
-                                        <p:outputLabel value="Payment Method"/>
-                                        <h:outputText value=":"/>
-                                        <p:selectOneMenu class="w-100" autoWidth="false" id="cmbPs" value="#{postFinalBillInwardPaymentController.refundCurrent.paymentMethod}">
-                                            <f:selectItem itemLabel="Select Payment Method"/>
-                                            <f:selectItems value="#{postFinalBillInwardPaymentController.paymentMethods}"/>
-                                            <p:ajax process="cmbPs" update="pnlPaymentMethodDetails" event="change"/>
-                                        </p:selectOneMenu>
+                                <h:panelGroup rendered="#{postFinalBillInwardPaymentController.originalBillToRefund ne null}">
+                                    <p:panel id="paid">
+                                        <f:facet name="header">
+                                            <h:outputText styleClass="fas fa-file-invoice"></h:outputText>
+                                            <h:outputLabel value="Post Final Payments Made" class="mx-4"></h:outputLabel>
+                                            <p:commandButton
+                                                ajax="false"
+                                                value="Change Bill"
+                                                icon="fas fa-arrow-left"
+                                                class="ui-button-secondary float-end"
+                                                action="#{postFinalBillInwardPaymentController.clearSelectedBillToRefund}"/>
+                                        </f:facet>
+                                        <h:panelGrid columns="3" class="w-100">
+                                            <h:outputLabel value="Bill No"/>
+                                            <h:outputLabel value=":" ></h:outputLabel>
+                                            <h:outputLabel value="#{postFinalBillInwardPaymentController.originalBillToRefund.deptId}"/>
 
-                                        <p:outputLabel value="Amount"/>
-                                        <h:outputText value=":"/>
-                                        <p:inputText
-                                            class="w-100"
-                                            autocomplete="off"
-                                            onfocus="this.select()"
-                                            value="#{postFinalBillInwardPaymentController.refundCurrent.total}"/>
-                                    </h:panelGrid>
+                                            <h:outputLabel value="Bill Net Total"/>
+                                            <h:outputLabel value=":" ></h:outputLabel>
+                                            <h:outputLabel value="#{postFinalBillInwardPaymentController.originalBillToRefund.netTotal}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
 
-                                    <h:panelGroup id="pnlPaymentMethodDetails" layout="block" class="mt-2">
-                                        <h:panelGroup rendered="#{postFinalBillInwardPaymentController.refundCurrent.paymentMethod eq 'Card'}" layout="block">
-                                            <pa:creditCard paymentMethodData="#{postFinalBillInwardPaymentController.paymentMethodData}"/>
+                                            <h:outputLabel value="Remaining Refundable" style="color: green"/>
+                                            <h:outputLabel value=":" ></h:outputLabel>
+                                            <h:outputLabel value="#{postFinalBillInwardPaymentController.getRemainingRefundableAmount(postFinalBillInwardPaymentController.originalBillToRefund)}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                        </h:panelGrid>
+                                    </p:panel>
+                                    <p:panel id="amount" class="my-2">
+                                        <f:facet name="header" >
+                                            <h:outputText styleClass="fas fa-money-bill-wave"></h:outputText>
+                                            <h:outputLabel value="Payment Details" class="mx-4"></h:outputLabel>
+                                        </f:facet>
+
+                                        <h:panelGrid columns="3" class="w-100" columnClasses="col-label,col-colon,col-value" >
+                                            <p:outputLabel value="Payment Method"/>
+                                            <h:outputText value=":"/>
+                                            <p:selectOneMenu class="w-100" autoWidth="false" id="cmbPs" value="#{postFinalBillInwardPaymentController.refundCurrent.paymentMethod}">
+                                                <f:selectItem itemLabel="Select Payment Method"/>
+                                                <f:selectItems value="#{postFinalBillInwardPaymentController.paymentMethods}"/>
+                                                <p:ajax process="cmbPs" update="pnlPaymentMethodDetails" event="change"/>
+                                            </p:selectOneMenu>
+
+                                            <p:outputLabel value="Amount"/>
+                                            <h:outputText value=":"/>
+                                            <p:inputText
+                                                class="w-100"
+                                                autocomplete="off"
+                                                onfocus="this.select()"
+                                                value="#{postFinalBillInwardPaymentController.refundCurrent.total}"/>
+                                        </h:panelGrid>
+
+                                        <h:panelGroup id="pnlPaymentMethodDetails" layout="block" class="mt-2">
+                                            <h:panelGroup rendered="#{postFinalBillInwardPaymentController.refundCurrent.paymentMethod eq 'Card'}" layout="block">
+                                                <pa:creditCard paymentMethodData="#{postFinalBillInwardPaymentController.paymentMethodData}"/>
+                                            </h:panelGroup>
+
+                                            <h:panelGroup rendered="#{postFinalBillInwardPaymentController.refundCurrent.paymentMethod eq 'Cheque'}" layout="block">
+                                                <pa:cheque paymentMethodData="#{postFinalBillInwardPaymentController.paymentMethodData}"/>
+                                            </h:panelGroup>
+
+                                            <h:panelGroup rendered="#{postFinalBillInwardPaymentController.refundCurrent.paymentMethod eq 'Slip'}" layout="block">
+                                                <pa:slip paymentMethodData="#{postFinalBillInwardPaymentController.paymentMethodData}"/>
+                                            </h:panelGroup>
                                         </h:panelGroup>
 
-                                        <h:panelGroup rendered="#{postFinalBillInwardPaymentController.refundCurrent.paymentMethod eq 'Cheque'}" layout="block">
-                                            <pa:cheque paymentMethodData="#{postFinalBillInwardPaymentController.paymentMethodData}"/>
-                                        </h:panelGroup>
-
-                                        <h:panelGroup rendered="#{postFinalBillInwardPaymentController.refundCurrent.paymentMethod eq 'Slip'}" layout="block">
-                                            <pa:slip paymentMethodData="#{postFinalBillInwardPaymentController.paymentMethodData}"/>
-                                        </h:panelGroup>
-                                    </h:panelGroup>
-
-                                </p:panel>
+                                    </p:panel>
+                                </h:panelGroup>
 
                             </div>
                         </div>

--- a/src/main/webapp/inward/inward_bill_post_final_payment_refund.xhtml
+++ b/src/main/webapp/inward/inward_bill_post_final_payment_refund.xhtml
@@ -136,7 +136,7 @@
                                     <p:panel id="paid">
                                         <f:facet name="header">
                                             <h:outputText styleClass="fas fa-file-invoice"></h:outputText>
-                                            <h:outputLabel value="Post Final Payments Made" class="mx-4"></h:outputLabel>
+                                            <h:outputLabel value="Bill Details" class="mx-4"></h:outputLabel>
                                             <p:commandButton
                                                 ajax="false"
                                                 value="Change Bill"

--- a/src/main/webapp/inward/inward_bill_refund.xhtml
+++ b/src/main/webapp/inward/inward_bill_refund.xhtml
@@ -77,8 +77,8 @@
                             <h:outputText styleClass="fa-solid fa-address-card fa-lg" style="margin-left: 8px;"/>
                             <p:outputLabel value="Inward Refund Payment" class="m-2"/>
                             <h:panelGroup style="float: right; padding-right: 10px;">
-                                <p:commandButton class="ui-button-warning" icon="fas fa-arrow-rotate-left" id="btnRefund" 
-                                                 ajax="false" value="Refund" action="#{inwardRefundController.pay}" />
+                                <p:commandButton class="ui-button-warning" icon="fas fa-arrow-rotate-left" id="btnRefund"
+                                                 ajax="false" value="Refund" onclick="if (!confirm('Process this refund?')) return false;" action="#{inwardRefundController.pay}" />
                                 <p:commandButton class="ui-button-danger mx-2" icon="fas fa-ban" ajax="false" 
                                                  value="Clear" action="#{inwardRefundController.makeNull}" />
                             </h:panelGroup>
@@ -97,80 +97,124 @@
                                 </p:panel>
                             </div>
                             <div class="col-md-6">
-                                <p:panel id="paid">
+                                <p:panel id="billPicker" rendered="#{inwardRefundController.originalBillToRefund eq null}">
                                     <f:facet name="header">
-                                        <h:outputText styleClass="fas fa-file-invoice"></h:outputText>
-                                        <h:outputLabel value="Bill Details" class="mx-4"></h:outputLabel>
+                                        <h:outputText styleClass="fas fa-list"></h:outputText>
+                                        <h:outputLabel value="Select Payment Bill to Refund" class="mx-4"></h:outputLabel>
                                     </f:facet>
-                                    <h:panelGrid columns="3" class="w-100" rendered="#{inwardRefundController.current.patientEncounter.paymentFinalized}">
-                                        <h:outputLabel value="Due Amount" style="color: red"/>
-                                        <h:outputLabel value=":" ></h:outputLabel>
-                                        <h:outputLabel value="#{inwardRefundController.paidAmount}">                              
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputLabel> 
-                                        <h:outputLabel value="Refundable Amount"  style="color: green"/>
-                                        <h:outputLabel value=":" ></h:outputLabel>
-                                        <h:outputLabel value="#{inwardRefundController.netTotal - inwardRefundController.paidAmount}" >                              
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputLabel>                           
-
-                                        <h:outputLabel value="Final Bill Total"/>
-                                        <h:outputLabel value=":" ></h:outputLabel>
-                                        <h:outputLabel value="#{inwardRefundController.netTotal}">
-                                            <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputLabel>
-
-                                    </h:panelGrid>
-                                    <h:panelGrid columns="3" class="w-100" rendered="#{!inwardRefundController.current.patientEncounter.paymentFinalized}">
-                                        <p:spacer/>
-                                        <h:outputLabel value="No Record Found" style="font-size: 1.3em; text-align: center" />
-                                        <h:outputLabel value="" />
-                                    </h:panelGrid>
+                                    <p:dataTable
+                                        id="tblEligiblePaymentBills"
+                                        widgetVar="wvEligiblePaymentBills"
+                                        rowKey="#{eb.id}"
+                                        value="#{inwardRefundController.eligiblePaymentBills}"
+                                        var="eb"
+                                        styleClass="table table-sm"
+                                        emptyMessage="No refundable payment bills found for this BHT.">
+                                        <p:column headerText="Bill No">
+                                            <h:outputText value="#{eb.deptId}"/>
+                                        </p:column>
+                                        <p:column headerText="Paid At">
+                                            <h:outputText value="#{eb.createdAt}">
+                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                            </h:outputText>
+                                        </p:column>
+                                        <p:column headerText="Payment Method">
+                                            <h:outputText value="#{eb.paymentMethod}"/>
+                                        </p:column>
+                                        <p:column headerText="Net Total" styleClass="text-end">
+                                            <h:outputText value="#{eb.netTotal}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                                        </p:column>
+                                        <p:column headerText="Remaining Refundable" styleClass="text-end">
+                                            <h:outputText value="#{inwardRefundController.getRemainingRefundableAmount(eb)}"><f:convertNumber pattern="#,##0.00"/></h:outputText>
+                                        </p:column>
+                                        <p:column headerText="Action">
+                                            <p:commandButton
+                                                ajax="false"
+                                                value="Select"
+                                                icon="fas fa-check"
+                                                title="Refund payment bill #{eb.deptId}"
+                                                action="#{inwardRefundController.selectBillToRefundListener}">
+                                                <f:setPropertyActionListener value="#{eb}" target="#{inwardRefundController.originalBillToRefund}"/>
+                                            </p:commandButton>
+                                        </p:column>
+                                    </p:dataTable>
                                 </p:panel>
-                                <p:panel id="amount" class="my-2">
-                                    <f:facet name="header" >
-                                        <h:outputText styleClass="fas fa-money-bill-wave"></h:outputText>
-                                        <h:outputLabel value="Payment Details" class="mx-4"></h:outputLabel>
-                                    </f:facet>
 
-                                    <h:panelGrid columns="3" class="w-100" columnClasses="col-label,col-colon,col-value" >
-                                        <p:outputLabel value="Payment Method"/>
-                                        <h:outputText value=":"/>
-                                        <p:selectOneMenu class="w-100" autoWidth="false" id="cmbPs" value="#{inwardRefundController.current.paymentMethod}">
-                                            <f:selectItem itemLabel="Select Payment Method"/>
-                                            <f:selectItems value="#{inwardRefundController.paymentMethods}"/>
-                                            <p:ajax process="cmbPs" update="pnlPaymentMethodDetails" event="change"/>
-                                        </p:selectOneMenu>
+                                <h:panelGroup rendered="#{inwardRefundController.originalBillToRefund ne null}">
+                                    <p:panel id="paid">
+                                        <f:facet name="header">
+                                            <h:outputText styleClass="fas fa-file-invoice"></h:outputText>
+                                            <h:outputLabel value="Bill Details" class="mx-4"></h:outputLabel>
+                                            <p:commandButton
+                                                ajax="false"
+                                                value="Change Bill"
+                                                icon="fas fa-arrow-left"
+                                                class="ui-button-secondary float-end"
+                                                action="#{inwardRefundController.clearSelectedBillToRefund}"/>
+                                        </f:facet>
+                                        <h:panelGrid columns="3" class="w-100">
+                                            <h:outputLabel value="Bill No"/>
+                                            <h:outputLabel value=":" ></h:outputLabel>
+                                            <h:outputLabel value="#{inwardRefundController.originalBillToRefund.deptId}"/>
 
-                                        <p:outputLabel value="Amount"/>
-                                        <h:outputText value=":"/>
-                                        <p:inputText 
-                                            class="w-100" 
-                                            autocomplete="off" 
-                                            onfocus="this.select()"
-                                            value="#{inwardRefundController.current.total}"/>
-                                    </h:panelGrid>
+                                            <h:outputLabel value="Bill Net Total"/>
+                                            <h:outputLabel value=":" ></h:outputLabel>
+                                            <h:outputLabel value="#{inwardRefundController.originalBillToRefund.netTotal}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
 
-                                    <h:panelGroup id="pnlPaymentMethodDetails" layout="block" class="mt-2">
-                                        <h:panelGroup rendered="#{inwardRefundController.current.paymentMethod eq 'Card'}" layout="block">
-                                            <pa:creditCard paymentMethodData="#{inwardRefundController.paymentMethodData}"/>
+                                            <h:outputLabel value="Remaining Refundable" style="color: green"/>
+                                            <h:outputLabel value=":" ></h:outputLabel>
+                                            <h:outputLabel value="#{inwardRefundController.getRemainingRefundableAmount(inwardRefundController.originalBillToRefund)}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                        </h:panelGrid>
+                                    </p:panel>
+                                    <p:panel id="amount" class="my-2">
+                                        <f:facet name="header" >
+                                            <h:outputText styleClass="fas fa-money-bill-wave"></h:outputText>
+                                            <h:outputLabel value="Payment Details" class="mx-4"></h:outputLabel>
+                                        </f:facet>
+
+                                        <h:panelGrid columns="3" class="w-100" columnClasses="col-label,col-colon,col-value" >
+                                            <p:outputLabel value="Payment Method"/>
+                                            <h:outputText value=":"/>
+                                            <p:selectOneMenu class="w-100" autoWidth="false" id="cmbPs" value="#{inwardRefundController.current.paymentMethod}">
+                                                <f:selectItem itemLabel="Select Payment Method"/>
+                                                <f:selectItems value="#{inwardRefundController.paymentMethods}"/>
+                                                <p:ajax process="cmbPs" update="pnlPaymentMethodDetails" event="change"/>
+                                            </p:selectOneMenu>
+
+                                            <p:outputLabel value="Amount"/>
+                                            <h:outputText value=":"/>
+                                            <p:inputText
+                                                class="w-100"
+                                                autocomplete="off"
+                                                onfocus="this.select()"
+                                                value="#{inwardRefundController.current.total}"/>
+                                        </h:panelGrid>
+
+                                        <h:panelGroup id="pnlPaymentMethodDetails" layout="block" class="mt-2">
+                                            <h:panelGroup rendered="#{inwardRefundController.current.paymentMethod eq 'Card'}" layout="block">
+                                                <pa:creditCard paymentMethodData="#{inwardRefundController.paymentMethodData}"/>
+                                            </h:panelGroup>
+
+                                            <h:panelGroup rendered="#{inwardRefundController.current.paymentMethod eq 'Cheque'}" layout="block">
+                                                <pa:cheque paymentMethodData="#{inwardRefundController.paymentMethodData}"/>
+                                            </h:panelGroup>
+
+                                            <h:panelGroup rendered="#{inwardRefundController.current.paymentMethod eq 'Slip'}" layout="block">
+                                                <pa:slip paymentMethodData="#{inwardRefundController.paymentMethodData}"/>
+                                            </h:panelGroup>
                                         </h:panelGroup>
 
-                                        <h:panelGroup rendered="#{inwardRefundController.current.paymentMethod eq 'Cheque'}" layout="block">
-                                            <pa:cheque paymentMethodData="#{inwardRefundController.paymentMethodData}"/>
-                                        </h:panelGroup>
-
-                                        <h:panelGroup rendered="#{inwardRefundController.current.paymentMethod eq 'Slip'}" layout="block">
-                                            <pa:slip paymentMethodData="#{inwardRefundController.paymentMethodData}"/>
-                                        </h:panelGroup>
-                                    </h:panelGroup>
-
-                                </p:panel>
+                                    </p:panel>
+                                </h:panelGroup>
 
                             </div>
                         </div>
                     </p:panel>
-                </h:panelGroup>    
+                </h:panelGroup>
                 <p:panel rendered="#{inwardRefundController.printPreview}">
                     <p:commandButton ajax="false" value="New Bill" class="ui-button-success mb-3" icon="fas fa-plus" action="#{inwardRefundController.makeNull}" />
                     <bill:paymentRefund_1 bill="#{inwardRefundController.current}"/>


### PR DESCRIPTION
## Summary

Follow-up to PR #22623 (found during that PR's CodeRabbit review, filed as #22627). Both Inward refund flows had a design gap that let a payment be reversed twice:

- **Pre-final "Inward Deposit" refund** (`InwardRefundController`, pre-existing)
- **"Post Final Bill Inward Payment" refund** (`PostFinalBillInwardPaymentController`, #22617)

Both let a cashier type a free-form refund amount capped only by an *aggregate* "available to refund" total across the whole patient encounter, with no link back to any specific payment bill. `Bill.referenceBill` was never set and `Bill.setRefunded(true)` was never called on the original bill — so `InwardSearch.check()` and `cancelPostFinalPayment()`, which both **already** read `isRefunded()` as a cancel guard, could never actually block anything. A cashier could refund a payment, then separately cancel the same bill, double-reversing the balance.

## Fix

Redesigned both refund pages to match the established per-bill-selection pattern already used everywhere else in this codebase for refunds (OPD/Pharmacy/Channel/Clinic, per `BillReturnController`): the cashier now picks **one specific payment bill** from a list (showing remaining refundable amount per bill), refunds a full or partial amount against just that bill, and the refund is linked via `setReferenceBill()` / `setRefunded(true)` — mirroring the already-correct cancel-side `setCancelled()`/`setCancelledBill()` pattern.

Partial refunds remain supported: `refunded=true` blocks full-bill cancellation (the actual bug) the moment *any* refund is linked to a bill, while a new `getRemainingRefundableAmount()` (JPQL sum over `Bill` where `referenceBill = :originalBill`) tracks how much of that specific bill is still refundable, independent of the boolean flag.

No changes needed to `InwardSearch.check()` or `cancelPostFinalPayment()` — both already read `isRefunded()` correctly; the bug was entirely on the write side.

## Verification

Local Payara, Inward department, BHT/56753:

1. Recorded a fresh Post Final Bill Payment of 100.00 (Cash) — bill `InwardINWPFP/4`.
2. Opened the redesigned refund page — bill picker correctly listed all 3 payment bills for this encounter with accurate remaining-refundable amounts.
3. Selected `InwardINWPFP/4`, refunded a **partial** 40.00 — succeeded; bill picker then showed remaining refundable = 60.00 (still eligible for further partial refunds).
4. Confirmed in the DB directly:
   ```
   InwardINWPFP/4: REFUNDED=1, CANCELLED=0
   InwardINWREF/2: NETTOTAL=-40, REFERENCEBILL_ID -> InwardINWPFP/4
   ```
5. Independently confirmed via the Bill Administration admin viewer: `InwardINWPFP/4` shows `Refunded: Yes`, `Cancelled: No`.
6. Since `cancelPostFinalPayment()`'s existing guard (`if (getCurrent().isRefunded()) { "Already Refunded. Can not cancel." }`) reads exactly this flag, cancellation of this bill is now correctly blocked — closing the double-reversal gap.
7. Confirmed the mirrored pre-final deposit flow's redesigned picker (`InwardRefundController`) also renders correctly against real deposit data for the same BHT (`InwardINWPAY/59`, 550.00, correct remaining amount) — identical code path to the post-final flow already fully transaction-tested above.

`mvn -o -q compile` clean throughout.

Closes #22627

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Refunds now require selecting a specific eligible payment bill.
  * Added bill details, payment method, total, and remaining refundable amount to the selection view.
  * Selected bills can be changed before completing the refund.
  * Payment-method-specific fields appear after bill selection.
  * Added confirmation before submitting refunds.

* **Bug Fixes**
  * Refund amounts are now calculated and validated per payment bill.
  * Refunds are correctly linked to the selected original payment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->