### PR TITLE
#22578 Occupation Suggestions Not Displayed in Search Admission  

### DIFF
--- a/src/main/java/com/divudi/bean/clinical/ClinicalEntityController.java
+++ b/src/main/java/com/divudi/bean/clinical/ClinicalEntityController.java
@@ -320,4 +320,21 @@ public class ClinicalEntityController implements Serializable {
             }
         }
     }
+    
+    public List<ClinicalEntity> completeOccupation(String qry) {
+        List<ClinicalEntity> list;
+        Map m = new HashMap();
+        m.put("t", SymanticType.Employment);
+        m.put("q", "%" + qry + "%");
+        String jpql = "select c from ClinicalEntity c "
+                + " where c.retired=false "
+                + " and c.symanticType=:t "
+                + " and c.name like :q "
+                + " order by c.name";
+        list = getFacade().findByJpql(jpql, m);
+        if (list == null) {
+            list = new ArrayList<>();
+        }
+        return list;
+    }
 }

--- a/src/main/webapp/inward/inpatient_search.xhtml
+++ b/src/main/webapp/inward/inpatient_search.xhtml
@@ -187,10 +187,19 @@
 
 
                                 <p:outputLabel value="Occupation" ></p:outputLabel>
-                                <p:inputText
+                                <p:autoComplete
+                                    id="occupation"
                                     class="w-100"
-                                    value="#{admissionController.occupationForSearch}" >
-                                </p:inputText>
+                                    inputStyleClass="form-control"
+                                    value="#{admissionController.occupationForSearch}"
+                                    completeMethod="#{clinicalEntityController.completeOccupation}"
+                                    var="occ"
+                                    itemLabel="#{occ.name}"
+                                    itemValue="#{occ.name}"
+                                    placeholder="Occupation"
+                                    maxResults="15"
+                                    size="10">
+                                </p:autoComplete>
 
                                 <p:outputLabel value="Insurance Company" ></p:outputLabel>
                                 <p:selectOneMenu

--- a/src/main/webapp/inward/inpatient_search.xhtml
+++ b/src/main/webapp/inward/inpatient_search.xhtml
@@ -191,6 +191,7 @@
                                     id="occupation"
                                     class="w-100"
                                     inputStyleClass="form-control"
+                                    forceSelection="true"
                                     value="#{admissionController.occupationForSearch}"
                                     completeMethod="#{clinicalEntityController.completeOccupation}"
                                     var="occ"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added occupation autocomplete search with suggestions limited to 15 results.
  * Occupation entries now require selecting a matching option from the suggestions.
  * Search results are sorted by name and exclude retired occupations.

* **Bug Fixes**
  * Prevented invalid or unmatched occupation values from being entered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->