### PR TITLE
fix(pharmacy): enforce remaining-PO-qty clamp visibly on GRN Receiving Qty edit

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
@@ -1967,12 +1967,17 @@ public class GrnCostingController implements Serializable {
         onEdit(bi);
     }
 
-    public void onEdit(BillItem tmp) {
-        setBatch(tmp);
-        BillItemFinanceDetails f = tmp.getBillItemFinanceDetails();
-        if (f == null) {
-            return;
-        }
+    /**
+     * Clamps a bill item's quantity down to the PO's remaining orderable
+     * qty and surfaces an error message when it's over. Shared by both
+     * onEdit() (Purchase Rate blur) and qtyChangedListner() (Qty field's
+     * own blur) so the rule is enforced - and visible - no matter which
+     * field the user edits. See issue #22681: previously only onEdit() had
+     * this check, and its f:ajax render list didn't include the Qty field
+     * or the messages panel, so the clamp silently corrected the saved qty
+     * while the screen kept showing the rejected value.
+     */
+    private void clampQuantityToRemaining(BillItem tmp, BillItemFinanceDetails f) {
         if (tmp.getReferanceBillItem() != null) {
             double remains = getRemainingQty(tmp.getPharmaceuticalBillItem());
             if (remains < f.getQuantity().doubleValue()) {
@@ -1981,6 +1986,15 @@ public class GrnCostingController implements Serializable {
                 JsfUtil.addErrorMessage("You cant Change Qty than Remaining qty");
             }
         }
+    }
+
+    public void onEdit(BillItem tmp) {
+        setBatch(tmp);
+        BillItemFinanceDetails f = tmp.getBillItemFinanceDetails();
+        if (f == null) {
+            return;
+        }
+        clampQuantityToRemaining(tmp, f);
 
         if (f.getLineGrossRate().compareTo(f.getRetailSaleRatePerUnit()) > 0) {
             f.setRetailSaleRatePerUnit(f.getLineGrossRate());
@@ -2091,6 +2105,8 @@ public class GrnCostingController implements Serializable {
                 return;
             }
         }
+
+        clampQuantityToRemaining(tmp, f);
 
         recalculateFinancialsBeforeAddingBillItem(f);
 

--- a/src/main/webapp/pharmacy/pharmacy_grn_costing_with_save_approve.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_grn_costing_with_save_approve.xhtml
@@ -194,10 +194,10 @@
                                         class="text-end text-primary w-100"
                                         value="#{bi.billItemFinanceDetails.lineGrossRate}"
                                         id="pRate" >
-                                        <f:ajax 
-                                            event="blur" 
-                                            execute="pRate" 
-                                            render=":#{p:resolveFirstComponentWithId('panelBillDetails',view).clientId} total doeDateOnlyShort profMargin batch pRate rRate diff :#{p:resolveFirstComponentWithId('txtBillNetTotal', view).clientId} :#{p:resolveFirstComponentWithId('billFinanceDetails', view).clientId}"
+                                        <f:ajax
+                                            event="blur"
+                                            execute="pRate"
+                                            render=":#{p:resolveFirstComponentWithId('panelBillDetails',view).clientId} txtQty total doeDateOnlyShort profMargin batch pRate rRate diff :#{p:resolveFirstComponentWithId('txtBillNetTotal', view).clientId} :#{p:resolveFirstComponentWithId('billFinanceDetails', view).clientId} :#{p:resolveFirstComponentWithId('messages',view).clientId}"
                                             listener="#{grnCostingController.onEdit(bi)}"></f:ajax>
                                     </p:inputText>
                                 </p:column>


### PR DESCRIPTION
## Summary
- Fixes #22681: entering a GRN Receiving Qty greater than the PO's remaining orderable quantity was silently corrected with no visible feedback, and the Receiving Qty box kept showing the rejected value indefinitely (surviving even a full Save postback) while the database and totals used the silently-clamped quantity.
- `qtyChangedListner()` (bound to the Qty field's own blur) never enforced the "can't exceed remaining PO qty" rule at all; only `onEdit()` (bound to Purchase Rate's blur) had it, and that field's `f:ajax render` list omitted both the Qty input and the messages panel, so the correction and its warning never reached the browser.
- Extracted the clamp into a shared `clampQuantityToRemaining()` and call it from both listeners, and added the Qty field + messages panel to the Purchase Rate field's render list.

## Verification

Found and verified live while testing checklist item "Edit a saved (not yet finalized) GRN" from #22595 (GRN legacy-vs-DTO parity QA):

**Before fix:** entering Receiving Qty=15 against a PO with 10 remaining, then editing Purchase Rate, produced no error message; Receiving Qty box kept showing 15 after Save; DB showed the two backing records disagreeing with each other — `BILLITEM.QTY=10` but `BILLITEMFINANCEDETAILS.QUANTITY=15` with `LINENETTOTAL=4500` (computed off qty=10, not matching its own stored qty=15 × rate).

**After fix:** editing the Qty field directly now shows "You cant Change Qty than Remaining qty" immediately, the field visibly corrects to 10, and all totals (Gross/Net/Sale Value) are consistent. Re-verified via direct DB query that `BILLITEM.QTY` and `BILLITEMFINANCEDETAILS.QUANTITY` now agree (10/10) with a consistent `LINENETTOTAL` (4500 = 10×450).

## Test plan
- [x] Reproduced the original bug live against `pharmacy_grn_costing_with_save_approve.xhtml` (fresh login/session, not just AJAX partial state)
- [x] Rebuilt, redeployed, re-verified fix live with the same repro steps
- [x] Confirmed DB consistency between `BILLITEM` and `BILLITEMFINANCEDETAILS` post-fix

Closes #22681

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented pharmacy receipt quantities from exceeding the remaining purchase-order quantity, regardless of which field is edited.
  * Improved validation feedback by ensuring processing and correction messages are displayed after purchase-rate changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->