### PR TITLE
fix(pharmacy): exclude pending Direct Purchase Returns from movement out report

### DIFF
--- a/src/main/java/com/divudi/service/BillService.java
+++ b/src/main/java/com/divudi/service/BillService.java
@@ -2750,6 +2750,14 @@ public class BillService {
         // correctly negative (the 2 positive outliers are the tracked writer anomaly, not the
         // norm). An earlier version of this query special-cased this bill type to skip negation,
         // which was backwards and displayed real returns with a negative out-quantity - see #21833.
+        //
+        // Pending (not yet approved) Direct Purchase Return bills are excluded below: pbi.qty is
+        // only sign-flipped to the correct negative-for-out value at approval time
+        // (DirectPurchaseReturnWorkflowController.completeApproval() -> updateStock()); before
+        // that, prepareBillItems() leaves it as a positive "available to return" quantity, which
+        // is not yet a real stock movement and would net incorrectly if included. Every other
+        // bill type in this report is unaffected by this filter (they don't use the completed
+        // flag the same way and are left as before).
         jpql = "select new com.divudi.core.data.dto.PharmacyMovementOutByItemDTO( "
                 + " it.id, "
                 + " coalesce(it.name, 'N/A'), "
@@ -2768,9 +2776,11 @@ public class BillService {
                 + " where (b.retired = false or b.retired is null) "
                 + " and (bi.retired = false or bi.retired is null) "
                 + " and b.billTypeAtomic in :billTypesAtomics "
+                + " and (b.billTypeAtomic <> :directPurchaseReturnBta or b.completed = true) "
                 + " and b.createdAt between :fromDate and :toDate ";
 
         params.put("billTypesAtomics", billTypeAtomics);
+        params.put("directPurchaseReturnBta", BillTypeAtomic.PHARMACY_DIRECT_PURCHASE_REFUND);
         params.put("fromDate", fromDate);
         params.put("toDate", toDate);
 


### PR DESCRIPTION
## What changed

Follow-up to #21833 / PR #22688 (already merged), per reviewer feedback: the movement-out-by-item report should only count **approved** Direct Purchase Returns.

`PharmaceuticalBillItem.qty` for a Direct Purchase Return is only flipped to the correct negative-for-out value at approval time — `DirectPurchaseReturnWorkflowController.completeApproval()` → `updateStock()`. Before approval, `prepareBillItems()` leaves it as a positive "available to return" quantity, which isn't a real stock movement yet (stock hasn't actually left).

`BillService.fetchPharmacyMovementOutByItemDTOs()` previously included these pending bills unconditionally, netting their provisional positive quantity against genuine completed movements. This adds a targeted filter — `and (b.billTypeAtomic <> :directPurchaseReturnBta or b.completed = true)` — so only completed (approved) Direct Purchase Return bills are counted. Every other bill type in the report is untouched by this filter.

## Verification

Simulated the fixed query directly against the local `ruhunu` DB:

```sql
... WHERE b.BILLTYPEATOMIC = 'PHARMACY_DIRECT_PURCHASE_REFUND'
AND (b.BILLTYPEATOMIC <> 'PHARMACY_DIRECT_PURCHASE_REFUND' OR b.COMPLETED = 1)
```

Returned rows are exclusively `COMPLETED = 1` with correctly positive `report_qty`; all `COMPLETED = 0` (pending) rows are excluded, as intended. Local build (`mvn clean package -DskipTests`) succeeded; local Payara redeploy completed with no errors in `server.log`.

Related to #21833

🤖 Generated with [Claude Code](https://claude.ai/code)