### PR TITLE
feat(inward): opt-in per-admission-type bill number serial for deposit and post-final payments

### DIFF
--- a/developer_docs/configuration/bill-number-config-options.md
+++ b/developer_docs/configuration/bill-number-config-options.md
@@ -56,8 +56,8 @@ public static final String BILL_NUMBER_GENERATION_STRATEGY_FOR_INSTITUTION_ID_IS
 **Default**: `false`
 **Description**: When enabled, the **Inward Deposit** (`InwardPaymentBill` / `BillNumberSuffix.INWPAY`) and **Post Final Payment** (`PostFinalBillInwardPayment` / `BillNumberSuffix.INWPFP`) bill numbers are given a separate serial counter per `AdmissionType` (e.g. "BHT" vs "OPD Card") instead of one shared serial across all admission types for the department/institution. The `AdmissionType` code and an extra delimiter are inserted into the bill number, right after the existing suffix and before the numeric serial. Only applies when the bill's `PatientEncounter` has a non-null `AdmissionType`; otherwise the legacy (shared-serial) behavior is used regardless of this setting. Default (`false`) behavior is byte-for-byte identical to the pre-existing bill number format.
 
-**Example Output (enabled, admission type code `BHT`)**: `ICU/INWPAY/BHT/000001`
-**Example Output (disabled, legacy format)**: `ICU/INWPAY/000001`
+**Example Output (enabled, admission type code `BHT`)**: `ICUINWPAY/BHT/1`
+**Example Output (disabled, legacy format)**: `ICUINWPAY/1`
 
 ## Bill Type Suffix Configuration
 

--- a/developer_docs/configuration/bill-number-config-options.md
+++ b/developer_docs/configuration/bill-number-config-options.md
@@ -49,6 +49,16 @@ public static final String BILL_NUMBER_GENERATION_STRATEGY_FOR_INSTITUTION_ID_IS
 
 **Example Output**: `POR/MPH/25/000001`
 
+### 4. Unique Serial Per Admission Type for Inward Payments
+
+**Key**: `Bill Number Generation Strategy - Unique Serial Per Admission Type for Inward Payments`
+**Type**: Boolean
+**Default**: `false`
+**Description**: When enabled, the **Inward Deposit** (`InwardPaymentBill` / `BillNumberSuffix.INWPAY`) and **Post Final Payment** (`PostFinalBillInwardPayment` / `BillNumberSuffix.INWPFP`) bill numbers are given a separate serial counter per `AdmissionType` (e.g. "BHT" vs "OPD Card") instead of one shared serial across all admission types for the department/institution. The `AdmissionType` code and an extra delimiter are inserted into the bill number, right after the existing suffix and before the numeric serial. Only applies when the bill's `PatientEncounter` has a non-null `AdmissionType`; otherwise the legacy (shared-serial) behavior is used regardless of this setting. Default (`false`) behavior is byte-for-byte identical to the pre-existing bill number format.
+
+**Example Output (enabled, admission type code `BHT`)**: `ICU/INWPAY/BHT/000001`
+**Example Output (disabled, legacy format)**: `ICU/INWPAY/000001`
+
 ## Bill Type Suffix Configuration
 
 ### Dynamic Configuration Keys

