### PR TITLE
fix(pharmacy): generate GRN bill number before mutating stock in approve

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
@@ -3322,6 +3322,63 @@ public class GrnCostingController implements Serializable {
         calculateBillTotalsFromItems();
         distributeProportionalBillValuesToItems(getBillItems(), getGrnBill());
 
+        // Generate the bill number BEFORE the stock-mutating item loop below. This method
+        // has no surrounding transaction of its own (GrnCostingController is a plain CDI
+        // bean, not an EJB), so each Facade edit/create call below commits independently.
+        // Bill number generation depends on config lookups and can fail for reasons
+        // unrelated to the GRN itself (e.g. a missing DB column from an out-of-sync
+        // schema, as happened live during QA - issue #22595). If that failure happened
+        // AFTER the stock/batch loop had already run, the stock addition would remain
+        // committed even though the GRN never became PHARMACY_GRN, and a retry would
+        // silently double the stock. Doing this first keeps the risky, config-driven
+        // work outside the item loop's blast radius.
+        // Check if bill number suffix is configured, if not set default "GRN" for Pharmacy GRN
+        String billSuffix = configOptionApplicationController.getLongTextValueByKey("Bill Number Suffix for " + BillTypeAtomic.PHARMACY_GRN, "");
+        if (billSuffix == null || billSuffix.trim().isEmpty()) {
+            // Set default suffix for Pharmacy GRN if not configured
+            configOptionApplicationController.setLongTextValueByKey("Bill Number Suffix for " + BillTypeAtomic.PHARMACY_GRN, "GRN");
+        }
+
+        boolean billNumberGenerationStrategyForDepartmentIdIsPrefixInsDeptYearCount = configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy GRN - Prefix + Institution Code + Department Code + Year + Yearly Number and Yearly Number", false);
+        boolean billNumberGenerationStrategyForDepartmentIdIsPrefixInsYearCount = configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy GRN - Prefix + Institution Code + Year + Yearly Number and Yearly Number", false);
+        boolean billNumberGenerationStrategyForInstitutionIdIsPrefixInsYearCount = configOptionApplicationController.getBooleanValueByKey("Institution Number Generation Strategy for Pharmacy GRN - Prefix + Institution Code + Year + Yearly Number and Yearly Number", false);
+
+        // Handle Department ID generation
+        String deptId;
+        if (billNumberGenerationStrategyForDepartmentIdIsPrefixInsDeptYearCount) {
+            deptId = getBillNumberBean().departmentBillNumberGeneratorYearlyWithPrefixInsDeptYearCount(
+                    sessionController.getDepartment(),
+                    BillTypeAtomic.PHARMACY_GRN
+            );
+        } else if (billNumberGenerationStrategyForDepartmentIdIsPrefixInsYearCount) {
+            deptId = getBillNumberBean().departmentBillNumberGeneratorYearlyWithPrefixInsYearCountInstitutionWide(
+                    sessionController.getDepartment(),
+                    BillTypeAtomic.PHARMACY_GRN
+            );
+        } else {
+            // Default behavior - use the original method
+            deptId = getBillNumberBean().departmentBillNumberGeneratorYearly(sessionController.getDepartment(), BillTypeAtomic.PHARMACY_GRN);
+        }
+
+        // Handle Institution ID generation separately
+        String insId;
+        if (billNumberGenerationStrategyForInstitutionIdIsPrefixInsYearCount) {
+            insId = getBillNumberBean().institutionBillNumberGeneratorYearlyWithPrefixInsYearCountInstitutionWide(
+                    sessionController.getDepartment(),
+                    BillTypeAtomic.PHARMACY_GRN
+            );
+        } else {
+            // Default behavior - use the department ID for institution ID or original method
+            if (billNumberGenerationStrategyForDepartmentIdIsPrefixInsDeptYearCount || billNumberGenerationStrategyForDepartmentIdIsPrefixInsYearCount) {
+                insId = deptId;
+            } else {
+                insId = getBillNumberBean().institutionBillNumberGenerator(getSessionController().getInstitution(), BillType.PharmacyGrnBill, BillClassType.BilledBill, BillNumberSuffix.GRN);
+            }
+        }
+
+        getCurrentGrnBillPre().setDeptId(deptId);
+        getCurrentGrnBillPre().setInsId(insId);
+
         // Process bill items for finalization with full stock management
         for (BillItem grnBillItem : getBillItems()) {
             BillItemFinanceDetails f = grnBillItem.getBillItemFinanceDetails();
@@ -3374,53 +3431,6 @@ public class GrnCostingController implements Serializable {
             }
 
         }
-
-        // Check if bill number suffix is configured, if not set default "GRN" for Pharmacy GRN
-        String billSuffix = configOptionApplicationController.getLongTextValueByKey("Bill Number Suffix for " + BillTypeAtomic.PHARMACY_GRN, "");
-        if (billSuffix == null || billSuffix.trim().isEmpty()) {
-            // Set default suffix for Pharmacy GRN if not configured
-            configOptionApplicationController.setLongTextValueByKey("Bill Number Suffix for " + BillTypeAtomic.PHARMACY_GRN, "GRN");
-        }
-
-        boolean billNumberGenerationStrategyForDepartmentIdIsPrefixInsDeptYearCount = configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy GRN - Prefix + Institution Code + Department Code + Year + Yearly Number and Yearly Number", false);
-        boolean billNumberGenerationStrategyForDepartmentIdIsPrefixInsYearCount = configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Pharmacy GRN - Prefix + Institution Code + Year + Yearly Number and Yearly Number", false);
-        boolean billNumberGenerationStrategyForInstitutionIdIsPrefixInsYearCount = configOptionApplicationController.getBooleanValueByKey("Institution Number Generation Strategy for Pharmacy GRN - Prefix + Institution Code + Year + Yearly Number and Yearly Number", false);
-
-        // Handle Department ID generation
-        String deptId;
-        if (billNumberGenerationStrategyForDepartmentIdIsPrefixInsDeptYearCount) {
-            deptId = getBillNumberBean().departmentBillNumberGeneratorYearlyWithPrefixInsDeptYearCount(
-                    sessionController.getDepartment(),
-                    BillTypeAtomic.PHARMACY_GRN
-            );
-        } else if (billNumberGenerationStrategyForDepartmentIdIsPrefixInsYearCount) {
-            deptId = getBillNumberBean().departmentBillNumberGeneratorYearlyWithPrefixInsYearCountInstitutionWide(
-                    sessionController.getDepartment(),
-                    BillTypeAtomic.PHARMACY_GRN
-            );
-        } else {
-            // Default behavior - use the original method
-            deptId = getBillNumberBean().departmentBillNumberGeneratorYearly(sessionController.getDepartment(), BillTypeAtomic.PHARMACY_GRN);
-        }
-
-        // Handle Institution ID generation separately
-        String insId;
-        if (billNumberGenerationStrategyForInstitutionIdIsPrefixInsYearCount) {
-            insId = getBillNumberBean().institutionBillNumberGeneratorYearlyWithPrefixInsYearCountInstitutionWide(
-                    sessionController.getDepartment(),
-                    BillTypeAtomic.PHARMACY_GRN
-            );
-        } else {
-            // Default behavior - use the department ID for institution ID or original method
-            if (billNumberGenerationStrategyForDepartmentIdIsPrefixInsDeptYearCount || billNumberGenerationStrategyForDepartmentIdIsPrefixInsYearCount) {
-                insId = deptId;
-            } else {
-                insId = getBillNumberBean().institutionBillNumberGenerator(getSessionController().getInstitution(), BillType.PharmacyGrnBill, BillClassType.BilledBill, BillNumberSuffix.GRN);
-            }
-        }
-
-        getCurrentGrnBillPre().setDeptId(deptId);
-        getCurrentGrnBillPre().setInsId(insId);
 
         // Set finalization timestamps and user
         getCurrentGrnBillPre().setEditedAt(new Date());


### PR DESCRIPTION
## Summary

- `approveGrnWithSaveApprove()` in `GrnCostingController` now generates the GRN bill number *before* running the stock/batch-mutating item-processing loop, instead of after.
- This closes a window where a failure during bill-number generation (config lookups + `BillNumberBean` calls) — which can be triggered by things unrelated to the GRN itself, such as a schema gap — could leave stock/batch/PO-quantity side effects committed while the bill stayed in `PHARMACY_GRN_PRE`. A retried Approve would then bypass the existing idempotency guard (which only fires once `billTypeAtomic == PHARMACY_GRN`, set near the very end of the method) and re-run the stock loop, double-counting stock.

## Why

Found live while testing GRN Report / Stock Ledger / Bin Card variance (#22595, part of the #21893 legacy-vs-DTO GRN parity effort). A schema gap unrelated to this code path caused an Approve to fail partway through, after stock had already been added; retrying then added the same stock a second time. Confirmed via duplicate "STOCK IN" rows in the Stock Ledger DTO report and a doubled physical `STOCK` quantity.

Full details and root-cause analysis: #22677

## Change

`GrnCostingController.java`: moved the bill-number-generation block (config flag reads + `getBillNumberBean()...` calls, setting `deptId`/`insId` on the bill) to before the item-processing loop. Bill-number generation has no dependency on the item loop's outputs, and the item loop doesn't use `deptId`/`insId`, so this is a pure reorder with no behavior change on the successful path.

Note: this narrows the failure window but doesn't make the whole method atomic — a failure *during* the stock loop itself could still leave partial state for a multi-item GRN. Full atomicity would need an explicit transaction boundary; left as potential follow-up.

## Test plan

- [x] Live end-to-end: created a fresh test PO (Aerohaler, qty 5) → approved PO → created GRN → Finalize → Approve, all against the rebuilt/redeployed local app with this fix.
- [x] Verified in DB: new batch (`TEST-DOUBLEADD-FIX`) shows `STOCK = 5`, matching the receipt qty exactly (no double-count).
- [x] Verified bill reached `PHARMACY_GRN` with correctly negated `NETTOTAL` (-2,142.70).

Closes #22677

🤖 Generated with [Claude Code](https://claude.com/claude-code)