### PR TITLE
fix(inward): Department filter now uses ward department in Inpatient Service Summary

### DIFF
--- a/src/main/java/com/divudi/bean/report/MdInwardReportController.java
+++ b/src/main/java/com/divudi/bean/report/MdInwardReportController.java
@@ -2219,7 +2219,11 @@ public class MdInwardReportController implements Serializable {
         }
         if (dept != null) {
             if (itemPath != null) {
-                sql.append(" AND ").append(itemPath).append(".department=:dept ");
+                // Filter by the patient's ward department (patientEncounter.department),
+                // not the service item's owning/pricing department (itemPath.department).
+                // Item-level department rarely matches the ward, so the old itemPath-based
+                // filter always returned zero rows (issue #20822).
+                sql.append(" AND ").append(encounterPath).append(".department=:dept ");
             } else {
                 sql.append(" AND ").append(billPath).append(".toDepartment=:dept ");
             }


### PR DESCRIPTION
## Summary

Fixes #20822 — the **Department** filter on the Inpatient Service Summary report (`inward/report_md_inward_item.xhtml`) returned no data when a department was selected.

## Root Cause

`MdInwardReportController.appendOptionalFilters()` built the `dept` filter for the `bi`/`bf` (BillItem/BillFee) query aliases as:

```java
sql.append(" AND ").append(itemPath).append(".department=:dept ");
// -> bi.item.department=:dept / bf.billItem.item.department=:dept
```

This filters on the **service item's catalog/pricing department**, not the **patient's ward department**. Inward service items are almost never catalogued under the ward's own department, so the filter always returned zero rows.

## Fix

Changed the `dept != null` branch to use `encounterPath` (already computed in the method for the Payment Method / Admission Type filters) instead of `itemPath`:

```java
sql.append(" AND ").append(encounterPath).append(".department=:dept ");
// -> bi.bill.patientEncounter.department=:dept / bf.bill.patientEncounter.department=:dept
```

This matches the pattern already used by 30+ other department filters in this same controller. Scope is limited to the `dept` branch for `itemPath != null` aliases (`bi`/`bf`) — the `institution`/`category`/`item` filters and the unrelated `"b"` alias (`processServiceBills()`, a different report tab, not reported broken) are untouched.

## Verification (local Payara, Galle Co-Operative Hospital DB, date range 2026-06-01–2026-08-05)

**All Departments (baseline)** — 7 rows, total 19,500.00:

![Unfiltered baseline](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/20822-01-before-dept-filter-unfiltered.png)

**Department = Inward** — correctly returns 6 rows, excluding the one row whose *item* is catalogued under "Inward" but whose patient's actual ward is OPD:

![Filtered by Inward](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/20822-02-after-dept-filter-inward.png)

**Department = OPD** — correctly isolates just that excluded row:

![Filtered by OPD](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/20822-03-after-dept-filter-opd.png)

Cross-checked directly against the local DB — queried `patientencounter.department_id` per bill and confirmed every returned row's actual ward matches the selected filter exactly (evidence and full query posted on the issue).

`mvn clean package` build passed (185 tests, 0 failures) and the WAR redeployed cleanly to local Payara with no errors in `server.log`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved department filtering in inward reports to use the patient encounter’s department for item-related results.
  * Preserved existing department filtering for bill-level results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->