### PR TITLE
fix(credit): fix var="cc" EL collision hiding Credit Company search results

### DIFF
--- a/src/main/webapp/admin/data/edit_payment.xhtml
+++ b/src/main/webapp/admin/data/edit_payment.xhtml
@@ -396,9 +396,9 @@
                                             <h:outputText value="#{billSearch.payment.creditCompany.name}" rendered="#{not webUserController.hasPrivilege('Developers')}"/>
                                             <p:autoComplete value="#{billSearch.payment.creditCompany}"
                                                           completeMethod="#{institutionController.completeCompany}"
-                                                          var="cc"
-                                                          itemLabel="#{cc.name}"
-                                                          itemValue="#{cc}"
+                                                          var="ccIns"
+                                                          itemLabel="#{ccIns.name}"
+                                                          itemValue="#{ccIns}"
                                                           forceSelection="true"
                                                           rendered="#{webUserController.hasPrivilege('Developers')}"/>
                                         </h:panelGroup>

--- a/src/main/webapp/credit/credit_compnay_bill_payment_inward.xhtml
+++ b/src/main/webapp/credit/credit_compnay_bill_payment_inward.xhtml
@@ -63,10 +63,10 @@
                                             forceSelection="true"
                                             value="#{cashRecieveBillController.creditCompany}"
                                             completeMethod="#{institutionController.completeCreditCompany}"
-                                            var="cc" itemLabel="#{cc.name}" itemValue="#{cc}"
+                                            var="ccIns" itemLabel="#{ccIns.name}" itemValue="#{ccIns}"
                                             class="w-100" inputStyleClass="w-100">
                                             <p:column headerText="Company Name">
-                                                <h:outputText value="#{cc.name}" />
+                                                <h:outputText value="#{ccIns.name}" />
                                             </p:column>
                                         </p:autoComplete>
                                     </div>

--- a/src/main/webapp/credit/inward_credit_company_debtor_grouped_report.xhtml
+++ b/src/main/webapp/credit/inward_credit_company_debtor_grouped_report.xhtml
@@ -45,7 +45,7 @@
                             <p:autoComplete id="cmbCc" styleClass="w-100" inputStyleClass="w-100 form-control"
                                             value="#{creditCompanyDebtorGroupedReportController.institution}"
                                             completeMethod="#{institutionController.completeCreditCompany}"
-                                            var="cc" itemLabel="#{cc.name}" itemValue="#{cc}"
+                                            var="ccIns" itemLabel="#{ccIns.name}" itemValue="#{ccIns}"
                                             forceSelection="true" />
 
                             <!-- Row 2: Date Basis -->

--- a/src/main/webapp/credit/inward_credit_company_debtor_report.xhtml
+++ b/src/main/webapp/credit/inward_credit_company_debtor_report.xhtml
@@ -52,9 +52,9 @@
                                 inputStyleClass="w-100 form-control"
                                 value="#{inwardReportController1.institution}"
                                 completeMethod="#{institutionController.completeCreditCompany}"
-                                var="cc"
-                                itemLabel="#{cc.name}"
-                                itemValue="#{cc}"
+                                var="ccIns"
+                                itemLabel="#{ccIns.name}"
+                                itemValue="#{ccIns}"
                                 forceSelection="true" />
 
                             <!-- Row 2: Date Basis -->

--- a/src/main/webapp/credit/inward_credit_company_payment_report.xhtml
+++ b/src/main/webapp/credit/inward_credit_company_payment_report.xhtml
@@ -52,9 +52,9 @@
                                 inputStyleClass="w-100 form-control"
                                 value="#{inwardReportController1.institution}"
                                 completeMethod="#{institutionController.completeCreditCompany}"
-                                var="cc"
-                                itemLabel="#{cc.name}"
-                                itemValue="#{cc}"
+                                var="ccIns"
+                                itemLabel="#{ccIns.name}"
+                                itemValue="#{ccIns}"
                                 forceSelection="true" />
 
                             <!-- Row 2: Date Basis -->


