### PR TITLE
fix(inward): allow negative drawer balance for professional/surgery payments via config

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardStaffPaymentBillController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardStaffPaymentBillController.java
@@ -405,7 +405,9 @@ public class InwardStaffPaymentBillController implements Serializable {
             double drawerBalance = userDrawer.getCashInHandValue();
             double paymentAmount = getTotalPayingWithoutWht();
 
-            if (configOptionApplicationController.getBooleanValueByKey("Enable Drawer Manegment", true)) {
+            boolean allowNegativeDrawer = configOptionApplicationController.getBooleanValueByKey(
+                    "Inward Professional Payments - Allow Negative Drawer Balance", false);
+            if (configOptionApplicationController.getBooleanValueByKey("Enable Drawer Manegment", true) && !allowNegativeDrawer) {
                 if (drawerBalance < paymentAmount) {
                     JsfUtil.addErrorMessage("Not enough cash in your drawer to make this payment");
                     return;

--- a/src/main/java/com/divudi/bean/inward/InwardSurgeryPaymentBillController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSurgeryPaymentBillController.java
@@ -539,7 +539,9 @@ public class InwardSurgeryPaymentBillController implements Serializable {
                 double drawerBalance = userDrawer.getCashInHandValue();
                 double paymentAmount = getTotalPayingWithoutWht();
 
-                if (configOptionApplicationController.getBooleanValueByKey("Enable Drawer Manegment", true)) {
+                boolean allowNegativeDrawer = configOptionApplicationController.getBooleanValueByKey(
+                        "Inward Professional Payments - Allow Negative Drawer Balance", false);
+                if (configOptionApplicationController.getBooleanValueByKey("Enable Drawer Manegment", true) && !allowNegativeDrawer) {
                     if (drawerBalance < paymentAmount) {
                         JsfUtil.addErrorMessage("Not enough cash in your drawer to make this payment");
                         return;


### PR DESCRIPTION
## Summary
- Doctor/surgeon cash payments on the Inward Professional Payment and Inward Surgery Payment pages were hard-blocked with "Not enough cash in your drawer to make this payment" whenever the drawer balance was lower than the payment amount — but this workflow legitimately needs to allow the drawer to go negative.
- Adds a new config option, `Inward Professional Payments - Allow Negative Drawer Balance` (default `false`, preserving current behavior), that bypasses the insufficient-balance block when enabled.
- Scoped to `InwardSurgeryPaymentBillController.settle()` and `InwardStaffPaymentBillController.settle()` for now (urgent fix). The same duplicated drawer-check pattern exists in several other controllers (Channelling staff payment, OPD/Pharmacy financial transactions, etc.) — tracked as follow-up in the issue, out of scope here.

Closes #22638

## Test plan
- [x] `mvn compile` succeeds
- [x] Deployed locally and confirmed app starts and Inward Professional Payment page renders
- [x] End-to-end verified in browser against a real professional fee bill:
  - Config option **off** (default): "Settle Professional Payment" correctly blocked with "Not enough cash in your drawer to make this payment"
  - Config option **on** (toggled via the app's own `PUT /api/config/{key}` endpoint): settlement succeeds ("Successfully Paid"), payment bill created (`PROFESSIONAL_PAYMENT_FOR_STAFF_FOR_INWARD_SERVICE`)
  - Drawer balance confirmed to move by the exact payment amount and go further negative (-24,446.26 → -30,001.26 for a 5,555.00 payment)