### PR TITLE
fix(pharmacy): block GRN finalize when discount exceeds purchase rate

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
@@ -3161,7 +3161,32 @@ public class GrnCostingController implements Serializable {
             msg = quantityValidationMsg;
         }
 
+        // Discount Rate is a per-unit discount amount, not a percentage. Nothing
+        // upstream clamps it against the Purchase Rate, so a discount larger than
+        // the purchase rate silently drives the line's net rate (and therefore the
+        // whole GRN) negative - i.e. the pharmacy would be "receiving" stock at a
+        // negative cost. Block finalization instead of persisting that nonsensical
+        // value (found during legacy-vs-DTO GRN QA, issue #22595).
+        String discountValidationMsg = validateLineDiscountRates(billItems);
+        if (!discountValidationMsg.isEmpty()) {
+            msg = discountValidationMsg;
+        }
+
         return msg;
+    }
+
+    private String validateLineDiscountRates(List<BillItem> billItems) {
+        for (BillItem bi : billItems) {
+            BillItemFinanceDetails f = bi.getBillItemFinanceDetails();
+            if (f == null || f.getLineNetRate() == null) {
+                continue;
+            }
+            if (f.getLineNetRate().compareTo(BigDecimal.ZERO) < 0) {
+                String itemName = bi.getItem() != null ? bi.getItem().getName() : "Unknown Item";
+                return "Item " + itemName + ": Discount Rate cannot exceed Purchase Rate (results in a negative net rate)";
+            }
+        }
+        return "";
     }
 
     private String validateGrnQuantities(List<BillItem> billItems) {

--- a/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
@@ -3178,10 +3178,19 @@ public class GrnCostingController implements Serializable {
     private String validateLineDiscountRates(List<BillItem> billItems) {
         for (BillItem bi : billItems) {
             BillItemFinanceDetails f = bi.getBillItemFinanceDetails();
-            if (f == null || f.getLineNetRate() == null) {
+            if (f == null) {
                 continue;
             }
-            if (f.getLineNetRate().compareTo(BigDecimal.ZERO) < 0) {
+            // Compare the raw discount/gross rates directly rather than the derived
+            // lineNetRate, which recalculateFinancialsBeforeAddingBillItem() rounds to
+            // 4 decimal places - a discount only fractionally above the gross rate
+            // could otherwise round down to 0.0000 and slip past a >= 0 check.
+            BigDecimal grossRate = f.getLineGrossRate();
+            BigDecimal discountRate = f.getLineDiscountRate();
+            if (grossRate == null || discountRate == null) {
+                continue;
+            }
+            if (discountRate.compareTo(grossRate) > 0) {
                 String itemName = bi.getItem() != null ? bi.getItem().getName() : "Unknown Item";
                 return "Item " + itemName + ": Discount Rate cannot exceed Purchase Rate (results in a negative net rate)";
             }


### PR DESCRIPTION
## Summary
- The GRN costing page's item-level "Discount Rate" field is a per-unit discount amount, not a percentage, and nothing validated it against the item's Purchase Rate.
- Entering a discount larger than the purchase rate drove the line's net rate negative, and by extension the whole GRN's Net Total negative — the pharmacy would be recorded as receiving stock at a negative cost. Neither Save nor Finalize blocked this; the negative-value bill was persisted with no warning.
- Added `validateLineDiscountRates()` to `GrnCostingController.errorCheck()`, shared by both the combined save/finalize/approve flow and the legacy split `settle()` flow via `validateInputs()`. Save remains unrestricted (drafts may be incomplete by design); Finalize is now blocked with a clear per-item message.

Closes #22668

## Test plan
- [x] Rebuilt and redeployed locally
- [x] Live Playwright re-verification: discount(5) > purchaseRate(2.89) case now blocked at Finalize with "Item Paracetol 500mg: Discount Rate cannot exceed Purchase Rate (results in a negative net rate)", zero DB writes for that attempt
- [x] Happy path verified: discount(0.29) + Bill Expense (Transport, 5.00, considered for costing) finalizes correctly, Net Total = 44.00 confirmed in DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent pharmacy goods receipt line discounts from creating negative net rates.
  * Displays an item-specific error message before the receipt can be finalized or saved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->