### PR TITLE
SLH hotfix: lab income report Collecting Centre column + persistence config

### DIFF
--- a/src/main/webapp/reportLab/laboratary_income_report.xhtml
+++ b/src/main/webapp/reportLab/laboratary_income_report.xhtml
@@ -351,7 +351,8 @@
                                 <h:outputText value="#{row.bill.patient.person.nameWithTitle}"  style="padding: 2px!important; margin: 0px!important;" />
                             </p:column>
 
-                            <p:column headerText="Collecting Centre"  style="padding: 2px!important; margin: 0px!important;" >
+                            <p:column headerText="Collecting Centre"  style="padding: 2px!important; margin: 0px!important;"
+                                rendered="#{configOptionApplicationController.getBooleanValueByKey('Laboratory Income Report - Show Collecting Centre Column',true)}">
                                 <h:outputText value="#{row.bill.collectingCentre.name}"  style="padding: 2px!important; margin: 0px!important;" />
                             </p:column>
 

--- a/src/main/webapp/reportLab/laboratary_income_report.xhtml
+++ b/src/main/webapp/reportLab/laboratary_income_report.xhtml
@@ -352,7 +352,7 @@
                             </p:column>
 
                             <p:column headerText="Collecting Centre"  style="padding: 2px!important; margin: 0px!important;"
-                                rendered="#{configOptionApplicationController.getBooleanValueByKey('Laboratory Income Report - Show Collecting Centre Column',true)}">
+                                rendered="#{configOptionApplicationController.getBooleanValueByKey('Laboratory Income Report - Show Collecting Centre Column',false)}">
                                 <h:outputText value="#{row.bill.collectingCentre.name}"  style="padding: 2px!important; margin: 0px!important;" />
                             </p:column>
 

--- a/src/main/webapp/reportLab/laboratary_income_report.xhtml
+++ b/src/main/webapp/reportLab/laboratary_income_report.xhtml
@@ -279,11 +279,9 @@
                             </p:commandButton>
                         </div>
 
-
-
                         <p:dataTable
                             id="tbl"
-                            style="padding: 2px!important; margin-top: 10px!important; margin: 0px!important; font-size: #{laborataryReportController.fontSizeForScreen}!important; zoom: 1.6;" 
+                            style="width: 2000px; padding: 2px!important; margin-top: 10px!important; margin: 0px!important; font-size: #{laborataryReportController.fontSizeForScreen}!important; zoom: 1.6;" 
                             styleClass="ui-datatable-borderless ui-datatable-sm compact-datatable"
                             value="#{laborataryReportController.bundle.rows}" 
                             var="row"
@@ -351,6 +349,10 @@
 
                             <p:column headerText="Patient"  style="padding: 2px!important; margin: 0px!important;" >
                                 <h:outputText value="#{row.bill.patient.person.nameWithTitle}"  style="padding: 2px!important; margin: 0px!important;" />
+                            </p:column>
+
+                            <p:column headerText="Collecting Centre"  style="padding: 2px!important; margin: 0px!important;" >
+                                <h:outputText value="#{row.bill.collectingCentre.name}"  style="padding: 2px!important; margin: 0px!important;" />
                             </p:column>
 
                             <p:column headerText="Date"   width="8em" style="padding: 2px!important; margin: 0px!important;">
@@ -481,6 +483,7 @@
                             </p:column>
 
                         </p:dataTable>
+
                     </p:panel>
                 </h:form>
 


### PR DESCRIPTION
## Summary
Hotfix for Southern Lanka Hospital (SLH) production. Refs #22696.

- **Laboratory Income Report**: add a "Collecting Centre" column so each bill row shows its originating collecting centre, and set an explicit `width: 2000px` on the report table so columns render correctly at the report's zoom level.
- The new column is gated behind config key `Laboratory Income Report - Show Collecting Centre Column` (default `false`), so it stays hidden unless explicitly enabled per deployment.

## Changes
1. `55c68a6` feat(report): add Collecting Centre column to laboratory income report
2. `9b84d4c` feat(report): add config option to toggle Collecting Centre column
3. `8b62380` fix(report): default Collecting Centre column config option to false

## Test plan
- [ ] Run the Laboratory Income Report and confirm the Collecting Centre column is hidden by default.
- [ ] Toggle config option `Laboratory Income Report - Show Collecting Centre Column` to `true` and confirm the column shows correct data and the table renders without layout issues.