### PR TITLE
fix(inward): source invoice journal charges by CalculationMethod, not a flat BillItem sum

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -1465,6 +1465,21 @@ Not Paid Tokens** → **Call Customer** → **Accept Payment** → enter Tendere
 Settle**. Then from `pharmacy_search_pre_bill.xhtml` → **Search Paid Only Tokens** → **View Payment Bill**
 lands on the reprint/cancel page for that bill.
 
+## 55. `inward_bill_professional.xhtml` "Add Professional Fee" silently no-ops if the Speciality autocomplete is left empty
+
+On "Add New Professional Fees", the `+ Add Professional Fee` button is a
+`type="submit"` full postback guarded only by a JS `confirm(...)` — clicking
+it and accepting the dialog looks successful (page reloads, no visible
+error) but the row never appears in "Professional Fees for This Encounter"
+and no `BILLFEE` row is inserted, if the **Speciality** autocomplete (above
+Doctor) was left blank. This is the same zero-observable-signal
+required-field pattern as §37, just on a different page/field — the Doctor
+field alone is not enough. Fix: search and select a Speciality (e.g. type
+`PHYSICIAN`, press Enter) before Doctor/Fee Amount/Add. Confirmed via
+`mysql.general_log`: with Speciality empty, no `INSERT INTO BILLFEE`
+statement reaches the server at all; with it filled, the insert fires
+immediately. Verified while testing issue #22665.
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.

--- a/src/main/java/com/divudi/bean/inward/InwardInvoiceJournalController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardInvoiceJournalController.java
@@ -1,17 +1,27 @@
 package com.divudi.bean.inward;
 
 import com.divudi.bean.common.ConfigOptionApplicationController;
+import com.divudi.core.data.BillType;
 import com.divudi.core.data.BillTypeAtomic;
+import com.divudi.core.data.FeeType;
 import com.divudi.core.data.PaymentMethod;
 import com.divudi.core.data.dto.InwardInvoiceJournalRowDto;
 import com.divudi.core.data.inward.AdmissionStatus;
+import com.divudi.core.data.inward.CalculationMethod;
 import com.divudi.core.data.inward.InwardChargeType;
+import com.divudi.core.entity.BillFee;
+import com.divudi.core.entity.Consultant;
 import com.divudi.core.entity.Department;
+import com.divudi.core.entity.EncounterCreditCompany;
 import com.divudi.core.entity.Institution;
 import com.divudi.core.entity.PatientEncounter;
 import com.divudi.core.entity.Payment;
 import com.divudi.core.entity.inward.AdmissionType;
+import com.divudi.core.entity.inward.PatientRoom;
+import com.divudi.core.facade.BillFeeFacade;
+import com.divudi.core.facade.EncounterCreditCompanyFacade;
 import com.divudi.core.facade.PatientEncounterFacade;
