### PR TITLE
Make credit company limit optional in allocation logic

### DIFF
--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -489,10 +489,6 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
     }
 
     public void addCreditCompnay() {
-        if (encounterCreditCompany.getCreditLimit() <= 0) {
-            JsfUtil.addErrorMessage("Credit limit must be greater than zero");
-            return;
-        }
         if (encounterCreditCompany.getInstitution() != null) {
             encounterCreditCompany.setPatientEncounter(current);
             encounterCreditCompanies.add(encounterCreditCompany);

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -2547,11 +2547,17 @@ public class BhtSummeryController implements Serializable {
         updateTotal();
         Double due = netTotal - (paidByCompany + paidByPatient);
         List<EncounterCreditCompany> encounterCreditCompanys = fillCreditCompaniesByPatient(patientEncounter);
-        for (EncounterCreditCompany ecc : encounterCreditCompanys) {
+        for (int i = 0; i < encounterCreditCompanys.size(); i++) {
+            EncounterCreditCompany ecc = encounterCreditCompanys.get(i);
             if (due > 0) {
-                if (due > ecc.getCreditLimit()) {
-                    saveCreditBillForCreditCompany(patientEncounter, ecc, ecc.getCreditLimit());
-                    due = due - ecc.getCreditLimit();
+                boolean isLastCompany = i == encounterCreditCompanys.size() - 1;
+                // Credit limit is a guide for splitting across multiple companies, not a
+                // hard cap: the last company (or the only one, the common case) always
+                // takes whatever due remains rather than leaving it unallocated.
+                double cap = (!isLastCompany && ecc.getCreditLimit() > 0) ? ecc.getCreditLimit() : due;
+                if (due > cap) {
+                    saveCreditBillForCreditCompany(patientEncounter, ecc, cap);
+                    due = due - cap;
                 } else {
                     saveCreditBillForCreditCompany(patientEncounter, ecc, due);
                     due = due - due;
@@ -2624,9 +2630,12 @@ public class BhtSummeryController implements Serializable {
                     Comparator.nullsLast(Comparator.naturalOrder())));
             // Every registered company gets a row (0.00 when the due is already
             // covered) so the cashier can redistribute freely. Auto-split honours
-            // each company's credit limit; manual edits afterwards are not capped.
+            // each company's credit limit as a guide when one is recorded (>0);
+            // an unset/zero limit (now optional) is treated as no cap rather than
+            // always suggesting 0. Manual edits afterwards are not capped either way.
             for (EncounterCreditCompany ecc : eccs) {
-                double alloc = Math.min(Math.max(0.0, remaining), ecc.getCreditLimit());
+                double cap = ecc.getCreditLimit() > 0 ? ecc.getCreditLimit() : remaining;
+                double alloc = Math.min(Math.max(0.0, remaining), cap);
                 creditCompanyAllocations.add(new CreditCompanyAllocation(ecc, alloc));
                 remaining -= alloc;
             }
@@ -2708,10 +2717,6 @@ public class BhtSummeryController implements Serializable {
             JsfUtil.addErrorMessage("Please select a credit company");
             return false;
         }
-        if (newEncounterCreditCompany.getCreditLimit() <= 0) {
-            JsfUtil.addErrorMessage("Please enter a credit limit greater than zero");
-            return false;
-        }
         if (creditCompanyAllocations == null) {
             creditCompanyAllocations = new ArrayList<>();
         }
@@ -2748,7 +2753,13 @@ public class BhtSummeryController implements Serializable {
                 ccSum += alloc.getAllocatedAmount();
             }
         }
-        double allocatable = Math.max(0.0, Math.min(expected - ccSum, newEncounterCreditCompany.getCreditLimit()));
+        double remainingDue = expected - ccSum;
+        // Suggested amount only — the cashier can raise it further in the allocation
+        // table (checkCreditAllocationTotal doesn't cap by credit limit). A recorded
+        // limit (>0) is used as the suggestion cap; an optional/unset limit suggests
+        // the full remaining due instead of always defaulting to 0.
+        double cap = newEncounterCreditCompany.getCreditLimit() > 0 ? newEncounterCreditCompany.getCreditLimit() : remainingDue;
+        double allocatable = Math.max(0.0, Math.min(remainingDue, cap));
         creditCompanyAllocations.add(new CreditCompanyAllocation(newEncounterCreditCompany, allocatable));
         moveCompanyRowsAbovePatientRow();
         recalculatePatientPortion();


### PR DESCRIPTION
## Summary
Refactors credit company allocation logic to treat credit limits as optional guidance rather than hard requirements. When a credit limit is unset or zero, the system now allocates the full remaining due instead of defaulting to zero. This allows more flexible credit company management while maintaining backward compatibility for companies with explicit limits.

## Key Changes
- **BhtSummeryController.createCreditBillForCreditCompany()**: Changed loop to index-based iteration to identify the last company. The last company (or only company) now always receives whatever due remains, while intermediate companies are capped by their credit limit if set (>0).
- **BhtSummeryController.populateCreditCompanyAllocations()**: Updated allocation calculation to use credit limit as a cap only when explicitly set (>0); otherwise uses remaining due as the cap.
- **BhtSummeryController.addNewCreditCompanyInternal()**: Removed validation requiring credit limit > 0. Updated suggested allocation logic to respect the same optional-limit pattern: use credit limit as cap if set, otherwise suggest full remaining due.
- **AdmissionController.addCreditCompnay()**: Removed validation requiring credit limit > 0, allowing credit companies to be added without a pre-set limit.

## Implementation Details
- Credit limits now function as allocation guides during auto-split, not hard caps. Manual edits in the allocation table remain uncapped in either case.
- The last credit company in a list always receives the full remaining due, preventing unallocated balances.
- Zero or unset credit limits are treated identically (no cap), making the limit field truly optional.
- Comments added to clarify the new behavior for future maintainers.

https://claude.ai/code/session_019zhrcThVHTmMXHpEK3DmhL