### PR DESCRIPTION
## What this fixes

Issue #22666 reported that the "Credit Company" search field on
`credit/inward_credit_company_payment_report.xhtml` returned no results
even though matching credit company records exist.

**Root cause**: the `p:autoComplete` used `var="cc"` as its per-suggestion
loop variable, with `itemLabel="#{cc.name}"` / `itemValue="#{cc}"`. `cc` is
a *reserved* JSF/Facelets implicit EL identifier (normally the enclosing
composite component, `#{cc.attrs.xxx}`). When PrimeFaces evaluates each
suggestion's label during the AJAX partial response, the standard EL
resolver intercepts the bare name `cc` *before* the component's own loop
variable — so `#{cc.name}` silently evaluated to `null` instead of the
suggestion's actual name, rendering every match as a **blank row**:

```xml
<li id="frm:cmbCc_item_0" class="ui-autocomplete-item ..." data-item-label=""></li>
```

This looked identical to "no results found" — hence the issue report.

The exact same copy-pasted `var="cc"` pattern was present in 4 other
`p:autoComplete` fields across the credit/inward reporting pages, all
failing identically, so this PR fixes all 5 in one pass (see the issue
comment for scope discussion):

- `credit/inward_credit_company_payment_report.xhtml` (reported page)
- `credit/inward_credit_company_debtor_report.xhtml`
- `credit/inward_credit_company_debtor_grouped_report.xhtml`
- `admin/data/edit_payment.xhtml`
- `credit/credit_compnay_bill_payment_inward.xhtml` (tabular-mode suggestion list — its child `p:column` also referenced `#{cc.name}`)

## Fix

Pure XHTML/EL change — renamed the loop variable from `cc` to `ccIns` in
each of the 5 `p:autoComplete` blocks above (and the one child `p:column`
that referenced it). No Java touched, no schema change, no `p:autoComplete`
attribute other than `var`/`itemLabel`/`itemValue` was changed.

## Verification

Rebuilt (`mvn clean package`) and redeployed locally, then re-tested
end-to-end with Playwright against the local `coop` DB copy (28 real
`CreditCompany`-type institutions):

- Searched "Aitken" on the reported page — suggestion now renders
  **"Aitken Spence"** (previously a blank row); confirmed via the raw
  PrimeFaces AJAX response (`data-item-label="Aitken Spence"`,
  `data-item-value="546927"`).
- Selecting the suggestion round-trips the company name into the field
  (not blank), and **Process** runs the report without error.
- Spot-checked `inward_credit_company_debtor_report.xhtml` (searched
  "HSBC" — renders correctly) and the tabular-mode
  `credit_compnay_bill_payment_inward.xhtml` (searched "Aitken" — the
  "Company Name" column now shows "Aitken Spence" instead of a blank
  cell).

Before/after screenshots and full root-cause writeup posted on
[issue #22666](https://github.com/hmislk/hmis/issues/22666#issuecomment-5188458378):

![Before — blank suggestion](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/22666-01-credit-company-search-blank-before-fix.png)
![After — fixed](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/22666-02-credit-company-search-fixed.png)
![After — tabular mode fixed](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/22666-03-credit-payment-voucher-search-fixed.png)

## Out of scope (follow-up issue to be filed)

~24 more occurrences of the same `var="cc"` collision exist in
`f:selectItems`/`p:selectOneMenu` dropdowns elsewhere in the codebase — a
related but distinct symptom (they show the raw
`lk.gov.health.entity.Institution[ id=... ]` toString() instead of a blank
row, confirmed live on `inward_bht_credit_payment_report.xhtml`). Left out
of this PR to keep the diff reviewable; will get its own issue/PR.

Fixes #22666

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credit company selection handling across payment entry and reporting screens.
  * Credit company names, labels, and selected values continue to display consistently in autocomplete fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->