### PR TITLE
fix(opd): stop double-negating cancelled/refunded bill values in Itemized Sales Summary

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -1316,6 +1316,18 @@ balance locally):
   panel beforehand isn't necessary once you're driving it via JS, but doing a
   quick `browser_snapshot` after any of this is worth it to confirm the
   visible label actually changed before submitting the form.
+- Confirmed again while verifying issue #22649 (OPD Itemized Sales Summary
+  cancellation-doubling report): `itemized_sale_summary_dto.xhtml`'s From/To
+  `p:calendar` inputs silently reverted to today's date after `.fill()`, every
+  time — as soon as the *other* date field (or any other input on the page)
+  was touched next, both fields resnapped to their pre-fill value. If you'd
+  rather not reach for `browser_evaluate`/widget internals, driving the actual
+  calendar UI works just as reliably: click the input to open its popup, click
+  the "Previous"/"Next" month arrows (found via `browser_find` for the visible
+  month/year text, since the arrows' refs change every re-render) until the
+  target month is showing, then click the day-number link. This sets the
+  widget's real internal Date object (unlike a raw `.fill()`), so the value
+  survives subsequent postbacks/field changes.
 - Separately: local test data can have **zero** BillFee rows with
   `paidValue == feeValue` (nobody has ever settled a professional payment
   through this exact local DB copy) — check with a quick SQL count before

--- a/src/main/java/com/divudi/service/BillService.java
+++ b/src/main/java/com/divudi/service/BillService.java
@@ -3205,12 +3205,15 @@ public class BillService {
                 + " coalesce(bi.item.category.name, 'No Category')," // Category name for display
                 + " bi.item.id," // Item ID for navigation
                 + " coalesce(bi.item.name, 'No Item')," // Item name for display
-                + " sum(case when b.billClassType in (:cancel, :refund) then -1 else 1 end)," // Count
-                + " sum(case when b.billClassType in (:cancel, :refund) then -bi.hospitalFee else bi.hospitalFee end),"
-                + " sum(case when b.billClassType in (:cancel, :refund) then -bi.staffFee else bi.staffFee end),"
-                + " sum(case when b.billClassType in (:cancel, :refund) then -bi.grossValue else bi.grossValue end),"
-                + " sum(case when b.billClassType in (:cancel, :refund) then -bi.discount else bi.discount end),"
-                + " sum(case when b.billClassType in (:cancel, :refund) then -bi.netValue else bi.netValue end)"
+                + " sum(case when b.billClassType in (:cancel, :refund) then -1 else 1 end)," // Count (no stored sign)
+                // Fee/value columns are ALREADY stored negative on cancellation/refund bill
+                // items, so they are summed as-is. Negating them here would double-negate and
+                // make cancellations show as positive (the fee-doubling bug of issue #22649).
+                + " sum(bi.hospitalFee),"
+                + " sum(bi.staffFee),"
+                + " sum(bi.grossValue),"
+                + " sum(bi.discount),"
+                + " sum(bi.netValue)"
                 + ") "
                 + " from BillItem bi join bi.bill b "
                 + " where b.retired=:ret "


### PR DESCRIPTION
## Summary
- Fixes #22649 — the OPD **Itemized Sales Summary (Fast - DTO-Based)** report inflated Gross/Hospital Fee/Professional Fee/Net Amount totals whenever a bill in the date range was cancelled or refunded.
- Root cause: `BillItem` fee/value columns (`hospitalFee`, `staffFee`, `grossValue`, `discount`, `netValue`) are already stored **negative** on `CancelledBill`/`RefundBill` rows, but `BillService.fetchOpdSaleSummaryDTOs()` re-negated them in a `CASE WHEN`, flipping them back positive and **adding** the cancelled amount instead of subtracting it.
- This is the same bug class as #21918, which was fixed for the sibling `fetchItemizedServiceInstanceDTOs()` method (Itemized Service Summary OPD+Inward) but never applied here. This PR mirrors that same pattern: sum the fee/value columns as-is (they're already correctly signed); only the synthetic `Count` column keeps its `CASE WHEN` sign flip.
- Read-only reporting fix — no stored data changes, no other callers of `fetchOpdSaleSummaryDTOs()` exist.

## Test plan
- [x] Confirmed the bug against **coop production** DB directly (see issue #22649 for the original production evidence: SCANNING CHARGES, 03 Aug 2026).
- [x] Built and redeployed locally (`mvn clean package -DskipTests` + `asadmin redeploy`).
- [x] Verified end-to-end via Playwright against the local coop-mirrored DB: found a real local MRI - BRAIN billing sequence (11-12 Apr 2026, OPD - Diagnostic Centre) — 5 `BilledBill` rows @ 25,000 gross each, 1 `CancelledBill` reversing one of them (-25,000).
- [x] Ran the actual "Itemized Sales Summary (Fast - DTO-Based)" report through the browser after the fix — confirmed it now shows Count 4, Hospital Fee 100,000.0, Gross Amount 100,000.00, Net Amount 100,000.00 (correct: 4 net valid sales × 25,000), instead of the pre-fix inflated 150,000 (5 × 25,000 + the flipped-positive cancellation).

![Itemized Sales Summary showing MRI - BRAIN correctly netted to Count 4, Gross/Net 100,000](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/22649-01-itemized-sales-summary-mri-brain-fixed.png)

Full verification details posted on the issue: https://github.com/hmislk/hmis/issues/22649#issuecomment-5169374614

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected financial totals for cancellation and refund transactions.
  - Preserved negative transaction counts while accurately calculating fees, gross amounts, discounts, and net values.

- **Documentation**
  - Added guidance for reliably selecting dates in calendar fields during end-to-end testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->