### PR TITLE
fix(inward): show cancelled/returned medicine on Interim Bill print breakup

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -4929,6 +4929,13 @@ public class BhtSummeryController implements Serializable {
         btas.add(BillTypeAtomic.DIRECT_ISSUE_THEATRE_MEDICINE_RETURN);
         btas.add(BillTypeAtomic.DIRECT_ISSUE_THEATRE_MEDICINE_CANCELLATION);
 
+        List<BillTypeAtomic> medicineCancellationBtas = new ArrayList<>();
+        medicineCancellationBtas.add(BillTypeAtomic.PHARMACY_DIRECT_ISSUE_CANCELLED);
+        medicineCancellationBtas.add(BillTypeAtomic.DIRECT_ISSUE_INWARD_MEDICINE_CANCELLATION);
+        medicineCancellationBtas.add(BillTypeAtomic.DIRECT_ISSUE_INWARD_DISCHARGE_MEDICINE_CANCELLATION);
+        medicineCancellationBtas.add(BillTypeAtomic.ISSUE_MEDICINE_ON_REQUEST_INWARD_CANCELLATION);
+        medicineCancellationBtas.add(BillTypeAtomic.DIRECT_ISSUE_THEATRE_MEDICINE_CANCELLATION);
+
         for (ChargeItemTotal i : chargeItemTotals) {
             switch (i.getInwardChargeType()) {
                 case AdmissionFee:
@@ -4960,6 +4967,11 @@ public class BhtSummeryController implements Serializable {
                 case Medicine:
                     if (!configOptionApplicationController.getBooleanValueByKey("Medicine, Sort by the type of department that issued it.", false)) {
                         i.setTotal(getInwardBean().calCostOfIssueByBill(getPatientEncounter(), btas, childPatientEncouters));
+                    }
+                    break;
+                case CancelledReturnedMedicine:
+                    if (!configOptionApplicationController.getBooleanValueByKey("Medicine, Sort by the type of department that issued it.", false)) {
+                        i.setTotal(getInwardBean().calCancelledCostOfIssueByBill(getPatientEncounter(), medicineCancellationBtas, childPatientEncouters));
                     }
                     break;
                 case GeneralIssuing:

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -4932,9 +4932,13 @@ public class BhtSummeryController implements Serializable {
         List<BillTypeAtomic> medicineCancellationBtas = new ArrayList<>();
         medicineCancellationBtas.add(BillTypeAtomic.PHARMACY_DIRECT_ISSUE_CANCELLED);
         medicineCancellationBtas.add(BillTypeAtomic.DIRECT_ISSUE_INWARD_MEDICINE_CANCELLATION);
+        medicineCancellationBtas.add(BillTypeAtomic.DIRECT_ISSUE_INWARD_MEDICINE_RETURN);
         medicineCancellationBtas.add(BillTypeAtomic.DIRECT_ISSUE_INWARD_DISCHARGE_MEDICINE_CANCELLATION);
+        medicineCancellationBtas.add(BillTypeAtomic.DIRECT_ISSUE_INWARD_DISCHARGE_MEDICINE_RETURN);
         medicineCancellationBtas.add(BillTypeAtomic.ISSUE_MEDICINE_ON_REQUEST_INWARD_CANCELLATION);
+        medicineCancellationBtas.add(BillTypeAtomic.ISSUE_MEDICINE_ON_REQUEST_INWARD_RETURN);
         medicineCancellationBtas.add(BillTypeAtomic.DIRECT_ISSUE_THEATRE_MEDICINE_CANCELLATION);
+        medicineCancellationBtas.add(BillTypeAtomic.DIRECT_ISSUE_THEATRE_MEDICINE_RETURN);
 
         for (ChargeItemTotal i : chargeItemTotals) {
             switch (i.getInwardChargeType()) {

--- a/src/main/java/com/divudi/bean/inward/InwardBeanController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardBeanController.java
@@ -500,6 +500,31 @@ public class InwardBeanController implements Serializable {
         return getBillItemFacade().findDoubleByJpql(sql, hm);
     }
     
+    /**
+     * Sums the value of cancelled/returned issue bills as a positive magnitude, so it can be
+     * printed as its own breakup line instead of silently netting out of the parent charge
+     * total (issue #22674). {@code cancellationBtas} should be the cancellation-only subset of
+     * the {@link BillTypeAtomic} list already used to compute the parent charge type's net total.
+     */
+    public double calCancelledCostOfIssueByBill(PatientEncounter patientEncounter, List<BillTypeAtomic> cancellationBtas, List<PatientEncounter> cpts) {
+        String sql;
+        HashMap hm;
+        sql = "SELECT  sum(b.netTotal)"
+                + " FROM Bill b "
+                + " WHERE b.retired=false "
+                + " and b.billTypeAtomic IN :btp "
+                + " and  b.patientEncounter IN :pe";
+        hm = new HashMap();
+        hm.put("btp", cancellationBtas);
+        List<PatientEncounter> pts = new ArrayList<>();
+        pts.add(patientEncounter);
+        if (cpts != null && !cpts.isEmpty()) {
+            pts.addAll(cpts);
+        }
+        hm.put("pe", pts);
+        return -getBillItemFacade().findDoubleByJpql(sql, hm);
+    }
+
     public double calCostOfIssueByBill(PatientEncounter patientEncounter, List<BillTypeAtomic> btas, List<PatientEncounter> cpts, DepartmentType billingDepartmentType) {
         String sql;
         HashMap hm;

--- a/src/main/java/com/divudi/core/data/inward/InwardChargeType.java
+++ b/src/main/java/com/divudi/core/data/inward/InwardChargeType.java
@@ -22,6 +22,7 @@ public enum InwardChargeType {
     MedicalCareICU("Medical Care", CalculationMethod.PATIENT_ROOM, true),//Goes With Room
     MedicalServices("Medical Services", true),
     Medicine("Medicine", CalculationMethod.PHARMACY_BILL, true),//For BHT ISSUE
+    CancelledReturnedMedicine("Cancelled/Returned Medicine", true),//Value of cancelled/returned medicine issues, shown separately so it is visible on printed breakups (issue #22674)
     MedicinesAndSurgicalSupplies("Medicines and Surgical Supplies", true),//For Surgery Bill Medicines
     MOCharges("MO Charges", CalculationMethod.PATIENT_ROOM, true),//GOES WITH PATIENT ROOM
     MaintainCharges("Maintain Charges", CalculationMethod.PATIENT_ROOM, true),//GOES WITH PATIENT ROOM


### PR DESCRIPTION
## Summary
- The printed Inward Interim Bill breakup (`intrimBill.xhtml`) sums each `InwardChargeType` category net of cancellations, so a cancelled medicine bill vanishes from the total with no trace — anyone reconciling from the printout alone can't tell a cancellation happened (issue #22674).
- Adds `InwardChargeType.CancelledReturnedMedicine`, populated from a new `InwardBeanController.calCancelledCostOfIssueByBill()` JPQL sum over the same 5 medicine cancellation `BillTypeAtomic`s already netted into the `Medicine` total (`PHARMACY_DIRECT_ISSUE_CANCELLED`, `DIRECT_ISSUE_INWARD_MEDICINE_CANCELLATION`, `DIRECT_ISSUE_INWARD_DISCHARGE_MEDICINE_CANCELLATION`, `ISSUE_MEDICINE_ON_REQUEST_INWARD_CANCELLATION`, `DIRECT_ISSUE_THEATRE_MEDICINE_CANCELLATION`).
- No XHTML changes needed — `intrimBill.xhtml` already renders any non-zero charge-type row generically, so the new line appears automatically once populated in `createChargeItemTotals()`.
- Scoped to Medicine only (the exact repro in the issue), guarded by the same `Medicine, Sort by the type of department that issued it.` config check as the existing `Medicine` case. Store Issue / Service / Professional Fee cancellations have their own `*_CANCELLATION` atomics and are out of scope here.

## Test plan
- [x] `mvn clean package` — full suite passes (185/185 tests)
- [x] Traced the exact cancellation in the Galle Coop production DB: bill `14000979` (original, `CANCELLED=1`) ↔ bill `14001591` (`DIRECT_ISSUE_INWARD_MEDICINE_CANCELLATION`, `NETTOTAL=-6200.0811`, `CANCELLEDBILL_ID→14000979`)
- [x] Verified the same admission exists in the local DB copy (BHT/56886, encounter 13859870)
- [x] Rebuilt and redeployed locally; drove the real Inward flow with Playwright (`Inpatient Dashboard → Interim Bill → Print Interim Bill`)
- [x] New "Cancelled/Returned Medicine" line reads **6,200.08**, matching the DB value exactly; `Medicine` line unchanged (15,368.87) confirming the existing net calculation wasn't altered, only made visible

### Before (production)
Charges panel showed only 3 flat totals, no trace of the cancelled bill:

![before](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/22674-01-before-charges-panel-no-cancellation-line.png)

### After (local rebuild, same admission's data)
Printed Interim Bill breakup now shows the cancelled amount as its own line:

![after](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/22674-02-after-print-breakup-cancelled-medicine-line.png)

Fixes #22674

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved inpatient billing summaries to accurately account for cancelled and returned medicines.
  - Included medicine cancellations from pharmacy, inpatient, discharge, request-based, and theatre billing workflows.
  - Cancellation totals now include related patient encounters and correctly reflect cancelled issue costs when medicines are not grouped by issuing department.
  - Added clearer classification for cancelled or returned medicine charges in inward billing records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->