### PR TITLE
fix(pharmacy): legacy GRN list Path 3 query silently matched 0 rows

### DIFF
--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -7850,8 +7850,10 @@ public class SearchController implements Serializable {
      */
     private void fillGrnsByBulkQuery(List<Bill> poList, List<BillTypeAtomic> grnBillTypesAtomicsToList) {
         Map<Long, List<Bill>> grnsByPoId = new HashMap<>();
+        List<Long> poIds = new ArrayList<>();
         for (Bill po : poList) {
             grnsByPoId.put(po.getId(), new ArrayList<>());
+            poIds.add(po.getId());
         }
 
         // Path 1: GRN.referenceBill is the PO
@@ -7899,11 +7901,17 @@ public class SearchController implements Serializable {
         // end up linked one hop further up the approval chain than expected, so resolve
         // each approval bill's own referenceBill (the original PO) and match on that
         // too, mirroring Path 1/2's tolerance for an alternate linking path.
+        // NOTE: must filter on b.id IN :poIds here, not "b IN :pos" against a
+        // List<Bill> - comparing the root identification variable directly to an
+        // entity-valued list parameter silently matches zero rows under EclipseLink,
+        // unlike a navigated path expression (e.g. Path 1/2's "g.referenceBill IN
+        // :pos"). This previously left the legacy page's GRN list empty even after
+        // porting Path 3 from the DTO method (which correctly uses "b.id IN :poIds").
         Map<Long, List<Long>> approvalIdsByOriginalPoId = new HashMap<>();
         String originalPoJpql = "SELECT b.id, b.referenceBill.id FROM Bill b "
-                + "WHERE b IN :pos AND b.referenceBill IS NOT NULL";
+                + "WHERE b.id IN :poIds AND b.referenceBill IS NOT NULL";
         Map<String, Object> originalPoParams = new HashMap<>();
-        originalPoParams.put("pos", poList);
+        originalPoParams.put("poIds", poIds);
         List<Object> originalPoRows = getBillFacade().findObjects(originalPoJpql, originalPoParams);
         if (originalPoRows != null) {
             for (Object row : originalPoRows) {


### PR DESCRIPTION
## Summary
- The legacy "Purchase Orders for Receiving" page's GRN count/list was still empty for a PO whose GRN links one hop further up the approval chain, even after the #22630/PR #22631 fix that was supposed to resolve exactly this.
- Root cause: `fillGrnsByBulkQuery()`'s Path 3 outer query compared the root identification variable directly against an entity-valued list parameter (`b IN :pos` with `List<Bill>`), which silently matches zero rows under EclipseLink — unlike a navigated path expression against the same kind of list (Path 1/2's `g.referenceBill IN :pos`).
- Fixed by switching to `b.id IN :poIds` (`List<Long>`), matching the already-working DTO sibling `fillGrnDtosByBulkQuery()`.

Closes #22644

## Test plan
- [x] Rebuilt and redeployed locally
- [x] Added temporary debug logging to confirm `originalPoRows=0` before the fix, correct approval→original-PO mapping after
- [x] Live Playwright re-verification: legacy page (`pharmacy_purchase_order_list_for_recieve.xhtml`) now shows GRN `MP/GRN/26/037967` under PO `MP/PO/26/037966`, matching the DTO page (`pharmacy_purchase_order_list_for_recieve_dto.xhtml`)
- [x] Debug logging removed before commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved purchase order filtering when loading goods received notes.
  * Ensured approval-chain results are limited to the relevant purchase orders for more accurate data display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->