### PR TITLE
Auto-populate doctor speciality on doctor selection in professional fees

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardProfessionalBillController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardProfessionalBillController.java
@@ -545,6 +545,12 @@ public class InwardProfessionalBillController implements Serializable {
         return suggestions;
     }
 
+    public void onDoctorSelect(AjaxBehaviorEvent event) {
+        if (currentBillFee != null && currentBillFee.getStaff() != null && currentBillFee.getStaff().getSpeciality() != null) {
+            currentBillFee.setSpeciality(currentBillFee.getStaff().getSpeciality());
+        }
+    }
+
     public boolean isToClearBill() {
         return toClearBill;
     }

--- a/src/main/webapp/inward/inward_bill_professional.xhtml
+++ b/src/main/webapp/inward/inward_bill_professional.xhtml
@@ -315,7 +315,7 @@
                                                     maxResults="20"
                                                     itemLabel="#{mys.person.nameWithTitle}" 
                                                     itemValue="#{mys}">
-                                                    <f:ajax event="itemSelect" execute="scStaff" render="pIxAdd pBillDetails" />
+                                                    <f:ajax event="itemSelect" execute="scStaff" listener="#{inwardProfessionalBillController.onDoctorSelect}" render="pIxAdd pBillDetails" />
                                                     <p:column headerText="Doctor Name" style="padding: 5px;">
                                                         <h:outputLabel value="#{mys.person.nameWithTitle}" styleClass="fw-bold" />
                                                     </p:column>


### PR DESCRIPTION
## Summary
- In **Add New Professional Fees** (`inward_bill_professional.xhtml`), selecting a doctor now automatically populates the Speciality field with that doctor's speciality, instead of requiring a separate manual selection.
- Added `onDoctorSelect(AjaxBehaviorEvent)` to `InwardProfessionalBillController`, wired as the `listener` on the doctor autocomplete's `<f:ajax itemSelect>`. It copies `currentBillFee.getStaff().getSpeciality()` into `currentBillFee.setSpeciality(...)` when both are available.
- The existing `render="pIxAdd pBillDetails"` on that ajax already re-renders the panel containing the speciality autocomplete (`acSpeciality`), so no additional render target was needed.

## Test plan
- [ ] In Add New Professional Fees, select a doctor that has a speciality set and confirm the Speciality field auto-fills.
- [ ] Select a doctor with no speciality set and confirm no error occurs and the Speciality field stays as previously chosen/empty.
- [ ] Confirm manually selecting a Speciality first (which filters doctors) still works and doctor selection doesn't override an already-matching speciality unexpectedly.

Closes #20676

---
_Generated by [Claude Code](https://claude.ai/code/session_01AbM551Ger8kcbaatatGhfP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Selecting a doctor now automatically applies their specialty to the professional bill fee when available.
  - Existing bill fields continue to update as expected after selecting a doctor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->