### PR TITLE
feat(inward): warn when settling discharge with unchecked inward bills

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -3198,6 +3198,18 @@ public class BhtSummeryController implements Serializable {
         return false;
     }
 
+    private boolean hasAnyUncheckedInwardBills() {
+        return getInwardBean().checkByBillFee(getPatientEncounter(), new BilledBill(), BillType.InwardBill)
+                || getInwardBean().checkByBillFee(getPatientEncounter(), new BilledBill(), BillType.InwardProfessional)
+                || getInwardBean().checkByBillItem(getPatientEncounter(), new PreBill(), BillType.PharmacyBhtPre)
+                || getInwardBean().checkByBillItem(getPatientEncounter(), new RefundBill(), BillType.PharmacyBhtPre)
+                || getInwardBean().checkByBillItem(getPatientEncounter(), new PreBill(), BillType.StoreBhtPre)
+                || getInwardBean().checkByBillItem(getPatientEncounter(), new RefundBill(), BillType.StoreBhtPre)
+                || getInwardBean().checkByBillItem(getPatientEncounter(), new BilledBill(), BillType.InwardOutSideBill)
+                || getInwardBean().checkByBillItem(getPatientEncounter(), new BilledBill(), BillType.InwardPaymentBill)
+                || getInwardBean().checkByBillItem(getPatientEncounter(), new RefundBill(), BillType.InwardPaymentBill);
+    }
+
     public String toSettle() {
 
         if (getPatientEncounter() == null) {
@@ -3224,10 +3236,18 @@ public class BhtSummeryController implements Serializable {
         System.out.println("Option = " + configOptionApplicationController.getBooleanValueByKey("Need to check inward bills before discharge"));
 
         System.out.println("Starting Bills Checking Process.... ");
-        if (getPatientEncounter().getAdmissionType().getAdmissionTypeEnum() == AdmissionTypeEnum.Admission && !getWebUserController().hasPrivilege("InwardBillSettleWithoutCheck")) {
-            System.out.println("Checking.... ---> ");
-            if (checkBill()) {
-                return "";
+        if (getPatientEncounter().getAdmissionType().getAdmissionTypeEnum() == AdmissionTypeEnum.Admission) {
+            if (!getWebUserController().hasPrivilege("InwardBillSettleWithoutCheck")) {
+                System.out.println("Checking.... ---> ");
+                if (checkBill()) {
+                    return "";
+                }
+            } else if (!configOptionApplicationController.getBooleanValueByKey("Need to check inward bills before discharge")
+                    && hasAnyUncheckedInwardBills()) {
+                JsfUtil.addWarningMessage("Settling with unchecked Inward Service / Professional / Pharmacy / Store / Payment bills. "
+                        + "Proceeding because you hold the 'Inward Bill Settle Without Check' privilege.");
+            } else {
+                System.out.println("Ignore Checking.... ---> ");
             }
         } else {
             System.out.println("Ignore Checking.... ---> ");


### PR DESCRIPTION
## Summary

Recovered from an in-progress session whose uncommitted work was left in this checkout. Verified it does not already exist on `development` and compiles cleanly.

Users holding the `InwardBillSettleWithoutCheck` privilege currently bypass the discharge bill-checking step (`checkBill()`) entirely and silently - no indication is given that Inward Service, Professional, Pharmacy, Store, or Payment bills for the encounter were never checked.

This adds `hasAnyUncheckedInwardBills()` to detect any such unchecked bill on the encounter, and surfaces a warning message on settle when:
- the user holds `InwardBillSettleWithoutCheck` (so the normal check was skipped), AND
- the `"Need to check inward bills before discharge"` config option is disabled, AND
- at least one unchecked bill is actually present

This keeps the privileged bypass functionally unchanged but makes it visible instead of silent.

## Test plan
- [ ] As a user without `InwardBillSettleWithoutCheck`: settle/discharge behaves as before (full bill check enforced)
- [ ] As a user with `InwardBillSettleWithoutCheck`, with `"Need to check inward bills before discharge"` disabled, and at least one unchecked Inward Service/Professional/Pharmacy/Store/Payment bill: settling now shows the warning message and still proceeds
- [ ] Same privileged user with all relevant bills already checked: settles with no warning (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)