### PR TITLE
fix(membership): search families by any member's NIC or phone

### DIFF
--- a/src/main/java/com/divudi/bean/common/PatientController.java
+++ b/src/main/java/com/divudi/bean/common/PatientController.java
@@ -2452,7 +2452,10 @@ public class PatientController implements Serializable, ControllerWithPatient {
         String jpql = "Select f "
                 + "from Family f "
                 + "where f.retired=false "
-                + "and (f.phoneNo = :pn or f.membershipCardNo = :mcn) ";
+                + "and (f.phoneNo = :pn or f.membershipCardNo = :mcn "
+                + "     or exists (select fm from FamilyMember fm "
+                + "                where fm.family=f and fm.retired=false "
+                + "                and (fm.patient.person.mobile = :pn or fm.patient.person.phone = :pn))) ";
         Map params = new HashMap();
         Long mcn;
         try {
@@ -2527,7 +2530,10 @@ public class PatientController implements Serializable, ControllerWithPatient {
         String jpql = "Select f "
                 + " from Family f "
                 + " where f.retired=false "
-                + " and f.chiefHouseHolder.person.nic like :nic "
+                + " and (f.chiefHouseHolder.person.nic like :nic "
+                + "      or exists (select fm from FamilyMember fm "
+                + "                 where fm.family=f and fm.retired=false "
+                + "                 and fm.patient.person.nic like :nic)) "
                 + " order by f.chiefHouseHolder.person.name";
         Map params = new HashMap();
         params.put("nic", "%" + searchNic.trim().toUpperCase() + "%");


### PR DESCRIPTION
## Summary
- `searchFamilyByNIC()` and `searchFamily()` (the "By Member NIC No" and "By Membership Card No / Phone" panels on Members → Search Families) previously only matched the **Chief Householder's** own NIC/phone, so searching by any other registered family member's NIC or phone returned "No matching families found" even though that person was a registered member of a family.
- Both JPQL queries in `PatientController.java` now additionally match via an `EXISTS` subquery over `FamilyMember` (non-retired members only), so a family is found whether the searched NIC/phone belongs to the CHH or to any other member.
- No entity/schema changes — reuses existing `FamilyMember.family`/`FamilyMember.patient`/`Patient.person`/`Person.nic`/`Person.mobile`/`Person.phone` relationships already used elsewhere in this class.

## Test plan
Verified end-to-end via Playwright against local Payara + local `coop` DB, using a real family (2+ members) where the member's own NIC/phone differ from the CHH's:
- [x] "By Member NIC No" search using a **non-CHH member's** NIC now returns that family (previously returned nothing)
- [x] "By Membership Card No / Phone" search using a **non-CHH member's** mobile/phone now returns that family (previously returned nothing)
- [x] Regression: searching by the **CHH's own** NIC still returns the correct family (existing behavior unaffected)

Screenshots omitted from this PR since the local dev DB contains real patient/member names (COOP data) — see project no-PII-in-public-GitHub policy.

Closes #18642

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved family search by matching phone numbers from either the family record or active members.
  * Improved NIC searches to include the household holder and active family members.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->