### PR TITLE
Fix GRN Payment bills persisted as base Bill class

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/SupplierPaymentController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/SupplierPaymentController.java
@@ -2642,7 +2642,7 @@ public class SupplierPaymentController implements Serializable {
             return;
         }
         current = billService.reloadBill(current);
-        Bill newlyCreatedSupplierPaymentBill = new Bill();
+        Bill newlyCreatedSupplierPaymentBill = new BilledBill();
         newlyCreatedSupplierPaymentBill.copy(current);
         newlyCreatedSupplierPaymentBill.copyValue(current);
         newlyCreatedSupplierPaymentBill.setReferenceBill(current);

--- a/src/main/resources/db/migrations/v2.17.0/migration-info.json
+++ b/src/main/resources/db/migrations/v2.17.0/migration-info.json
@@ -9,6 +9,6 @@
   "data_changes": true,
   "requires_downtime": false,
   "estimated_duration_minutes": 1,
-  "note": "Backfills DTYPE='BilledBill' on historical BILLTYPE='GrnPaymentPre' rows that were saved with DTYPE='Bill' due to SupplierPaymentController.settleApprovedSupplierPayment() instantiating the base Bill class instead of BilledBill. These rows were silently excluded from every GRN Payment listing query. Only touches rows where DTYPE='Bill' — safe to re-run.",
+  "note": "Backfills DTYPE='BilledBill' on historical BILLTYPE='GrnPaymentPre' rows that were saved with DTYPE='Bill' due to SupplierPaymentController.settleApprovedSupplierPayment() instantiating the base Bill class instead of BilledBill. These rows were silently excluded from every GRN Payment listing query. Only touches rows where DTYPE='Bill' — safe to re-run. Affected bill IDs are recorded into migration_v2170_grn_payment_bill_ids so rollback.sql can revert exactly those rows without touching unrelated bills correctly created as BilledBill after this migration runs.",
   "rollback": "rollback.sql"
 }

--- a/src/main/resources/db/migrations/v2.17.0/migration-info.json
+++ b/src/main/resources/db/migrations/v2.17.0/migration-info.json
@@ -1,0 +1,14 @@
+{
+  "version": "v2.17.0",
+  "description": "Fix DTYPE for GRN Payment bills mis-saved as base Bill class",
+  "issue": "#22717 — GRN Payment listing never shows data, bills persisted as base Bill class",
+  "author": "Dr M H B Ariyaratne",
+  "date": "2026-08-06",
+  "type": "data",
+  "tables_affected": ["bill"],
+  "data_changes": true,
+  "requires_downtime": false,
+  "estimated_duration_minutes": 1,
+  "note": "Backfills DTYPE='BilledBill' on historical BILLTYPE='GrnPaymentPre' rows that were saved with DTYPE='Bill' due to SupplierPaymentController.settleApprovedSupplierPayment() instantiating the base Bill class instead of BilledBill. These rows were silently excluded from every GRN Payment listing query. Only touches rows where DTYPE='Bill' — safe to re-run.",
+  "rollback": "rollback.sql"
+}