--- a/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
+++ b/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
@@ -252,6 +252,7 @@ public class ConfigOptionApplicationController implements Serializable {
         getBooleanValueByKey("Bill Number Generation Strategy for Department ID is Prefix Dept Ins Year Count", false);
         getBooleanValueByKey("Bill Number Generation Strategy for Department ID is Prefix Ins Year Count", false);
         getBooleanValueByKey("Bill Number Generation Strategy for Institution ID is Prefix Ins Year Count", false);
+        getBooleanValueByKey("Bill Number Generation Strategy - Unique Serial Per Admission Type for Inward Payments", false);
 
         // Bill-type-specific numbering strategies for Purchase Order Requests (POR)
         getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy Purchase Order Request - Prefix + Department Code + Institution Code + Year + Yearly Number", false);

--- a/src/main/java/com/divudi/bean/inward/InwardPaymentController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardPaymentController.java
@@ -33,6 +33,7 @@ import com.divudi.core.entity.Patient;
 import com.divudi.core.entity.PatientDeposit;
 import com.divudi.core.entity.PatientEncounter;
 import com.divudi.core.entity.Person;
+import com.divudi.core.entity.inward.AdmissionType;
 import com.divudi.core.facade.BillFeeFacade;
 import com.divudi.core.facade.BillItemFacade;
 import com.divudi.core.facade.BilledBillFacade;
@@ -873,8 +874,19 @@ public class InwardPaymentController implements Serializable, ControllerWithMult
         getCurrent().setBillType(BillType.InwardPaymentBill);
         getCurrent().setBillTypeAtomic(BillTypeAtomic.INWARD_DEPOSIT);
         getCurrent().setPaymentMethod(paymentMethod);
-        getCurrent().setDeptId(getBillNumberBean().institutionBillNumberGenerator(getSessionController().getDepartment(), getCurrent().getBillType(), BillClassType.BilledBill, BillNumberSuffix.INWPAY));
-        getCurrent().setInsId(getBillNumberBean().institutionBillNumberGenerator(getSessionController().getInstitution(), getCurrent().getBillType(), BillClassType.BilledBill, BillNumberSuffix.INWPAY));
+
+        AdmissionType admissionTypeForBillNumber = getCurrent().getPatientEncounter() != null
+                ? getCurrent().getPatientEncounter().getAdmissionType() : null;
+        boolean uniqueSerialPerAdmissionType = admissionTypeForBillNumber != null
+                && configOptionApplicationController.getBooleanValueByKey(
+                        "Bill Number Generation Strategy - Unique Serial Per Admission Type for Inward Payments", false);
+        if (uniqueSerialPerAdmissionType) {
+            getCurrent().setDeptId(getBillNumberBean().institutionBillNumberGenerator(getSessionController().getDepartment(), getCurrent().getBillType(), BillClassType.BilledBill, BillNumberSuffix.INWPAY, admissionTypeForBillNumber));
+            getCurrent().setInsId(getBillNumberBean().institutionBillNumberGenerator(getSessionController().getInstitution(), getCurrent().getBillType(), BillClassType.BilledBill, BillNumberSuffix.INWPAY, admissionTypeForBillNumber));
+        } else {
+            getCurrent().setDeptId(getBillNumberBean().institutionBillNumberGenerator(getSessionController().getDepartment(), getCurrent().getBillType(), BillClassType.BilledBill, BillNumberSuffix.INWPAY));
+            getCurrent().setInsId(getBillNumberBean().institutionBillNumberGenerator(getSessionController().getInstitution(), getCurrent().getBillType(), BillClassType.BilledBill, BillNumberSuffix.INWPAY));
+        }
         getCurrent().setBillDate(new Date());
         getCurrent().setBillTime(new Date());
         getCurrent().setPatient(getCurrent().getPatientEncounter().getPatient());

--- a/src/main/java/com/divudi/bean/inward/PostFinalBillInwardPaymentController.java
+++ b/src/main/java/com/divudi/bean/inward/PostFinalBillInwardPaymentController.java
@@ -10,6 +10,7 @@ package com.divudi.bean.inward;
 
 import com.divudi.bean.cashTransaction.FinancialTransactionController;
 import com.divudi.bean.common.BillBeanController;
+import com.divudi.bean.common.ConfigOptionApplicationController;
 import com.divudi.bean.common.ControllerWithMultiplePayments;
 import com.divudi.bean.common.SessionController;
 import com.divudi.core.util.JsfUtil;
@@ -32,6 +33,7 @@ import com.divudi.core.entity.PatientEncounter;
 import com.divudi.core.entity.Payment;
 import com.divudi.core.entity.RefundBill;
 import com.divudi.core.entity.WebUser;
+import com.divudi.core.entity.inward.AdmissionType;
 import com.divudi.core.facade.BillFacade;
 import com.divudi.core.facade.BillFeeFacade;
 import com.divudi.core.facade.BillItemFacade;
@@ -96,6 +98,8 @@ public class PostFinalBillInwardPaymentController implements Serializable, Contr
     private PaymentSchemeController paymentSchemeController;
     @Inject
     private FinancialTransactionController financialTransactionController;
+    @Inject
+    private ConfigOptionApplicationController configOptionApplicationController;
     // </editor-fold>
 
     // <editor-fold defaultstate="collapsed" desc="Variables">
@@ -627,8 +631,19 @@ public class PostFinalBillInwardPaymentController implements Serializable, Contr
         getCurrent().setBillType(BillType.PostFinalBillInwardPayment);
         getCurrent().setBillTypeAtomic(BillTypeAtomic.POST_FINAL_BILL_INWARD_PAYMENT);
         getCurrent().setPaymentMethod(paymentMethod);
-        getCurrent().setDeptId(getBillNumberBean().institutionBillNumberGenerator(getSessionController().getDepartment(), getCurrent().getBillType(), BillClassType.BilledBill, BillNumberSuffix.INWPFP));
-        getCurrent().setInsId(getBillNumberBean().institutionBillNumberGenerator(getSessionController().getInstitution(), getCurrent().getBillType(), BillClassType.BilledBill, BillNumberSuffix.INWPFP));
+
+        AdmissionType admissionTypeForBillNumber = getCurrent().getPatientEncounter() != null
+                ? getCurrent().getPatientEncounter().getAdmissionType() : null;
+        boolean uniqueSerialPerAdmissionType = admissionTypeForBillNumber != null
+                && configOptionApplicationController.getBooleanValueByKey(
+                        "Bill Number Generation Strategy - Unique Serial Per Admission Type for Inward Payments", false);
+        if (uniqueSerialPerAdmissionType) {
+            getCurrent().setDeptId(getBillNumberBean().institutionBillNumberGenerator(getSessionController().getDepartment(), getCurrent().getBillType(), BillClassType.BilledBill, BillNumberSuffix.INWPFP, admissionTypeForBillNumber));
+            getCurrent().setInsId(getBillNumberBean().institutionBillNumberGenerator(getSessionController().getInstitution(), getCurrent().getBillType(), BillClassType.BilledBill, BillNumberSuffix.INWPFP, admissionTypeForBillNumber));
+        } else {
+            getCurrent().setDeptId(getBillNumberBean().institutionBillNumberGenerator(getSessionController().getDepartment(), getCurrent().getBillType(), BillClassType.BilledBill, BillNumberSuffix.INWPFP));
+            getCurrent().setInsId(getBillNumberBean().institutionBillNumberGenerator(getSessionController().getInstitution(), getCurrent().getBillType(), BillClassType.BilledBill, BillNumberSuffix.INWPFP));
+        }
         getCurrent().setBillDate(new Date());
         getCurrent().setBillTime(new Date());
         getCurrent().setPatient(getCurrent().getPatientEncounter().getPatient());

--- a/src/main/java/com/divudi/core/entity/BillNumber.java
+++ b/src/main/java/com/divudi/core/entity/BillNumber.java
@@ -11,6 +11,7 @@ import com.divudi.core.data.BillType;
 import com.divudi.core.data.BillTypeAtomic;
 import com.divudi.core.data.PaymentMethod;
 import com.divudi.core.data.RequestType;
+import com.divudi.core.entity.inward.AdmissionType;
 import java.io.Serializable;
 import java.util.Date;
 import javax.persistence.Entity;
@@ -65,7 +66,9 @@ public class BillNumber implements Serializable {
     private RequestType requestType;
     @Enumerated(EnumType.STRING)
     private AppointmentType appointmentType;
-    
+    @ManyToOne
+    private AdmissionType admissionType;
+
 
     public boolean isRetired() {
         return retired;
@@ -260,6 +263,14 @@ public class BillNumber implements Serializable {
 
     public void setAppointmentType(AppointmentType appointmentType) {
         this.appointmentType = appointmentType;
+    }
+
+    public AdmissionType getAdmissionType() {
+        return admissionType;
+    }
+
+    public void setAdmissionType(AdmissionType admissionType) {
+        this.admissionType = admissionType;
     }
 
 }

--- a/src/main/java/com/divudi/ejb/BillNumberGenerator.java
+++ b/src/main/java/com/divudi/ejb/BillNumberGenerator.java
@@ -1041,6 +1041,29 @@ public class BillNumberGenerator {
         return result.toString();
     }
 
+    /**
+     * Same as {@link #institutionBillNumberGenerator(Institution, BillType, BillClassType, BillNumberSuffix)}
+     * but keeps a separate serial per {@link AdmissionType} (e.g. BHT vs OPD
+     * Card admissions), for use only when the "Bill Number Generation
+     * Strategy - Unique Serial Per Admission Type for Inward Payments"
+     * config option is enabled. Does not alter the behavior of the existing
+     * 4-argument overload above.
+     */
+    public synchronized String institutionBillNumberGenerator(Institution ins, BillType billType, BillClassType billClassType, BillNumberSuffix billNumberSuffix, AdmissionType admissionType) {
+        BillNumber billNumber = fetchLastBillNumber(ins, billType, billClassType, admissionType);
+        StringBuilder result = new StringBuilder();
+        Long b = billNumber.getLastBillNumber();
+        result.append(ins.getInstitutionCode());
+        result.append(billNumberSuffix.getSuffix());
+        result.append(getBillNumberDelimiter());
+        result.append(admissionType.getCode());
+        result.append(getBillNumberDelimiter());
+        result.append(++b);
+        billNumber.setLastBillNumber(b);
+        billNumberFacade.edit(billNumber);
+        return result.toString();
+    }
+
     public synchronized String fetchPaymentSchemeCount(PaymentScheme paymentScheme, BillType billType, Institution institution) {
         if (paymentScheme == null) {
             return "";
@@ -1234,6 +1257,36 @@ public class BillNumberGenerator {
             result.append(billNumberSuffix);
         }
 
+        result.append(getBillNumberDelimiter());
+        result.append(++b);
+
+        billNumber.setLastBillNumber(b);
+        billNumberFacade.edit(billNumber);
+
+        return result.toString();
+    }
+
+    /**
+     * Same as {@link #institutionBillNumberGenerator(Department, BillType, BillClassType, BillNumberSuffix)}
+     * but keeps a separate serial per {@link AdmissionType} (e.g. BHT vs OPD
+     * Card admissions), for use only when the "Bill Number Generation
+     * Strategy - Unique Serial Per Admission Type for Inward Payments"
+     * config option is enabled. Does not alter the behavior of the existing
+     * 4-argument overload above.
+     */
+    public synchronized String institutionBillNumberGenerator(Department dep, BillType billType, BillClassType billClassType, BillNumberSuffix billNumberSuffix, AdmissionType admissionType) {
+
+        BillNumber billNumber = fetchLastBillNumber(dep, billType, billClassType, admissionType);
+        StringBuilder result = new StringBuilder();
+        Long b = billNumber.getLastBillNumber();
+        result.append(dep.getDepartmentCode());
+
+        if (billNumberSuffix != BillNumberSuffix.NONE) {
+            result.append(billNumberSuffix);
+        }
+
+        result.append(getBillNumberDelimiter());
+        result.append(admissionType.getCode());
         result.append(getBillNumberDelimiter());
         result.append(++b);
 
@@ -1826,6 +1879,102 @@ public class BillNumberGenerator {
 
     }
 
+    /**
+     * Same as {@link #fetchLastBillNumber(Department, BillType, BillClassType)}
+     * but keeps a separate serial per {@link AdmissionType}. Only used by the
+     * new admission-type-aware {@code institutionBillNumberGenerator}
+     * overload; the original 3-argument method above is untouched and keeps
+     * driving all existing callers.
+     */
+    private BillNumber fetchLastBillNumber(Department department, BillType billType, BillClassType billClassType, AdmissionType admissionType) {
+        String sql = "SELECT b FROM "
+                + " BillNumber b "
+                + " where b.retired=false "
+                + " and  b.billType=:bTp "
+                + " and b.billClassType=:bcl "
+                + " and b.department=:dep "
+                + " and b.admissionType=:admType ";
+        HashMap hm = new HashMap();
+        hm.put("bTp", billType);
+        hm.put("bcl", billClassType);
+        hm.put("dep", department);
+        hm.put("admType", admissionType);
+        BillNumber billNumber = billNumberFacade.findFirstByJpql(sql, hm);
+        if (billNumber == null) {
+            sql = "SELECT b FROM "
+                    + " Bill b "
+                    + " where b.retired=false "
+                    + " and  b.billType=:bTp "
+                    + " and b.billClassType=:bcl "
+                    + " and b.department=:dep "
+                    + " order by b.id desc ";
+            hm = new HashMap();
+            hm.put("bTp", BillType.StoreOrderApprove);
+            hm.put("bcl", billClassType);
+            hm.put("dep", department);
+            Bill bill = billFacade.findFirstByJpql(sql, hm);
+            if (bill != null) {
+                String[] parts = splitByBillNumberDelimiter(bill.getDeptId());
+                if (parts.length > 1) {
+                    billNumber = new BillNumber();
+                    billNumber.setBillType(billType);
+                    billNumber.setBillClassType(billClassType);
+                    billNumber.setDepartment(department);
+                    billNumber.setAdmissionType(admissionType);
+                    billNumber.setLastBillNumber(Long.valueOf(parts[1]));
+                    billNumberFacade.create(billNumber);
+                    return billNumber;
+                }
+            }
+        }
+        if (billNumber == null) {
+            billNumber = new BillNumber();
+            billNumber.setBillType(billType);
+            billNumber.setBillClassType(billClassType);
+            billNumber.setDepartment(department);
+            billNumber.setAdmissionType(admissionType);
+
+            sql = "SELECT count(b) FROM Bill b "
+                    + " where b.billType=:bTp "
+                    + " and b.retired=false"
+                    + " and b.deptId is not null "
+                    + " and type(b)=:class"
+                    + " and b.department=:dep "
+                    + " and b.patientEncounter.admissionType=:admType ";
+            hm = new HashMap();
+            hm.put("bTp", billType);
+            hm.put("dep", department);
+            hm.put("admType", admissionType);
+
+            switch (billClassType) {
+                case BilledBill:
+                    hm.put("class", BilledBill.class);
+                    break;
+                case CancelledBill:
+                    hm.put("class", CancelledBill.class);
+                    break;
+                case RefundBill:
+                    hm.put("class", RefundBill.class);
+                    break;
+                case PreBill:
+                    hm.put("class", PreBill.class);
+                    break;
+            }
+
+            Long dd = getBillFacade().findAggregateLong(sql, hm, TemporalType.DATE);
+            if (dd == null) {
+                dd = 0L;
+            }
+
+            billNumber.setLastBillNumber(dd);
+
+            billNumberFacade.create(billNumber);
+        }
+
+        return billNumber;
+
+    }
+
     private synchronized BillNumber fetchLastBillNumber(Institution institution, Department toDepartment, BillType billType, BillClassType billClassType) {
         String sql = "SELECT b FROM "
                 + " BillNumber b "
@@ -1945,6 +2094,107 @@ public class BillNumberGenerator {
             hm = new HashMap();
             hm.put("bTp", billType);
             hm.put("ins", institution);
+
+            switch (billClassType) {
+                case BilledBill:
+                    hm.put("class", BilledBill.class);
+                    break;
+                case CancelledBill:
+                    hm.put("class", CancelledBill.class);
+                    break;
+                case RefundBill:
+                    hm.put("class", RefundBill.class);
+                    break;
+                case PreBill:
+                    hm.put("class", PreBill.class);
+                    break;
+            }
+
+            Long dd = getBillFacade().findAggregateLong(sql, hm, TemporalType.DATE);
+
+            if (dd == null) {
+                dd = 0L;
+            }
+
+            billNumber.setLastBillNumber(dd);
+
+            billNumberFacade.create(billNumber);
+        }
+
+        return billNumber;
+
+    }
+
+    /**
+     * Same as {@link #fetchLastBillNumber(Institution, BillType, BillClassType)}
+     * but keeps a separate serial per {@link AdmissionType}. Only used by the
+     * new admission-type-aware {@code institutionBillNumberGenerator}
+     * overload; the original 3-argument method above is untouched and keeps
+     * driving all existing callers.
+     */
+    private BillNumber fetchLastBillNumber(Institution institution, BillType billType, BillClassType billClassType, AdmissionType admissionType) {
+        String sql = "SELECT b FROM "
+                + " BillNumber b "
+                + " where b.retired=false "
+                + " and b.billType=:bTp "
+                + " and b.billClassType=:bcl"
+                + " and b.institution=:ins "
+                + " and b.toDepartment is null "
+                + " and b.admissionType=:admType ";
+        HashMap hm = new HashMap();
+        hm.put("bTp", billType);
+        hm.put("bcl", billClassType);
+        hm.put("ins", institution);
+        hm.put("admType", admissionType);
+        BillNumber billNumber = billNumberFacade.findFirstByJpql(sql, hm);
+
+        if (billNumber == null && billType == BillType.StoreOrderApprove) {
+            sql = "SELECT b FROM "
+                    + " Bill b "
+                    + " where b.retired=false "
+                    + " and  b.billType=:bTp "
+                    + " and b.billClassType=:bcl "
+                    + " and b.institution=:ins "
+                    + " order by b.id desc ";
+            hm = new HashMap();
+            hm.put("bTp", BillType.StoreOrderApprove);
+            hm.put("bcl", billClassType);
+            hm.put("ins", institution);
+            Bill bill = billFacade.findFirstByJpql(sql, hm);
+
+            if (bill != null) {
+                String[] parts = splitByBillNumberDelimiter(bill.getInsId());
+                if (parts.length > 1) {
+                    billNumber = new BillNumber();
+                    billNumber.setBillType(billType);
+                    billNumber.setBillClassType(billClassType);
+                    billNumber.setInstitution(institution);
+                    billNumber.setAdmissionType(admissionType);
+                    billNumber.setLastBillNumber(Long.valueOf(parts[1]));
+                    billNumberFacade.create(billNumber);
+                    return billNumber;
+                }
+            }
+        }
+        if (billNumber == null) {
+            billNumber = new BillNumber();
+            billNumber.setBillType(billType);
+            billNumber.setBillClassType(billClassType);
+            billNumber.setInstitution(institution);
+            billNumber.setAdmissionType(admissionType);
+
+            sql = "SELECT count(b) FROM Bill b "
+                    + " where b.billType=:bTp "
+                    + " and b.retired=false"
+                    + " and b.deptId is not null "
+                    + " and type(b)=:class"
+                    + " and b.institution=:ins "
+                    + " and b.toDepartment is null  "
+                    + " and b.patientEncounter.admissionType=:admType ";
+            hm = new HashMap();
+            hm.put("bTp", billType);
+            hm.put("ins", institution);
+            hm.put("admType", admissionType);
 
             switch (billClassType) {
                 case BilledBill:

--- a/src/main/java/com/divudi/ejb/BillNumberGenerator.java
+++ b/src/main/java/com/divudi/ejb/BillNumberGenerator.java
@@ -1900,7 +1900,7 @@ public class BillNumberGenerator {
         hm.put("dep", department);
         hm.put("admType", admissionType);
         BillNumber billNumber = billNumberFacade.findFirstByJpql(sql, hm);
-        if (billNumber == null) {
+        if (billNumber == null && billType == BillType.StoreOrderApprove) {
             sql = "SELECT b FROM "
                     + " Bill b "
                     + " where b.retired=false "


### PR DESCRIPTION
## Summary
- Adds a new opt-in config, `Bill Number Generation Strategy - Unique Serial Per Admission Type for Inward Payments` (Boolean, default `false`), for Inward Deposit and Post Final Payment bills.
- When enabled, each `AdmissionType` (e.g. BHT vs OPD Card) gets its own bill-number serial for these two flows, with the admission type's code inserted into the formatted bill number.
- When disabled (default), behavior is byte-for-byte identical to today — existing 4-arg `institutionBillNumberGenerator`/`fetchLastBillNumber` overloads (used by ~50+ other bill types across the codebase) are untouched; new admission-type-aware behavior lives entirely in new additive overloads.
- `BillNumber` gains a new nullable `admissionType` FK column (only populated when the new strategy is active).

Closes #22667

## Test plan
Verified end-to-end against a local deployment (department: Inward), using real local admissions of both admission types:

**Config OFF (regression):** Inward Deposit bill number unchanged (`InwardINWPAY/3` / `COOPWA/3`).

**Config ON:**
| Flow | Admission Type | Dept Bill No | Institution Bill No |
|---|---|---|---|
| Inward Deposit | BHT | `InwardINWPAY/BHT/4` | `COOPWA/BHT/4` |
| Inward Deposit | OPD Card | `InwardINWPAY/OPDCARD/1` | `COOPWA/OPDCARD/1` |
| Post Final Payment | BHT | `InwardINWPFP/BHT/2` | `COOPINWPFP/BHT/2` |
| Post Final Payment | OPD Card | `InwardINWPFP/OPDCARD/1` | `COOPINWPFP/OPDCARD/1` |

- [x] Confirmed in `billnumber` table: each admission type gets its own row, correctly self-initialized by counting only that admission type's prior bills (JPQL join through `patientEncounter.admissionType`), not double-counting.
- [x] Confirmed pre-existing legacy counters (no admission type) remain untouched at their original values.
- [x] Config toggled via the app's admin UI (`admin_mange_application_options.xhtml`), not raw SQL, so the running app's L2 cache picked it up correctly.

![Config option enabled](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/22667_config_option_enabled.png)

Full verification details posted on the issue: https://github.com/hmislk/hmis/issues/22667#issuecomment-5185915240

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional configuration to maintain separate inward-payment bill serial numbers for each admission type.
  * Generated bill numbers can include the admission type code when the option is enabled.
  * Existing numbering behavior remains unchanged by default.
  * Supports admission-type-specific numbering for institution and department bills.

* **Documentation**
  * Documented the new bill-number configuration option, including its behavior and default setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->