### PR TITLE
fix(inward): guard against null drawer in professional payment settle()

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardStaffPaymentBillController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardStaffPaymentBillController.java
@@ -402,15 +402,17 @@ public class InwardStaffPaymentBillController implements Serializable {
         }
         if (paymentMethod == PaymentMethod.Cash) {
             Drawer userDrawer = drawerService.getUsersDrawer(sessionController.getLoggedUser());
-            double drawerBalance = userDrawer.getCashInHandValue();
-            double paymentAmount = getTotalPayingWithoutWht();
+            if (userDrawer != null) {
+                double drawerBalance = userDrawer.getCashInHandValue();
+                double paymentAmount = getTotalPayingWithoutWht();
 
-            boolean allowNegativeDrawer = configOptionApplicationController.getBooleanValueByKey(
-                    "Inward Professional Payments - Allow Negative Drawer Balance", false);
-            if (configOptionApplicationController.getBooleanValueByKey("Enable Drawer Manegment", true) && !allowNegativeDrawer) {
-                if (drawerBalance < paymentAmount) {
-                    JsfUtil.addErrorMessage("Not enough cash in your drawer to make this payment");
-                    return;
+                boolean allowNegativeDrawer = configOptionApplicationController.getBooleanValueByKey(
+                        "Inward Professional Payments - Allow Negative Drawer Balance", false);
+                if (configOptionApplicationController.getBooleanValueByKey("Enable Drawer Manegment", true) && !allowNegativeDrawer) {
+                    if (drawerBalance < paymentAmount) {
+                        JsfUtil.addErrorMessage("Not enough cash in your drawer to make this payment");
+                        return;
+                    }
                 }
             }
         }

--- a/src/main/java/com/divudi/bean/inward/InwardStaffPaymentBillController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardStaffPaymentBillController.java
@@ -403,7 +403,7 @@ public class InwardStaffPaymentBillController implements Serializable {
         if (paymentMethod == PaymentMethod.Cash) {
             Drawer userDrawer = drawerService.getUsersDrawer(sessionController.getLoggedUser());
             if (userDrawer != null) {
-                double drawerBalance = userDrawer.getCashInHandValue();
+                double drawerBalance = userDrawer.getCashInHandValue() != null ? userDrawer.getCashInHandValue() : 0.0;
                 double paymentAmount = getTotalPayingWithoutWht();
 
                 boolean allowNegativeDrawer = configOptionApplicationController.getBooleanValueByKey(

--- a/src/main/java/com/divudi/bean/inward/InwardSurgeryPaymentBillController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSurgeryPaymentBillController.java
@@ -536,7 +536,7 @@ public class InwardSurgeryPaymentBillController implements Serializable {
         if (paymentMethod == PaymentMethod.Cash && !feeCollectedByDoctor) {
             Drawer userDrawer = drawerService.getUsersDrawer(sessionController.getLoggedUser());
             if (userDrawer != null) {
-                double drawerBalance = userDrawer.getCashInHandValue();
+                double drawerBalance = userDrawer.getCashInHandValue() != null ? userDrawer.getCashInHandValue() : 0.0;
                 double paymentAmount = getTotalPayingWithoutWht();
 
                 boolean allowNegativeDrawer = configOptionApplicationController.getBooleanValueByKey(


### PR DESCRIPTION
## Summary
- Follow-up to #22640 (merged), which added the `Inward Professional Payments - Allow Negative Drawer Balance` config option.
- Production (coop staging) hit a 500 `NullPointerException` at `InwardStaffPaymentBillController.java:405` when settling an Inward Professional Payment: `drawerService.getUsersDrawer(...)` returned `null` (the settling user has no `Drawer` record) and the very next line dereferenced it unconditionally.
- `InwardSurgeryPaymentBillController` already null-guards this same call; this PR mirrors that pattern in `InwardStaffPaymentBillController.settle()` so the cash-balance check is simply skipped when the user has no drawer, instead of crashing the page.

Stack trace from staging:
```
Caused by: java.lang.NullPointerException:
    at com.divudi.bean.inward.InwardStaffPaymentBillController.settle(InwardStaffPaymentBillController.java:405)
```

## Test plan
- [x] `mvn compile` succeeds
- [x] Local dev environment did not surface this bug because the test user already had a `Drawer` row — confirmed via code inspection that `InwardSurgeryPaymentBillController` already handles the null case the same way this PR adds to `InwardStaffPaymentBillController`
- [ ] Verify on staging/production that settling a professional payment as a user without a drawer no longer 500s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cash settlement validation when a user drawer is unavailable.
  * Treated missing drawer cash balances as zero to prevent settlement errors.
  * Prevented settlements when available drawer cash is insufficient and negative balances are not allowed.
  * Applied drawer-balance checks according to configured drawer management settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->