### PR TITLE
fix(inward): refresh Admission entity before rendering edit-BHT page

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtEditController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtEditController.java
@@ -712,12 +712,20 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
             JsfUtil.addErrorMessage("No Admission to edit");
             return "";
         }
+        // Re-fetch fresh from the DB. 'current' may be a stale in-memory Admission
+        // carried over from a @SessionScoped bean (e.g. admissionController) that
+        // was loaded earlier in the session, before other flows (room edits, etc.)
+        // updated related entities such as currentPatientRoom. (Issue #20463)
+        if (current.getId() != null) {
+            current = getFacade().find(current.getId());
+        }
+
         // audit: store original details
         if (current.getId() != null) {
             originalAdmission = new HashMap<>();
             admissionToAuditMap(originalAdmission, current);
         }
-        
+
         admissionController.setCurrent(current);
         createPatientRoom();
         fillCreditCompaniesByPatient();


### PR DESCRIPTION
## Summary
- Investigated issue #20463 ("Admitted At not reflected in Interim Bill"). Confirmed `PatientRoom.admittedAt` edits already flow correctly to the Interim Bill via `BhtSummeryController.createTables()` — no bug there.
- Found the actual bug: `BhtEditController.navigateToEditAdmissionDetails()` (backing `inward_edit_bht.xhtml`) reused a stale in-memory `Admission` entity carried over from the session-scoped `AdmissionController`, so the page's own "Room Details" panel (`current.currentPatientRoom.admittedAt`) could show outdated data even after a hard reload, if the room was updated via a different page earlier in the session.
- Fix: re-fetch `current` fresh from the DB (`getFacade().find(current.getId())`) at the top of `navigateToEditAdmissionDetails()`.
- Confirmed `PatientEncounter.dateOfAdmission` and `PatientRoom.admittedAt` remain correctly independent — this fix does not introduce any propagation between them.

## Test plan
- [x] Built and redeployed locally (Maven + Payara)
- [x] Playwright: edited `PatientRoom.admittedAt` on `inward_patient_room_details.xhtml` (19:35 → 17:35), confirmed DB updated
- [x] Playwright: navigated to `inward_edit_bht.xhtml` — **before fix**, Room Details panel showed stale 19:35 even after hard reload; **after fix**, correctly shows 17:35
- [x] Playwright: edited `dateOfAdmission` on `inward_edit_bht.xhtml` and saved — confirmed `dateOfAdmission`/`printingAdmissionTime` update, and `PatientRoom.admittedAt` remains untouched (fields stay independent)
- [x] Verified DB state directly via MySQL after each step
- [x] Screenshots and full verification comment posted to issue #20463

Closes #20463

🤖 Generated with [Claude Code](https://claude.com/claude-code)