### PR TITLE
Add Collecting Centre column to laboratory income report (config-gated)

### DIFF
--- a/src/main/webapp/reportLab/laboratary_income_report.xhtml
+++ b/src/main/webapp/reportLab/laboratary_income_report.xhtml
@@ -279,11 +279,9 @@
                             </p:commandButton>
                         </div>
 
-
-
                         <p:dataTable
                             id="tbl"
-                            style="padding: 2px!important; margin-top: 10px!important; margin: 0px!important; font-size: #{laborataryReportController.fontSizeForScreen}!important; zoom: 1.6;" 
+                            style="width: 2000px; padding: 2px!important; margin-top: 10px!important; margin: 0px!important; font-size: #{laborataryReportController.fontSizeForScreen}!important; zoom: 1.6;" 
                             styleClass="ui-datatable-borderless ui-datatable-sm compact-datatable"
                             value="#{laborataryReportController.bundle.rows}" 
                             var="row"
@@ -363,6 +361,10 @@
                             
                             <p:column headerText="BHT No" width="6em" style="padding: 2px!important; margin: 0px!important;">
                                 <h:outputText value="#{row.bhtNo}"  style="padding: 2px!important; margin: 0px!important;" ></h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Collecting Centre"  style="padding: 2px!important; margin: 0px!important;" >
+                                <h:outputText value="#{row.bill.collectingCentre.name}"  style="padding: 2px!important; margin: 0px!important;" />
                             </p:column>
 
                             <p:column headerText="Date"   width="8em" style="padding: 2px!important; margin: 0px!important;">
@@ -493,6 +495,7 @@
                             </p:column>
 
                         </p:dataTable>
+
                     </p:panel>
                 </h:form>
 

--- a/src/main/webapp/reportLab/laboratary_income_report.xhtml
+++ b/src/main/webapp/reportLab/laboratary_income_report.xhtml
@@ -363,7 +363,8 @@
                                 <h:outputText value="#{row.bhtNo}"  style="padding: 2px!important; margin: 0px!important;" ></h:outputText>
                             </p:column>
 
-                            <p:column headerText="Collecting Centre"  style="padding: 2px!important; margin: 0px!important;" >
+                            <p:column headerText="Collecting Centre"  style="padding: 2px!important; margin: 0px!important;"
+                                rendered="#{configOptionApplicationController.getBooleanValueByKey('Laboratory Income Report - Show Collecting Centre Column',true)}">
                                 <h:outputText value="#{row.bill.collectingCentre.name}"  style="padding: 2px!important; margin: 0px!important;" />
                             </p:column>
 

--- a/src/main/webapp/reportLab/laboratary_income_report.xhtml
+++ b/src/main/webapp/reportLab/laboratary_income_report.xhtml
@@ -364,7 +364,7 @@
                             </p:column>
 
                             <p:column headerText="Collecting Centre"  style="padding: 2px!important; margin: 0px!important;"
-                                rendered="#{configOptionApplicationController.getBooleanValueByKey('Laboratory Income Report - Show Collecting Centre Column',true)}">
+                                rendered="#{configOptionApplicationController.getBooleanValueByKey('Laboratory Income Report - Show Collecting Centre Column',false)}">
                                 <h:outputText value="#{row.bill.collectingCentre.name}"  style="padding: 2px!important; margin: 0px!important;" />
                             </p:column>
 


### PR DESCRIPTION
## Summary
Merge to `development` of the Laboratory Income Report change originally shipped as an SLH prod hotfix (#22696, PR #22697).

- Add a "Collecting Centre" column so each bill row shows its originating collecting centre, and set an explicit `width: 2000px` on the report table so columns render correctly at the report's zoom level.
- Gate the column behind config key `Laboratory Income Report - Show Collecting Centre Column` (default `false`), so it stays hidden unless explicitly enabled per deployment.

## Changes
Cherry-picked from `22696-slh-lab-income-report-persistence-config-hotfix`:
1. `55c68a6` feat(report): add Collecting Centre column to laboratory income report
2. `9b84d4c` feat(report): add config option to toggle Collecting Centre column
3. `8b62380` fix(report): default Collecting Centre column config option to false

Note: the persistence.xml datasource/JNDI changes from the SLH hotfix are environment-specific and intentionally not included here.

## Test plan
- [ ] Run the Laboratory Income Report and confirm the Collecting Centre column is hidden by default.
- [ ] Toggle config option `Laboratory Income Report - Show Collecting Centre Column` to `true` and confirm the column shows correct data and the table renders without layout issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional “Collecting Centre” column to the Laboratory Income Report, displaying each bill’s collecting-centre name when enabled.
  * Improved report table layout with a fixed width for better consistency.
  * Added spacing after the report table for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->