### PR TITLE
fix(ci): undeploy stale ruhunuLocal registration before local staging redeploy

### DIFF
--- a/.github/workflows/ruhunu_local_server_ci_cd.yml
+++ b/.github/workflows/ruhunu_local_server_ci_cd.yml
@@ -148,6 +148,9 @@ jobs:
           rm -rf "$PAYARA_DOMAIN/applications/$APP_NAME"
           rm -rf "$PAYARA_DOMAIN/generated/xml/$APP_NAME"
           rm -rf "$PAYARA_DOMAIN/generated/jsp/$APP_NAME"
+          rm -rf "$PAYARA_DOMAIN/generated/ejb/$APP_NAME"
+          rm -rf "$PAYARA_DOMAIN/generated/altdd/$APP_NAME"
+          rm -rf "$PAYARA_DOMAIN/generated/policy/$APP_NAME"
 
           echo "=== Starting Payara domain ==="
           "$ASADMIN" start-domain
@@ -158,7 +161,26 @@ jobs:
           chmod 600 "$PASS_FILE"
 
           echo "=== Payara: registered applications ==="
-          "$ASADMIN" --user admin --passwordfile "$PASS_FILE" list-applications || true
+          REGISTERED_APPS=$("$ASADMIN" --user admin --passwordfile "$PASS_FILE" list-applications 2>&1) || true
+          echo "$REGISTERED_APPS"
+
+          # -----------------------------------------------------------------------
+          # Deleting the exploded application/generated directories above does NOT
+          # remove the <application> entry from domain.xml. If a previous run died
+          # after start-domain but before (or during) deploy, domain.xml still
+          # thinks $APP_NAME is registered, its backing directory is now gone, and
+          # every subsequent deploy fails with "Application with name $APP_NAME is
+          # already registered" (confirmed in Payara's server.log and in the
+          # failed GitHub Actions deploy logs). Since this is a fresh JVM
+          # that has not successfully started the app (no live EJB timers to
+          # corrupt — that was the failure mode this whole restart dance exists to
+          # avoid), it's safe to undeploy the stale registration here before
+          # redeploying.
+          # -----------------------------------------------------------------------
+          if echo "$REGISTERED_APPS" | grep -q "^$APP_NAME "; then
+            echo "=== $APP_NAME already registered in domain.xml — undeploying stale entry before redeploy ==="
+            "$ASADMIN" --user admin --passwordfile "$PASS_FILE" undeploy "$APP_NAME" || true
+          fi
 
           echo "=== Payara: JDBC resources ==="
           "$ASADMIN" --user admin --passwordfile "$PASS_FILE" list-jdbc-resources || true
@@ -168,7 +190,7 @@ jobs:
 
           DEPLOY_EXIT=0
           "$ASADMIN" --user admin --passwordfile "$PASS_FILE" \
-            deploy --contextroot "$CONTEXT_PATH" --name "$APP_NAME" \
+            deploy --force=true --contextroot "$CONTEXT_PATH" --name "$APP_NAME" \
             "$WAR_DIR/$WAR_NAME" || DEPLOY_EXIT=$?
 
           if [ "$DEPLOY_EXIT" -ne 0 ]; then


### PR DESCRIPTION
## Summary
- The `rh-local-staging` deploy job stops Payara, deletes `ruhunuLocal`'s exploded `applications/`/`generated/*` directories, restarts the domain, and redeploys — but deleting those directories never clears the `<application>` entry in `domain.xml`.
- Once a run leaves that stale registration behind, every subsequent restart logs `Application previously deployed is not at its original location any more`, and every subsequent deploy fails with `Application with name ruhunuLocal is already registered` — confirmed in `server.log` on the staging box and in the logs of the failed Actions run (`rh ls (#22715)`, job "Deploy to Payara").
- This has been failing on every push to `rh-local-staging` today.

## Fix
- After the fresh domain restart, check `list-applications`; if `ruhunuLocal` is still registered, `undeploy` it before attempting the new deploy. This is safe here because it's a freshly-started JVM with no live EJB timers yet (the scenario the existing stop/wipe/restart dance was written to avoid).
- Also clean up `generated/ejb`, `generated/altdd`, `generated/policy` for the app (previously only `applications`, `generated/xml`, `generated/jsp` were wiped).
- Pass `--force=true` on the deploy as a second safety net.

## Test plan
- [ ] Push to `rh-local-staging` (or merge into it) and confirm the `deploy` job succeeds and the app comes up at `http://<server>:8010/rhLocal/faces/index1.xhtml`.
- [ ] Confirm `server.log` no longer shows `already registered` / `not at its original location` on the next few deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment reliability by removing stale generated artifacts before restart.
  * Automatically removes outdated application registrations when detected.
  * Forces deployment updates to ensure the latest version is applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->