### PR TITLE
Issue #22719: Explicit appointment deposit conversion on admission

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -1553,8 +1553,11 @@ While testing issue #22719 (appointment → admission → deposit conversion), t
     that widget only *computes* a DOB client-side via a JS listener that a
     plain `fill()`/`pressSequentially()` doesn't reliably trigger. Set the
     **Date of Birth** `p:calendar` field directly instead (click → Ctrl+A →
-    type `dd/mm/yyyy` → Escape → Save) and verify `SELECT DOB FROM person` is
-    non-NULL before retrying the admission.
+    type `dd/mm/yyyy` → Escape → Save) and verify
+    `SELECT DOB FROM person WHERE ID = (SELECT PERSON_ID FROM patient WHERE ID = <patientId>)`
+    returns a non-NULL row for the specific patient under test before
+    retrying the admission — an unfiltered `SELECT DOB FROM person` returns
+    every patient in the DB and can't confirm the one that matters.
   - To find *which* config key is blocking an error message with no field
     reference, `grep` the exact error string in
     `src/main/java/com/divudi/bean/inward/AdmissionController.java` to find

--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -1530,6 +1530,42 @@ respectively. If a specific admission seems "missing" from one tab, search by
 the label that tab actually renders (BHT number on the BHT tab, room name on
 the Rooms tab), not by patient name — neither tab's buttons show it.
 
