### PR TITLE
fix(inward): block returns and cancellations for discharged patients

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardSearch.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSearch.java
@@ -1309,6 +1309,11 @@ public class InwardSearch implements Serializable {
                 return;
             }
 
+            if (getBill().getPatientEncounter().isDischarged()) {
+                JsfUtil.addErrorMessage("Sorry, patient is discharged.");
+                return;
+            }
+
             if (checkPaid()) {
                 JsfUtil.addErrorMessage("Doctor Payment Already Paid So Cant Cancel Bill");
                 return;
@@ -1457,6 +1462,11 @@ public class InwardSearch implements Serializable {
 
             if (getBill().getPatientEncounter().isPaymentFinalized()) {
                 JsfUtil.addErrorMessage("Final Payment is Finalized You can't Cancel");
+                return;
+            }
+
+            if (getBill().getPatientEncounter().isDischarged()) {
+                JsfUtil.addErrorMessage("Sorry, patient is discharged.");
                 return;
             }
 
@@ -1929,6 +1939,10 @@ public class InwardSearch implements Serializable {
                 JsfUtil.addErrorMessage("There is some bills refering this Surgery .Cancel those bills first");
                 return;
             }
+            if (getBill().getPatientEncounter() != null && getBill().getPatientEncounter().isDischarged()) {
+                JsfUtil.addErrorMessage("Sorry, patient is discharged.");
+                return;
+            }
 
             CancelledBill cb = createCancelBill();
             //Copy & paste
@@ -2085,6 +2099,11 @@ public class InwardSearch implements Serializable {
 
             if (getBill().getPatientEncounter().isPaymentFinalized()) {
                 JsfUtil.addErrorMessage("Final Payment is Finalized You can't Cancel");
+                return;
+            }
+
+            if (getBill().getPatientEncounter().isDischarged()) {
+                JsfUtil.addErrorMessage("Sorry, patient is discharged.");
                 return;
             }
 

--- a/src/main/java/com/divudi/bean/inward/InwardSearch.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSearch.java
@@ -1409,6 +1409,11 @@ public class InwardSearch implements Serializable {
                 return;
             }
 
+            if (getBill().getPatientEncounter().isDischarged()) {
+                JsfUtil.addErrorMessage("Sorry, patient is discharged.");
+                return;
+            }
+
             if (checkPaid()) {
                 JsfUtil.addErrorMessage("Doctor Payment Already Paid So Cant Cancel Bill");
                 return;

--- a/src/main/java/com/divudi/bean/inward/InwardServiceRefundController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardServiceRefundController.java
@@ -134,6 +134,10 @@ public class InwardServiceRefundController implements Serializable {
             JsfUtil.addErrorMessage("Cannot return services: nursing discharge has been confirmed for this patient.");
             return null;
         }
+        if (bill.getPatientEncounter() != null && bill.getPatientEncounter().isDischarged()) {
+            JsfUtil.addErrorMessage("Sorry, patient is discharged.");
+            return null;
+        }
         inwardSearch.setBill(bill);
         if (!isSupportedForReturn(bill)) {
             JsfUtil.addErrorMessage("Unsupported bill type for inward service return");

--- a/src/main/java/com/divudi/bean/pharmacy/BhtIssueReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/BhtIssueReturnController.java
@@ -432,6 +432,10 @@ public class BhtIssueReturnController implements Serializable {
             JsfUtil.addErrorMessage("Cannot return medicines: nursing discharge has already been confirmed for this patient.");
             return;
         }
+        if (getBill().getPatientEncounter().isDischarged()) {
+            JsfUtil.addErrorMessage("Sorry, patient is discharged.");
+            return;
+        }
         if (getBill().getPatientEncounter().isPaymentFinalized()) {
             JsfUtil.addErrorMessage("This Bill Already Discharged");
             return;

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyReturnFromWardReceiveController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyReturnFromWardReceiveController.java
@@ -419,6 +419,11 @@ public class PharmacyReturnFromWardReceiveController implements Serializable {
             JsfUtil.addErrorMessage("This return has no carrying staff (porter) recorded - cannot receive. Please contact the returning ward.");
             return;
         }
+        if (returnedBill.getPatientEncounter() != null
+                && returnedBill.getPatientEncounter().isDischarged()) {
+            JsfUtil.addErrorMessage("Sorry, patient is discharged.");
+            return;
+        }
 
         boolean forceComplete = completed && webUserController.hasPrivilege(Privileges.PharmacyReturnFromWardForceComplete.toString());
 

--- a/src/main/java/com/divudi/bean/pharmacy/WardPharmacyReturnToPharmacyController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/WardPharmacyReturnToPharmacyController.java
@@ -516,6 +516,11 @@ public class WardPharmacyReturnToPharmacyController implements Serializable {
             JsfUtil.addErrorMessage("Select the destination pharmacy department.");
             return;
         }
+        if (selectedReceiveBill.getPatientEncounter() != null
+                && selectedReceiveBill.getPatientEncounter().isDischarged()) {
+            JsfUtil.addErrorMessage("Sorry, patient is discharged.");
+            return;
+        }
 
         List<BillItem> itemsToReturn = new ArrayList<>();
         for (ReturnLine line : getReturnLines()) {


### PR DESCRIPTION
## Summary

Direct Issue to inpatients already hard-blocks once a patient's `PatientEncounter` is discharged (`isDischarged()`), with no privilege bypass. The corresponding *return* and *cancellation* flows had no such check, so a discharged patient's already-issued medicines, surgery services, timed services, general inpatient services, and professional fees could still be returned or cancelled after discharge.

This adds the same unconditional `isDischarged()` guard (no privilege override, matching Direct Issue's existing behavior) to every patient-encounter-linked return/cancel action:

**Pharmacy returns**
- `BhtIssueReturnController.settle()` — direct-issue medicine return
- `WardPharmacyReturnToPharmacyController.settle()` / `doSettle()` — ward-to-pharmacy return
- `PharmacyReturnFromWardReceiveController.doSettle()` — pharmacy receipt of that return

**Inpatient service returns/cancellations**
- `InwardServiceRefundController.refundInwardServiceBill()` — shared return method for surgery-service, timed-service, and general inpatient service bills (all use `BillTypeAtomic.INWARD_SERVICE_BILL`)
- `InwardSearch.cancelSurgeryBill()` — surgery cancellation
- `InwardSearch.cancelBillService()` — timed/general service cancellation
- `InwardSearch.cancelProfessional()` — professional fee cancellation
- `InwardSearch.cancelTheatreProfessionalFeeBill()` — theatre-linked professional fee cancellation (also covers the call from `InwardProfessionalBillController.cancelSurgeryProfessionalFeeBill()`, which delegates here)

Out of scope: `IssueReturnController` (pharmacy disposal-issue return) is a department-level flow not tied to any `PatientEncounter`, so discharge status doesn't apply there. Professional fee bills have no partial "return" action anywhere in the codebase — only full cancellation — so only the two cancel methods needed fixing for that category.

## Test plan
- [ ] Discharge a test inpatient BHT, then attempt a direct-issue medicine return via `BhtIssueReturnController` — confirm blocked with "Sorry, patient is discharged."
- [ ] Attempt a ward-to-pharmacy return and pharmacy receipt of a return for a discharged patient — confirm both blocked
- [ ] Attempt to return/cancel a surgery service, timed service, general inpatient service item for a discharged patient — confirm blocked
- [ ] Attempt to cancel a professional fee bill (both general and theatre-linked) for a discharged patient — confirm blocked
- [ ] Confirm these same actions still succeed normally for a non-discharged patient (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented cancellation of inward, theatre, surgery, and professional bills for discharged patients.
  * Blocked service refunds and pharmacy returns involving discharged patient encounters.
  * Prevented ward pharmacy return settlements for discharged patients.
  * Added clear error messages when these actions are attempted.
  * Stopped related payment, settlement, stock movement, and return processing after validation fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->