### PR TITLE
fix(pharmacy): correct Direct Purchase Return sign in movement out report

### DIFF
--- a/src/main/java/com/divudi/service/BillService.java
+++ b/src/main/java/com/divudi/service/BillService.java
@@ -2743,21 +2743,19 @@ public class BillService {
         // positive = stock came back on a return). For a "movement OUT" report we want the
         // quantity that went out, so we negate the summed pbi.qty: a sale yields a positive
         // out-quantity and a return reduces it, matching the signed value columns below.
-        // Direct Purchase Return is an exception: DirectPurchaseReturnController always
-        // persists pbi.qty as a positive magnitude (see its calculateBillItemDetails()), not
-        // the negative-for-out convention above, even though it is itself an OUT movement
-        // (goods leaving stock back to the supplier). This is a known writer bug tracked
-        // under #21032/#21053 (pbi.qty should be negative for this bill type but the writer
-        // is not yet fixed there); negating it here like a normal sale would flip its sign
-        // and net it against genuine sales, so it's added un-negated to match the current
-        // (buggy) persisted convention. If #21053 is ever fixed to store negative qty for
-        // this bill type, this special case must be removed at the same time.
+        // Direct Purchase Return follows this same convention: DirectPurchaseReturnWorkflowController
+        // (the writer wired to the UI) persists pbi.qty as negative at approval, same as every
+        // other OUT movement here (goods leaving stock back to the supplier) - confirmed by
+        // #21053, where 1098/1100 real DIRECT_PURCHASE_REFUND rows on ruhunu have pbi.qty
+        // correctly negative (the 2 positive outliers are the tracked writer anomaly, not the
+        // norm). An earlier version of this query special-cased this bill type to skip negation,
+        // which was backwards and displayed real returns with a negative out-quantity - see #21833.
         jpql = "select new com.divudi.core.data.dto.PharmacyMovementOutByItemDTO( "
                 + " it.id, "
                 + " coalesce(it.name, 'N/A'), "
                 + " it.code, "
                 + " coalesce(cat.name, 'N/A'), "
-                + " coalesce(sum(case when b.billTypeAtomic = :directPurchaseReturnBta then pbi.qty else (pbi.qty * -1.0) end), 0.0), "
+                + " (coalesce(sum(pbi.qty), 0.0) * -1.0), "
                 + " coalesce(sum(bi.grossValue), 0.0), "
                 + " coalesce(sum(bi.discount), 0.0), "
                 + " coalesce(sum(bi.marginValue), 0.0), "
@@ -2773,7 +2771,6 @@ public class BillService {
                 + " and b.createdAt between :fromDate and :toDate ";
 
         params.put("billTypesAtomics", billTypeAtomics);
-        params.put("directPurchaseReturnBta", BillTypeAtomic.PHARMACY_DIRECT_PURCHASE_REFUND);
         params.put("fromDate", fromDate);
         params.put("toDate", toDate);
 


### PR DESCRIPTION
## What changed

Reopens/re-fixes #21833 after QA (Irani96) marked the earlier fix (PR #22307) as "not fix" without further detail.

**Root cause of "not fix"**: PR #22307 added `PHARMACY_DIRECT_PURCHASE_REFUND` to the report's bill-type list (correct), but also special-cased it in `BillService.fetchPharmacyMovementOutByItemDTOs()` to skip negating `pbi.qty`, on the premise that the writer always persists it as a positive magnitude. That premise was backwards:

- `DirectPurchaseReturnWorkflowController.completeApproval()` → `updateStock()` explicitly negates `pbi.qty` at approval (`phi.setQty(-Math.abs(phi.getQty()))`), matching the same negative-for-out convention already used by every other bill type in this query.
- #21053 independently confirms this: 1098/1100 real `PHARMACY_DIRECT_PURCHASE_REFUND` rows on `ruhunu` have `pbi.qty` correctly negative. The 2 outlier rows it flagged are wrong in a *different* field (`BillItemFinanceDetails.quantity` / `BillItem.qty`), not `pbi.qty` — unrelated to this query.

So the special-cased query left the (correctly negative) real-world value **un-negated**, displaying Direct Purchase Returns with a **negative** out-quantity in the By Item view instead of positive.

**Fix**: removed the special-case `CASE WHEN` and reverted to the plain negation (`pbi.qty * -1.0`) used for every other bill type — the same treatment Direct Purchase Return should always have had.

## Verification

Browser-based UI verification on `qa1` was blocked by a reproducible hang when clicking "Create Return" on a fresh Direct Purchase Return (server-side, unrelated to this fix — worth its own investigation separately). Verified instead against real data:

- **Local `ruhunu` DB, full sweep** of all `PHARMACY_DIRECT_PURCHASE_REFUND` item-rows:

  | COMPLETED | rows | `pbi.qty` negative | `pbi.qty` positive | anomalies |
  |---|---|---|---|---|
  | 1 (approved) | 55 | 55 | 0 | **0** |
  | 0 (pending) | 1108 | 0 | 1108 | **0** (expected pre-approval state) |

  100% of approved returns have negative `pbi.qty` — no sign anomalies, no backfill needed for this field.

- **Direct SQL simulation of the fixed query** against a real approved return (bill `R/DP/RHD/MPH/26/000005`, id `3592226`): now correctly computes **+20** for `Atrauman Ag 10cmx20cm` (previously the buggy special-case computed **-20**).

- Local build (`mvn clean package -DskipTests`) succeeded; local Payara redeploy completed with no errors in `server.log`.

- Confirmed `Pharmacy Direct Purchase Refund` is present in the report's "Included Pharmacy Bill Types" panel on `qa1` (i.e. the bill-type-list half of #22307's fix is deployed and correct — only the sign computation needed fixing).

Closes #21833

🤖 Generated with [Claude Code](https://claude.ai/code)