### PR TITLE
fix(pharmacy): correct GRN Return bill number missing suffix segment

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
@@ -203,13 +203,9 @@ public class GrnReturnWorkflowController implements Serializable {
         ));
 
         // 🔧 BILL NUMBER GENERATION CONFIGURATIONS
-        metadata.addConfigOption(new ConfigOptionInfo(
-            "Bill Number Suffix for GRN Return",
-            "Custom suffix to append to GRN Return bill numbers",
-            OptionScope.APPLICATION
-        ));
-
-        // 🔧 CRITICAL: Bill Number Generation Strategies for PHARMACY_GRN_RETURN
+        // NOTE: BillNumberGenerator's methods read the suffix under this enum-based key
+        // ("Bill Number Suffix for " + BillTypeAtomic), not under a "GRN Return" label -
+        // this is the only key that actually affects generated bill numbers (hmislk/hmis#22639).
         metadata.addConfigOption(new ConfigOptionInfo(
             "Bill Number Suffix for PHARMACY_GRN_RETURN",
             "Custom suffix to append to pharmacy GRN return bill numbers (used by BillNumberGenerator methods)",
@@ -978,10 +974,24 @@ public class GrnReturnWorkflowController implements Serializable {
         boolean isNewBill = (currentBill.getId() == null);
 
         if (isNewBill) {
-            // Set default suffix for GRN Return if not already set
-            String billNumberSuffix = configOptionApplicationController.getShortTextValueByKey("Bill Number Suffix for GRN Return", "GRNR");
-            if (billNumberSuffix == null || billNumberSuffix.trim().isEmpty()) {
-                billNumberSuffix = "GRNR";
+            // BillNumberGenerator's methods all read the suffix under the enum-based
+            // key "Bill Number Suffix for " + BillTypeAtomic (i.e. "...PHARMACY_GRN_RETURN"),
+            // never under the human-readable "Bill Number Suffix for GRN Return" key this
+            // method used to populate here. That mismatch left the enum-based key empty,
+            // so every generated GRN Return number was missing its suffix segment
+            // (e.g. "MP//26/037972" instead of "MP/GRNR/26/037972") regardless of which
+            // numbering strategy a department has configured, since every strategy branch
+            // below ultimately reads the same enum-based key. Migrate any legacy value
+            // over on first use so existing deployments' configured suffix keeps working
+            // without a manual Settings-UI step. (hmislk/hmis#22639)
+            String correctSuffixKey = "Bill Number Suffix for " + BillTypeAtomic.PHARMACY_GRN_RETURN;
+            String currentSuffix = configOptionApplicationController.getLongTextValueByKey(correctSuffixKey, "");
+            if (currentSuffix == null || currentSuffix.trim().isEmpty()) {
+                String legacySuffix = configOptionApplicationController.getShortTextValueByKey("Bill Number Suffix for GRN Return", "GRNR");
+                if (legacySuffix == null || legacySuffix.trim().isEmpty()) {
+                    legacySuffix = "GRNR";
+                }
+                configOptionApplicationController.setLongTextValueByKey(correctSuffixKey, legacySuffix);
             }
 
             currentBill.setBillType(BillType.PharmacyGrnReturn);


### PR DESCRIPTION
## Summary
- `GrnReturnWorkflowController.saveBill()` read/wrote the GRN Return numbering suffix under the human-readable config key `"Bill Number Suffix for GRN Return"`, but every `BillNumberGenerator` method that actually generates the bill number reads it under the enum-based key `"Bill Number Suffix for PHARMACY_GRN_RETURN"`. The two keys never matched, so the suffix was always empty regardless of numbering strategy (e.g. `MP//26/037972` instead of `MP/GRNR/26/037972`).
- Migrates any legacy value into the enum-based key on first use, so existing deployments keep their configured suffix without a manual Settings-UI step, and fixes the page metadata registration to point at the key that's actually read.

## Test plan
- [x] Rebuilt and redeployed locally; confirmed the enum-based config key (`Bill Number Suffix for PHARMACY_GRN_RETURN`) was empty in the local DB before the fix, causing `MP//26/037972`.
- [x] Verified live via Playwright: created, finalized, and approved a new GRN Return against `MP/GRN/26/037967` — new bill number generated as `MP/GRNR/26/037974` (suffix present, DB-confirmed `CHECKED=1, COMPLETED=1`).
- [x] Verified the full stock deduction / payment creation / approval flow still completes correctly (no regression to functional behavior, only the number format).

Closes #22639

🤖 Generated with [Claude Code](https://claude.com/claude-code)