### PR TITLE
Fix typos in Inward Dues and Access menu item URL

### DIFF
--- a/src/main/webapp/resources/ezcomp/menu.xhtml
+++ b/src/main/webapp/resources/ezcomp/menu.xhtml
@@ -1956,7 +1956,7 @@
                     <p:menuitem  ajax="false"  action="/revenue_reports/index?faces-redirect=true" value="Revenue Reports"   icon="fa fa-chart-area" ></p:menuitem>
                     <p:menuitem  ajax="false"  action="/reportInstitution/report_referrals_index?faces-redirect=true" value="Referral Reports"   icon="fa fa-user-friends" ></p:menuitem>
                     <p:menuitem  ajax="false"  action="/reportLab/report_lab?faces-redirect=true" value="Lab Report"   icon="fa fa-vials" ></p:menuitem>
-                    <p:menuitem  ajax="false"  action="/credit/index_inward_due_acces?faces-redirect=trues" value="Inward Dues and Access"   icon="fa fa-bed" ></p:menuitem>
+                    <p:menuitem  ajax="false"  action="/credit/index_inward_due_access?faces-redirect=true" value="Inward Dues and Access"   icon="fa fa-bed" ></p:menuitem>
                     <p:menuitem  ajax="false"  action="/credit/index_opd_due_access?faces-redirect=true" value="Opd Dues and Access"   icon="fa fa-hospital-user" ></p:menuitem>
                     <p:menuitem  ajax="false"  action="/credit/index_pharmacy_due_access?faces-redirect=true" value="Pharmacy Dues and Access"   icon="fa fa-pills" ></p:menuitem>
                     <p:menuitem  ajax="false"  action="/dataAdmin/report_entered_data?faces-redirect=true" value="Check Entered Data"   icon="fa fa-search" ></p:menuitem>


### PR DESCRIPTION
## Summary
Corrected two typos in the menu configuration for the "Inward Dues and Access" report link.

## Changes
- Fixed action URL from `/credit/index_inward_due_acces` to `/credit/index_inward_due_access` (corrected spelling of "access")
- Fixed `faces-redirect` parameter value from `trues` to `true` (removed extra 's')

## Notes
This is a JSF-only XHTML change that corrects the navigation URL to properly route to the Inward Dues and Access report page.

https://claude.ai/code/session_01L94e86qi726tiHNid7NqLw