### PR TITLE
fix(pharmacy): handle LocalDateTime/LocalDate in GRN Quick View date conversion

### DIFF
--- a/src/main/java/com/divudi/service/pharmacy/PharmacyGrnNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PharmacyGrnNativeSqlService.java
@@ -8,6 +8,9 @@ package com.divudi.service.pharmacy;
 import com.divudi.core.data.dto.pharmacy.GrnPrintHeaderDto;
 import com.divudi.core.data.dto.pharmacy.GrnPrintItemDto;
 import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -310,6 +313,14 @@ public class PharmacyGrnNativeSqlService {
         if (o instanceof Timestamp) return new Date(((Timestamp) o).getTime());
         if (o instanceof java.sql.Date) return new Date(((java.sql.Date) o).getTime());
         if (o instanceof Date) return (Date) o;
+        // EclipseLink native queries can return java.time types for DATETIME
+        // columns instead of java.sql.Timestamp, depending on driver/version.
+        if (o instanceof LocalDateTime) {
+            return Date.from(((LocalDateTime) o).atZone(ZoneId.systemDefault()).toInstant());
+        }
+        if (o instanceof LocalDate) {
+            return Date.from(((LocalDate) o).atStartOfDay(ZoneId.systemDefault()).toInstant());
+        }
         return null;
     }
 }


### PR DESCRIPTION
## Summary
- Fixes #22684: GRN Quick View (`pharmacy_grn_native.xhtml`) always showed blank "GRN Date" and "PO Date".
- Root cause: `PharmacyGrnNativeSqlService.toDate()` only handled `java.sql.Timestamp`/`java.sql.Date`/`java.util.Date`. EclipseLink's native query execution returns `java.time.LocalDateTime` for DATETIME columns (this driver/version), which silently fell through to `return null`.
- The native SQL query text itself was verified correct by running it directly against MySQL — only the Java-side type conversion was broken.

## Verification
- Reproduced live: created + approved a GRN, "View Finalized GRN" showed blank dates.
- Rebuilt, redeployed, re-verified: GRN Date and PO Date now correctly show `05 Aug 2026 13:44:38` / `05 Aug 2026 13:43:50`, matching direct DB query results for the same bill.

## Test plan
- [x] Reproduced live against `pharmacy_grn_native.xhtml`
- [x] Confirmed root cause via direct SQL execution (query correct, Java conversion broken)
- [x] Rebuilt/redeployed/re-verified fix live

Closes #22684