+## 58. `inward_admission.xhtml` Room No autocomplete excludes the room already reserved by the very appointment being admitted; a required-config error can look like a blocked flow
+
+While testing issue #22719 (appointment → admission → deposit conversion), two admission-form gotchas surfaced together:
+
+- **Room No autocomplete only lists currently-*available* rooms** — a room
+  already reserved for the appointment/patient being admitted (e.g. via the
+  appointment's own `Reservation`) does **not** appear in the completion list,
+  even though it's "theirs." Typing the exact room number/name returns "No
+  results found." This isn't a bug in the flow under test — just pick any
+  other available room from the list (e.g. `Room 410` instead of the
+  originally-reserved `Room 101`) to proceed; the room shown on the
+  reservation and the room picked at admission time are independent fields.
+- **A hidden `ConfigOption` boolean can block the whole Admit action with no
+  visual hint on the form.** `AdmissionController` checks
+  `"Patient Age is Required in Patient Admission"` (default `false`, but was
+  `true` on this Galle Co-op local dev DB) and rejects with "Patient Age is
+  Required" if the patient has no DOB — the message doesn't say which field
+  or where to fix it. Two related traps while fixing it:
+  - Typing into the **Years/Months/Days** age inputs on `patient_edit.xhtml`
+    looks like it commits (`textbox "Years": "30"`) but doesn't persist a DOB —
+    that widget only *computes* a DOB client-side via a JS listener that a
+    plain `fill()`/`pressSequentially()` doesn't reliably trigger. Set the
+    **Date of Birth** `p:calendar` field directly instead (click → Ctrl+A →
+    type `dd/mm/yyyy` → Escape → Save) and verify `SELECT DOB FROM person` is
+    non-NULL before retrying the admission.
+  - To find *which* config key is blocking an error message with no field
+    reference, `grep` the exact error string in
+    `src/main/java/com/divudi/bean/inward/AdmissionController.java` to find
+    the `configOptionApplicationController.getBooleanValueByKey("...")` call,
+    then toggle it via **Admin → Manage → Application Options → List
+    Application Options → filter by key → Edit Option** (per §26 — never via
+    raw SQL, the L2 cache won't see it). If you flip a real setting to unblock
+    a test, **toggle it back afterward** and confirm via
+    `SELECT OPTIONVALUE FROM configoption WHERE OPTIONKEY = '...'` — this is
+    live config on a real hospital's local dev copy, not disposable test data.
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.

--- a/src/main/java/com/divudi/bean/common/AppointmentController.java
+++ b/src/main/java/com/divudi/bean/common/AppointmentController.java
@@ -900,6 +900,10 @@ public class AppointmentController implements Serializable, ControllerWithPatien
     }
 
     private Bill saveCacelBill(Bill originalBill) {
+        return saveCacelBill(originalBill, comment);
+    }
+
+    private Bill saveCacelBill(Bill originalBill, String comments) {
         Bill newCancelBill = new Bill();
 
         newCancelBill.copy(originalBill);
@@ -915,7 +919,7 @@ public class AppointmentController implements Serializable, ControllerWithPatien
         newCancelBill.setReferenceBill(originalBill);
         newCancelBill.setBillDate(new Date());
         newCancelBill.setBillTime(new Date());
-        newCancelBill.setComments(comment);
+        newCancelBill.setComments(comments);
 
         newCancelBill.setCreatedAt(new Date());
         newCancelBill.setCreater(sessionController.getLoggedUser());
@@ -947,10 +951,13 @@ public class AppointmentController implements Serializable, ControllerWithPatien
      * other controllers with an explicit bill/appointment instead of relying
      * on this bean's page-scoped currentBill/currentAppointment/comment
      * state. Used by the Inward appointment-to-admission deposit conversion
-     * flow (issue #22719).
+     * flow (issue #22719). Unlike {@link #cancelAppointment()}, this passes
+     * {@code reason} straight through as the cancel bill's comment instead of
+     * reading the page-scoped {@code comment} field, which may be stale or
+     * unrelated when this bean's session is reused across pages.
      */
     public Bill cancelAppointmentBillForConversion(Bill originalBill, Appointment apt, String reason) {
-        Bill cancelBill = saveCacelBill(originalBill);
+        Bill cancelBill = saveCacelBill(originalBill, reason);
         cancelAppointment(cancelBill, apt, reason);
         createCancelPayments(originalBill, cancelBill);
         return cancelBill;

--- a/src/main/java/com/divudi/bean/common/AppointmentController.java
+++ b/src/main/java/com/divudi/bean/common/AppointmentController.java
@@ -939,6 +939,23 @@ public class AppointmentController implements Serializable, ControllerWithPatien
         return newCancelBill;
     }
 
+    /**
+     * Cancels an appointment bill using the same cancel-bill pattern as
+     * {@link #cancelAppointment()} — creates an INWARD_APPOINTMENT_CANCEL_BILL
+     * with inverted value referencing the original bill, marks the original
+     * bill cancelled, and clones/inverts its payments — but callable from
+     * other controllers with an explicit bill/appointment instead of relying
+     * on this bean's page-scoped currentBill/currentAppointment/comment
+     * state. Used by the Inward appointment-to-admission deposit conversion
+     * flow (issue #22719).
+     */
+    public Bill cancelAppointmentBillForConversion(Bill originalBill, Appointment apt, String reason) {
+        Bill cancelBill = saveCacelBill(originalBill);
+        cancelAppointment(cancelBill, apt, reason);
+        createCancelPayments(originalBill, cancelBill);
+        return cancelBill;
+    }
+
     public void cancelAppointment() {
         if (comment == null || comment.trim().isEmpty()) {
             JsfUtil.addErrorMessage("No Comment Selected.");

--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -9,6 +9,7 @@
 package com.divudi.bean.inward;
 
 import com.divudi.bean.common.AppointmentController;
+import com.divudi.bean.common.BillSearch;
 import com.divudi.bean.common.ClinicalFindingValueController;
 import com.divudi.bean.common.ConfigOptionApplicationController;
 import com.divudi.bean.common.ConfigOptionController;
@@ -24,6 +25,7 @@ import com.divudi.core.data.admin.PageMetadata;
 
 import com.divudi.core.data.ApplicationInstitution;
 import com.divudi.core.data.PaymentMethod;
+import com.divudi.core.data.dataStructure.ComponentDetail;
 import com.divudi.core.data.dataStructure.PaymentMethodData;
 import com.divudi.core.data.dataStructure.YearMonthDay;
 import com.divudi.core.data.inward.AdmissionStatus;
@@ -32,6 +34,7 @@ import com.divudi.core.data.inward.AdmissionTypeEnum;
 import com.divudi.core.entity.Appointment;
 import com.divudi.core.entity.Bill;
 import com.divudi.core.entity.Doctor;
+import com.divudi.core.entity.Payment;
 import com.divudi.core.entity.EncounterCreditCompany;
 import com.divudi.core.entity.Institution;
 import com.divudi.core.entity.Patient;
@@ -167,6 +170,8 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
     ClinicalFindingValueController clinicalFindingValueController;
     @Inject
     AppointmentController appointmentController;
+    @Inject
+    BillSearch billSearch;
     @Inject
     private ConfigOptionController configOptionController;
     @Inject
@@ -2426,6 +2431,10 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         PaymentMethod appointmentPaymentMethod = originalBill.getPaymentMethod() != null
                 ? originalBill.getPaymentMethod()
                 : getCurrent().getPaymentMethod();
+        PaymentMethodData conversionPaymentMethodData = buildPaymentMethodDataFromOriginalPayment(originalBill, appointmentPaymentMethod, amount);
+        if (conversionPaymentMethodData != null) {
+            getInwardPaymentController().setPaymentMethodData(conversionPaymentMethodData);
+        }
         getInwardPaymentController().setPaymentMethod(appointmentPaymentMethod);
         getInwardPaymentController().getCurrent().setPaymentMethod(appointmentPaymentMethod);
         getInwardPaymentController().getCurrent().setPatientEncounter(current);
@@ -2435,6 +2444,79 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
 
         pendingAppointmentConversion = null;
         JsfUtil.addSuccessMessage("Appointment deposit converted to Inward Deposit.");
+    }
+
+    /**
+     * Builds the {@link PaymentMethodData} needed by
+     * {@link InwardPaymentController#pay()} so the new Inward Deposit
+     * carries the same bank/cheque/reference details as the original
+     * appointment deposit payment — e.g. a cheque given as "Sampath Bank
+     * 1134" for the appointment must produce a new deposit payment that
+     * also reads "Sampath Bank 1134", not just the same amount and payment
+     * method. Returns {@code null} for {@code Cash} (no extra data needed)
+     * and for methods with no original {@link Payment} row to copy from.
+     * {@code PatientDeposit} is intentionally not handled here — reversing
+     * and re-consuming deposit balance correctly needs its own dedicated
+     * fix and was already unsupported by this conversion flow before this
+     * method existed.
+     */
+    private PaymentMethodData buildPaymentMethodDataFromOriginalPayment(Bill originalBill, PaymentMethod method, double amount) {
+        if (method == null || method == PaymentMethod.Cash) {
+            return null;
+        }
+        List<Payment> originalPayments = billSearch.fetchBillPayments(originalBill);
+        if (originalPayments == null || originalPayments.isEmpty()) {
+            return null;
+        }
+        Payment original = originalPayments.get(0);
+
+        PaymentMethodData pmd = new PaymentMethodData();
+        ComponentDetail cd;
+        switch (method) {
+            case Card:
+                cd = pmd.getCreditCard();
+                cd.setInstitution(original.getBank());
+                cd.setNo(original.getCreditCardRefNo());
+                cd.setComment(original.getComments());
+                cd.setTotalValue(amount);
+                break;
+            case Cheque:
+                cd = pmd.getCheque();
+                cd.setInstitution(original.getBank());
+                cd.setNo(original.getChequeRefNo());
+                cd.setDate(original.getChequeDate());
+                cd.setComment(original.getComments());
+                cd.setTotalValue(amount);
+                break;
+            case Slip:
+                cd = pmd.getSlip();
+                cd.setInstitution(original.getBank());
+                cd.setDate(original.getChequeDate() != null ? original.getChequeDate() : original.getPaymentDate());
+                cd.setReferenceNo(original.getReferenceNo());
+                cd.setComment(original.getComments());
+                cd.setTotalValue(amount);
+                break;
+            case ewallet:
+                cd = pmd.getEwallet();
+                cd.setInstitution(original.getBank());
+                cd.setReferenceNo(original.getReferenceNo());
+                cd.setReferralNo(original.getPolicyNo());
+                cd.setComment(original.getComments());
+                cd.setTotalValue(amount);
+                break;
+            case OnlineSettlement:
+                cd = pmd.getOnlineSettlement();
+                cd.setInstitution(original.getBank());
+                cd.setReferenceNo(original.getReferenceNo());
+                cd.setDate(original.getPaymentDate());
+                cd.setComment(original.getComments());
+                cd.setTotalValue(amount);
+                break;
+            default:
+                return null;
+        }
+        pmd.setPaymentMethod(method);
+        return pmd;
     }
     // </editor-fold>
 

--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -2369,6 +2369,10 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
     }
 
     public String navigateToAppointmentDepositConversion() {
+        if (!webUserController.hasPrivilege("InwardEditPaymentDetails")) {
+            JsfUtil.addErrorMessage("You are not authorized to convert appointment deposits.");
+            return "";
+        }
         if (current == null) {
             JsfUtil.addErrorMessage("No Admission Selected");
             return "";
@@ -2391,10 +2395,26 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
      * user-triggered instead of silent (issue #22719).
      */
     public void convertAppointmentDepositToInwardDeposit() {
+        if (!webUserController.hasPrivilege("InwardEditPaymentDetails")) {
+            JsfUtil.addErrorMessage("You are not authorized to convert appointment deposits.");
+            return;
+        }
         if (pendingAppointmentConversion == null || pendingAppointmentConversion.getBill() == null) {
             JsfUtil.addErrorMessage("No appointment deposit to convert.");
             return;
         }
+        // Re-validate against the current admission and re-check cancellation
+        // status right before acting: current is @SessionScoped and could have
+        // changed in another tab, and this also rejects a second click on an
+        // already-converted deposit (its bill.cancelled is now true, so it no
+        // longer matches).
+        Appointment revalidated = findPendingAppointmentDepositConversion(current);
+        if (revalidated == null || !revalidated.getId().equals(pendingAppointmentConversion.getId())) {
+            JsfUtil.addErrorMessage("This appointment deposit conversion is no longer valid for the current admission. Please retry from the dashboard.");
+            pendingAppointmentConversion = null;
+            return;
+        }
+        pendingAppointmentConversion = revalidated;
         Bill originalBill = pendingAppointmentConversion.getBill();
         double amount = originalBill.getTotal();
 

--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -2324,11 +2324,99 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
 
     }
 
-    private void updateAppointmentBill() {
-        getAppointmentBill().setRefunded(true);
-        getBillFacade().edit(getAppointmentBill());
+    // <editor-fold defaultstate="collapsed" desc="Appointment Deposit Conversion (Issue #22719)">
+    /**
+     * The appointment (linked via {@link Appointment#getPatientEncounter()})
+     * whose deposit bill is pending conversion into an Inward Deposit for the
+     * current admission. Populated by {@link #navigateToAppointmentDepositConversion()}.
+     */
+    private Appointment pendingAppointmentConversion;
 
+    public Appointment getPendingAppointmentConversion() {
+        return pendingAppointmentConversion;
     }
+
+    /**
+     * Finds the appointment linked to this admission (via
+     * {@code Appointment.patientEncounter}, set by {@link #updateAppointment()}
+     * at admission time) whose bill is still an un-cancelled
+     * INWARD_APPOINTMENT_BILL — i.e. its deposit has not yet been converted
+     * into an Inward Deposit for this admission.
+     */
+    private Appointment findPendingAppointmentDepositConversion(PatientEncounter enc) {
+        if (enc == null || enc.getId() == null) {
+            return null;
+        }
+        String jpql = "select a from Appointment a "
+                + " where a.retired = false "
+                + " and a.patientEncounter = :enc "
+                + " and a.bill is not null "
+                + " and a.bill.billTypeAtomic = :bta "
+                + " and a.bill.cancelled = false ";
+        HashMap<String, Object> m = new HashMap<>();
+        m.put("enc", enc);
+        m.put("bta", BillTypeAtomic.INWARD_APPOINTMENT_BILL);
+        return getAppointmentFacade().findFirstByJpql(jpql, m);
+    }
+
+    /**
+     * Drives the Inpatient Dashboard warning banner — true when this
+     * admission has an appointment deposit that has not yet been converted
+     * into an Inward Deposit.
+     */
+    public boolean isHasPendingAppointmentDepositConversion() {
+        return findPendingAppointmentDepositConversion(current) != null;
+    }
+
+    public String navigateToAppointmentDepositConversion() {
+        if (current == null) {
+            JsfUtil.addErrorMessage("No Admission Selected");
+            return "";
+        }
+        pendingAppointmentConversion = findPendingAppointmentDepositConversion(current);
+        if (pendingAppointmentConversion == null) {
+            JsfUtil.addErrorMessage("No pending appointment deposit found for this admission.");
+            return "";
+        }
+        return "/inward/appointment_deposit_conversion?faces-redirect=true";
+    }
+
+    /**
+     * Converts the linked appointment's deposit into this admission's Inward
+     * Deposit: properly cancels the original INWARD_APPOINTMENT_BILL (via
+     * {@link AppointmentController#cancelAppointmentBillForConversion}, the
+     * same cancel-bill pattern used by {@code AppointmentController.cancelAppointment()})
+     * and then creates a new INWARD_DEPOSIT bill for the same amount — same
+     * re-pay call the old auto-conversion used, just now explicit and
+     * user-triggered instead of silent (issue #22719).
+     */
+    public void convertAppointmentDepositToInwardDeposit() {
+        if (pendingAppointmentConversion == null || pendingAppointmentConversion.getBill() == null) {
+            JsfUtil.addErrorMessage("No appointment deposit to convert.");
+            return;
+        }
+        Bill originalBill = pendingAppointmentConversion.getBill();
+        double amount = originalBill.getTotal();
+
+        appointmentController.cancelAppointmentBillForConversion(
+                originalBill,
+                pendingAppointmentConversion,
+                "Converted to Inward Deposit on Admission — BHT " + getCurrent().getBhtNo());
+
+        PaymentMethod appointmentPaymentMethod = originalBill.getPaymentMethod() != null
+                ? originalBill.getPaymentMethod()
+                : getCurrent().getPaymentMethod();
+        getInwardPaymentController().setPaymentMethod(appointmentPaymentMethod);
+        getInwardPaymentController().getCurrent().setPaymentMethod(appointmentPaymentMethod);
+        getInwardPaymentController().getCurrent().setPatientEncounter(current);
+        getInwardPaymentController().getCurrent().setTotal(amount);
+        getInwardPaymentController().pay();
+        getInwardPaymentController().makeNull();
+
+        pendingAppointmentConversion = null;
+        JsfUtil.addSuccessMessage("Appointment deposit converted to Inward Deposit.");
+    }
+    // </editor-fold>
 
     public void listnerForAppoimentSelect(Bill ap) {
         if (ap == null) {
@@ -2812,23 +2900,16 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
 
         getFacade().edit(getCurrent());
 
-        double appointmentFee = 0;
+        // Issue #22719: Do NOT auto re-pay the appointment fee as a new Inward
+        // Deposit here — that silently duplicated the payment (the appointment
+        // bill was only ever flagged refunded=true, not properly cancelled, so
+        // nothing offset the original INWARD_APPOINTMENT_BILL). Just link the
+        // appointment to the new encounter; converting the appointment deposit
+        // into an Inward Deposit is now an explicit, user-triggered action from
+        // the Inpatient Dashboard (see navigateToAppointmentDepositConversion /
+        // convertAppointmentDepositToInwardDeposit).
         if (getAppointmentBill() != null) {
-            appointmentFee = getAppointmentBill().getTotal();
             updateAppointment();
-            updateAppointmentBill();
-        }
-
-        if (appointmentFee != 0) {
-            PaymentMethod appointmentPaymentMethod = getAppointmentBill().getPaymentMethod() != null
-                    ? getAppointmentBill().getPaymentMethod()
-                    : getCurrent().getPaymentMethod();
-            getInwardPaymentController().setPaymentMethod(appointmentPaymentMethod);
-            getInwardPaymentController().getCurrent().setPaymentMethod(appointmentPaymentMethod);
-            getInwardPaymentController().getCurrent().setPatientEncounter(current);
-            getInwardPaymentController().getCurrent().setTotal(appointmentFee);
-            getInwardPaymentController().pay();
-            getInwardPaymentController().makeNull();
         }
 
         saveEncounterCreditCompanies(current);
@@ -2904,23 +2985,12 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
 
         getFacade().edit(getCurrent());
 
-        double appointmentFee = 0;
+        // Issue #22719: see saveSelected() above — the automatic re-pay/refunded
+        // flow was silently duplicating the appointment deposit. Only link the
+        // appointment to the new encounter here; the deposit conversion is now
+        // an explicit action from the Inpatient Dashboard.
         if (getAppointmentBill() != null) {
-            appointmentFee = getAppointmentBill().getTotal();
             updateAppointment();
-            updateAppointmentBill();
-        }
-
-        if (appointmentFee != 0) {
-            PaymentMethod appointmentPaymentMethod = getAppointmentBill().getPaymentMethod() != null
-                    ? getAppointmentBill().getPaymentMethod()
-                    : getCurrent().getPaymentMethod();
-            getInwardPaymentController().setPaymentMethod(appointmentPaymentMethod);
-            getInwardPaymentController().getCurrent().setPaymentMethod(appointmentPaymentMethod);
-            getInwardPaymentController().getCurrent().setPatientEncounter(current);
-            getInwardPaymentController().getCurrent().setTotal(appointmentFee);
-            getInwardPaymentController().pay();
-            getInwardPaymentController().makeNull();
         }
 
         saveEncounterCreditCompanies(current);

--- a/src/main/java/com/divudi/bean/inward/InwardProfessionalBillController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardProfessionalBillController.java
@@ -545,6 +545,12 @@ public class InwardProfessionalBillController implements Serializable {
         return suggestions;
     }
 
+    public void onDoctorSelect(AjaxBehaviorEvent event) {
+        if (currentBillFee != null && currentBillFee.getStaff() != null && currentBillFee.getStaff().getSpeciality() != null) {
+            currentBillFee.setSpeciality(currentBillFee.getStaff().getSpeciality());
+        }
+    }
+
     public boolean isToClearBill() {
         return toClearBill;
     }

--- a/src/main/webapp/inward/admission_profile.xhtml
+++ b/src/main/webapp/inward/admission_profile.xhtml
@@ -129,6 +129,30 @@
                     </div>
                 </ui:fragment>
 
+                <!-- Pending Appointment Deposit Conversion warning: the appointment
+                     that was admitted still has an un-cancelled appointment deposit
+                     bill that hasn't been converted into this admission's Inward
+                     Deposit. Admitting from an appointment no longer auto-converts
+                     the payment (it used to silently double-count it in Daily
+                     Return); conversion is now this explicit, user-triggered step.
+                     (Issue #22719) -->
+                <ui:fragment rendered="#{webUserController.hasPrivilege('InwardEditPaymentDetails') and admissionController.hasPendingAppointmentDepositConversion}">
+                    <div class="alert alert-warning d-flex justify-content-between align-items-center flex-wrap gap-2 my-2" role="alert">
+                        <div>
+                            <h:outputText styleClass="fas fa-triangle-exclamation me-2"/>
+                            <h:outputText value="This admission's appointment deposit has not yet been converted into an Inward Deposit."/>
+                        </div>
+                        <div class="d-flex gap-2">
+                            <p:commandButton
+                                value="Convert to Inward Deposit"
+                                ajax="false"
+                                icon="fa-solid fa-money-bill-transfer"
+                                class="ui-button-warning"
+                                action="#{admissionController.navigateToAppointmentDepositConversion()}"/>
+                        </div>
+                    </div>
+                </ui:fragment>
+
                 <div class="row">
                     <!-- Column 1: Patient Info -->
                     <div class="col-3">

--- a/src/main/webapp/inward/appointment_deposit_conversion.xhtml
+++ b/src/main/webapp/inward/appointment_deposit_conversion.xhtml
@@ -1,0 +1,104 @@
+﻿<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                 template="/resources/template/template.xhtml"
+                 xmlns:h="http://xmlns.jcp.org/jsf/html"
+                 xmlns:p="http://primefaces.org/ui"
+                 xmlns:f="http://xmlns.jcp.org/jsf/core"
+                 xmlns="http://www.w3.org/1999/xhtml">
+
+    <!-- Issue #22719: explicit, user-triggered conversion of an appointment's
+         deposit bill (INWARD_APPOINTMENT_BILL) into this admission's Inward
+         Deposit. Replaces the old silent auto re-pay that double-counted the
+         payment in Daily Return. -->
+    <ui:define name="content">
+        <h:form id="form">
+            <p:messages id="pageMessages"/>
+
+            <p:panel>
+                <f:facet name="header">
+                    <div class="d-flex justify-content-between align-items-center">
+                        <div class="d-flex align-items-center">
+                            <i class="fa-solid fa-money-bill-transfer fa-lg text-warning me-3"></i>
+                            <div>
+                                <h:outputText value="Convert Appointment Deposit to Inward Deposit" styleClass="fw-bold"/>
+                                <h:panelGroup rendered="#{admissionController.current ne null}" layout="block">
+                                    <small class="text-muted">
+                                        <h:outputText value="#{admissionController.current.patient.person.nameWithTitle}"/>
+                                        &nbsp;|&nbsp;BHT:&nbsp;
+                                        <h:outputText value="#{admissionController.current.bhtNo}"/>
+                                    </small>
+                                </h:panelGroup>
+                            </div>
+                        </div>
+                        <div class="d-flex gap-2">
+                            <p:commandButton
+                                value="Back to Dashboard"
+                                ajax="false"
+                                action="#{admissionController.navigateToAdmissionProfilePage()}"
+                                icon="fa fa-arrow-left"
+                                class="ui-button-secondary"/>
+                        </div>
+                    </div>
+                </f:facet>
+
+                <h:panelGroup rendered="#{admissionController.pendingAppointmentConversion eq null}" layout="block">
+                    <div class="text-center py-5">
+                        <i class="fa-solid fa-check-circle fa-3x text-success mb-3"></i>
+                        <p class="text-muted">No pending appointment deposit conversion for this admission.</p>
+                    </div>
+                </h:panelGroup>
+
+                <h:panelGroup rendered="#{admissionController.pendingAppointmentConversion ne null}" layout="block">
+                    <div class="alert alert-info" role="alert">
+                        <h:outputText styleClass="fas fa-circle-info me-2"/>
+                        <h:outputText value="This patient paid a deposit at the time of the appointment. Converting it will cancel the original appointment bill (offsetting it correctly in reports) and create a new Inward Deposit for the admission, for the same amount."/>
+                    </div>
+
+                    <p:panel header="Appointment Deposit Bill">
+                        <div class="row">
+                            <div class="col-3">
+                                <div class="text-muted small">Bill No</div>
+                                <div class="fs-5 fw-bold">
+                                    <h:outputText value="#{admissionController.pendingAppointmentConversion.bill.deptId}"/>
+                                </div>
+                            </div>
+                            <div class="col-3">
+                                <div class="text-muted small">Bill Date</div>
+                                <div class="fs-5 fw-bold">
+                                    <h:outputText value="#{admissionController.pendingAppointmentConversion.bill.billDate}">
+                                        <f:convertDateTime pattern="yyyy-MM-dd HH:mm"/>
+                                    </h:outputText>
+                                </div>
+                            </div>
+                            <div class="col-3">
+                                <div class="text-muted small">Payment Method</div>
+                                <div class="fs-5 fw-bold">
+                                    <h:outputText value="#{admissionController.pendingAppointmentConversion.bill.paymentMethod}"/>
+                                </div>
+                            </div>
+                            <div class="col-3">
+                                <div class="text-muted small">Amount</div>
+                                <div class="fs-5 fw-bold">
+                                    <h:outputText value="#{admissionController.pendingAppointmentConversion.bill.total}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </h:outputText>
+                                </div>
+                            </div>
+                        </div>
+                    </p:panel>
+
+                    <div class="mt-3">
+                        <p:commandButton
+                            value="Convert to Inward Deposit"
+                            ajax="false"
+                            rendered="#{webUserController.hasPrivilege('InwardEditPaymentDetails')}"
+                            action="#{admissionController.convertAppointmentDepositToInwardDeposit()}"
+                            icon="fa-solid fa-money-bill-transfer"
+                            class="ui-button-warning"/>
+                    </div>
+                </h:panelGroup>
+            </p:panel>
+        </h:form>
+    </ui:define>
+</ui:composition>

--- a/src/main/webapp/inward/appointment_deposit_conversion.xhtml
+++ b/src/main/webapp/inward/appointment_deposit_conversion.xhtml
@@ -67,7 +67,7 @@
                                 <div class="text-muted small">Bill Date</div>
                                 <div class="fs-5 fw-bold">
                                     <h:outputText value="#{admissionController.pendingAppointmentConversion.bill.billDate}">
-                                        <f:convertDateTime pattern="yyyy-MM-dd HH:mm"/>
+                                        <f:convertDateTime pattern="yyyy-MM-dd HH:mm" timeZone="Asia/Colombo"/>
                                     </h:outputText>
                                 </div>
                             </div>

--- a/src/main/webapp/inward/inward_bill_professional.xhtml
+++ b/src/main/webapp/inward/inward_bill_professional.xhtml
@@ -315,7 +315,7 @@
                                                     maxResults="20"
                                                     itemLabel="#{mys.person.nameWithTitle}" 
                                                     itemValue="#{mys}">
-                                                    <f:ajax event="itemSelect" execute="scStaff" render="pIxAdd pBillDetails" />
+                                                    <f:ajax event="itemSelect" execute="scStaff" listener="#{inwardProfessionalBillController.onDoctorSelect}" render="pIxAdd pBillDetails" />
                                                     <p:column headerText="Doctor Name" style="padding: 5px;">
                                                         <h:outputLabel value="#{mys.person.nameWithTitle}" styleClass="fw-bold" />
                                                     </p:column>


### PR DESCRIPTION
## Summary
Replaces the silent, automatic appointment deposit re-payment flow with an explicit, user-triggered conversion process. When admitting a patient from an appointment, the appointment's deposit bill is no longer automatically converted to an inward deposit. Instead, users must explicitly trigger the conversion from the Inpatient Dashboard, preventing silent payment duplication in Daily Return reports.

## Key Changes

- **Removed automatic deposit re-payment**: Deleted the silent auto re-pay logic from `saveSelected()` and `saveConvertSelected()` that was creating duplicate inward deposits without properly cancelling the original appointment bill.

- **Added explicit conversion workflow**:
  - New `pendingAppointmentConversion` field to track the appointment awaiting deposit conversion
  - `findPendingAppointmentDepositConversion()` queries for un-cancelled `INWARD_APPOINTMENT_BILL` entries linked to the current admission
  - `isHasPendingAppointmentDepositConversion()` drives the warning banner on the Inpatient Dashboard
  - `navigateToAppointmentDepositConversion()` navigates to the conversion page
  - `convertAppointmentDepositToInwardDeposit()` performs the actual conversion using the proper cancel-bill pattern

- **Proper bill cancellation**: Leverages `AppointmentController.cancelAppointmentBillForConversion()` (new public method) to properly cancel the original appointment bill with an `INWARD_APPOINTMENT_CANCEL_BILL`, matching the pattern used by `cancelAppointment()`.

- **New UI page**: Added `appointment_deposit_conversion.xhtml` with:
  - Display of the pending appointment deposit bill details (bill number, date, payment method, amount)
  - Informational alert explaining the conversion process
  - Conversion button (privilege-gated to `InwardEditPaymentDetails`)
  - Back button to return to the admission dashboard

- **Dashboard warning**: Added alert banner to `admission_profile.xhtml` that appears when an admission has a pending appointment deposit conversion, with a direct link to the conversion page.

## Implementation Details

- The conversion process preserves the original payment method from the appointment bill, falling back to the admission's payment method if not set
- The new inward deposit is created for the same amount as the original appointment deposit
- The original appointment bill is properly cancelled (not just marked refunded), ensuring correct offset in financial reports
- All changes are wrapped in an editor-fold section for maintainability
- Comprehensive JavaDoc explains the issue context and conversion flow

Closes #22719

https://claude.ai/code/session_01YTr4K9QNMjvBc8qPpLVC7T

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit conversion of appointment deposits into admission Inward Deposits.
  * Added a dedicated conversion page with admission and billing details.
  * Added navigation and privilege-controlled warnings and actions for pending conversions.
  * Added automatic speciality selection when choosing a doctor for professional billing.

* **Bug Fixes**
  * Prevented automatic deposit repayment during admission creation while preserving appointment-to-admission linking.
  * Improved appointment bill cancellation during deposit conversion, including cancellation reasons and payment reversal.

* **Documentation**
  * Added guidance for admission testing, including room availability, date-of-birth requirements, configuration checks, and verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->