### PR TITLE
fix(theater): refresh Surgery Workbench Timed Services and Professional Fees tabs

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -1499,8 +1499,8 @@ PrimeFaces.widgets.widget_form_startTime.setDate(new Date(2026, 7, 5, 19, 0, 0))
 ```
 `setDate()` both sets the widget's internal date **and** re-serializes the
 visible `_input` text using the field's configured pattern, so a DOM read
-right after confirms the committed value. Verified end-to-end for issue
-#20890: the typed-looking string round-tripped correctly through the
+right after confirms the committed value. Verified end-to-end for issue #20890:
+the typed-looking string round-tripped correctly through the
 non-AJAX submit and the saved `PATIENTITEM.FROMTIME`/`TOTIME` matched. Only
 use this shortcut for non-AJAX (full-postback) submits — for an AJAX
 `p:datePicker` where the *change* event itself must fire a listener, this

--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -1480,6 +1480,33 @@ field alone is not enough. Fix: search and select a Speciality (e.g. type
 statement reaches the server at all; with it filled, the insert fires
 immediately. Verified while testing issue #22665.
 
+## 56. `p:datePicker timeInput="true"` — typing into the input does not commit; use the PrimeFaces widget API for non-AJAX forms
+
+On `theater/inward_timed_service_consume_surgery.xhtml`'s Start/End Time
+fields (`p:datePicker showTime="true" timeInput="true"`, no `readonlyInput`
+set — `input.readOnly` is `false`), the documented "click → Ctrl+A →
+pressSequentially → Escape" pattern (§ "p:datePicker / p:calendar") left the
+input **empty** every time: `document.getElementById(...).value` read `""`
+both before and after `Escape`, with no visible error. Root cause wasn't
+narrowed further, but the fix that reliably works is to skip DOM typing
+entirely and drive the PrimeFaces widget directly — safe here because the
+submit button (`+ Add Service`) is `ajax="false"`, so (per §29) only the
+final submitted `_input` value matters:
+```js
+Object.keys(PrimeFaces.widgets).filter(k => /starttime|endtime/i.test(k))
+// -> ["widget_form_startTime", "widget_form_endTime"]
+PrimeFaces.widgets.widget_form_startTime.setDate(new Date(2026, 7, 5, 19, 0, 0));
+```
+`setDate()` both sets the widget's internal date **and** re-serializes the
+visible `_input` text using the field's configured pattern, so a DOM read
+right after confirms the committed value. Verified end-to-end for issue
+#20890: the typed-looking string round-tripped correctly through the
+non-AJAX submit and the saved `PATIENTITEM.FROMTIME`/`TOTIME` matched. Only
+use this shortcut for non-AJAX (full-postback) submits — for an AJAX
+`p:datePicker` where the *change* event itself must fire a listener, this
+bypasses that and the real key-event pattern would still be required (untested
+here).
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.

--- a/src/main/java/com/divudi/bean/inward/InwardProfessionalBillController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardProfessionalBillController.java
@@ -460,6 +460,7 @@ public class InwardProfessionalBillController implements Serializable {
         makeNullList();
         current = null;
         settlePreview = true;
+        surgeryBillController.refreshProEncounterComponents();
         JsfUtil.addSuccessMessage("Professional fee bill saved.");
     }
 

--- a/src/main/java/com/divudi/bean/inward/InwardTimedItemController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardTimedItemController.java
@@ -345,6 +345,7 @@ public class InwardTimedItemController implements Serializable {
         bf.setFeeValue(value);
         bf.setFeeGrossValue(value);
         updateBillFee(bf);
+        surgeryBillController.refreshTimedEncounterComponents();
     }
 
     public void removeTimedEncFromList(EncounterComponent encounterComponent) {
@@ -366,6 +367,7 @@ public class InwardTimedItemController implements Serializable {
         updateBillItem(encounterComponent.getBillItem());
         updateBill(encounterComponent.getBillItem().getBill());
         getBillBean().updateBatchBill(getBatchBill());
+        surgeryBillController.refreshTimedEncounterComponents();
     }
 
     private void retiredEncounterComponent(EncounterComponent encounterComponent) {
@@ -569,6 +571,7 @@ public class InwardTimedItemController implements Serializable {
         }
 
         getBillBean().updateBatchBill(getBatchBill());
+        surgeryBillController.refreshTimedEncounterComponents();
 
         JsfUtil.addSuccessMessage("Surgery Detail Successfull Updated");
 

--- a/src/main/java/com/divudi/bean/inward/SurgeryBillController.java
+++ b/src/main/java/com/divudi/bean/inward/SurgeryBillController.java
@@ -395,6 +395,7 @@ public class SurgeryBillController implements Serializable {
             patientItem.setRetiredAt(new Date());
             patientItem.setRetired(true);
             getPatientItemFacade().edit(patientItem);
+            refreshTimedEncounterComponents();
         }
     }
 
@@ -1292,13 +1293,36 @@ public class SurgeryBillController implements Serializable {
 
     public List<EncounterComponent> getProEncounterComponents() {
         if (proEncounterComponents == null) {
-            proEncounterComponents = new ArrayList<>();
+            fetchProEncounterComponents();
         }
         return proEncounterComponents;
     }
 
     public void setProEncounterComponents(List<EncounterComponent> proEncounterComponents) {
         this.proEncounterComponents = proEncounterComponents;
+    }
+
+    public void refreshProEncounterComponents() {
+        proEncounterComponents = null;
+    }
+
+    private void fetchProEncounterComponents() {
+        proEncounterComponents = new ArrayList<>();
+        if (surgeryBill == null || surgeryBill.getProcedure() == null
+                || surgeryBill.getProcedure().getId() == null) {
+            return;
+        }
+        String jpql = "SELECT ec FROM EncounterComponent ec"
+                + " WHERE ec.patientEncounter = :proc"
+                + " AND ec.billItem.bill.surgeryBillType = :sbt"
+                + " ORDER BY ec.orderNo";
+        HashMap<String, Object> params = new HashMap<>();
+        params.put("proc", surgeryBill.getProcedure());
+        params.put("sbt", SurgeryBillType.ProfessionalFee);
+        proEncounterComponents = getEncounterComponentFacade().findByJpql(jpql, params);
+        if (proEncounterComponents == null) {
+            proEncounterComponents = new ArrayList<>();
+        }
     }
 
     public PatientEncounterFacade getPatientEncounterFacade() {
@@ -1359,13 +1383,29 @@ public class SurgeryBillController implements Serializable {
 
     public List<EncounterComponent> getTimedEncounterComponents() {
         if (timedEncounterComponents == null) {
-            timedEncounterComponents = new ArrayList<>();
+            fetchTimedEncounterComponents();
         }
         return timedEncounterComponents;
     }
 
     public void setTimedEncounterComponents(List<EncounterComponent> timedEncounterComponents) {
         this.timedEncounterComponents = timedEncounterComponents;
+    }
+
+    public void refreshTimedEncounterComponents() {
+        timedEncounterComponents = null;
+    }
+
+    private void fetchTimedEncounterComponents() {
+        Bill timedBill = getSurgeryTimedServiceBill();
+        if (timedBill == null) {
+            timedEncounterComponents = new ArrayList<>();
+            return;
+        }
+        timedEncounterComponents = getBillBean().getEncounterComponents(timedBill);
+        if (timedEncounterComponents == null) {
+            timedEncounterComponents = new ArrayList<>();
+        }
     }
 
     public PatientItemFacade getPatientItemFacade() {


### PR DESCRIPTION
## Summary
- Fixes #20890 — added Timed Services never showed up on the Surgery Workbench's summary tabs
- Root cause: `SurgeryBillController`'s `proEncounterComponents`/`timedEncounterComponents` lists were only ever initialized to an empty `ArrayList`, never queried from the DB. The actual add pages (`InwardTimedItemController` for Timed Services, `InwardProfessionalBillController` for Professional Fees) are separate session-scoped beans, and every return navigation to the workbench is a plain JSF outcome string, so the workbench's cached lists never refreshed.
- Also fixed the Professional Fees tab, which had the identical bug (confirmed in a 2026-06-30 triage comment on the issue) — same root cause, same fix pattern, same files already being touched.
- `SurgeryBillController` getters now lazily re-fetch from the DB when the cached field is `null`; the add/update/remove actions in the other two beans call new `refreshTimedEncounterComponents()` / `refreshProEncounterComponents()` methods to invalidate the cache after a mutation (the same inject-and-call-back pattern already used once in the codebase for `refreshSurgeryBillFromDb()`).
- Also fixed the workbench's own "Remove" action on a Timed Service row (`SurgeryBillController.removeTimeService`) to invalidate the cache so the same-page postback re-renders fresh instead of showing a stale (already-removed) row.

## Test plan
- [x] `mvn clean package -DskipTests` — build passes
- [x] Redeployed locally (Payara, domain `rh`, port 9048) and confirmed no errors in `server.log`
- [x] Playwright pass against local Payara: logged in, selected THEATRE department, created a test surgery (Appendicectomy) on a synthetic non-finalized BHT admission
  - Confirmed both "Timed Services" and "Professional Fees" tabs start empty
  - Added a Timed Service ("Nebulization Test"), returned via "Surgery Dashboard" — new row appears on the workbench's Timed Services tab
  - Added a Professional Fee (Performed_By / Dr. Sujeewa Kariyawasam / 1,500.00), returned — new row appears on the workbench's Professional Fees tab
  - Clicked "Remove" on the Timed Service row from the workbench itself — row correctly re-renders showing "Deleted by ..." with Remove disabled (previously this tab was always empty, so this state was unreachable)
- [x] DB cross-check: `EncounterComponent` rows created with correct `BILLITEM_ID`/`SURGERYBILLTYPE` linkage for both the `TimedService` and `ProfessionalFee` bills; `PATIENTITEM.RETIRED=1` confirmed after the Remove action
- [x] Evidence (before/after screenshots) posted on issue #20890: https://github.com/hmislk/hmis/issues/20890#issuecomment-5192585266
- [x] Recorded a new Playwright gotcha found during testing (`p:datePicker timeInput="true"` typed input not committing) in `developer_docs/testing/playwright-e2e-workflow.md` §56

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Professional-fee and timed-service encounter details now refresh automatically after saving, updating, or removing items.
  * Encounter component lists now display current information instead of stale or missing data.
  * Improved reliability when loading encounter details after changes to surgery-related billing services.

* **Documentation**
  * Added testing guidance for date-and-time fields, including reliable value entry for forms using full-page submission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->