### PR TITLE
Add privilege control for general admissions search by date range

### DIFF
--- a/src/main/java/com/divudi/bean/common/UserPrivilageController.java
+++ b/src/main/java/com/divudi/bean/common/UserPrivilageController.java
@@ -246,6 +246,7 @@ public class UserPrivilageController implements Serializable {
         TreeNode searchNode = new DefaultTreeNode(new PrivilegeHolder(null, "Search"), inwardNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSearch, "Search Menu"), searchNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSearchServiceBill, "Search Service Bill"), searchNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSearchAdmissionsGeneralSearch, "Search Admissions - General Search (Date Range)"), searchNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSearchProfessionalBill, "Search Professional Bill"), searchNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSearchFinalBill, "Search Final Bill"), searchNode);
 

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -107,6 +107,7 @@ public enum Privileges {
     InwardSearchAdmissionsByCurrentDepartmentAnyInstitute("Inward Search Admissions By Current Department - Any Institute"),
     InwardSearchAdmissionsByCurrentDepartmentLoggedInstitute("Inward Search Admissions By Current Department - Logged Institute"),
     InwardSearchAdmissionsByCurrentDepartmentLoggedDepartment("Inward Search Admissions By Current Department - Logged Department"),
+    InwardSearchAdmissionsGeneralSearch("Inward Search Admissions - General Search (Date Range)"),
     InwardSettleFinalBillUnrestricted("Inward Settle Final Bill Without Restricted"),
     InwardSettleFinalBill("Inward Settle Final Bill"),
     InwardFinalBillCreateVersion("Inward Final Bill Create New Version"),

--- a/src/main/webapp/inward/inpatient_search.xhtml
+++ b/src/main/webapp/inward/inpatient_search.xhtml
@@ -61,6 +61,7 @@
                                     ajax="false"
                                     value="Search"
                                     icon="fas fa-search"
+                                    rendered="#{webUserController.hasPrivilege('InwardSearchAdmissionsGeneralSearch')}"
                                     action="#{admissionController.searchAdmissions}"
                                     class="mt-2 w-100 mb-3 ui-button-warning">
                                 </p:commandButton>


### PR DESCRIPTION
## Summary
Adds a new privilege `InwardSearchAdmissionsGeneralSearch` to control access to the general admissions search functionality (date range search) in the inpatient module. This allows administrators to restrict who can perform general admissions searches independently from other inward search privileges.

## Changes
- **Privileges.java**: Added new enum constant `InwardSearchAdmissionsGeneralSearch` with description "Inward Search Admissions - General Search (Date Range)"
- **UserPrivilageController.java**: Registered the new privilege in the privilege tree under the Inward Search Admissions node
- **inpatient_search.xhtml**: Added privilege check to the "Search" button using `rendered="#{webUserController.hasPrivilege('InwardSearchAdmissionsGeneralSearch')}"`

## Implementation Details
The privilege is positioned logically alongside other inward search admissions privileges (`InwardSearchAdmissionsByCurrentDepartment*`) in the privilege hierarchy, allowing fine-grained access control over different types of admissions searches.

https://claude.ai/code/session_01XCTvPjBz3k5fMiBTX7dm8B

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated permission for the Admissions general search by date range.
  * The Admissions general search option is now available only to users with the appropriate access privilege.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->