### PR TITLE
fix(pharmacy): add confirmation popup for Transfer Receive button

### DIFF
--- a/src/main/webapp/pharmacy/pharmacy_transfer_receive_native.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_receive_native.xhtml
@@ -36,6 +36,7 @@
                             class="ui-button-success mx-2"
                             action="#{transferReceiveNativeSqlController.settle}"
                             ajax="false"
+                            onclick="return confirm('Do you want to receive this transfer?');"
                             disabled="#{not webUserController.hasPrivilege('PharmacyReceiveFinalize')}">
                         </p:commandButton>
 


### PR DESCRIPTION
Adds a confirm() guard to the Receive button in
pharmacy_transfer_receive_native.xhtml so users are prompted before finalizing a transfer receive, matching the confirmation pattern used on the transfer request approval page.

Closes #20718


Claude-Session: https://claude.ai/code/session_0181394GsvmkKHWRNRB8ccMF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a confirmation prompt when selecting **Receive** for a pharmacy transfer.
  - Transfers are settled only after the action is confirmed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->