--- a/src/main/resources/db/migrations/v2.17.0/migration.sql
+++ b/src/main/resources/db/migrations/v2.17.0/migration.sql
@@ -1,0 +1,87 @@
+-- Migration v2.17.0: Fix DTYPE for GRN Payment bills saved as base Bill class
+-- Author: Dr M H B Ariyaratne
+-- Issue: #22717 — GRN Payment listing never shows data
+--
+-- Root cause:
+--   SupplierPaymentController.settleApprovedSupplierPayment() persisted GrnPaymentPre
+--   bills via `new Bill()` instead of `new BilledBill()`, so they were saved with
+--   DTYPE='Bill' (the base class). Every GRN Payment listing query — the entity-based
+--   fallback (type(b) IN (BilledBill, PreBill)) and the DTO query added in #20523
+--   (FROM BilledBill b) — requires DTYPE to be 'BilledBill' or 'PreBill', so these
+--   bills were silently excluded from every list.
+--
+--   The application code has been fixed to persist new GrnPaymentPre bills as
+--   BilledBill going forward. This migration backfills historical rows so they
+--   become visible in the GRN Payment search list retroactively.
+--
+-- Safe to re-run: UPDATE ... WHERE is idempotent (rows already fixed no longer match).
+--
+-- UNIVERSAL: detects actual table-name case via INFORMATION_SCHEMA so this works on both
+-- case-sensitive (Linux, lower_case_table_names=0) and case-insensitive (Windows/Azure) MySQL.
+
+SELECT 'Migration v2.17.0 - Fix DTYPE for GRN Payment bills saved as base Bill class' AS status;
+
+-- ── STEP 0: DETECT ACTUAL TABLE NAME CASE ────────────────────────────────────
+
+SET @bill_table = (
+    SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND UPPER(TABLE_NAME) = 'BILL'
+    LIMIT 1
+);
+
+SELECT CONCAT('Bill table: ', COALESCE(@bill_table, 'NOT FOUND')) AS info;
+
+-- ── BEFORE counts ────────────────────────────────────────────────────────────
+
+SELECT 'BEFORE: GrnPaymentPre bills mis-saved as base Bill class' AS status;
+
+SET @before_sql = IF(@bill_table IS NULL,
+    'SELECT "SKIPPED: bill table not found" AS status',
+    CONCAT(
+        'SELECT DTYPE, COUNT(*) AS cnt ',
+        'FROM ', @bill_table, ' ',
+        'WHERE BILLTYPE = ''GrnPaymentPre'' ',
+        'GROUP BY DTYPE'
+    )
+);
+PREPARE stmt FROM @before_sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- ── STEP 1: Bill → BilledBill for GrnPaymentPre rows ─────────────────────────
+
+SELECT 'Step 1: DTYPE Bill -> BilledBill for BILLTYPE=GrnPaymentPre' AS status;
+
+SET @sql = IF(@bill_table IS NULL,
+    'SELECT "SKIPPED: bill table not found" AS status',
+    CONCAT(
+        'UPDATE ', @bill_table, ' ',
+        'SET DTYPE = ''BilledBill'' ',
+        'WHERE BILLTYPE = ''GrnPaymentPre'' ',
+        '  AND DTYPE    = ''Bill'''
+    )
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SELECT ROW_COUNT() AS updated_step1;
+
+-- ── VERIFY ───────────────────────────────────────────────────────────────────
+
+SELECT 'AFTER: remaining GrnPaymentPre rows with DTYPE=Bill (should be 0)' AS status;
+
+SET @after_sql = IF(@bill_table IS NULL,
+    'SELECT "SKIPPED: bill table not found" AS status',
+    CONCAT(
+        'SELECT DTYPE, COUNT(*) AS cnt ',
+        'FROM ', @bill_table, ' ',
+        'WHERE BILLTYPE = ''GrnPaymentPre'' ',
+        'GROUP BY DTYPE'
+    )
+);
+PREPARE stmt FROM @after_sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SELECT 'Migration v2.17.0 completed' AS final_status;

--- a/src/main/resources/db/migrations/v2.17.0/migration.sql
+++ b/src/main/resources/db/migrations/v2.17.0/migration.sql
@@ -16,6 +16,13 @@
 --
 -- Safe to re-run: UPDATE ... WHERE is idempotent (rows already fixed no longer match).
 --
+-- ROLLBACK SAFETY: the affected bill IDs are recorded into
+-- migration_v2170_grn_payment_bill_ids before the UPDATE runs, and rollback.sql only
+-- reverts those exact IDs. This matters because, after this migration ships, newly
+-- settled GRN Payment bills are correctly created as BilledBill by the application
+-- code fix (#22717) — a rollback that matched on BILLTYPE/DTYPE alone would also
+-- revert those unrelated, already-correct rows.
+--
 -- UNIVERSAL: detects actual table-name case via INFORMATION_SCHEMA so this works on both
 -- case-sensitive (Linux, lower_case_table_names=0) and case-insensitive (Windows/Azure) MySQL.
 
@@ -48,9 +55,36 @@ PREPARE stmt FROM @before_sql;
 EXECUTE stmt;
 DEALLOCATE PREPARE stmt;
 
--- ── STEP 1: Bill → BilledBill for GrnPaymentPre rows ─────────────────────────
+-- ── STEP 1: RECORD AFFECTED BILL IDS FOR SAFE ROLLBACK ────────────────────────
 
-SELECT 'Step 1: DTYPE Bill -> BilledBill for BILLTYPE=GrnPaymentPre' AS status;
+SELECT 'Step 1: Recording affected bill IDs' AS status;
+
+SET @create_backup_sql = 'CREATE TABLE IF NOT EXISTS migration_v2170_grn_payment_bill_ids (
+    BILL_ID BIGINT NOT NULL PRIMARY KEY,
+    RECORDED_AT DATETIME DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4';
+PREPARE stmt FROM @create_backup_sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @record_sql = IF(@bill_table IS NULL,
+    'SELECT "SKIPPED: bill table not found" AS status',
+    CONCAT(
+        'INSERT IGNORE INTO migration_v2170_grn_payment_bill_ids (BILL_ID) ',
+        'SELECT ID FROM ', @bill_table, ' ',
+        'WHERE BILLTYPE = ''GrnPaymentPre'' ',
+        '  AND DTYPE    = ''Bill'''
+    )
+);
+PREPARE stmt FROM @record_sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SELECT ROW_COUNT() AS recorded_step1;
+
+-- ── STEP 2: Bill → BilledBill for the recorded GrnPaymentPre rows ────────────
+
+SELECT 'Step 2: DTYPE Bill -> BilledBill for recorded BILLTYPE=GrnPaymentPre rows' AS status;
 
 SET @sql = IF(@bill_table IS NULL,
     'SELECT "SKIPPED: bill table not found" AS status',
@@ -58,14 +92,15 @@ SET @sql = IF(@bill_table IS NULL,
         'UPDATE ', @bill_table, ' ',
         'SET DTYPE = ''BilledBill'' ',
         'WHERE BILLTYPE = ''GrnPaymentPre'' ',
-        '  AND DTYPE    = ''Bill'''
+        '  AND DTYPE    = ''Bill'' ',
+        '  AND ID IN (SELECT BILL_ID FROM migration_v2170_grn_payment_bill_ids)'
     )
 );
 PREPARE stmt FROM @sql;
 EXECUTE stmt;
 DEALLOCATE PREPARE stmt;
 
-SELECT ROW_COUNT() AS updated_step1;
+SELECT ROW_COUNT() AS updated_step2;
 
 -- ── VERIFY ───────────────────────────────────────────────────────────────────
 

--- a/src/main/resources/db/migrations/v2.17.0/migration.sql
+++ b/src/main/resources/db/migrations/v2.17.0/migration.sql
@@ -78,9 +78,10 @@ SET @record_sql = IF(@bill_table IS NULL,
 );
 PREPARE stmt FROM @record_sql;
 EXECUTE stmt;
+SET @recorded_step1 = ROW_COUNT();
 DEALLOCATE PREPARE stmt;
 
-SELECT ROW_COUNT() AS recorded_step1;
+SELECT @recorded_step1 AS recorded_step1;
 
 -- ── STEP 2: Bill → BilledBill for the recorded GrnPaymentPre rows ────────────
 
@@ -98,9 +99,10 @@ SET @sql = IF(@bill_table IS NULL,
 );
 PREPARE stmt FROM @sql;
 EXECUTE stmt;
+SET @updated_step2 = ROW_COUNT();
 DEALLOCATE PREPARE stmt;
 
-SELECT ROW_COUNT() AS updated_step2;
+SELECT @updated_step2 AS updated_step2;
 
 -- ── VERIFY ───────────────────────────────────────────────────────────────────
 

--- a/src/main/resources/db/migrations/v2.17.0/rollback.sql
+++ b/src/main/resources/db/migrations/v2.17.0/rollback.sql
@@ -43,8 +43,9 @@ SET @sql = IF(@bill_table IS NULL OR @backup_exists = 0,
 );
 PREPARE stmt FROM @sql;
 EXECUTE stmt;
+SET @reverted_step1 = ROW_COUNT();
 DEALLOCATE PREPARE stmt;
 
-SELECT ROW_COUNT() AS reverted_step1;
+SELECT @reverted_step1 AS reverted_step1;
 
 SELECT 'Rollback v2.17.0 completed' AS final_status;

--- a/src/main/resources/db/migrations/v2.17.0/rollback.sql
+++ b/src/main/resources/db/migrations/v2.17.0/rollback.sql
@@ -1,0 +1,43 @@
+-- Rollback v2.17.0: Revert DTYPE fix for GRN Payment bills
+-- WARNING: Only run if you need to undo migration v2.17.0 entirely. This restores the
+-- pre-fix (broken) state where these bills are excluded from the GRN Payment listing again.
+--
+-- UNIVERSAL: detects actual table-name case via INFORMATION_SCHEMA so this works on both
+-- case-sensitive (Linux, lower_case_table_names=0) and case-insensitive (Windows/Azure) MySQL.
+
+SELECT 'Rollback v2.17.0 - Reverting DTYPE fix for GRN Payment bills' AS status;
+
+-- ── STEP 0: DETECT ACTUAL TABLE NAME CASE ────────────────────────────────────
+
+SET @bill_table = (
+    SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND UPPER(TABLE_NAME) = 'BILL'
+    LIMIT 1
+);
+
+SELECT CONCAT('Bill table: ', COALESCE(@bill_table, 'NOT FOUND')) AS info;
+
+-- ── STEP 1: BilledBill → Bill for GrnPaymentPre rows fixed by this migration ─
+--
+--   NOTE: this only reverts rows that were previously updated by migration.sql.
+--   It cannot distinguish those from GrnPaymentPre bills that were legitimately
+--   created as BilledBill (e.g. by the code fix in #22717) after this migration
+--   ran, so this rollback is only safe immediately after applying the migration
+--   and before any new GRN Payment bills have been settled.
+
+SET @sql = IF(@bill_table IS NULL,
+    'SELECT "SKIPPED: bill table not found" AS status',
+    CONCAT(
+        'UPDATE ', @bill_table, ' ',
+        'SET DTYPE = ''Bill'' ',
+        'WHERE BILLTYPE = ''GrnPaymentPre'' ',
+        '  AND DTYPE    = ''BilledBill'''
+    )
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SELECT ROW_COUNT() AS reverted_step1;
+
+SELECT 'Rollback v2.17.0 completed' AS final_status;

--- a/src/main/resources/db/migrations/v2.17.0/rollback.sql
+++ b/src/main/resources/db/migrations/v2.17.0/rollback.sql
@@ -1,6 +1,12 @@
 -- Rollback v2.17.0: Revert DTYPE fix for GRN Payment bills
--- WARNING: Only run if you need to undo migration v2.17.0 entirely. This restores the
--- pre-fix (broken) state where these bills are excluded from the GRN Payment listing again.
+-- WARNING: Only run if you need to undo migration v2.17.0.
+--
+-- SCOPED TO RECORDED IDS: only reverts the exact bill IDs that migration.sql recorded
+-- into migration_v2170_grn_payment_bill_ids before it ran. This intentionally does NOT
+-- match on BILLTYPE/DTYPE alone, because by the time a rollback might be needed, new
+-- GRN Payment bills settled after this migration shipped are correctly created as
+-- BilledBill by the application code fix (#22717) — a broad DTYPE match would also
+-- revert those unrelated, already-correct rows back to the broken DTYPE='Bill' state.
 --
 -- UNIVERSAL: detects actual table-name case via INFORMATION_SCHEMA so this works on both
 -- case-sensitive (Linux, lower_case_table_names=0) and case-insensitive (Windows/Azure) MySQL.
@@ -15,23 +21,24 @@ SET @bill_table = (
     LIMIT 1
 );
 
+SET @backup_exists = (
+    SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND UPPER(TABLE_NAME) = 'MIGRATION_V2170_GRN_PAYMENT_BILL_IDS'
+);
+
 SELECT CONCAT('Bill table: ', COALESCE(@bill_table, 'NOT FOUND')) AS info;
+SELECT IF(@backup_exists > 0, 'Recorded bill ID table found', 'Recorded bill ID table NOT FOUND — nothing to roll back') AS info;
 
--- ── STEP 1: BilledBill → Bill for GrnPaymentPre rows fixed by this migration ─
---
---   NOTE: this only reverts rows that were previously updated by migration.sql.
---   It cannot distinguish those from GrnPaymentPre bills that were legitimately
---   created as BilledBill (e.g. by the code fix in #22717) after this migration
---   ran, so this rollback is only safe immediately after applying the migration
---   and before any new GRN Payment bills have been settled.
+-- ── STEP 1: BilledBill → Bill, restricted to recorded bill IDs ───────────────
 
-SET @sql = IF(@bill_table IS NULL,
-    'SELECT "SKIPPED: bill table not found" AS status',
+SET @sql = IF(@bill_table IS NULL OR @backup_exists = 0,
+    'SELECT "SKIPPED: bill table or recorded-ID table not found" AS status',
     CONCAT(
         'UPDATE ', @bill_table, ' ',
         'SET DTYPE = ''Bill'' ',
         'WHERE BILLTYPE = ''GrnPaymentPre'' ',
-        '  AND DTYPE    = ''BilledBill'''
+        '  AND DTYPE    = ''BilledBill'' ',
+        '  AND ID IN (SELECT BILL_ID FROM migration_v2170_grn_payment_bill_ids)'
     )
 );
 PREPARE stmt FROM @sql;


### PR DESCRIPTION
## Summary

- `SupplierPaymentController.settleApprovedSupplierPayment()` instantiated the settled GRN Payment bill via `new Bill()`, so `GrnPaymentPre` bills were persisted with `DTYPE='Bill'` (the base class) instead of `DTYPE='BilledBill'`.
- Every GRN Payment listing query — the entity-based fallback (`type(b) IN (BilledBill, PreBill)`) and the DTO query added in #20523 (`FROM BilledBill b`) — filters on `DTYPE IN ('BilledBill', 'PreBill')`, so these bills were silently excluded from the GRN Payment search list on every deployment.
- Fixed by instantiating `new BilledBill()` instead (kept the local variable typed as `Bill` so it still assigns cleanly from `billService.reloadBill(...)`'s `Bill` return type), matching the pattern already used elsewhere in this controller for finalized bills.
- Added data migration `v2.17.0` to backfill `DTYPE='BilledBill'` on existing `GrnPaymentPre` rows that were saved with `DTYPE='Bill'`, so historical GRN Payment bills become visible retroactively once an admin runs it via `/faces/admin/database_migration.xhtml`.

## Test plan

- [ ] Code review confirms `BilledBill` is a subtype of `Bill` and all downstream calls (`reloadBill`, `getBillFacade().create/edit`, `paymentService.createPayment`) accept `Bill`, so this compiles.
- [ ] Local build could not be verified in this sandbox (Maven dependency `com.github.hmislk:lims-middleware-libraries` is blocked by network policy, unrelated to this change) — please run a full build in CI/local dev.
- [ ] After deploy, settle a new supplier payment and confirm the resulting bill appears in `pharmacy_search.xhtml` with Bill Type = "Grn Payment".
- [ ] Run migration `v2.17.0` via `/faces/admin/database_migration.xhtml` on a non-prod DB and confirm historical `GrnPaymentPre` rows with `DTYPE='Bill'` are updated to `DTYPE='BilledBill'` and now show up in the GRN Payment list.

Closes #22717

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WgS6UsUkNRdxVoVxicQ84r)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected newly created supplier payment records for consistent recognition.
  * Updated historical GRN payment records to use the correct payment classification.

* **Maintenance**
  * Added a safe, repeatable database update with progress reporting and safeguards.
  * Added a targeted rollback option for reverting the historical data correction when needed.
  * Ensured the update can be safely rerun without duplicating changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->