+import com.divudi.core.facade.PatientRoomFacade;
 import com.divudi.core.facade.PaymentFacade;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -21,6 +31,7 @@ import java.util.Date;
 import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -50,6 +61,12 @@ public class InwardInvoiceJournalController implements Serializable {
     private PatientEncounterFacade patientEncounterFacade;
     @EJB
     private PaymentFacade paymentFacade;
+    @EJB
+    private BillFeeFacade billFeeFacade;
+    @EJB
+    private PatientRoomFacade patientRoomFacade;
+    @EJB
+    private EncounterCreditCompanyFacade encounterCreditCompanyFacade;
     @Inject
     private ConfigOptionApplicationController configOptionApplicationController;
 
@@ -128,9 +145,13 @@ public class InwardInvoiceJournalController implements Serializable {
         // --- bulk fetch credit settlement totals ---
         Map<Long, double[]> creditMap = fetchCreditSettlementByEncounter(encounters);
 
+        // --- bulk fetch credit company names (an encounter may have more than one) ---
+        Map<Long, List<String>> creditCompanyNamesMap = fetchCreditCompanyNamesByEncounter(encounters);
+
         // --- build one row per encounter ---
         for (PatientEncounter enc : encounters) {
-            InwardInvoiceJournalRowDto row = buildRow(enc, chargeMap, discountMarginMap, depositMap, creditMap);
+            InwardInvoiceJournalRowDto row = buildRow(enc, chargeMap, discountMarginMap, depositMap, creditMap,
+                    creditCompanyNamesMap);
             reportRows.add(row);
 
             // accumulate column totals and active types
@@ -224,44 +245,329 @@ public class InwardInvoiceJournalController implements Serializable {
     }
 
     /**
-     * Single bulk query: sum(grossValue) grouped by (patientEncounter, inwardChargeType)
-     * for all encounters in the set, covering all non-cancelled bill items.
-     * Returns Map< encounterId, Map<InwardChargeType, total> >.
+     * Dispatcher that combines per-CalculationMethod bulk (GROUP BY) queries into
+     * the same Map< encounterId, Map<InwardChargeType, total> > shape the caller
+     * expects. Each sub-fetch stays a single bulk query for the whole encounter
+     * set (no N+1 per-encounter queries) — see class docblock.
      *
-     * Uses BillItem.grossValue (hospital fee before discount / margin). Discount
-     * and service-charge totals are fetched separately from BillFee because
-     * BillItem.discount is not rolled up for inpatient bills (see BillBhtController.calTotals).
+     * Per InwardChargeType.getCalculationMethod():
+     *  - BILL_ITEM (default)  : BillItem on InwardBill/InwardOutSideBill (whitelist —
+     *                            naturally excludes both INWARD_FINAL_BILL and
+     *                            INWARD_ORIGINAL_FINAL_BILL snapshot bills, fixing
+     *                            the post-discharge double count).
+     *  - ADMISSION_FEE         : flat AdmissionType.admissionFee, read straight off
+     *                            the already-loaded encounters (no BillItem exists).
+     *  - PATIENT_ROOM           : PatientRoom.getCalculatedXxxCharge() (time-based)
+     *                            plus any service BillItems filed under the same
+     *                            charge type on InwardBill.
+     *  - BILL_FEE               : BillFee.feeValue on InwardProfessional bills,
+     *                            split Consultant (ProfessionalCharge) vs
+     *                            non-Consultant (DoctorAndNurses).
+     *  - PHARMACY_BILL/STORE_BILL: BillItem on the pharmacy-issue BillTypeAtomic
+     *                            list / StoreBhtPre, same as InwardChargeTypeDetailController.
      */
     private Map<Long, Map<InwardChargeType, Double>> fetchChargesByEncounter(
             List<PatientEncounter> encounters) {
 
         Map<Long, Map<InwardChargeType, Double>> result = new HashMap<>();
 
-        String jpql = "select bi.bill.patientEncounter.id, bi.inwardChargeType, sum(bi.grossValue)"
-                + " from BillItem bi"
+        mergeChargeMaps(result, fetchBillItemCharges(encounters));
+        mergeChargeMaps(result, fetchAdmissionFeeCharges(encounters));
+        mergeChargeMaps(result, fetchPatientRoomCalculatedCharges(encounters));
+        mergeChargeMaps(result, fetchPatientRoomServiceItemCharges(encounters));
+        mergeChargeMaps(result, fetchProfessionalFeeCharges(encounters));
+        mergeChargeMaps(result, fetchAssistingFeeCharges(encounters));
+        mergeChargeMaps(result, fetchPharmacyBillCharges(encounters));
+        mergeChargeMaps(result, fetchStoreBillCharges(encounters));
+
+        return result;
+    }
+
+    /**
+     * Returns the InwardChargeType values whose CalculationMethod matches, e.g.
+     * the default BILL_ITEM set (everything without an explicit CalculationMethod)
+     * or the 7 PATIENT_ROOM types.
+     */
+    private List<InwardChargeType> chargeTypesByCalculationMethod(CalculationMethod method) {
+        List<InwardChargeType> types = new ArrayList<>();
+        for (InwardChargeType ct : InwardChargeType.values()) {
+            if (ct.getCalculationMethod() == method) {
+                types.add(ct);
+            }
+        }
+        return types;
+    }
+
+    /** Merges a fragment charge map into the accumulator, summing on collision. */
+    private void mergeChargeMaps(Map<Long, Map<InwardChargeType, Double>> target,
+            Map<Long, Map<InwardChargeType, Double>> source) {
+        for (Map.Entry<Long, Map<InwardChargeType, Double>> e : source.entrySet()) {
+            Map<InwardChargeType, Double> inner = target.computeIfAbsent(
+                    e.getKey(), k -> new EnumMap<>(InwardChargeType.class));
+            for (Map.Entry<InwardChargeType, Double> ie : e.getValue().entrySet()) {
+                inner.merge(ie.getKey(), ie.getValue(), Double::sum);
+            }
+        }
+    }
+
+    /** Reads {encId, InwardChargeType, sum} triples from an Object[] result set into a charge map. */
+    private Map<Long, Map<InwardChargeType, Double>> collectChargeTypeRows(List<Object[]> rows) {
+        Map<Long, Map<InwardChargeType, Double>> result = new HashMap<>();
+        if (rows == null) {
+            return result;
+        }
+        for (Object[] r : rows) {
+            Long              encId = (Long) r[0];
+            InwardChargeType  type  = (InwardChargeType) r[1];
+            double            total = r[2] == null ? 0.0 : ((Number) r[2]).doubleValue();
+            result.computeIfAbsent(encId, k -> new EnumMap<>(InwardChargeType.class))
+                  .merge(type, total, Double::sum);
+        }
+        return result;
+    }
+
+    /**
+     * BILL_ITEM (default) charge types: BillItem on InwardBill/InwardOutSideBill
+     * only — a whitelist, which is the fix for bug #6 (this naturally excludes
+     * both INWARD_FINAL_BILL and INWARD_ORIGINAL_FINAL_BILL discharge-snapshot
+     * bills, unlike the old blacklist that only excluded the latter).
+     */
+    private Map<Long, Map<InwardChargeType, Double>> fetchBillItemCharges(List<PatientEncounter> encounters) {
+        List<InwardChargeType> types = chargeTypesByCalculationMethod(CalculationMethod.BILL_ITEM);
+        if (types.isEmpty()) {
+            return new HashMap<>();
+        }
+
+        String jpql = "select enc.id, bi.inwardChargeType, sum(bi.grossValue)"
+                + " from BillItem bi join bi.bill b join b.patientEncounter enc"
                 + " where bi.retired = false"
-                + " and bi.bill.retired = false"
-                + " and bi.bill.cancelled = false"
-                + " and bi.bill.billTypeAtomic != :originalFinalBillType"
-                + " and bi.bill.patientEncounter in :encs"
-                + " and bi.inwardChargeType is not null"
-                + " group by bi.bill.patientEncounter.id, bi.inwardChargeType";
+                + " and b.retired = false"
+                + " and b.cancelled = false"
+                + " and b.billType in :btps"
+                + " and enc in :encs"
+                + " and bi.inwardChargeType in :types"
+                + " group by enc.id, bi.inwardChargeType";
 
         Map<String, Object> params = new HashMap<>();
+        params.put("btps", Arrays.asList(BillType.InwardBill, BillType.InwardOutSideBill));
         params.put("encs", encounters);
-        params.put("originalFinalBillType", BillTypeAtomic.INWARD_ORIGINAL_FINAL_BILL);
+        params.put("types", types);
 
         List<Object[]> rows = patientEncounterFacade.findObjectArrayByJpql(jpql, params, TemporalType.TIMESTAMP);
+        return collectChargeTypeRows(rows);
+    }
+
+    /**
+     * ADMISSION_FEE: a flat AdmissionType.admissionFee value, never persisted as
+     * a BillItem — read straight off the already-loaded encounter list.
+     */
+    private Map<Long, Map<InwardChargeType, Double>> fetchAdmissionFeeCharges(List<PatientEncounter> encounters) {
+        Map<Long, Map<InwardChargeType, Double>> result = new HashMap<>();
+        for (PatientEncounter enc : encounters) {
+            if (enc.getAdmissionType() == null || enc.getId() == null) {
+                continue;
+            }
+            double fee = enc.getAdmissionType().getAdmissionFee();
+            if (fee == 0.0) {
+                continue;
+            }
+            result.computeIfAbsent(enc.getId(), k -> new EnumMap<>(InwardChargeType.class))
+                  .merge(InwardChargeType.AdmissionFee, fee, Double::sum);
+        }
+        return result;
+    }
+
+    /**
+     * PATIENT_ROOM — time-based half: PatientRoom.getCalculatedXxxCharge() per
+     * encounter, one bulk query then a Java-side pivot (see
+     * InwardChargeTypeBreakdownController.buildFromPatientRoom()/extractPatientRoomCharge()).
+     */
+    private Map<Long, Map<InwardChargeType, Double>> fetchPatientRoomCalculatedCharges(List<PatientEncounter> encounters) {
+        Map<Long, Map<InwardChargeType, Double>> result = new HashMap<>();
+
+        String jpql = "select pr from PatientRoom pr join pr.patientEncounter enc"
+                + " where pr.retired = false"
+                + " and enc in :encs";
+        Map<String, Object> params = new HashMap<>();
+        params.put("encs", encounters);
+
+        List<PatientRoom> rooms = patientRoomFacade.findByJpql(jpql, params, TemporalType.TIMESTAMP);
+        if (rooms == null) {
+            return result;
+        }
+        for (PatientRoom pr : rooms) {
+            PatientEncounter enc = pr.getPatientEncounter();
+            if (enc == null || enc.getId() == null) {
+                continue;
+            }
+            Map<InwardChargeType, Double> inner = result.computeIfAbsent(
+                    enc.getId(), k -> new EnumMap<>(InwardChargeType.class));
+            mergeIfNonZero(inner, InwardChargeType.RoomCharges, pr.getCalculatedRoomCharge());
+            mergeIfNonZero(inner, InwardChargeType.MOCharges, pr.getCalculatedMoCharge());
+            mergeIfNonZero(inner, InwardChargeType.NursingCharges, pr.getCalculatedNursingCharge());
+            mergeIfNonZero(inner, InwardChargeType.LinenCharges, pr.getCalculatedLinenCharge());
+            mergeIfNonZero(inner, InwardChargeType.AdministrationCharge, pr.getCalculatedAdministrationCharge());
+            mergeIfNonZero(inner, InwardChargeType.MedicalCareICU, pr.getCalculatedMedicalCareCharge());
+            mergeIfNonZero(inner, InwardChargeType.MaintainCharges, pr.getCalculatedMaintainCharge());
+        }
+        return result;
+    }
+
+    private void mergeIfNonZero(Map<InwardChargeType, Double> map, InwardChargeType type, double value) {
+        if (value != 0.0) {
+            map.merge(type, value, Double::sum);
+        }
+    }
+
+    /**
+     * PATIENT_ROOM — service-item half: BillItems filed directly under a
+     * PATIENT_ROOM charge type on InwardBill (e.g. an ad-hoc room-charge line),
+     * summed alongside the calculated time-based charge for the same type.
+     */
+    private Map<Long, Map<InwardChargeType, Double>> fetchPatientRoomServiceItemCharges(List<PatientEncounter> encounters) {
+        List<InwardChargeType> types = chargeTypesByCalculationMethod(CalculationMethod.PATIENT_ROOM);
+        if (types.isEmpty()) {
+            return new HashMap<>();
+        }
+
+        String jpql = "select enc.id, bi.inwardChargeType, sum(bi.grossValue)"
+                + " from BillItem bi join bi.bill b join b.patientEncounter enc"
+                + " where bi.retired = false"
+                + " and b.retired = false"
+                + " and b.cancelled = false"
+                + " and b.billType = :btp"
+                + " and enc in :encs"
+                + " and bi.inwardChargeType in :types"
+                + " group by enc.id, bi.inwardChargeType";
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("btp", BillType.InwardBill);
+        params.put("encs", encounters);
+        params.put("types", types);
+
+        List<Object[]> rows = patientEncounterFacade.findObjectArrayByJpql(jpql, params, TemporalType.TIMESTAMP);
+        return collectChargeTypeRows(rows);
+    }
+
+    /**
+     * BILL_FEE — Consultant staff → ProfessionalCharge. Same filter as
+     * InwardBeanController.createProfesionallFee().
+     */
+    private Map<Long, Map<InwardChargeType, Double>> fetchProfessionalFeeCharges(List<PatientEncounter> encounters) {
+        return fetchBillFeeCharges(encounters, true, InwardChargeType.ProfessionalCharge);
+    }
+
+    /**
+     * BILL_FEE — non-Consultant staff (assistants/nurses) → DoctorAndNurses.
+     * Same filter as InwardBeanController.createDoctorAndNurseFee().
+     */
+    private Map<Long, Map<InwardChargeType, Double>> fetchAssistingFeeCharges(List<PatientEncounter> encounters) {
+        return fetchBillFeeCharges(encounters, false, InwardChargeType.DoctorAndNurses);
+    }
+
+    private Map<Long, Map<InwardChargeType, Double>> fetchBillFeeCharges(
+            List<PatientEncounter> encounters, boolean consultantOnly, InwardChargeType targetType) {
+
+        Map<Long, Map<InwardChargeType, Double>> result = new HashMap<>();
+
+        String jpql = "select bf.bill.patientEncounter.id, sum(coalesce(bf.feeGrossValue, bf.feeValue))"
+                + " from BillFee bf"
+                + " where bf.retired = false"
+                + " and bf.bill.retired = false"
+                + " and bf.bill.cancelled = false"
+                + " and bf.bill.billType = :btp"
+                + " and bf.fee.feeType = :ftp"
+                + (consultantOnly ? " and type(bf.staff) = :staffClass" : " and type(bf.staff) != :staffClass")
+                + " and bf.bill.patientEncounter in :encs"
+                + " group by bf.bill.patientEncounter.id";
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("btp", BillType.InwardProfessional);
+        params.put("ftp", FeeType.Staff);
+        params.put("staffClass", Consultant.class);
+        params.put("encs", encounters);
+
+        List<Object[]> rows = billFeeFacade.findObjectArrayByJpql(jpql, params, TemporalType.TIMESTAMP);
         if (rows != null) {
             for (Object[] r : rows) {
-                Long            encId  = (Long) r[0];
-                InwardChargeType type  = (InwardChargeType) r[1];
-                Double           total = ((Number) r[2]).doubleValue();
+                Long   encId = (Long) r[0];
+                double total = r[1] == null ? 0.0 : ((Number) r[1]).doubleValue();
                 result.computeIfAbsent(encId, k -> new EnumMap<>(InwardChargeType.class))
-                      .put(type, total);
+                      .merge(targetType, total, Double::sum);
             }
         }
         return result;
+    }
+
+    /**
+     * PHARMACY_BILL (Medicine): same BillTypeAtomic whitelist as
+     * InwardChargeTypeDetailController.fetchPharmacyBillItemRows(), aggregated.
+     */
+    private Map<Long, Map<InwardChargeType, Double>> fetchPharmacyBillCharges(List<PatientEncounter> encounters) {
+        List<InwardChargeType> types = chargeTypesByCalculationMethod(CalculationMethod.PHARMACY_BILL);
+        if (types.isEmpty()) {
+            return new HashMap<>();
+        }
+
+        List<BillTypeAtomic> btas = new ArrayList<>();
+        btas.add(BillTypeAtomic.PHARMACY_DIRECT_ISSUE);
+        btas.add(BillTypeAtomic.PHARMACY_DIRECT_ISSUE_CANCELLED);
+        btas.add(BillTypeAtomic.DIRECT_ISSUE_INWARD_MEDICINE);
+        btas.add(BillTypeAtomic.DIRECT_ISSUE_INWARD_MEDICINE_RETURN);
+        btas.add(BillTypeAtomic.DIRECT_ISSUE_INWARD_MEDICINE_CANCELLATION);
+        btas.add(BillTypeAtomic.DIRECT_ISSUE_INWARD_DISCHARGE_MEDICINE);
+        btas.add(BillTypeAtomic.DIRECT_ISSUE_INWARD_DISCHARGE_MEDICINE_RETURN);
+        btas.add(BillTypeAtomic.DIRECT_ISSUE_INWARD_DISCHARGE_MEDICINE_CANCELLATION);
+        btas.add(BillTypeAtomic.ISSUE_MEDICINE_ON_REQUEST_INWARD);
+        btas.add(BillTypeAtomic.ISSUE_MEDICINE_ON_REQUEST_INWARD_RETURN);
+        btas.add(BillTypeAtomic.ISSUE_MEDICINE_ON_REQUEST_INWARD_CANCELLATION);
+
+        String jpql = "select enc.id, bi.inwardChargeType, sum(bi.grossValue)"
+                + " from BillItem bi join bi.bill b join b.patientEncounter enc"
+                + " where bi.retired = false"
+                + " and b.retired = false"
+                + " and b.cancelled = false"
+                + " and b.billTypeAtomic in :btas"
+                + " and enc in :encs"
+                + " and bi.inwardChargeType in :types"
+                + " group by enc.id, bi.inwardChargeType";
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("btas", btas);
+        params.put("encs", encounters);
+        params.put("types", types);
+
+        List<Object[]> rows = patientEncounterFacade.findObjectArrayByJpql(jpql, params, TemporalType.TIMESTAMP);
+        return collectChargeTypeRows(rows);
+    }
+
+    /**
+     * STORE_BILL (GeneralIssuing): same BillType.StoreBhtPre filter as
+     * InwardChargeTypeDetailController.fetchStoreBillItemRows(), aggregated.
+     */
+    private Map<Long, Map<InwardChargeType, Double>> fetchStoreBillCharges(List<PatientEncounter> encounters) {
+        List<InwardChargeType> types = chargeTypesByCalculationMethod(CalculationMethod.STORE_BILL);
+        if (types.isEmpty()) {
+            return new HashMap<>();
+        }
+
+        String jpql = "select enc.id, bi.inwardChargeType, sum(bi.grossValue)"
+                + " from BillItem bi join bi.bill b join b.patientEncounter enc"
+                + " where bi.retired = false"
+                + " and b.retired = false"
+                + " and b.cancelled = false"
+                + " and b.billType = :btp"
+                + " and enc in :encs"
+                + " and bi.inwardChargeType in :types"
+                + " group by enc.id, bi.inwardChargeType";
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("btp", BillType.StoreBhtPre);
+        params.put("encs", encounters);
+        params.put("types", types);
+
+        List<Object[]> rows = patientEncounterFacade.findObjectArrayByJpql(jpql, params, TemporalType.TIMESTAMP);
+        return collectChargeTypeRows(rows);
     }
 
     /**
@@ -271,6 +577,13 @@ public class InwardInvoiceJournalController implements Serializable {
      *
      * Reads from BillFee (not BillItem) because BillItem.discount is not
      * populated for inpatient bills — discount lives per-fee.
+     *
+     * Kept as a single query spanning all bill sources (not narrowed to the
+     * InwardBill/InwardOutSideBill whitelist used for gross charges) since fees
+     * can be filed against professional/pharmacy/store bills too. Excludes BOTH
+     * discharge-snapshot bill types — INWARD_FINAL_BILL and
+     * INWARD_ORIGINAL_FINAL_BILL — so post-discharge discount/service-charge
+     * totals aren't doubled (bug #6).
      */
     private Map<Long, double[]> fetchDiscountAndMarginByEncounter(List<PatientEncounter> encounters) {
         Map<Long, double[]> result = new HashMap<>();
@@ -280,13 +593,14 @@ public class InwardInvoiceJournalController implements Serializable {
                 + " where bf.retired = false"
                 + " and bf.bill.retired = false"
                 + " and bf.bill.cancelled = false"
-                + " and bf.bill.billTypeAtomic != :originalFinalBillType"
+                + " and bf.bill.billTypeAtomic not in :excludedTypes"
                 + " and bf.bill.patientEncounter in :encs"
                 + " group by bf.bill.patientEncounter.id";
 
         Map<String, Object> params = new HashMap<>();
         params.put("encs", encounters);
-        params.put("originalFinalBillType", BillTypeAtomic.INWARD_ORIGINAL_FINAL_BILL);
+        params.put("excludedTypes", Arrays.asList(
+                BillTypeAtomic.INWARD_FINAL_BILL, BillTypeAtomic.INWARD_ORIGINAL_FINAL_BILL));
 
         List<Object[]> rows = patientEncounterFacade.findObjectArrayByJpql(jpql, params, TemporalType.TIMESTAMP);
         if (rows != null) {
@@ -334,18 +648,25 @@ public class InwardInvoiceJournalController implements Serializable {
     /**
      * Single bulk query: credit settlement totals grouped by encounter.
      * Returns Map< encounterId, double[]{total} >.
+     *
+     * Groups/filters on bi.patientEncounter (the per-BillItem encounter link),
+     * NOT bi.bill.patientEncounter — the credit settlement Bill created by
+     * CashRecieveBillController.settleCreditForInwardCreditCompanyPaymentBills()
+     * is never given a patientEncounter (it can span multiple BHTs); only each
+     * BillItem carries its own patientEncounter. Filtering on bi.bill.patientEncounter
+     * silently dropped every settlement row (bug #5).
      */
     private Map<Long, double[]> fetchCreditSettlementByEncounter(List<PatientEncounter> encounters) {
         Map<Long, double[]> result = new HashMap<>();
 
-        String jpql = "select bi.bill.patientEncounter.id, sum(bi.netValue)"
+        String jpql = "select bi.patientEncounter.id, sum(bi.netValue)"
                 + " from BillItem bi"
                 + " where bi.retired = false"
                 + " and bi.bill.retired = false"
                 + " and bi.bill.cancelled = false"
                 + " and bi.bill.billTypeAtomic = :bta"
-                + " and bi.bill.patientEncounter in :encs"
-                + " group by bi.bill.patientEncounter.id";
+                + " and bi.patientEncounter in :encs"
+                + " group by bi.patientEncounter.id";
 
         Map<String, Object> params = new HashMap<>();
         params.put("bta",  BillTypeAtomic.INPATIENT_CREDIT_COMPANY_PAYMENT_RECEIVED);
@@ -362,12 +683,45 @@ public class InwardInvoiceJournalController implements Serializable {
         return result;
     }
 
+    /**
+     * Single bulk query: names of all non-retired EncounterCreditCompany rows
+     * grouped by encounter. A BHT can have more than one active credit company
+     * (the legacy PatientEncounter.creditCompany field only ever held one) —
+     * see buildRow() for how this is merged with the legacy field.
+     * Returns Map< encounterId, List<companyName> >.
+     */
+    private Map<Long, List<String>> fetchCreditCompanyNamesByEncounter(List<PatientEncounter> encounters) {
+        Map<Long, List<String>> result = new HashMap<>();
+
+        String jpql = "select ecc.patientEncounter.id, ecc.institution.name"
+                + " from EncounterCreditCompany ecc"
+                + " where ecc.retired = false"
+                + " and ecc.patientEncounter in :encs";
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("encs", encounters);
+
+        List<Object[]> rows = encounterCreditCompanyFacade.findObjectArrayByJpql(jpql, params, TemporalType.TIMESTAMP);
+        if (rows != null) {
+            for (Object[] r : rows) {
+                Long   encId = (Long) r[0];
+                String name  = (String) r[1];
+                if (name == null) {
+                    continue;
+                }
+                result.computeIfAbsent(encId, k -> new ArrayList<>()).add(name);
+            }
+        }
+        return result;
+    }
+
     private InwardInvoiceJournalRowDto buildRow(
             PatientEncounter enc,
             Map<Long, Map<InwardChargeType, Double>> chargeMap,
             Map<Long, double[]> discountMarginMap,
             Map<Long, Double> depositMap,
-            Map<Long, double[]> creditMap) {
+            Map<Long, double[]> creditMap,
+            Map<Long, List<String>> creditCompanyNamesMap) {
 
         InwardInvoiceJournalRowDto row = new InwardInvoiceJournalRowDto();
         row.setEncounterDatabaseId(enc.getId());
@@ -403,8 +757,19 @@ public class InwardInvoiceJournalController implements Serializable {
         if (credit != null) {
             row.setCreditSettlementTotal(credit[0]);
         }
-        if (enc.getCreditCompany() != null) {
-            row.setCreditCompanyName(enc.getCreditCompany().getName());
+        // credit company name(s) — a BHT may have more than one active company
+        // via EncounterCreditCompany; the legacy single-valued creditCompany
+        // field is kept for backward compat and merged in first.
+        Set<String> creditCompanyNames = new LinkedHashSet<>();
+        if (enc.getCreditCompany() != null && enc.getCreditCompany().getName() != null) {
+            creditCompanyNames.add(enc.getCreditCompany().getName());
+        }
+        List<String> extraNames = creditCompanyNamesMap.get(enc.getId());
+        if (extraNames != null) {
+            creditCompanyNames.addAll(extraNames);
+        }
+        if (!creditCompanyNames.isEmpty()) {
+            row.setCreditCompanyName(String.join(", ", creditCompanyNames));
         }
 
         return row;

--- a/src/main/java/com/divudi/bean/inward/InwardInvoiceJournalController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardInvoiceJournalController.java
@@ -593,7 +593,7 @@ public class InwardInvoiceJournalController implements Serializable {
                 + " where bf.retired = false"
                 + " and bf.bill.retired = false"
                 + " and bf.bill.cancelled = false"
-                + " and bf.bill.billTypeAtomic not in :excludedTypes"
+                + " and (bf.bill.billTypeAtomic is null or bf.bill.billTypeAtomic not in :excludedTypes)"
                 + " and bf.bill.patientEncounter in :encs"
                 + " group by bf.bill.patientEncounter.id";
 


### PR DESCRIPTION
## Summary

The Inpatient Invoice Journal (`inward_report_invoice_journal.xhtml` / `InwardInvoiceJournalController`) summed every charge type from a single flat `BillItem` query — that only works for the default calculation method. Fixes all 6 symptoms reported in #22665:

**Before discharge**
- Admission Fee stuck at 0 — it's a flat `AdmissionType.admissionFee` value, never a `BillItem`.
- Only one credit company shown when a BHT had two — the journal only read the legacy single `PatientEncounter.creditCompany` field, not the `EncounterCreditCompany` collection.
- Room Charges stuck at 0 — computed on the live `PatientRoom` entity, not summed from `BillItem`.
- Professional/Assisting Charge stuck at 0 — lives in `BillFee` on `InwardProfessional` bills, not `BillItem`.

**After discharge**
- Credit Settlement never showed — the settlement `Bill` is never assigned a `patientEncounter` (it can span multiple BHTs); only each `BillItem` carries one, but the query joined through the bill.
- Charges doubled — discharge writes a full duplicate set of `BillItem`/`BillFee` rows onto two new snapshot bills (`INWARD_FINAL_BILL` and `INWARD_ORIGINAL_FINAL_BILL`); the old query's blacklist only excluded one of the two.

## Fix approach

Dispatches charge-total fetching by `InwardChargeType.getCalculationMethod()`, sourcing each group from the correct table — mirroring the pattern already used by the sibling `InwardChargeTypeDetailController` / `InwardChargeTypeBreakdownController` (built for the same #19321 report family):

- `BILL_ITEM` (default): switched from a `billTypeAtomic` blacklist to a `billType` whitelist (`InwardBill`/`InwardOutSideBill`) — this is what fixes the post-discharge doubling, since the whitelist naturally excludes the discharge-time snapshot bills.
- `ADMISSION_FEE`: read `AdmissionType.admissionFee` directly, no `BillItem` query.
- `PATIENT_ROOM`: `PatientRoom`'s calculated fields plus `InwardBill` service items.
- `BILL_FEE`: `BillFee` on `InwardProfessional` bills, split `ProfessionalCharge` (Consultant staff) vs `DoctorAndNurses` (non-Consultant), using `coalesce(feeGrossValue, feeValue)` to stay consistent with the "gross" semantics of the rest of the map.
- `PHARMACY_BILL`/`STORE_BILL`: kept on their existing atomic/billType filters so they aren't silently zeroed by the new whitelist.
- Credit company: merged in all `EncounterCreditCompany` rows alongside the legacy single field.
- Credit settlement: grouped on `BillItem.patientEncounter` instead of `Bill.patientEncounter`.

## Test plan

Verified end-to-end against local Payara with a synthetic test admission (department: Inward) — created fresh via Playwright, no real patient data:
- [x] Admitted with "OPD Card" admission type (500 flat fee), 2 credit companies (Fairfirst Insurance, Ceylinco Life), assigned a room.
- [x] Added a professional fee (3,000) for a Consultant.
- [x] Pre-discharge journal: Admission Fee 500, Room Charges 1,250, Professional Charge 3,000, both credit companies listed — all previously 0/incomplete.
- [x] Discharged and finalized the bill — confirmed in DB that duplicate `BillItem`/`BillFee` snapshot rows are created on `INWARD_FINAL_BILL`/`INWARD_ORIGINAL_FINAL_BILL` (and a third copy of the professional fee).
- [x] Post-discharge journal: same totals as pre-discharge (no doubling) — Gross Total 4,750.
- [x] Settled the credit company payment (4,750) — confirmed in DB the settlement bill has `patientEncounter = NULL` while the `BillItem` carries it correctly.
- [x] Post-settlement journal: Credit Settlement column now shows 4,750.
- [x] `mvn clean package` compiles clean; local Payara redeploy with no server.log errors.

Full before/after table posted on the issue: https://github.com/hmislk/hmis/issues/22665#issuecomment-5191346317

Closes #22665


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inward invoice journal charge calculations across bill items, admissions, room charges, professional fees, pharmacy, and store bills.
  * Improved handling of discounts, service charges, credit settlements, and credit-company details.
  * Prevented duplicate credit-company names in invoice journal results.

* **Documentation**
  * Documented that a specialty must be selected before submitting a professional fee.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->