### PR TITLE
fix(admin): preserve privilege checkbox state through search re-render

### DIFF
--- a/src/main/webapp/admin/users/user_privileges.xhtml
+++ b/src/main/webapp/admin/users/user_privileges.xhtml
@@ -108,7 +108,7 @@
                                 autocomplete="off">
                                 <p:ajax
                                     event="keyup"
-                                    process="@this"
+                                    process="@this tree"
                                     listener="#{userPrivilageController.filterPrivileges}"
                                     update="tree"
                                     oncomplete="PF('privTree').filter()" />


### PR DESCRIPTION
## Summary
- Fixes #22648: saving privileges on `admin/users/user_privileges.xhtml` could silently retire unrelated, previously-granted privileges.
- Root cause: the search box's AJAX call (`process="@this"`, `update="tree"`) only decoded itself, not the tree, before re-rendering the tree from stale server-side selection state — silently reverting any checkbox the admin had just clicked but not yet submitted.
- Fix: `process="@this tree"` so the search keystroke captures current checkbox state before the tree re-renders. One-line XHTML change, no Java changes needed.

## Test plan
- [x] Reproduced the exact bug mechanism live against `buddhika`/Inward: unchecked a privilege, triggered the search AJAX re-render, confirmed via DOM inspection (`ui-state-active` class / check icon) that the uncheck survived instead of reverting.
- [x] Submitted "Update User Privileges" and confirmed in the DB that exactly the one intended privilege was retired (710 → 709 active), with zero collateral changes to the other 709.
- [x] Restored the original state (re-checked, re-submitted) and confirmed the count returned to exactly 710.
- [x] JSF-only change — no Java compilation required per project convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved privilege search so results correctly account for both the search text and the privileges tree.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->