### PR TITLE
feat(pharmacy): native SQL Purchase Order Request page

### DIFF
--- a/docs/superpowers/plans/2026-08-07-po-request-native.md
+++ b/docs/superpowers/plans/2026-08-07-po-request-native.md
@@ -196,7 +196,6 @@ git commit -m "feat(pharmacy): add PurchaseOrderRequestLineData DTO for native P
 
 **Files:**
 - Create: `src/main/java/com/divudi/service/pharmacy/PurchaseOrderRequestNativeSqlService.java`
-- Test: `src/test/java/com/divudi/service/pharmacy/PurchaseOrderRequestNativeSqlServiceTest.java`
 
 **Interfaces:**
 - Consumes: `PurchaseOrderRequestLineData` (Task 1)
@@ -207,45 +206,25 @@ git commit -m "feat(pharmacy): add PurchaseOrderRequestLineData DTO for native P
   - `boolean isBillChecked(long billId)` — used by controller guards
   - Later tasks (3, 4) call these exact method names/signatures.
 
-This test uses an in-memory/test persistence unit exactly like existing native
-service tests in this codebase — check `src/test/java/com/divudi/service/pharmacy/`
-for the harness pattern already used by `RetailSaleNativeSqlService`'s tests and
-follow the same `@Before`/entity-manager setup before writing this test, since this
-plan cannot assume a specific harness without seeing it.
+**Codebase testing convention for native SQL services (verified against
+`BhtIssueRequestNativeSqlServiceTest`/`BhtIssueRequestNativeSqlService`, the only
+existing test precedent for a `@Stateless` native SQL service in this package):
+there is no EntityManager/database test harness for these services anywhere in
+the codebase. Only package-private, EntityManager-free pure logic gets a JUnit
+test. Methods that call `em.createNativeQuery(...)` are NOT unit tested — they
+are verified via Task 11's Playwright + manual DB-query pass instead.** Do not
+invent a test container or in-memory persistence unit; none exists here.
 
-- [ ] **Step 1: Write the failing test**
+This task's `createDraftBill`/`updateDraftBillHeader`/`isBillChecked` all touch
+`em` directly and have no extractable pure logic (no branching on plain
+values) — per the convention above, they get no JUnit test in this task. The
+package-private `resolveTable()` table-name-resolution helper also touches
+`em` and is not unit tested for the same reason (matches
+`BhtIssueRequestNativeSqlService`, whose own `resolveTable`-equivalent has no
+test — only its return-nothing pure helpers like `str`/`toBool`/`toDate` do).
 
-```java
-package com.divudi.service.pharmacy;
-
-import org.junit.Test;
-import static org.junit.Assert.*;
-
-public class PurchaseOrderRequestNativeSqlServiceTest {
-
-    // Follow the same EntityManager/test-container setup pattern as
-    // RetailSaleNativeSqlServiceTest in this package — copy its @Before,
-    // persistence-unit name, and teardown exactly, then adapt the body below.
-
-    @Test
-    public void createDraftBillPersistsPharmacyOrderPreAtomic() {
-        PurchaseOrderRequestNativeSqlService service = new PurchaseOrderRequestNativeSqlService();
-        // inject test EntityManager per harness pattern
-
-        long billId = service.createDraftBill(1L, 1L, 1L, "POR-0001", "POR-0001");
-
-        assertTrue(billId > 0);
-        assertTrue(service.isBillChecked(billId) == false);
-    }
-}
-```
-
-- [ ] **Step 2: Run test to verify it fails**
-
-Run: `mvn -q -Dtest=PurchaseOrderRequestNativeSqlServiceTest test`
-Expected: FAIL — compile error, class does not exist.
-
-- [ ] **Step 3: Write minimal implementation**
+- [ ] **Step 1: Write the implementation directly (no test-first step — see
+  convention note above; this task has no pure logic to isolate)**
 
 ```java
 package com.divudi.service.pharmacy;
@@ -365,15 +344,15 @@ public class PurchaseOrderRequestNativeSqlService {
 }
 ```
 
-- [ ] **Step 4: Run test to verify it passes**
+- [ ] **Step 2: Compile check**
 
-Run: `mvn -q -Dtest=PurchaseOrderRequestNativeSqlServiceTest test`
-Expected: PASS
+Run: `mvn -q compile`
+Expected: BUILD SUCCESS
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 3: Commit**
 
 ```bash
-git add src/main/java/com/divudi/service/pharmacy/PurchaseOrderRequestNativeSqlService.java src/test/java/com/divudi/service/pharmacy/PurchaseOrderRequestNativeSqlServiceTest.java
+git add src/main/java/com/divudi/service/pharmacy/PurchaseOrderRequestNativeSqlService.java
 git commit -m "feat(pharmacy): native SQL draft-bill create/update for PO Request"
 ```
 
@@ -383,52 +362,121 @@ git commit -m "feat(pharmacy): native SQL draft-bill create/update for PO Reques
 
 **Files:**
 - Modify: `src/main/java/com/divudi/service/pharmacy/PurchaseOrderRequestNativeSqlService.java`
-- Modify: `src/test/java/com/divudi/service/pharmacy/PurchaseOrderRequestNativeSqlServiceTest.java`
+- Create: `src/test/java/com/divudi/service/pharmacy/PurchaseOrderRequestNativeSqlServiceTest.java`
 
 **Interfaces:**
-- Consumes: `PurchaseOrderRequestLineData` (Task 1), `createDraftBill`/`billItemTable`/`pharmBillItemTable` (Task 2)
-- Produces: `long saveLine(long billId, PurchaseOrderRequestLineData line)` — inserts or
-  updates `billitem` + `pharmaceuticalbillitem` natively, persists/merges
-  `BillItemFinanceDetails` via JPA, returns the `billitem` id. Task 4 (finalize) and
-  the controller (Task 5) call this for every line on every save.
+- Consumes: `PurchaseOrderRequestLineData` (Task 1), `billItemTable`/`pharmBillItemTable` (Task 2)
+- Produces:
+  - `long saveLine(long billId, PurchaseOrderRequestLineData line)` — inserts or
+    updates `billitem` + `pharmaceuticalbillitem` natively, persists/merges
+    `BillItemFinanceDetails` via JPA, returns the `billitem` id. Task 4 (finalize) and
+    the controller (Task 5) call this for every line on every save.
+  - `LineValues computeLineValues(PurchaseOrderRequestLineData line)` — package-private,
+    pure (no `em` access), extracts the calculation math from legacy
+    `calculateLineValues()` into a testable unit. `LineValues` is a package-private
+    static nested class on the service exposing (all `BigDecimal`, all
+    package-private final fields with a package-private constructor, matching
+    `BhtIssueRequestNativeSqlServiceTest`'s convention of testing package-private
+    logic directly, same package, no getters needed): `qty, freeQty, purchaseRate,
+    retailRate, unitsPerPack, grossValue, netValue, purchaseValue, retailValue,
+    netRate, pbiQty (double), pbiFreeQty (double), pbiPurchaseRate (double),
+    pbiRetailRate (double)`. `saveLine()` calls `computeLineValues()` first, then
+    uses the returned values for both the native SQL and the BIFD JPA write —
+    no duplicated math between the two.
 
-Mirrors the calculation in legacy `calculateLineValues()` (read §2 of the design
-spec) but the persistence is native for `billitem`/`pharmaceuticalbillitem`, JPA for
-`BillItemFinanceDetails`.
+**Codebase testing convention (see Task 2's note):** only pure logic gets a
+JUnit test. `saveLine()` itself touches `em` and is not unit tested — verified
+via Task 11's Playwright + DB pass. `computeLineValues()` has no `em` access and
+mirrors legacy `calculateLineValues()`'s branching (AMPP vs non-AMPP, zero-qty
+netRate guard) — it gets a real test here, following
+`BhtIssueRequestNativeSqlServiceTest`'s pattern of testing package-private pure
+methods directly via `new PurchaseOrderRequestNativeSqlService()` with no mocks.
 
 - [ ] **Step 1: Write the failing test**
 
 ```java
-@Test
-public void saveLineInsertsBillItemAndPharmaceuticalBillItem() {
-    PurchaseOrderRequestNativeSqlService service = new PurchaseOrderRequestNativeSqlService();
-    // inject test EntityManager per harness pattern
-    long billId = service.createDraftBill(1L, 1L, 1L, "POR-0002", "POR-0002");
+package com.divudi.service.pharmacy;
 
-    PurchaseOrderRequestLineData line = new PurchaseOrderRequestLineData();
-    line.setItemId(500L); // seed a test Item fixture with id 500 per harness convention
-    line.setAmpp(false);
-    line.setQuantity(new java.math.BigDecimal("10"));
-    line.setFreeQuantity(new java.math.BigDecimal("1"));
-    line.setPurchaseRate(new java.math.BigDecimal("25.50"));
-    line.setRetailRate(new java.math.BigDecimal("30.00"));
-    line.setUnitsPerPack(java.math.BigDecimal.ONE);
-    line.setSerialNo(0);
-    line.setCreaterId(1L);
+import com.divudi.core.data.dto.pharmacy.PurchaseOrderRequestLineData;
+import org.junit.jupiter.api.Test;
 
-    long billItemId = service.saveLine(billId, line);
+import java.math.BigDecimal;
 
-    assertTrue(billItemId > 0);
-    // Follow-up assertion: read back via native query and confirm
-    // netValue = 255.00 (25.50 * 10), matching calculateLineValues()'s
-    // "purchase rate * qty" rule for non-AMPP items.
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PurchaseOrderRequestNativeSqlServiceTest {
+
+    private final PurchaseOrderRequestNativeSqlService service = new PurchaseOrderRequestNativeSqlService();
+
+    @Test
+    void computeLineValues_nonAmpp_purchaseRateTimesQtyIsGrossAndNetValue() {
+        PurchaseOrderRequestLineData line = new PurchaseOrderRequestLineData();
+        line.setAmpp(false);
+        line.setQuantity(new BigDecimal("10"));
+        line.setFreeQuantity(new BigDecimal("1"));
+        line.setPurchaseRate(new BigDecimal("25.50"));
+        line.setRetailRate(new BigDecimal("30.00"));
+        line.setUnitsPerPack(BigDecimal.ONE);
+
+        PurchaseOrderRequestNativeSqlService.LineValues v = service.computeLineValues(line);
+
+        assertEquals(new BigDecimal("255.00"), v.grossValue.setScale(2));
+        assertEquals(new BigDecimal("255.00"), v.netValue.setScale(2));
+        assertEquals(new BigDecimal("280.50"), v.purchaseValue.setScale(2)); // 25.50 * (10+1)
+        assertEquals(new BigDecimal("330.00"), v.retailValue.setScale(2));  // 30.00 * (10+1)
+        assertEquals(25.50, v.pbiPurchaseRate, 0.0001); // non-AMPP: no pack conversion
+        assertEquals(10.0, v.pbiQty, 0.0001);
+    }
+
+    @Test
+    void computeLineValues_ampp_convertsQtyAndRateByUnitsPerPack() {
+        PurchaseOrderRequestLineData line = new PurchaseOrderRequestLineData();
+        line.setAmpp(true);
+        line.setQuantity(new BigDecimal("2")); // 2 packs
+        line.setFreeQuantity(BigDecimal.ZERO);
+        line.setPurchaseRate(new BigDecimal("100")); // rate per pack
+        line.setRetailRate(new BigDecimal("120"));
+        line.setUnitsPerPack(new BigDecimal("10")); // 10 units per pack
+
+        PurchaseOrderRequestNativeSqlService.LineValues v = service.computeLineValues(line);
+
+        assertEquals(20.0, v.pbiQty, 0.0001); // 2 packs * 10 units/pack
+        assertEquals(10.0, v.pbiPurchaseRate, 0.0001); // 100 / 10 units per pack
+        assertEquals(12.0, v.pbiRetailRate, 0.0001); // 120 / 10
+    }
+
+    @Test
+    void computeLineValues_zeroQuantity_netRateIsZeroNotDivideByZero() {
+        PurchaseOrderRequestLineData line = new PurchaseOrderRequestLineData();
+        line.setAmpp(false);
+        line.setQuantity(BigDecimal.ZERO);
+        line.setFreeQuantity(BigDecimal.ZERO);
+        line.setPurchaseRate(new BigDecimal("50"));
+        line.setRetailRate(new BigDecimal("60"));
+        line.setUnitsPerPack(BigDecimal.ONE);
+
+        PurchaseOrderRequestNativeSqlService.LineValues v = service.computeLineValues(line);
+
+        assertEquals(BigDecimal.ZERO.setScale(2), v.netRate.setScale(2));
+    }
+
+    @Test
+    void computeLineValues_nullFields_defaultToZeroOrOne() {
+        PurchaseOrderRequestLineData line = new PurchaseOrderRequestLineData();
+        // quantity, freeQuantity, purchaseRate, retailRate, unitsPerPack all left null
+
+        PurchaseOrderRequestNativeSqlService.LineValues v = service.computeLineValues(line);
+
+        assertEquals(BigDecimal.ZERO.setScale(2), v.grossValue.setScale(2));
+        assertEquals(BigDecimal.ONE, v.unitsPerPack);
+    }
 }
 ```
 
 - [ ] **Step 2: Run test to verify it fails**
 
 Run: `mvn -q -Dtest=PurchaseOrderRequestNativeSqlServiceTest test`
-Expected: FAIL — `saveLine` does not exist.
+Expected: FAIL — `computeLineValues`/`LineValues` do not exist.
 
 - [ ] **Step 3: Write minimal implementation**
 
@@ -440,7 +488,29 @@ import java.math.BigDecimal;
 
 // ... inside the class ...
 
-public long saveLine(long billId, com.divudi.core.data.dto.pharmacy.PurchaseOrderRequestLineData line) {
+/**
+ * Pure calculation extracted from legacy calculateLineValues() — no em access,
+ * unit tested directly. AMPP items store rates per-pack on BillItemFinanceDetails
+ * but per-unit on PharmaceuticalBillItem; non-AMPP items use the same rate for both.
+ */
+static final class LineValues {
+    final BigDecimal qty, freeQty, purchaseRate, retailRate, unitsPerPack;
+    final BigDecimal grossValue, netValue, purchaseValue, retailValue, netRate;
+    final double pbiQty, pbiFreeQty, pbiPurchaseRate, pbiRetailRate;
+
+    LineValues(BigDecimal qty, BigDecimal freeQty, BigDecimal purchaseRate, BigDecimal retailRate,
+               BigDecimal unitsPerPack, BigDecimal grossValue, BigDecimal netValue,
+               BigDecimal purchaseValue, BigDecimal retailValue, BigDecimal netRate,
+               double pbiQty, double pbiFreeQty, double pbiPurchaseRate, double pbiRetailRate) {
+        this.qty = qty; this.freeQty = freeQty; this.purchaseRate = purchaseRate; this.retailRate = retailRate;
+        this.unitsPerPack = unitsPerPack; this.grossValue = grossValue; this.netValue = netValue;
+        this.purchaseValue = purchaseValue; this.retailValue = retailValue; this.netRate = netRate;
+        this.pbiQty = pbiQty; this.pbiFreeQty = pbiFreeQty;
+        this.pbiPurchaseRate = pbiPurchaseRate; this.pbiRetailRate = pbiRetailRate;
+    }
+}
+
+LineValues computeLineValues(com.divudi.core.data.dto.pharmacy.PurchaseOrderRequestLineData line) {
     BigDecimal qty = line.getQuantity() != null ? line.getQuantity() : BigDecimal.ZERO;
     BigDecimal freeQty = line.getFreeQuantity() != null ? line.getFreeQuantity() : BigDecimal.ZERO;
     BigDecimal purchaseRate = line.getPurchaseRate() != null ? line.getPurchaseRate() : BigDecimal.ZERO;
@@ -452,7 +522,23 @@ public long saveLine(long billId, com.divudi.core.data.dto.pharmacy.PurchaseOrde
     BigDecimal netValue = grossValue;
     BigDecimal purchaseValue = purchaseRate.multiply(qty.add(freeQty));
     BigDecimal retailValue = retailRate.multiply(qty.add(freeQty));
-    BigDecimal netRate = qty.doubleValue() > 0 ? netValue.divide(qty, java.math.RoundingMode.HALF_UP) : BigDecimal.ZERO;
+    BigDecimal netRate = qty.doubleValue() > 0
+            ? netValue.divide(qty, 2, java.math.RoundingMode.HALF_UP) : BigDecimal.ZERO;
+
+    double pbiQty = line.isAmpp() ? qty.doubleValue() * unitsPerPack.doubleValue() : qty.doubleValue();
+    double pbiFreeQty = line.isAmpp() ? freeQty.doubleValue() * unitsPerPack.doubleValue() : freeQty.doubleValue();
+    double pbiPurchaseRate = line.isAmpp() ? purchaseRate.doubleValue() / unitsPerPack.doubleValue() : purchaseRate.doubleValue();
+    double pbiRetailRate = line.isAmpp() ? retailRate.doubleValue() / unitsPerPack.doubleValue() : retailRate.doubleValue();
+
+    return new LineValues(qty, freeQty, purchaseRate, retailRate, unitsPerPack, grossValue, netValue,
+            purchaseValue, retailValue, netRate, pbiQty, pbiFreeQty, pbiPurchaseRate, pbiRetailRate);
+}
+
+public long saveLine(long billId, com.divudi.core.data.dto.pharmacy.PurchaseOrderRequestLineData line) {
+    LineValues v = computeLineValues(line);
+    BigDecimal qty = v.qty, freeQty = v.freeQty, purchaseRate = v.purchaseRate, retailRate = v.retailRate;
+    BigDecimal grossValue = v.grossValue, netValue = v.netValue, netRate = v.netRate;
+    BigDecimal purchaseValue = v.purchaseValue, retailValue = v.retailValue, unitsPerPack = v.unitsPerPack;
 
     long billItemId;
     if (line.getBillItemId() == null) {
@@ -488,10 +574,7 @@ public long saveLine(long billId, com.divudi.core.data.dto.pharmacy.PurchaseOrde
             .executeUpdate();
     }
 
-    double pbiQty = line.isAmpp() ? qty.doubleValue() * unitsPerPack.doubleValue() : qty.doubleValue();
-    double pbiFreeQty = line.isAmpp() ? freeQty.doubleValue() * unitsPerPack.doubleValue() : freeQty.doubleValue();
-    double pbiPurchaseRate = line.isAmpp() ? purchaseRate.doubleValue() / unitsPerPack.doubleValue() : purchaseRate.doubleValue();
-    double pbiRetailRate = line.isAmpp() ? retailRate.doubleValue() / unitsPerPack.doubleValue() : retailRate.doubleValue();
+    double pbiQty = v.pbiQty, pbiFreeQty = v.pbiFreeQty, pbiPurchaseRate = v.pbiPurchaseRate, pbiRetailRate = v.pbiRetailRate;
 
     if (line.getPharmaceuticalBillItemId() == null) {
         em.createNativeQuery(
@@ -614,60 +697,69 @@ git commit -m "feat(pharmacy): native SQL line-item insert/update for PO Request
 
 **Interfaces:**
 - Consumes: `billTable()`, `billItemTable()`, `pharmBillItemTable()` (Task 2)
-- Produces: `void finalizeBill(long billId, long editorId)` — promotes
-  `BILLTYPEATOMIC` to `PHARMACY_ORDER` and sets `checked=1, checkeAt=now,
-  checkedBy_ID=editorId`; `int retireZeroQtyLines(long billId, long retirerId)` —
-  retires (native `UPDATE billitem/pharmaceuticalbillitem SET retired=1,...`) any
-  line whose `qty+freeQty <= 0`, sets `remainingQty`/`remainingFreeQty` on surviving
-  lines, returns count of surviving (non-retired) lines with qty > 0 — mirrors legacy
-  `finalizeBillComponent()`'s `totalBillItemsCount` accumulation. Controller (Task 5)
-  calls both in sequence for the Finalize button.
+- Produces:
+  - `void finalizeBill(long billId, long editorId)` — promotes
+    `BILLTYPEATOMIC` to `PHARMACY_ORDER` and sets `checked=1, checkeAt=now,
+    checkedBy_ID=editorId`
+  - `int retireZeroQtyLines(long billId, long retirerId)` —
+    retires (native `UPDATE billitem/pharmaceuticalbillitem SET retired=1,...`) any
+    line whose `qty+freeQty <= 0`, sets `remainingQty`/`remainingFreeQty` on surviving
+    lines, returns count of surviving (non-retired) lines with qty > 0 — mirrors legacy
+    `finalizeBillComponent()`'s `totalBillItemsCount` accumulation. Controller (Task 5)
+    calls both in sequence for the Finalize button.
+  - `boolean isZeroQtyLine(double qty, double freeQty)` — package-private, pure
+    predicate extracted from legacy `finalizeBillComponent()`'s `totalUnits.compareTo(BigDecimal.ZERO) <= 0`
+    check, called by `retireZeroQtyLines` for each row.
+
+**Codebase testing convention (see Task 2/3's notes):** `finalizeBill` and
+`retireZeroQtyLines` both touch `em` directly (native UPDATE/SELECT) and are not
+unit tested — verified via Task 11's Playwright + DB pass. `isZeroQtyLine` has no
+`em` access and gets a real test, same pattern as Task 3's `computeLineValues`.
 
 - [ ] **Step 1: Write the failing test**
 
 ```java
 @Test
-public void finalizeBillPromotesAtomicAndSetsChecked() {
-    PurchaseOrderRequestNativeSqlService service = new PurchaseOrderRequestNativeSqlService();
-    long billId = service.createDraftBill(1L, 1L, 1L, "POR-0003", "POR-0003");
-
-    service.finalizeBill(billId, 1L);
-
-    assertTrue(service.isBillChecked(billId));
+void isZeroQtyLine_trueWhenQtyAndFreeQtyBothZero() {
+    assertTrue(service.isZeroQtyLine(0.0, 0.0));
 }
 
 @Test
-public void retireZeroQtyLinesRetiresLinesWithNoQuantity() {
-    PurchaseOrderRequestNativeSqlService service = new PurchaseOrderRequestNativeSqlService();
-    long billId = service.createDraftBill(1L, 1L, 1L, "POR-0004", "POR-0004");
+void isZeroQtyLine_falseWhenQtyPositive() {
+    assertFalse(service.isZeroQtyLine(5.0, 0.0));
+}
 
-    com.divudi.core.data.dto.pharmacy.PurchaseOrderRequestLineData zeroLine =
-            new com.divudi.core.data.dto.pharmacy.PurchaseOrderRequestLineData();
-    zeroLine.setItemId(500L);
-    zeroLine.setQuantity(java.math.BigDecimal.ZERO);
-    zeroLine.setFreeQuantity(java.math.BigDecimal.ZERO);
-    zeroLine.setPurchaseRate(java.math.BigDecimal.TEN);
-    zeroLine.setRetailRate(java.math.BigDecimal.TEN);
-    zeroLine.setUnitsPerPack(java.math.BigDecimal.ONE);
-    zeroLine.setCreaterId(1L);
-    service.saveLine(billId, zeroLine);
+@Test
+void isZeroQtyLine_falseWhenOnlyFreeQtyPositive() {
+    assertFalse(service.isZeroQtyLine(0.0, 3.0));
+}
 
-    int survivingCount = service.retireZeroQtyLines(billId, 1L);
-
-    assertEquals(0, survivingCount);
+@Test
+void isZeroQtyLine_trueWhenNegativeTotal() {
+    // Defensive: legacy compares totalUnits <= 0, so a negative sum (shouldn't
+    // happen in practice but the guard must match) also counts as zero-qty.
+    assertTrue(service.isZeroQtyLine(-1.0, 0.5));
 }
 ```
+
+(Add these four `@Test` methods to `PurchaseOrderRequestNativeSqlServiceTest`,
+same class as Task 3's tests — import `assertTrue`/`assertFalse` from
+`org.junit.jupiter.api.Assertions` alongside the existing `assertEquals` import.)
 
 - [ ] **Step 2: Run test to verify it fails**
 
 Run: `mvn -q -Dtest=PurchaseOrderRequestNativeSqlServiceTest test`
-Expected: FAIL — `finalizeBill`/`retireZeroQtyLines` do not exist.
+Expected: FAIL — `isZeroQtyLine` does not exist.
 
 - [ ] **Step 3: Write minimal implementation**
 
 Add to `PurchaseOrderRequestNativeSqlService`:
 
 ```java
+boolean isZeroQtyLine(double qty, double freeQty) {
+    return (qty + freeQty) <= 0;
+}
+
 public void finalizeBill(long billId, long editorId) {
     em.createNativeQuery(
         "UPDATE " + billTable()
@@ -697,9 +789,8 @@ public int retireZeroQtyLines(long billId, long retirerId) {
         long billItemId = ((Number) row[0]).longValue();
         double qty = row[1] != null ? ((Number) row[1]).doubleValue() : 0.0;
         double freeQty = row[2] != null ? ((Number) row[2]).doubleValue() : 0.0;
-        double total = qty + freeQty;
 
-        if (total <= 0) {
+        if (isZeroQtyLine(qty, freeQty)) {
             em.createNativeQuery(
                 "UPDATE " + billItemTable() + " SET retired=1, retirer_ID=?, retiredAt=?, retireComments=? WHERE ID=?")
                 .setParameter(1, retirerId)

--- a/docs/superpowers/plans/2026-08-07-po-request-native.md
+++ b/docs/superpowers/plans/2026-08-07-po-request-native.md
@@ -1078,9 +1078,19 @@ public void removeItem(BillItem bi) {
     if (currentBill == null || bi == null) {
         return;
     }
+    if (currentBill.isChecked()) {
+        JsfUtil.addErrorMessage("Cannot modify a finalized bill");
+        return;
+    }
     bi.setRetired(true);
+    if (bi.getId() != null) {
+        purchaseOrderRequestNativeSqlService.retireLine(bi.getId(), sessionController.getLoggedUser().getId());
+    }
     billItems.remove(bi);
     calculateBillTotals();
+    if (currentBill.getId() != null) {
+        purchaseOrderRequestNativeSqlService.updateBillTotals(currentBill.getId(), currentBill.getNetTotal(), currentBill.getTotal());
+    }
     itemHistoryVisible = false;
 }
 
@@ -1228,14 +1238,30 @@ public synchronized void finalizeRequest() {
         JsfUtil.addErrorMessage("Please add bill items.");
         return;
     }
-    saveRequestWithoutMessage();
-
-    purchaseOrderRequestNativeSqlService.finalizeBill(currentBill.getId(), sessionController.getLoggedUser().getId());
-    int survivingCount = purchaseOrderRequestNativeSqlService.retireZeroQtyLines(currentBill.getId(), sessionController.getLoggedUser().getId());
-    if (survivingCount == 0) {
+    // Every guard below runs against the IN-MEMORY line list, before any native
+    // mutation reaches the DB. finalizeBill() sets checked=1 and promotes
+    // BILLTYPEATOMIC, and retireZeroQtyLines() retires lines -- both commit
+    // immediately. Letting them run first and only then discovering the bill had
+    // no real quantity left the bill permanently checked=1 with every line
+    // retired, and the page disables Save and Finalize once checked=true, so it
+    // could never be recovered.
+    if (!allBillItemsValid(billItems)) {
+        JsfUtil.addErrorMessage("Please ensure each item has quantity and purchase price.");
+        return;
+    }
+    if (calculateTotalBillItemsCount(billItems) == 0) {
         JsfUtil.addErrorMessage("Please enter item quantities for the bill.");
         return;
     }
+
+    // Validation passed -- safe to persist, then promote.
+    if (!saveRequestWithoutMessage()) {
+        return;
+    }
+
+    // Finalize and the per-line zero-qty sweep run as one EJB call so both
+    // native writes share a single transaction.
+    purchaseOrderRequestNativeSqlService.finalizeAndRetireZeroQtyLines(currentBill.getId(), sessionController.getLoggedUser().getId());
 
     currentBill = billFacade.find(currentBill.getId());
     billItems = loadBillItems(currentBill);

--- a/docs/superpowers/plans/2026-08-07-po-request-native.md
+++ b/docs/superpowers/plans/2026-08-07-po-request-native.md
@@ -1411,6 +1411,39 @@ then do a global find-and-replace of `purchaseOrderRequestController` →
 numbered-controller pattern that caused the #15845 defect (single window only, per
 design spec §8), so a plain unanchored replace of this one bean name is safe here.
 
+**Two controller gaps discovered by a pre-flight EL audit (before this task was
+dispatched) that must be fixed on the CONTROLLER first, not the XHTML** — the
+legacy page directly binds `action="#{purchaseOrderRequestController.resetBillValues}"`
+(3 call sites: a "New"/"Clear" button) and
+`action="#{purchaseOrderRequestController.removeSelected()}"` (a "Remove Selected"
+bulk-delete button on the item table). Both would silently fail at JSF EL resolution
+time (`MethodNotFoundException`/`PropertyNotFoundException` at runtime, NOT a
+compile error — `mvn compile` would report success on a broken page):
+
+1. `PurchaseOrderRequestNativeSqlController.resetBillValues()` (added by Task 5)
+   is currently `private`. Change it to `public void resetBillValues()` — no other
+   change needed, it's already correct logic, just wrong visibility for direct
+   XHTML action binding.
+2. `PurchaseOrderRequestNativeSqlController` has no `removeSelected()` method at
+   all yet. Add one, ported verbatim from legacy
+   `PurchaseOrderRequestController.removeSelected()`
+   (`src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestController.java:129-148`
+   at time of writing — search by name, don't trust the line number) — same
+   `isAuthorized("SAVE", "PurchaseOrderSave")` guard, same null-guard on
+   `selectedBillItems`, same per-item soft-retire loop. **Adapt the persistence
+   call**: legacy calls `saveRequestWithoutMessage()` then
+   `billItemFacade.edit(b)` per already-saved item; the native controller must
+   call `saveRequestWithoutMessage()` (already exists, Task 7) then
+   `purchaseOrderRequestNativeSqlService.retireLine(b.getId(), sessionController.getLoggedUser().getId())`
+   for each selected item that has a non-null `getId()` (mirrors Task 6's fix to
+   `removeItem()`, which had this exact same native-retire requirement — reuse
+   the same `retireLine` service method, do not write a new one). Then remove the
+   retired items from `billItems` and recalculate totals, same shape as
+   `removeItem()`.
+
+Add this fix as part of this task's Step 1 (before copying the XHTML), so the
+copied page has a controller it can actually bind to.
+
 Add a small "Legacy View" link near the page header (same visual treatment as
 `pharmacy_reprint_po_native.xhtml`'s Legacy View button, per the print-page guide
 pattern) pointing back to `pharmacy_purhcase_order_request.xhtml`, for use during

--- a/docs/superpowers/plans/2026-08-07-po-request-native.md
+++ b/docs/superpowers/plans/2026-08-07-po-request-native.md
@@ -1338,29 +1338,47 @@ git commit -m "feat(pharmacy): wire saveRequest/finalizeRequest to native servic
 
 ---
 
-## Task 8: Controller — bulk-add, rate lookups, email (ported verbatim)
+## Task 8: Controller — bulk-add item methods (ported verbatim)
+
+**Correction to an earlier draft of this task:** the rate-lookup chain
+(`applyLastRatesToBillItem` both overloads, `fetchLastPurchaseRatesForItems`,
+`fetchLastRetailRatesForItems`, and all their private helpers) and the email
+methods (`prepareEmailDialog`, `sendPurchaseOrderEmail`, `generatePurchaseOrderHtml`)
+were **already copied into `PurchaseOrderRequestNativeSqlController` by Task 5**
+(confirmed present in the file — Task 5's own review verified them verbatim
+against legacy). Only the bulk-add and item-history-display methods below are
+still missing. Do NOT copy the rate-lookup or email methods again — they already
+exist in the file; re-adding them would either duplicate a method (compile error)
+or silently diverge from the Task-5-verified copy.
 
 **Files:**
 - Modify: `src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestNativeSqlController.java`
 
 **Interfaces:**
-- Consumes: nothing new — pure JPQL/JPA logic
+- Consumes: `applyLastRatesToBillItem`/`fetchLastPurchaseRatesForItems`/
+  `fetchLastRetailRatesForItems` (already present from Task 5 — call them, don't
+  recreate them), `getUnitsPerPack` (already present from Task 5)
 - Produces: `generateBillComponentsForAllSupplierItems(List<Item>)`,
   `addAllSupplierItems()`, `addAllSupplierItemsBelowRol()`, `displayItemDetails(BillItem)`,
-  `closeItemHistory()`, `prepareEmailDialog()`, `sendPurchaseOrderEmail()` — same
-  names as legacy for the copied XHTML.
+  `closeItemHistory()` — same names as legacy for the copied XHTML.
 
-Copy these methods from `PurchaseOrderRequestController` **verbatim** per Task 5's
-instructions (§2/§4 of the design spec establish these are out of the native-SQL
-migration surface — they are read-only JPQL or unrelated JPA writes like `AppEmail`).
-Only adapt field/method access to this controller's field names (`billItems`,
+Copy these methods from `PurchaseOrderRequestController` **verbatim** — read the
+legacy file first to find their current exact line numbers rather than trusting
+any line-number reference in this plan (line numbers drift). Search for
+`generateBillComponentsForAllSupplierItems`, `addAllSupplierItems`,
+`addAllSupplierItemsBelowRol`, `displayItemDetails`, `closeItemHistory` in
+`PurchaseOrderRequestController.java` and copy each method body verbatim. Only
+adapt field/method access to this controller's field names (`billItems`,
 `currentBill`, `sessionController`, `configOptionApplicationController`,
 `pharmacyBean` — inject `@EJB private PharmacyBean pharmacyBean;` if not already
 present) — do not alter the logic itself.
 
-- [ ] **Step 1: Copy the methods listed above from `PurchaseOrderRequestController`
-  lines 495–976 (rate lookups) and 1019–1443 (bulk-add, email) verbatim**, adjusting
-  only field references to match this controller.
+- [ ] **Step 1: Find and copy the 5 methods listed above from
+  `PurchaseOrderRequestController` verbatim**, adjusting only field references to
+  match this controller. Do NOT touch or re-copy any rate-lookup or email method —
+  verify each of the 5 target methods doesn't already exist in the new controller
+  before adding it (a quick grep for the method name), since this brief itself was
+  corrected once already for over-claiming what was missing.
 
 - [ ] **Step 2: Compile check**
 

--- a/docs/superpowers/plans/2026-08-07-po-request-native.md
+++ b/docs/superpowers/plans/2026-08-07-po-request-native.md
@@ -1,0 +1,1383 @@
+# Native Purchase Order Request Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the JPA-entity write path of the Purchase Order Request page
+(create → repeated draft save → item CRUD → finalize → email) with a native-SQL
+implementation, with 100% functional parity with `PurchaseOrderRequestController`.
+
+**Architecture:** New `PurchaseOrderRequestNativeSqlService` (`@Stateless`) does native
+`INSERT`/`UPDATE` for `bill`, `billitem`, `pharmaceuticalbillitem` (all `IDENTITY`-PK
+tables, matching `RetailSaleNativeSqlService`'s `INSERT` + `SELECT LAST_INSERT_ID()`
+pattern). `BillItemFinanceDetails` (also `IDENTITY` PK but carrying business-rule-heavy
+calculation logic) stays JPA `persist`/`merge`, per the retail-sale precedent. A new
+`PurchaseOrderRequestNativeSqlController` (`@Named @SessionScoped`, matching the scope
+of every other controller in this bill family) owns validation, item-list state, rate
+lookups (reused verbatim — already JPQL, not raw entity walking), and email — all
+unchanged from the legacy controller, since none of that is the EAGER-cascade cost
+this migration targets.
+
+**Tech Stack:** Java 11, JPA/EclipseLink (`hmisPU` persistence unit), JSF 2.x +
+PrimeFaces, MySQL (via native SQL for the hot write path).
+
+## Global Constraints
+
+- **NO MOCK DATA** — every task operates against real entities/tables.
+- **NEVER MODIFY EXISTING CONSTRUCTORS** — only add new ones; the legacy
+  `PurchaseOrderRequestController` and its collaborators (`BillFacade`,
+  `BillItemFacade`, `PharmaceuticalBillItemFacade`) must not change signatures.
+- **JPQL FIRST, NATIVE SQL LAST** — native SQL is used only for the `bill`/`billitem`/
+  `pharmaceuticalbillitem` write path per the approved design spec's performance
+  rationale; every other query (rate lookups, item search, email) stays JPQL/JPA.
+- **`findLongByJpql` for COUNT queries** — n/a to this plan (no new COUNT queries), but
+  any added later must follow this rule.
+- Table names must be resolved case-insensitively via `INFORMATION_SCHEMA.TABLES`
+  (`resolveTable()` pattern from `RetailSaleNativeSqlService`), never hardcoded upper
+  or lower case — per `developer_docs/database/migration-development-guide.md` and
+  this codebase's existing native services.
+- After every native `INSERT`/`UPDATE`, evict `Bill`, `BillItem`,
+  `PharmaceuticalBillItem` from the EclipseLink L2 cache.
+- Persistence.xml JNDI: leave local (`jdbc/coop`/`jdbc/ruhunuAudit`) during
+  development; restore CI/CD placeholders only immediately after `git push` (handled
+  outside this plan, per CLAUDE.md).
+- Design spec: `docs/superpowers/specs/2026-08-07-po-request-native-design.md` —
+  every task below implements a piece of it; do not deviate from its scope boundary
+  (only `bill`/`billitem`/`pharmaceuticalbillitem` are touched; no BIFD/BFD-table
+  native writes, no stock/GRN involvement at this phase).
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `src/main/java/com/divudi/core/data/dto/pharmacy/PurchaseOrderRequestLineData.java` (new) | Plain input DTO carrying one line's data from controller to service (item id, qty, free qty, purchase rate, retail rate, units-per-pack, existing `BillItem`/`PharmaceuticalBillItem` id if editing) |
+| `src/main/java/com/divudi/service/pharmacy/PurchaseOrderRequestNativeSqlService.java` (new) | `@Stateless` — native SQL create/update draft bill, native SQL insert/update line items, in-place finalize promotion, zero-qty line retirement |
+| `src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestNativeSqlController.java` (new) | `@Named @SessionScoped` — page-backing bean: item list state, add/remove/edit, rate lookups (ported verbatim from legacy), bulk-add, email, navigation |
+| `src/main/webapp/pharmacy/pharmacy_purhcase_order_request_native.xhtml` (new) | Copy of legacy page layout, EL bindings repointed to the new controller |
+| `src/main/webapp/pharmacy/pharmacy_purhcase_order_list_to_finalize.xhtml` (modify) | Repoint "Edit" action from `purchaseOrderRequestController.navigateToUpdatePurchaseOrder()` to the new controller's equivalent |
+| `src/test/java/com/divudi/service/pharmacy/PurchaseOrderRequestNativeSqlServiceTest.java` (new) | Unit/integration tests for the native service |
+
+---
+
+## Task 1: `PurchaseOrderRequestLineData` DTO
+
+**Files:**
+- Create: `src/main/java/com/divudi/core/data/dto/pharmacy/PurchaseOrderRequestLineData.java`
+- Test: `src/test/java/com/divudi/core/data/dto/pharmacy/PurchaseOrderRequestLineDataTest.java`
+
+**Interfaces:**
+- Consumes: nothing (plain data holder)
+- Produces: `PurchaseOrderRequestLineData` with getters/setters for:
+  `Long billItemId` (null = new line), `Long pharmaceuticalBillItemId` (null = new),
+  `Long itemId`, `boolean isAmpp`, `BigDecimal quantity`, `BigDecimal freeQuantity`,
+  `BigDecimal purchaseRate`, `BigDecimal retailRate`, `BigDecimal unitsPerPack`,
+  `int serialNo`, `Long createrId`. Later tasks (2, 3) consume these exact field names.
+
+- [ ] **Step 1: Write the failing test**
+
+```java
+package com.divudi.core.data.dto.pharmacy;
+
+import org.junit.Test;
+import java.math.BigDecimal;
+import static org.junit.Assert.assertEquals;
+
+public class PurchaseOrderRequestLineDataTest {
+    @Test
+    public void gettersReturnValuesSetByConstructorArgs() {
+        PurchaseOrderRequestLineData d = new PurchaseOrderRequestLineData();
+        d.setBillItemId(5L);
+        d.setPharmaceuticalBillItemId(7L);
+        d.setItemId(100L);
+        d.setAmpp(true);
+        d.setQuantity(BigDecimal.TEN);
+        d.setFreeQuantity(BigDecimal.ONE);
+        d.setPurchaseRate(BigDecimal.valueOf(12.5));
+        d.setRetailRate(BigDecimal.valueOf(15.0));
+        d.setUnitsPerPack(BigDecimal.valueOf(10));
+        d.setSerialNo(2);
+        d.setCreaterId(1L);
+
+        assertEquals(Long.valueOf(5L), d.getBillItemId());
+        assertEquals(Long.valueOf(7L), d.getPharmaceuticalBillItemId());
+        assertEquals(Long.valueOf(100L), d.getItemId());
+        assertEquals(true, d.isAmpp());
+        assertEquals(BigDecimal.TEN, d.getQuantity());
+        assertEquals(BigDecimal.ONE, d.getFreeQuantity());
+        assertEquals(BigDecimal.valueOf(12.5), d.getPurchaseRate());
+        assertEquals(BigDecimal.valueOf(15.0), d.getRetailRate());
+        assertEquals(BigDecimal.valueOf(10), d.getUnitsPerPack());
+        assertEquals(2, d.getSerialNo());
+        assertEquals(Long.valueOf(1L), d.getCreaterId());
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mvn -q -Dtest=PurchaseOrderRequestLineDataTest test`
+Expected: FAIL — compile error, class does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```java
+package com.divudi.core.data.dto.pharmacy;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+
+public class PurchaseOrderRequestLineData implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Long billItemId;
+    private Long pharmaceuticalBillItemId;
+    private Long itemId;
+    private boolean ampp;
+    private BigDecimal quantity;
+    private BigDecimal freeQuantity;
+    private BigDecimal purchaseRate;
+    private BigDecimal retailRate;
+    private BigDecimal unitsPerPack;
+    private int serialNo;
+    private Long createrId;
+
+    public Long getBillItemId() { return billItemId; }
+    public void setBillItemId(Long billItemId) { this.billItemId = billItemId; }
+
+    public Long getPharmaceuticalBillItemId() { return pharmaceuticalBillItemId; }
+    public void setPharmaceuticalBillItemId(Long pharmaceuticalBillItemId) { this.pharmaceuticalBillItemId = pharmaceuticalBillItemId; }
+
+    public Long getItemId() { return itemId; }
+    public void setItemId(Long itemId) { this.itemId = itemId; }
+
+    public boolean isAmpp() { return ampp; }
+    public void setAmpp(boolean ampp) { this.ampp = ampp; }
+
+    public BigDecimal getQuantity() { return quantity; }
+    public void setQuantity(BigDecimal quantity) { this.quantity = quantity; }
+
+    public BigDecimal getFreeQuantity() { return freeQuantity; }
+    public void setFreeQuantity(BigDecimal freeQuantity) { this.freeQuantity = freeQuantity; }
+
+    public BigDecimal getPurchaseRate() { return purchaseRate; }
+    public void setPurchaseRate(BigDecimal purchaseRate) { this.purchaseRate = purchaseRate; }
+
+    public BigDecimal getRetailRate() { return retailRate; }
+    public void setRetailRate(BigDecimal retailRate) { this.retailRate = retailRate; }
+
+    public BigDecimal getUnitsPerPack() { return unitsPerPack; }
+    public void setUnitsPerPack(BigDecimal unitsPerPack) { this.unitsPerPack = unitsPerPack; }
+
+    public int getSerialNo() { return serialNo; }
+    public void setSerialNo(int serialNo) { this.serialNo = serialNo; }
+
+    public Long getCreaterId() { return createrId; }
+    public void setCreaterId(Long createrId) { this.createrId = createrId; }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `mvn -q -Dtest=PurchaseOrderRequestLineDataTest test`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/java/com/divudi/core/data/dto/pharmacy/PurchaseOrderRequestLineData.java src/test/java/com/divudi/core/data/dto/pharmacy/PurchaseOrderRequestLineDataTest.java
+git commit -m "feat(pharmacy): add PurchaseOrderRequestLineData DTO for native PO request writes"
+```
+
+---
+
+## Task 2: `PurchaseOrderRequestNativeSqlService` — draft bill create/update
+
+**Files:**
+- Create: `src/main/java/com/divudi/service/pharmacy/PurchaseOrderRequestNativeSqlService.java`
+- Test: `src/test/java/com/divudi/service/pharmacy/PurchaseOrderRequestNativeSqlServiceTest.java`
+
+**Interfaces:**
+- Consumes: `PurchaseOrderRequestLineData` (Task 1)
+- Produces:
+  - `long createDraftBill(long departmentId, long institutionId, long createrId, String deptId, String insId)` →
+    returns new bill id, `BILLTYPEATOMIC='PHARMACY_ORDER_PRE'`, `checked=0`
+  - `void updateDraftBillHeader(long billId, Long toInstitutionId, PaymentMethod paymentMethod, int creditDuration, boolean consignment, DepartmentType departmentType, Long editorId)`
+  - `boolean isBillChecked(long billId)` — used by controller guards
+  - Later tasks (3, 4) call these exact method names/signatures.
+
+This test uses an in-memory/test persistence unit exactly like existing native
+service tests in this codebase — check `src/test/java/com/divudi/service/pharmacy/`
+for the harness pattern already used by `RetailSaleNativeSqlService`'s tests and
+follow the same `@Before`/entity-manager setup before writing this test, since this
+plan cannot assume a specific harness without seeing it.
+
+- [ ] **Step 1: Write the failing test**
+
+```java
+package com.divudi.service.pharmacy;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class PurchaseOrderRequestNativeSqlServiceTest {
+
+    // Follow the same EntityManager/test-container setup pattern as
+    // RetailSaleNativeSqlServiceTest in this package — copy its @Before,
+    // persistence-unit name, and teardown exactly, then adapt the body below.
+
+    @Test
+    public void createDraftBillPersistsPharmacyOrderPreAtomic() {
+        PurchaseOrderRequestNativeSqlService service = new PurchaseOrderRequestNativeSqlService();
+        // inject test EntityManager per harness pattern
+
+        long billId = service.createDraftBill(1L, 1L, 1L, "POR-0001", "POR-0001");
+
+        assertTrue(billId > 0);
+        assertTrue(service.isBillChecked(billId) == false);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mvn -q -Dtest=PurchaseOrderRequestNativeSqlServiceTest test`
+Expected: FAIL — compile error, class does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```java
+package com.divudi.service.pharmacy;
+
+import com.divudi.core.data.BillTypeAtomic;
+import com.divudi.core.data.BillType;
+import com.divudi.core.data.DepartmentType;
+import com.divudi.core.data.PaymentMethod;
+import javax.ejb.Stateless;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.sql.Timestamp;
+import java.util.Date;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Native SQL write path for the Purchase Order Request draft bill.
+ * Only bill / billitem / pharmaceuticalbillitem are touched here —
+ * BillItemFinanceDetails stays JPA (IDENTITY PK, calculation-heavy),
+ * matching RetailSaleNativeSqlService's split.
+ * Related issue: #22727
+ */
+@Stateless
+public class PurchaseOrderRequestNativeSqlService {
+
+    private static final Logger LOGGER = Logger.getLogger(PurchaseOrderRequestNativeSqlService.class.getName());
+
+    @PersistenceContext(unitName = "hmisPU")
+    private EntityManager em;
+
+    private String tBill;
+    private String tBillItem;
+    private String tPharmBillItem;
+
+    public long createDraftBill(long departmentId, long institutionId, long createrId, String deptId, String insId) {
+        Date now = new Date();
+        em.createNativeQuery(
+            "INSERT INTO " + billTable()
+            + " (BILLTYPEATOMIC, billType, department_ID, institution_ID, fromDepartment_ID, fromInstitution_ID,"
+            + " creater_ID, createdAt, checked, retired, cancelled, deptId, insId, netTotal, total)"
+            + " VALUES (?,?,?,?,?,?,?,?,0,0,0,?,?,0,0)")
+            .setParameter(1, BillTypeAtomic.PHARMACY_ORDER_PRE.toString())
+            .setParameter(2, BillType.PharmacyOrder.toString())
+            .setParameter(3, departmentId)
+            .setParameter(4, institutionId)
+            .setParameter(5, departmentId)
+            .setParameter(6, institutionId)
+            .setParameter(7, createrId)
+            .setParameter(8, new Timestamp(now.getTime()))
+            .setParameter(9, deptId)
+            .setParameter(10, insId)
+            .executeUpdate();
+        long billId = ((Number) em.createNativeQuery("SELECT LAST_INSERT_ID()").getSingleResult()).longValue();
+        evictCache();
+        return billId;
+    }
+
+    public void updateDraftBillHeader(long billId, Long toInstitutionId, PaymentMethod paymentMethod,
+                                       int creditDuration, boolean consignment, DepartmentType departmentType,
+                                       Long editorId) {
+        em.createNativeQuery(
+            "UPDATE " + billTable()
+            + " SET toInstitution_ID=?, paymentMethod=?, creditDuration=?, consignment=?,"
+            + " departmentType=?, editor_ID=?, editedAt=?"
+            + " WHERE ID=?")
+            .setParameter(1, toInstitutionId)
+            .setParameter(2, paymentMethod != null ? paymentMethod.toString() : null)
+            .setParameter(3, creditDuration)
+            .setParameter(4, consignment ? 1 : 0)
+            .setParameter(5, departmentType != null ? departmentType.toString() : null)
+            .setParameter(6, editorId)
+            .setParameter(7, new Timestamp(new Date().getTime()))
+            .setParameter(8, billId)
+            .executeUpdate();
+        evictCache();
+    }
+
+    public boolean isBillChecked(long billId) {
+        Object result = em.createNativeQuery(
+            "SELECT checked FROM " + billTable() + " WHERE ID=?")
+            .setParameter(1, billId)
+            .getSingleResult();
+        if (result instanceof Boolean) return (Boolean) result;
+        if (result instanceof Number) return ((Number) result).intValue() != 0;
+        return false;
+    }
+
+    private void evictCache() {
+        javax.persistence.Cache cache = em.getEntityManagerFactory().getCache();
+        cache.evict(com.divudi.core.entity.Bill.class);
+    }
+
+    private String resolveTable(String upperName) {
+        Object name = em.createNativeQuery(
+            "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES "
+            + "WHERE TABLE_SCHEMA = DATABASE() AND UPPER(TABLE_NAME) = ? LIMIT 1")
+            .setParameter(1, upperName)
+            .getSingleResult();
+        return name.toString();
+    }
+
+    private String billTable() {
+        if (tBill == null) tBill = resolveTable("BILL");
+        return tBill;
+    }
+
+    private String billItemTable() {
+        if (tBillItem == null) tBillItem = resolveTable("BILLITEM");
+        return tBillItem;
+    }
+
+    private String pharmBillItemTable() {
+        if (tPharmBillItem == null) tPharmBillItem = resolveTable("PHARMACEUTICALBILLITEM");
+        return tPharmBillItem;
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `mvn -q -Dtest=PurchaseOrderRequestNativeSqlServiceTest test`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/java/com/divudi/service/pharmacy/PurchaseOrderRequestNativeSqlService.java src/test/java/com/divudi/service/pharmacy/PurchaseOrderRequestNativeSqlServiceTest.java
+git commit -m "feat(pharmacy): native SQL draft-bill create/update for PO Request"
+```
+
+---
+
+## Task 3: `PurchaseOrderRequestNativeSqlService` — line item insert/update + BIFD
+
+**Files:**
+- Modify: `src/main/java/com/divudi/service/pharmacy/PurchaseOrderRequestNativeSqlService.java`
+- Modify: `src/test/java/com/divudi/service/pharmacy/PurchaseOrderRequestNativeSqlServiceTest.java`
+
+**Interfaces:**
+- Consumes: `PurchaseOrderRequestLineData` (Task 1), `createDraftBill`/`billItemTable`/`pharmBillItemTable` (Task 2)
+- Produces: `long saveLine(long billId, PurchaseOrderRequestLineData line)` — inserts or
+  updates `billitem` + `pharmaceuticalbillitem` natively, persists/merges
+  `BillItemFinanceDetails` via JPA, returns the `billitem` id. Task 4 (finalize) and
+  the controller (Task 5) call this for every line on every save.
+
+Mirrors the calculation in legacy `calculateLineValues()` (read §2 of the design
+spec) but the persistence is native for `billitem`/`pharmaceuticalbillitem`, JPA for
+`BillItemFinanceDetails`.
+
+- [ ] **Step 1: Write the failing test**
+
+```java
+@Test
+public void saveLineInsertsBillItemAndPharmaceuticalBillItem() {
+    PurchaseOrderRequestNativeSqlService service = new PurchaseOrderRequestNativeSqlService();
+    // inject test EntityManager per harness pattern
+    long billId = service.createDraftBill(1L, 1L, 1L, "POR-0002", "POR-0002");
+
+    PurchaseOrderRequestLineData line = new PurchaseOrderRequestLineData();
+    line.setItemId(500L); // seed a test Item fixture with id 500 per harness convention
+    line.setAmpp(false);
+    line.setQuantity(new java.math.BigDecimal("10"));
+    line.setFreeQuantity(new java.math.BigDecimal("1"));
+    line.setPurchaseRate(new java.math.BigDecimal("25.50"));
+    line.setRetailRate(new java.math.BigDecimal("30.00"));
+    line.setUnitsPerPack(java.math.BigDecimal.ONE);
+    line.setSerialNo(0);
+    line.setCreaterId(1L);
+
+    long billItemId = service.saveLine(billId, line);
+
+    assertTrue(billItemId > 0);
+    // Follow-up assertion: read back via native query and confirm
+    // netValue = 255.00 (25.50 * 10), matching calculateLineValues()'s
+    // "purchase rate * qty" rule for non-AMPP items.
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mvn -q -Dtest=PurchaseOrderRequestNativeSqlServiceTest test`
+Expected: FAIL — `saveLine` does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `PurchaseOrderRequestNativeSqlService`:
+
+```java
+import com.divudi.core.entity.BillItemFinanceDetails;
+import java.math.BigDecimal;
+
+// ... inside the class ...
+
+public long saveLine(long billId, com.divudi.core.data.dto.pharmacy.PurchaseOrderRequestLineData line) {
+    BigDecimal qty = line.getQuantity() != null ? line.getQuantity() : BigDecimal.ZERO;
+    BigDecimal freeQty = line.getFreeQuantity() != null ? line.getFreeQuantity() : BigDecimal.ZERO;
+    BigDecimal purchaseRate = line.getPurchaseRate() != null ? line.getPurchaseRate() : BigDecimal.ZERO;
+    BigDecimal retailRate = line.getRetailRate() != null ? line.getRetailRate() : BigDecimal.ZERO;
+    BigDecimal unitsPerPack = (line.getUnitsPerPack() != null && line.getUnitsPerPack().doubleValue() > 0)
+            ? line.getUnitsPerPack() : BigDecimal.ONE;
+
+    BigDecimal grossValue = purchaseRate.multiply(qty);
+    BigDecimal netValue = grossValue;
+    BigDecimal purchaseValue = purchaseRate.multiply(qty.add(freeQty));
+    BigDecimal retailValue = retailRate.multiply(qty.add(freeQty));
+    BigDecimal netRate = qty.doubleValue() > 0 ? netValue.divide(qty, java.math.RoundingMode.HALF_UP) : BigDecimal.ZERO;
+
+    long billItemId;
+    if (line.getBillItemId() == null) {
+        em.createNativeQuery(
+            "INSERT INTO " + billItemTable()
+            + " (bill_ID, item_ID, qty, netValue, grossValue, Rate, netRate,"
+            + " createdAt, creater_ID, retired, refunded, billItemRefunded,"
+            + " consideredForCosting, inwardChargeType, searialNo)"
+            + " VALUES (?,?,?,?,?,?,?,?,?,0,0,0,1,'Medicine',?)")
+            .setParameter(1, billId)
+            .setParameter(2, line.getItemId())
+            .setParameter(3, qty.doubleValue())
+            .setParameter(4, netValue.doubleValue())
+            .setParameter(5, grossValue.doubleValue())
+            .setParameter(6, purchaseRate.doubleValue())
+            .setParameter(7, netRate.doubleValue())
+            .setParameter(8, new Timestamp(new Date().getTime()))
+            .setParameter(9, line.getCreaterId())
+            .setParameter(10, line.getSerialNo())
+            .executeUpdate();
+        billItemId = ((Number) em.createNativeQuery("SELECT LAST_INSERT_ID()").getSingleResult()).longValue();
+    } else {
+        billItemId = line.getBillItemId();
+        em.createNativeQuery(
+            "UPDATE " + billItemTable()
+            + " SET qty=?, netValue=?, grossValue=?, Rate=?, netRate=? WHERE ID=?")
+            .setParameter(1, qty.doubleValue())
+            .setParameter(2, netValue.doubleValue())
+            .setParameter(3, grossValue.doubleValue())
+            .setParameter(4, purchaseRate.doubleValue())
+            .setParameter(5, netRate.doubleValue())
+            .setParameter(6, billItemId)
+            .executeUpdate();
+    }
+
+    double pbiQty = line.isAmpp() ? qty.doubleValue() * unitsPerPack.doubleValue() : qty.doubleValue();
+    double pbiFreeQty = line.isAmpp() ? freeQty.doubleValue() * unitsPerPack.doubleValue() : freeQty.doubleValue();
+    double pbiPurchaseRate = line.isAmpp() ? purchaseRate.doubleValue() / unitsPerPack.doubleValue() : purchaseRate.doubleValue();
+    double pbiRetailRate = line.isAmpp() ? retailRate.doubleValue() / unitsPerPack.doubleValue() : retailRate.doubleValue();
+
+    if (line.getPharmaceuticalBillItemId() == null) {
+        em.createNativeQuery(
+            "INSERT INTO " + pharmBillItemTable()
+            + " (billItem_ID, qty, freeQty, purchaseRate, purchaseRatePack, purchaseValue,"
+            + " retailRate, retailRatePack, retailRateInUnit, retailValue, costRate, costRatePack, costValue,"
+            + " createdAt, creater_ID)"
+            + " VALUES (?,?,?,?,?,?,?,?,?,?,0,0,0,?,?)")
+            .setParameter(1, billItemId)
+            .setParameter(2, pbiQty)
+            .setParameter(3, pbiFreeQty)
+            .setParameter(4, pbiPurchaseRate)
+            .setParameter(5, purchaseRate.doubleValue())
+            .setParameter(6, purchaseValue.doubleValue())
+            .setParameter(7, pbiRetailRate)
+            .setParameter(8, retailRate.doubleValue())
+            .setParameter(9, pbiRetailRate)
+            .setParameter(10, retailValue.doubleValue())
+            .setParameter(11, new Timestamp(new Date().getTime()))
+            .setParameter(12, line.getCreaterId())
+            .executeUpdate();
+    } else {
+        em.createNativeQuery(
+            "UPDATE " + pharmBillItemTable()
+            + " SET qty=?, freeQty=?, purchaseRate=?, purchaseRatePack=?, purchaseValue=?,"
+            + " retailRate=?, retailRatePack=?, retailRateInUnit=?, retailValue=? WHERE billItem_ID=?")
+            .setParameter(1, pbiQty)
+            .setParameter(2, pbiFreeQty)
+            .setParameter(3, pbiPurchaseRate)
+            .setParameter(4, purchaseRate.doubleValue())
+            .setParameter(5, purchaseValue.doubleValue())
+            .setParameter(6, pbiRetailRate)
+            .setParameter(7, retailRate.doubleValue())
+            .setParameter(8, pbiRetailRate)
+            .setParameter(9, retailValue.doubleValue())
+            .setParameter(10, billItemId)
+            .executeUpdate();
+    }
+
+    saveBillItemFinanceDetails(billItemId, line, qty, freeQty, purchaseRate, retailRate, netValue, grossValue,
+            netRate, unitsPerPack, pbiQty, pbiFreeQty);
+
+    evictLineCache();
+    return billItemId;
+}
+
+private void saveBillItemFinanceDetails(long billItemId, com.divudi.core.data.dto.pharmacy.PurchaseOrderRequestLineData line,
+        BigDecimal qty, BigDecimal freeQty, BigDecimal purchaseRate, BigDecimal retailRate,
+        BigDecimal netValue, BigDecimal grossValue, BigDecimal netRate, BigDecimal unitsPerPack,
+        double quantityByUnits, double freeQuantityByUnits) {
+    BillItemFinanceDetails bifd;
+    if (line.getBillItemId() != null) {
+        String jpql = "SELECT bi.billItemFinanceDetails FROM BillItem bi WHERE bi.id = :id";
+        java.util.List<BillItemFinanceDetails> existing = em.createQuery(jpql, BillItemFinanceDetails.class)
+                .setParameter("id", billItemId)
+                .getResultList();
+        bifd = (existing != null && !existing.isEmpty() && existing.get(0) != null) ? existing.get(0) : new BillItemFinanceDetails();
+    } else {
+        bifd = new BillItemFinanceDetails();
+    }
+
+    bifd.setLineNetRate(purchaseRate);
+    bifd.setLineGrossRate(purchaseRate);
+    bifd.setGrossRate(purchaseRate);
+    bifd.setLineNetTotal(netValue);
+    bifd.setLineGrossTotal(grossValue);
+    bifd.setGrossTotal(grossValue);
+    bifd.setQuantity(qty);
+    bifd.setFreeQuantity(freeQty);
+    bifd.setQuantityByUnits(BigDecimal.valueOf(quantityByUnits));
+    bifd.setFreeQuantityByUnits(BigDecimal.valueOf(freeQuantityByUnits));
+    bifd.setRetailSaleRate(retailRate);
+    bifd.setUnitsPerPack(unitsPerPack);
+    bifd.setValueAtPurchaseRate(purchaseRate.multiply(qty.add(freeQty)));
+    bifd.setValueAtRetailRate(retailRate.multiply(qty.add(freeQty)));
+    bifd.setLineCost(BigDecimal.ZERO);
+    bifd.setLineCostRate(BigDecimal.ZERO);
+    bifd.setValueAtCostRate(BigDecimal.ZERO);
+
+    if (bifd.getId() == null) {
+        bifd.setCreatedAt(new Date());
+        em.persist(bifd);
+        em.flush();
+        em.createNativeQuery("UPDATE " + billItemTable() + " SET BILLITEMFINANCEDETAILS_ID=? WHERE ID=?")
+                .setParameter(1, bifd.getId())
+                .setParameter(2, billItemId)
+                .executeUpdate();
+    } else {
+        em.merge(bifd);
+    }
+}
+
+private void evictLineCache() {
+    javax.persistence.Cache cache = em.getEntityManagerFactory().getCache();
+    cache.evict(com.divudi.core.entity.BillItem.class);
+    cache.evict(com.divudi.core.entity.pharmacy.PharmaceuticalBillItem.class);
+    cache.evict(BillItemFinanceDetails.class);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `mvn -q -Dtest=PurchaseOrderRequestNativeSqlServiceTest test`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/java/com/divudi/service/pharmacy/PurchaseOrderRequestNativeSqlService.java src/test/java/com/divudi/service/pharmacy/PurchaseOrderRequestNativeSqlServiceTest.java
+git commit -m "feat(pharmacy): native SQL line-item insert/update for PO Request"
+```
+
+---
+
+## Task 4: `PurchaseOrderRequestNativeSqlService` — finalize + zero-qty retirement
+
+**Files:**
+- Modify: `src/main/java/com/divudi/service/pharmacy/PurchaseOrderRequestNativeSqlService.java`
+- Modify: `src/test/java/com/divudi/service/pharmacy/PurchaseOrderRequestNativeSqlServiceTest.java`
+
+**Interfaces:**
+- Consumes: `billTable()`, `billItemTable()`, `pharmBillItemTable()` (Task 2)
+- Produces: `void finalizeBill(long billId, long editorId)` — promotes
+  `BILLTYPEATOMIC` to `PHARMACY_ORDER` and sets `checked=1, checkeAt=now,
+  checkedBy_ID=editorId`; `int retireZeroQtyLines(long billId, long retirerId)` —
+  retires (native `UPDATE billitem/pharmaceuticalbillitem SET retired=1,...`) any
+  line whose `qty+freeQty <= 0`, sets `remainingQty`/`remainingFreeQty` on surviving
+  lines, returns count of surviving (non-retired) lines with qty > 0 — mirrors legacy
+  `finalizeBillComponent()`'s `totalBillItemsCount` accumulation. Controller (Task 5)
+  calls both in sequence for the Finalize button.
+
+- [ ] **Step 1: Write the failing test**
+
+```java
+@Test
+public void finalizeBillPromotesAtomicAndSetsChecked() {
+    PurchaseOrderRequestNativeSqlService service = new PurchaseOrderRequestNativeSqlService();
+    long billId = service.createDraftBill(1L, 1L, 1L, "POR-0003", "POR-0003");
+
+    service.finalizeBill(billId, 1L);
+
+    assertTrue(service.isBillChecked(billId));
+}
+
+@Test
+public void retireZeroQtyLinesRetiresLinesWithNoQuantity() {
+    PurchaseOrderRequestNativeSqlService service = new PurchaseOrderRequestNativeSqlService();
+    long billId = service.createDraftBill(1L, 1L, 1L, "POR-0004", "POR-0004");
+
+    com.divudi.core.data.dto.pharmacy.PurchaseOrderRequestLineData zeroLine =
+            new com.divudi.core.data.dto.pharmacy.PurchaseOrderRequestLineData();
+    zeroLine.setItemId(500L);
+    zeroLine.setQuantity(java.math.BigDecimal.ZERO);
+    zeroLine.setFreeQuantity(java.math.BigDecimal.ZERO);
+    zeroLine.setPurchaseRate(java.math.BigDecimal.TEN);
+    zeroLine.setRetailRate(java.math.BigDecimal.TEN);
+    zeroLine.setUnitsPerPack(java.math.BigDecimal.ONE);
+    zeroLine.setCreaterId(1L);
+    service.saveLine(billId, zeroLine);
+
+    int survivingCount = service.retireZeroQtyLines(billId, 1L);
+
+    assertEquals(0, survivingCount);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mvn -q -Dtest=PurchaseOrderRequestNativeSqlServiceTest test`
+Expected: FAIL — `finalizeBill`/`retireZeroQtyLines` do not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `PurchaseOrderRequestNativeSqlService`:
+
+```java
+public void finalizeBill(long billId, long editorId) {
+    em.createNativeQuery(
+        "UPDATE " + billTable()
+        + " SET BILLTYPEATOMIC=?, checked=1, checkeAt=?, checkedBy_ID=?, editor_ID=?, editedAt=? WHERE ID=?")
+        .setParameter(1, BillTypeAtomic.PHARMACY_ORDER.toString())
+        .setParameter(2, new Timestamp(new Date().getTime()))
+        .setParameter(3, editorId)
+        .setParameter(4, editorId)
+        .setParameter(5, new Timestamp(new Date().getTime()))
+        .setParameter(6, billId)
+        .executeUpdate();
+    evictCache();
+}
+
+@SuppressWarnings("unchecked")
+public int retireZeroQtyLines(long billId, long retirerId) {
+    java.util.List<Object[]> rows = em.createNativeQuery(
+        "SELECT bi.ID, pbi.qty, pbi.freeQty FROM " + billItemTable() + " bi "
+        + "JOIN " + pharmBillItemTable() + " pbi ON pbi.billItem_ID = bi.ID "
+        + "WHERE bi.bill_ID = ? AND bi.retired = 0")
+        .setParameter(1, billId)
+        .getResultList();
+
+    int survivingCount = 0;
+    Timestamp now = new Timestamp(new Date().getTime());
+    for (Object[] row : rows) {
+        long billItemId = ((Number) row[0]).longValue();
+        double qty = row[1] != null ? ((Number) row[1]).doubleValue() : 0.0;
+        double freeQty = row[2] != null ? ((Number) row[2]).doubleValue() : 0.0;
+        double total = qty + freeQty;
+
+        if (total <= 0) {
+            em.createNativeQuery(
+                "UPDATE " + billItemTable() + " SET retired=1, retirer_ID=?, retiredAt=?, retireComments=? WHERE ID=?")
+                .setParameter(1, retirerId)
+                .setParameter(2, now)
+                .setParameter(3, "Retired at Finalising PO")
+                .setParameter(4, billItemId)
+                .executeUpdate();
+            em.createNativeQuery(
+                "UPDATE " + pharmBillItemTable() + " SET retired=1, retirer_ID=?, retiredAt=? WHERE billItem_ID=?")
+                .setParameter(1, retirerId)
+                .setParameter(2, now)
+                .setParameter(3, billItemId)
+                .executeUpdate();
+        } else {
+            em.createNativeQuery(
+                "UPDATE " + pharmBillItemTable() + " SET remainingQty=qty, remainingFreeQty=freeQty WHERE billItem_ID=?")
+                .setParameter(1, billItemId)
+                .executeUpdate();
+            survivingCount++;
+        }
+    }
+    evictLineCache();
+    return survivingCount;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `mvn -q -Dtest=PurchaseOrderRequestNativeSqlServiceTest test`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/java/com/divudi/service/pharmacy/PurchaseOrderRequestNativeSqlService.java src/test/java/com/divudi/service/pharmacy/PurchaseOrderRequestNativeSqlServiceTest.java
+git commit -m "feat(pharmacy): native SQL finalize + zero-qty line retirement for PO Request"
+```
+
+---
+
+## Task 5: `PurchaseOrderRequestNativeSqlController` — scaffolding, navigation, guards
+
+**Files:**
+- Create: `src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestNativeSqlController.java`
+
+**Interfaces:**
+- Consumes: `PurchaseOrderRequestNativeSqlService` (Tasks 2–4),
+  `SessionController.getLoggedUser()`, `WebUserController.hasPrivilege(String)`,
+  `BillNumberGenerator` (unchanged JPA-backed sequence logic — reused, not
+  reimplemented, per the design spec's rationale)
+- Produces: `String navigateToCreateNewPurchaseOrder()`,
+  `String navigateToUpdatePurchaseOrder(Long billId)` — Task 9 (XHTML) and the
+  List-to-Finalize page (Task 10) call these by name.
+
+This task has no independent unit test — it is thin JSF scaffolding wired to the
+already-tested service. Verify it manually via the Playwright pass in Task 11. Copy
+the following pieces from `PurchaseOrderRequestController` **verbatim, unchanged**
+(these are pure JPQL/validation logic, not part of the native-SQL migration surface,
+per the design spec §2 and §4 function inventory):
+
+- `isAuthorized(String action, String requiredPrivilege)` — copy body exactly
+- `getDealorItems()`, `filterItemsByDepartmentType()`,
+  `completeItemForSelectedDepartmentType()` — copy exactly
+- `applyLastRatesToBillItem()` (both overloads), `getUnitsPerPack()`,
+  `fetchLastPurchaseRatesForItems()`, `fetchLastRetailRatesForItems()`,
+  `fetchLastRatesForItems()`, and every private helper it calls down to
+  `getRateByItemId()` — copy exactly, unchanged; these are read-only JPQL
+  queries, not the EAGER-cascade cost this migration targets
+- `createAndAssignBillNumber()` — copy exactly, delegates to `BillNumberGenerator`
+- `prepareEmailDialog()`, `sendPurchaseOrderEmail()`, `generatePurchaseOrderHtml()`
+  — copy exactly; these read `currentBill` (kept as a live JPA entity for display/
+  email — see below), not part of the native write path
+
+- [ ] **Step 1: Write the controller skeleton**
+
+```java
+package com.divudi.bean.pharmacy;
+
+import com.divudi.bean.common.SessionController;
+import com.divudi.bean.common.WebUserController;
+import com.divudi.bean.common.ConfigOptionApplicationController;
+import com.divudi.bean.common.ConfigOptionController;
+import com.divudi.core.data.BillTypeAtomic;
+import com.divudi.core.data.DepartmentType;
+import com.divudi.core.data.PaymentMethod;
+import com.divudi.core.data.dto.pharmacy.PurchaseOrderRequestLineData;
+import com.divudi.core.entity.Bill;
+import com.divudi.core.entity.BillItem;
+import com.divudi.core.entity.pharmacy.PharmaceuticalBillItem;
+import com.divudi.core.facade.BillFacade;
+import com.divudi.core.util.JsfUtil;
+import com.divudi.ejb.BillNumberGenerator;
+import com.divudi.service.pharmacy.PurchaseOrderRequestNativeSqlService;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import javax.ejb.EJB;
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+/**
+ * SessionScoped controller for the native-SQL Purchase Order Request page.
+ * Native SQL: bill create/update, billitem+PBI writes (via the service).
+ * JPA (unchanged): rate lookups, bill-number generation, email — see
+ * docs/superpowers/specs/2026-08-07-po-request-native-design.md §3.
+ * Related issue: #22727
+ */
+@Named
+@SessionScoped
+public class PurchaseOrderRequestNativeSqlController implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Inject
+    private SessionController sessionController;
+    @Inject
+    private WebUserController webUserController;
+    @Inject
+    private ConfigOptionApplicationController configOptionApplicationController;
+    @Inject
+    private ConfigOptionController configOptionController;
+
+    @EJB
+    private PurchaseOrderRequestNativeSqlService purchaseOrderRequestNativeSqlService;
+    @EJB
+    private BillNumberGenerator billNumberBean;
+    @EJB
+    private BillFacade billFacade;
+
+    private Bill currentBill;
+    private BillItem currentBillItem;
+    private List<BillItem> billItems;
+    private List<BillItem> selectedBillItems;
+    private boolean printPreview;
+    private boolean itemHistoryVisible;
+    private Long billId;
+    private String emailRecipient;
+
+    public String navigateToCreateNewPurchaseOrder() {
+        resetBillValues();
+        currentBill = new Bill();
+        return "/pharmacy/pharmacy_purhcase_order_request_native?faces-redirect=true";
+    }
+
+    public String navigateToUpdatePurchaseOrder(Long billId) {
+        if (billId == null) {
+            JsfUtil.addErrorMessage("No Bill");
+            return "";
+        }
+        resetBillValues();
+        this.billId = billId;
+        currentBill = billFacade.find(billId);
+        if (currentBill == null) {
+            JsfUtil.addErrorMessage("Bill not found");
+            return "";
+        }
+        billItems = loadBillItems(currentBill);
+        return "/pharmacy/pharmacy_purhcase_order_request_native?faces-redirect=true";
+    }
+
+    private List<BillItem> loadBillItems(Bill bill) {
+        String jpql = "select bi from BillItem bi where bi.retired=:ret and bi.bill=:bill order by bi.searialNo";
+        java.util.Map<String, Object> m = new java.util.HashMap<>();
+        m.put("ret", false);
+        m.put("bill", bill);
+        return billFacade.findByJpql(jpql, m) instanceof List ? (List<BillItem>) (List<?>) billFacade.findByJpql(jpql, m) : new ArrayList<>();
+    }
+
+    private void resetBillValues() {
+        currentBill = null;
+        currentBillItem = new BillItem();
+        billItems = new ArrayList<>();
+        selectedBillItems = null;
+        printPreview = false;
+        itemHistoryVisible = false;
+        billId = null;
+    }
+
+    private boolean isAuthorized(String action, String requiredPrivilege) {
+        if (!webUserController.hasPrivilege(requiredPrivilege)) {
+            JsfUtil.addErrorMessage("You don't have permission to " + action.toLowerCase() + " purchase orders.");
+            return false;
+        }
+        return true;
+    }
+
+    // Getters/setters
+    public Bill getCurrentBill() { return currentBill; }
+    public void setCurrentBill(Bill currentBill) { this.currentBill = currentBill; }
+    public BillItem getCurrentBillItem() { return currentBillItem; }
+    public void setCurrentBillItem(BillItem currentBillItem) { this.currentBillItem = currentBillItem; }
+    public List<BillItem> getBillItems() { return billItems; }
+    public void setBillItems(List<BillItem> billItems) { this.billItems = billItems; }
+    public List<BillItem> getSelectedBillItems() { return selectedBillItems; }
+    public void setSelectedBillItems(List<BillItem> selectedBillItems) { this.selectedBillItems = selectedBillItems; }
+    public boolean isPrintPreview() { return printPreview; }
+    public void setPrintPreview(boolean printPreview) { this.printPreview = printPreview; }
+    public boolean isItemHistoryVisible() { return itemHistoryVisible; }
+    public void setItemHistoryVisible(boolean itemHistoryVisible) { this.itemHistoryVisible = itemHistoryVisible; }
+    public Long getBillId() { return billId; }
+    public void setBillId(Long billId) { this.billId = billId; }
+    public String getEmailRecipient() { return emailRecipient; }
+    public void setEmailRecipient(String emailRecipient) { this.emailRecipient = emailRecipient; }
+}
+```
+
+- [ ] **Step 2: Compile check**
+
+Run: `mvn -q compile`
+Expected: BUILD SUCCESS (no tests yet — this is JSF scaffolding, verified via
+Playwright in Task 11)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestNativeSqlController.java
+git commit -m "feat(pharmacy): scaffold PurchaseOrderRequestNativeSqlController"
+```
+
+---
+
+## Task 6: Controller — `addItem` / `removeItem` / `onEdit` wired to native service
+
+**Files:**
+- Modify: `src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestNativeSqlController.java`
+
+**Interfaces:**
+- Consumes: `PurchaseOrderRequestNativeSqlService.saveLine()` (Task 3)
+- Produces: `void addItem()`, `void removeItem(BillItem bi)`, `void onEdit(BillItem bi)`
+  — same method names/signatures as the legacy controller so the copied XHTML
+  (Task 9) needs zero EL renaming beyond the bean name prefix.
+
+Port the **exact guard logic** from legacy `addItem()` (department-type matching,
+duplicate-item check gated on `Prevent Duplicate Items in Purchase Orders`,
+auto-department-type-assignment) and `onEdit()` (integer-only qty gated on
+`Pharmacy Purchase - Quantity Must Be Integer`) — see design spec §2. Only the
+persistence call changes: instead of `billItemFacade.create()/.edit()`, build a
+`PurchaseOrderRequestLineData` from the in-memory `BillItem`/`PharmaceuticalBillItem`
+and call `purchaseOrderRequestNativeSqlService.saveLine()`.
+
+- [ ] **Step 1: Implement `addItem`, `removeItem`, `onEdit`**
+
+```java
+public void addItem() {
+    if (currentBillItem.getItem() == null) {
+        JsfUtil.addErrorMessage("Please select and item from the list");
+        return;
+    }
+
+    if (currentBill.getDepartmentType() == null) {
+        currentBill.setDepartmentType(currentBillItem.getItem().getDepartmentType() != null
+                ? currentBillItem.getItem().getDepartmentType() : DepartmentType.Pharmacy);
+    }
+
+    DepartmentType itemDepartmentType = currentBillItem.getItem().getDepartmentType();
+    if (itemDepartmentType != null && !itemDepartmentType.equals(currentBill.getDepartmentType())) {
+        JsfUtil.addErrorMessage("Cannot add items from different department types. "
+                + "Bill is set for " + currentBill.getDepartmentType().getLabel()
+                + " items, but you are trying to add a " + itemDepartmentType.getLabel() + " item.");
+        return;
+    }
+
+    if (configOptionApplicationController.getBooleanValueByKey("Prevent Duplicate Items in Purchase Orders", false)) {
+        for (BillItem existing : billItems) {
+            if (existing != null && !existing.isRetired() && existing.getItem() != null
+                    && existing.getItem().equals(currentBillItem.getItem())) {
+                JsfUtil.addErrorMessage("This item has already been added to the purchase order. Please update the quantity of the existing item instead of adding it again.");
+                return;
+            }
+        }
+    }
+
+    currentBillItem.setSearialNo(billItems.size());
+    applyLastRatesToBillItem(currentBillItem);
+    billItems.add(currentBillItem);
+    calculateBillTotals();
+    currentBillItem = new BillItem();
+}
+
+public void removeItem(BillItem bi) {
+    if (!isAuthorized("SAVE", "PurchaseOrderSave")) {
+        return;
+    }
+    if (currentBill == null || bi == null) {
+        return;
+    }
+    bi.setRetired(true);
+    billItems.remove(bi);
+    calculateBillTotals();
+    itemHistoryVisible = false;
+}
+
+public void onEdit(BillItem bi) {
+    if (configOptionController.getBooleanValueByKey("Pharmacy Purchase - Quantity Must Be Integer", true)) {
+        java.math.BigDecimal qty = bi.getBillItemFinanceDetails().getQuantity();
+        java.math.BigDecimal freeQty = bi.getBillItemFinanceDetails().getFreeQuantity();
+        if (qty != null && qty.remainder(java.math.BigDecimal.ONE).compareTo(java.math.BigDecimal.ZERO) != 0) {
+            bi.getBillItemFinanceDetails().setQuantity(java.math.BigDecimal.ZERO);
+            JsfUtil.addErrorMessage("Please enter only whole numbers (integers) for quantity. Decimal values are not allowed.");
+            calculateBillTotals();
+            return;
+        }
+        if (freeQty != null && freeQty.remainder(java.math.BigDecimal.ONE).compareTo(java.math.BigDecimal.ZERO) != 0) {
+            bi.getBillItemFinanceDetails().setFreeQuantity(java.math.BigDecimal.ZERO);
+            JsfUtil.addErrorMessage("Please enter only whole numbers (integers) for free quantity. Decimal values are not allowed.");
+            calculateBillTotals();
+            return;
+        }
+    }
+    calculateBillTotals();
+}
+
+private void calculateBillTotals() {
+    double total = 0.0;
+    for (BillItem bi : billItems) {
+        if (bi != null && !bi.isRetired()) {
+            total += bi.getNetValue();
+        }
+    }
+    currentBill.setNetTotal(total);
+    currentBill.setTotal(total);
+}
+```
+
+Note: `applyLastRatesToBillItem` is the method copied verbatim per Task 5's
+instructions — it populates `BillItemFinanceDetails`/`PharmaceuticalBillItem` rate
+fields on the in-memory entity before it's ever sent to `saveLine()`.
+
+- [ ] **Step 2: Compile check**
+
+Run: `mvn -q compile`
+Expected: BUILD SUCCESS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestNativeSqlController.java
+git commit -m "feat(pharmacy): wire addItem/removeItem/onEdit to native controller"
+```
+
+---
+
+## Task 7: Controller — save draft / finalize wired to native service
+
+**Files:**
+- Modify: `src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestNativeSqlController.java`
+
+**Interfaces:**
+- Consumes: `PurchaseOrderRequestNativeSqlService.createDraftBill/updateDraftBillHeader/
+  saveLine/finalizeBill/retireZeroQtyLines` (Tasks 2–4)
+- Produces: `synchronized void saveRequest()`, `synchronized void finalizeRequest()` —
+  same names as legacy, called by the copied XHTML's Save/Finalize buttons.
+
+Port the exact validation order from legacy `saveRequestWithoutMessage()` and
+`finalizeRequest()` (design spec §2's guard list) — only the persistence calls
+change target from `billFacade`/`billItemFacade` to
+`purchaseOrderRequestNativeSqlService`. Keep the `synchronized` modifier — this is
+the issue #21417 double-submit guard and must not be dropped (design spec §2,
+"Concurrency guards").
+
+- [ ] **Step 1: Implement `saveRequest` and `finalizeRequest`**
+
+```java
+public synchronized void saveRequest() {
+    if (!isAuthorized("SAVE", "PurchaseOrderSave")) {
+        return;
+    }
+    boolean saved = saveRequestWithoutMessage();
+    if (saved) {
+        JsfUtil.addSuccessMessage("Request Saved");
+    }
+}
+
+private boolean saveRequestWithoutMessage() {
+    if (currentBill.isChecked()) {
+        JsfUtil.addErrorMessage("Cannot save a finalized bill");
+        return false;
+    }
+    if (currentBill.getToInstitution() == null) {
+        JsfUtil.addErrorMessage("Please select a supplier");
+        return false;
+    }
+
+    if (currentBill.getId() == null) {
+        long newBillId = purchaseOrderRequestNativeSqlService.createDraftBill(
+                sessionController.getLoggedUser().getDepartment().getId(),
+                sessionController.getLoggedUser().getDepartment().getInstitution().getId(),
+                sessionController.getLoggedUser().getId(),
+                createAndAssignBillNumber(),
+                createAndAssignBillNumber());
+        currentBill = billFacade.find(newBillId);
+    }
+
+    purchaseOrderRequestNativeSqlService.updateDraftBillHeader(
+            currentBill.getId(),
+            currentBill.getToInstitution().getId(),
+            currentBill.getPaymentMethod(),
+            currentBill.getCreditDuration(),
+            currentBill.isConsignment(),
+            currentBill.getDepartmentType(),
+            sessionController.getLoggedUser().getId());
+
+    for (BillItem bi : billItems) {
+        PurchaseOrderRequestLineData line = toLineData(bi);
+        long billItemId = purchaseOrderRequestNativeSqlService.saveLine(currentBill.getId(), line);
+        bi.setId(billItemId);
+    }
+
+    return true;
+}
+
+public synchronized void finalizeRequest() {
+    if (!isAuthorized("FINALIZE", "PurchaseOrderFinalize")) {
+        return;
+    }
+    if (currentBill == null) {
+        JsfUtil.addErrorMessage("No Bill");
+        return;
+    }
+    if (currentBill.getToInstitution() == null) {
+        JsfUtil.addErrorMessage("Please selectr a supplier");
+        return;
+    }
+    if (currentBill.isChecked()) {
+        JsfUtil.addErrorMessage("Cannot finalize an already finalized bill");
+        return;
+    }
+    if (currentBill.getPaymentMethod() == null) {
+        JsfUtil.addErrorMessage("Please select a payment method.");
+        return;
+    }
+    if (billItems == null || billItems.isEmpty()) {
+        JsfUtil.addErrorMessage("Please add bill items.");
+        return;
+    }
+    if (currentBill.getId() == null) {
+        saveRequestWithoutMessage();
+    } else {
+        saveRequestWithoutMessage();
+    }
+
+    purchaseOrderRequestNativeSqlService.finalizeBill(currentBill.getId(), sessionController.getLoggedUser().getId());
+    int survivingCount = purchaseOrderRequestNativeSqlService.retireZeroQtyLines(currentBill.getId(), sessionController.getLoggedUser().getId());
+    if (survivingCount == 0) {
+        JsfUtil.addErrorMessage("Please enter item quantities for the bill.");
+        return;
+    }
+
+    currentBill = billFacade.find(currentBill.getId());
+    billItems = loadBillItems(currentBill);
+    JsfUtil.addSuccessMessage("Request successfully finalized.");
+    printPreview = true;
+}
+
+private PurchaseOrderRequestLineData toLineData(BillItem bi) {
+    PurchaseOrderRequestLineData line = new PurchaseOrderRequestLineData();
+    line.setBillItemId(bi.getId());
+    line.setPharmaceuticalBillItemId(bi.getPharmaceuticalBillItem() != null ? bi.getPharmaceuticalBillItem().getId() : null);
+    line.setItemId(bi.getItem().getId());
+    line.setAmpp(bi.getItem() instanceof com.divudi.core.entity.pharmacy.Ampp);
+    line.setQuantity(bi.getBillItemFinanceDetails().getQuantity());
+    line.setFreeQuantity(bi.getBillItemFinanceDetails().getFreeQuantity());
+    line.setPurchaseRate(bi.getBillItemFinanceDetails().getLineGrossRate());
+    line.setRetailRate(bi.getBillItemFinanceDetails().getRetailSaleRate());
+    line.setUnitsPerPack(bi.getBillItemFinanceDetails().getUnitsPerPack());
+    line.setSerialNo(bi.getSearialNo());
+    line.setCreaterId(sessionController.getLoggedUser().getId());
+    return line;
+}
+```
+
+Note: `createAndAssignBillNumber()` here returns the generated `deptId`/`insId`
+string per the legacy method (copied per Task 5's instructions, adapted to
+`return` rather than mutate `currentBill` directly since the bill doesn't exist
+yet at that point in this native flow) — implement it in this task by adapting
+legacy `PurchaseOrderRequestController.createAndAssignBillNumber()`'s 4-strategy
+branching to return the computed `deptId` string, and call it twice (deptId
+strategy, then insId strategy) exactly as legacy does internally.
+
+- [ ] **Step 2: Compile check**
+
+Run: `mvn -q compile`
+Expected: BUILD SUCCESS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestNativeSqlController.java
+git commit -m "feat(pharmacy): wire saveRequest/finalizeRequest to native service"
+```
+
+---
+
+## Task 8: Controller — bulk-add, rate lookups, email (ported verbatim)
+
+**Files:**
+- Modify: `src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestNativeSqlController.java`
+
+**Interfaces:**
+- Consumes: nothing new — pure JPQL/JPA logic
+- Produces: `generateBillComponentsForAllSupplierItems(List<Item>)`,
+  `addAllSupplierItems()`, `addAllSupplierItemsBelowRol()`, `displayItemDetails(BillItem)`,
+  `closeItemHistory()`, `prepareEmailDialog()`, `sendPurchaseOrderEmail()` — same
+  names as legacy for the copied XHTML.
+
+Copy these methods from `PurchaseOrderRequestController` **verbatim** per Task 5's
+instructions (§2/§4 of the design spec establish these are out of the native-SQL
+migration surface — they are read-only JPQL or unrelated JPA writes like `AppEmail`).
+Only adapt field/method access to this controller's field names (`billItems`,
+`currentBill`, `sessionController`, `configOptionApplicationController`,
+`pharmacyBean` — inject `@EJB private PharmacyBean pharmacyBean;` if not already
+present) — do not alter the logic itself.
+
+- [ ] **Step 1: Copy the methods listed above from `PurchaseOrderRequestController`
+  lines 495–976 (rate lookups) and 1019–1443 (bulk-add, email) verbatim**, adjusting
+  only field references to match this controller.
+
+- [ ] **Step 2: Compile check**
+
+Run: `mvn -q compile`
+Expected: BUILD SUCCESS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestNativeSqlController.java
+git commit -m "feat(pharmacy): port bulk-add, rate lookup, and email logic to native controller"
+```
+
+---
+
+## Task 9: Native XHTML page
+
+**Files:**
+- Create: `src/main/webapp/pharmacy/pharmacy_purhcase_order_request_native.xhtml`
+
+**Interfaces:**
+- Consumes: every public method/getter on `PurchaseOrderRequestNativeSqlController`
+  (Tasks 5–8)
+- Produces: the page itself — Task 10 (List-to-Finalize) links to it.
+
+Copy `src/main/webapp/pharmacy/pharmacy_purhcase_order_request.xhtml` in full,
+then do a global find-and-replace of `purchaseOrderRequestController` →
+`purchaseOrderRequestNativeSqlController` (the new bean's `@Named` default name).
+**Verify no other bean references need renaming** — this page does not use the
+numbered-controller pattern that caused the #15845 defect (single window only, per
+design spec §8), so a plain unanchored replace of this one bean name is safe here.
+
+Add a small "Legacy View" link near the page header (same visual treatment as
+`pharmacy_reprint_po_native.xhtml`'s Legacy View button, per the print-page guide
+pattern) pointing back to `pharmacy_purhcase_order_request.xhtml`, for use during
+the review window before the legacy page is retired.
+
+- [ ] **Step 1: Copy and rename**
+
+```bash
+cp "src/main/webapp/pharmacy/pharmacy_purhcase_order_request.xhtml" "src/main/webapp/pharmacy/pharmacy_purhcase_order_request_native.xhtml"
+```
+
+Then edit the new file: replace every `purchaseOrderRequestController` with
+`purchaseOrderRequestNativeSqlController`, and add the Legacy View link.
+
+- [ ] **Step 2: Compile / deploy check**
+
+Run the project's local build+deploy per `developer_docs/deployment/` (or the `run`
+skill) and confirm the page loads without a JSF EL resolution error in
+`glassfish/domains/domain1/logs/server.log`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main/webapp/pharmacy/pharmacy_purhcase_order_request_native.xhtml
+git commit -m "feat(pharmacy): add native Purchase Order Request page"
+```
+
+---
+
+## Task 10: Wire List-to-Finalize picker to the new controller
+
+**Files:**
+- Modify: `src/main/webapp/pharmacy/pharmacy_purhcase_order_list_to_finalize.xhtml:284-287`
+
+**Interfaces:**
+- Consumes: `PurchaseOrderRequestNativeSqlController.navigateToUpdatePurchaseOrder(Long)`
+  (Task 5)
+
+- [ ] **Step 1: Repoint the Edit action**
+
+Change:
+```xml
+action="#{purchaseOrderRequestController.navigateToUpdatePurchaseOrder()}"
+...
+<f:setPropertyActionListener target="#{purchaseOrderRequestController.billId}" value="#{b.billId}"/>
+```
+to:
+```xml
+action="#{purchaseOrderRequestNativeSqlController.navigateToUpdatePurchaseOrder(b.billId)}"
+```
+
+(Passing `b.billId` directly as a method parameter replaces the
+`setPropertyActionListener` + no-arg-method pattern, since the new controller's
+`navigateToUpdatePurchaseOrder` takes `Long billId` directly — see Task 5's
+signature.)
+
+- [ ] **Step 2: Manual verify**
+
+Open `pharmacy_purhcase_order_list_to_finalize.xhtml` in the running app, click Edit
+on a draft PO, confirm it opens `pharmacy_purhcase_order_request_native.xhtml` with
+the correct bill loaded.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main/webapp/pharmacy/pharmacy_purhcase_order_list_to_finalize.xhtml
+git commit -m "feat(pharmacy): route List-to-Finalize Edit action to native PO Request page"
+```
+
+---
+
+## Task 11: Playwright verification + second-agent review
+
+**Files:** none (verification only)
+
+**Interfaces:** none
+
+- [ ] **Step 1: Playwright pass**
+
+Using the `playwright-e2e` skill, drive the running app through: create new PO
+request → add item (single, via autocomplete) → add item (bulk, "Add All Supplier
+Items") → add item (bulk, "Add All Supplier Items Below ROL") → edit a line's
+qty/rate → remove a line → save draft (click Save twice, confirm the bill row is
+not duplicated in the DB) → set payment method + supplier → finalize → confirm
+zero-qty lines were retired → open email dialog → send test email → confirm
+List-to-Finalize picker still opens this bill for further edits before finalize
+(N/A after finalize, since `isChecked()` blocks further edits, matching legacy).
+
+- [ ] **Step 2: DB verification**
+
+Run the queries from `developer_docs/pharmacy/native-sql-bill-migration-guide.md`
+§"Database Verification Checklist", adapted to this bill's tables (`bill`,
+`billitem`, `pharmaceuticalbillitem` only — skip the BIFD/BFD/stock/payment steps,
+which don't apply at this phase per design spec §5). Confirm: `BILLTYPEATOMIC`
+transitions `PHARMACY_ORDER_PRE` → `PHARMACY_ORDER`; no duplicate `billitem` rows
+from the double-save test; `remainingQty`/`remainingFreeQty` set correctly on
+finalize.
+
+- [ ] **Step 3: Second-agent review**
+
+Dispatch a fresh agent (or use `/code-review`) with the design spec's §4 function
+inventory table as the checklist: confirm every legacy method has a native
+equivalent present and wired, and that no button visible on
+`pharmacy_purhcase_order_request.xhtml` is missing from
+`pharmacy_purhcase_order_request_native.xhtml`.
+
+- [ ] **Step 4: Update GitHub issue and memory**
+
+Check off completed items on issue #22727, comment with the Playwright/DB
+verification results, and update the memory file
+`project_po_native_sql_migration_umbrella_22726.md` with Phase 1's completion status
+before starting Phase 2 (Approving page).
+
+---
+
+## Plan Self-Review Notes
+
+- **Spec coverage:** Every function in the design spec's §4 inventory table has a
+  corresponding task (Tasks 6–8) or is explicitly marked as copied verbatim.
+  Bill-number generation (§2) is handled in Task 7 via the adapted
+  `createAndAssignBillNumber()`. Email (§2) is Task 8. The two-bill cross-link is
+  explicitly out of scope for this phase (Phase 2's concern) — confirmed no task
+  here writes `referenceBill`.
+- **Type consistency:** `PurchaseOrderRequestLineData` field names introduced in
+  Task 1 are used identically in Tasks 3, 4, and 7 (`saveLine`, `toLineData`).
+  `PurchaseOrderRequestNativeSqlService` method signatures introduced in Tasks 2–4
+  are called with matching argument order/types in Task 7.
+- **Placeholder scan:** No TBD/TODO markers. Task 5's copy-instructions for §"getDealorItems"
+  etc. name exact legacy line ranges (Task 8) rather than saying "similar to legacy."
+- **Scope check:** This plan implements Phase 1 only (#22727). Phase 2 (Approving
+  page, #22726) is a separate plan, written after this phase's Playwright + review
+  gate (Task 11) passes, per the master issue's sequencing decision.

--- a/docs/superpowers/plans/2026-08-07-po-request-native.md
+++ b/docs/superpowers/plans/2026-08-07-po-request-native.md
@@ -1176,12 +1176,13 @@ private boolean saveRequestWithoutMessage() {
     }
 
     if (currentBill.getId() == null) {
+        String[] billNumbers = createAndAssignBillNumber();
         long newBillId = purchaseOrderRequestNativeSqlService.createDraftBill(
                 sessionController.getLoggedUser().getDepartment().getId(),
                 sessionController.getLoggedUser().getDepartment().getInstitution().getId(),
                 sessionController.getLoggedUser().getId(),
-                createAndAssignBillNumber(),
-                createAndAssignBillNumber());
+                billNumbers[0],
+                billNumbers[1]);
         currentBill = billFacade.find(newBillId);
     }
 
@@ -1227,11 +1228,7 @@ public synchronized void finalizeRequest() {
         JsfUtil.addErrorMessage("Please add bill items.");
         return;
     }
-    if (currentBill.getId() == null) {
-        saveRequestWithoutMessage();
-    } else {
-        saveRequestWithoutMessage();
-    }
+    saveRequestWithoutMessage();
 
     purchaseOrderRequestNativeSqlService.finalizeBill(currentBill.getId(), sessionController.getLoggedUser().getId());
     int survivingCount = purchaseOrderRequestNativeSqlService.retireZeroQtyLines(currentBill.getId(), sessionController.getLoggedUser().getId());
@@ -1263,13 +1260,69 @@ private PurchaseOrderRequestLineData toLineData(BillItem bi) {
 }
 ```
 
-Note: `createAndAssignBillNumber()` here returns the generated `deptId`/`insId`
-string per the legacy method (copied per Task 5's instructions, adapted to
-`return` rather than mutate `currentBill` directly since the bill doesn't exist
-yet at that point in this native flow) — implement it in this task by adapting
-legacy `PurchaseOrderRequestController.createAndAssignBillNumber()`'s 4-strategy
-branching to return the computed `deptId` string, and call it twice (deptId
-strategy, then insId strategy) exactly as legacy does internally.
+**`createAndAssignBillNumber()` must return `String[2]` = `{deptId, insId}` from a
+SINGLE call — never call it twice.** This is a correction to an earlier draft of
+this plan that called it twice (once "for deptId", once "for insId"); that is
+wrong and would generate two independent sequence numbers. Verified against the
+actual legacy method (`PurchaseOrderRequestController.java:830-881`): legacy
+computes `deptId` exactly once via one of 4 configured strategies (lines
+845-866), THEN computes `insId` either via its own separate strategy (line
+868-872) OR — in the default/most common case — by reusing the just-computed
+`deptId` value as `insId`'s fallback (lines 873-879: `if (billId != null &&
+!billId.trim().isEmpty()) { getCurrentBill().setInsId(billId); }`). `deptId` and
+`insId` are NOT independent draws from the sequence generator; `insId` depends
+on the `deptId` computed in the same invocation.
+
+Implement `createAndAssignBillNumber()` in this task as:
+
+```java
+private String[] createAndAssignBillNumber() {
+    String billSuffix = configOptionApplicationController.getLongTextValueByKey("Bill Number Suffix for " + BillTypeAtomic.PHARMACY_ORDER_PRE, "");
+    if (billSuffix == null || billSuffix.trim().isEmpty()) {
+        configOptionApplicationController.setLongTextValueByKey("Bill Number Suffix for " + BillTypeAtomic.PHARMACY_ORDER_PRE, "POR");
+    }
+
+    boolean stratDeptInsYear = configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Purchase Order Requests - Prefix + Department Code + Institution Code + Year + Yearly Number and Yearly Number", false);
+    boolean stratInsDeptYear = configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Purchase Order Requests - Prefix + Institution Code + Department Code + Year + Yearly Number and Yearly Number", false);
+    boolean stratInsYear = configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Purchase Order Requests - Prefix + Institution Code + Year + Yearly Number and Yearly Number", false);
+    boolean stratInsIdInsYear = configOptionApplicationController.getBooleanValueByKey("Institution Number Generation Strategy for Purchase Order Requests - Prefix + Institution Code + Year + Yearly Number and Yearly Number", false);
+
+    String deptId;
+    if (stratDeptInsYear) {
+        deptId = billNumberBean.departmentBillNumberGeneratorYearlyWithPrefixDeptInsYearCount(sessionController.getDepartment(), BillTypeAtomic.PHARMACY_ORDER_PRE);
+    } else if (stratInsDeptYear) {
+        deptId = billNumberBean.departmentBillNumberGeneratorYearlyWithPrefixInsDeptYearCount(sessionController.getDepartment(), BillTypeAtomic.PHARMACY_ORDER_PRE);
+    } else if (stratInsYear) {
+        deptId = billNumberBean.departmentBillNumberGeneratorYearlyWithPrefixInsYearCountInstitutionWide(sessionController.getDepartment(), BillTypeAtomic.PHARMACY_ORDER_PRE);
+    } else {
+        deptId = billNumberBean.departmentBillNumberGeneratorYearly(sessionController.getDepartment(), BillTypeAtomic.PHARMACY_ORDER_PRE);
+    }
+
+    String insId;
+    if (stratInsIdInsYear) {
+        insId = billNumberBean.institutionBillNumberGeneratorYearlyWithPrefixInsYearCountInstitutionWide(sessionController.getDepartment(), BillTypeAtomic.PHARMACY_ORDER_PRE);
+    } else {
+        insId = (deptId != null && !deptId.trim().isEmpty()) ? deptId : null;
+    }
+
+    return new String[]{deptId, insId};
+}
+```
+
+This adapts legacy's mutate-`currentBill`-directly style (there is no `currentBill`
+row yet at this point in the native flow — `createDraftBill()` hasn't been called
+yet) into a pure return, but preserves the exact same strategy branching and the
+exact same deptId→insId fallback relationship.
+
+**Task 5 already added a `private void createAndAssignBillNumber()` to this
+controller** (copied byte-for-byte from legacy per Task 5's "copy verbatim"
+instruction, at the time correctly matching legacy's own signature). That
+version calls `getCurrentBill().setDeptId(...)`/`setInsId(...)` directly — but
+at the point Task 7 needs to call it (before `createDraftBill()` has run), there
+is no bill row yet for `getCurrentBill()` to mutate. **Task 7 must REPLACE that
+existing method** with the `private String[] createAndAssignBillNumber()`
+version shown above (same name, changed signature and return type) — do not
+leave both versions in the file, and do not call the old void version anywhere.
 
 - [ ] **Step 2: Compile check**
 

--- a/docs/superpowers/specs/2026-08-07-po-request-native-design.md
+++ b/docs/superpowers/specs/2026-08-07-po-request-native-design.md
@@ -173,15 +173,20 @@ Rejected alternatives:
 
 ---
 
-## 5. Data written (native SQL)
+## 5. Data written (native SQL + JPA)
 
-Only the `bill`, `billitem`, `pharmaceuticalbillitem` tables are touched at this
-phase — there is no `billitemfinancedetails`/`billfinancedetails`/payment/stock
-involvement yet (POs don't move stock or money until GRN/approval). This is a
-narrower write surface than the retail-sale settle path.
+The `bill`, `billitem`, `pharmaceuticalbillitem` tables are written via native
+SQL. `BillItemFinanceDetails` is written via JPA persist/merge (IDENTITY PK,
+calculation-heavy — matches `RetailSaleNativeSqlService`'s split) and linked
+back to its owning `billitem` row through `BILLITEMFINANCEDETAILS_ID`. There is
+no `billfinancedetails`/payment/stock involvement yet (POs don't move stock or
+money until GRN/approval). This is a narrower write surface than the
+retail-sale settle path.
 
 After any native INSERT/UPDATE, evict from L2 cache: `Bill`, `BillItem`,
-`PharmaceuticalBillItem` (guide's common-mistake #6).
+`PharmaceuticalBillItem`, `BillItemFinanceDetails` (guide's common-mistake #6).
+When verifying a line write, check `BILLITEMFINANCEDETAILS_ID` linkage on the
+`billitem` row in addition to the native columns.
 
 ---
 

--- a/docs/superpowers/specs/2026-08-07-po-request-native-design.md
+++ b/docs/superpowers/specs/2026-08-07-po-request-native-design.md
@@ -1,0 +1,219 @@
+# Native Purchase Order Request — Design
+
+**Issue:** [#22727](https://github.com/hmislk/hmis/issues/22727)
+**Master issue:** [#22726](https://github.com/hmislk/hmis/issues/22726) — Phase 1 of the
+Purchase Order native migration.
+**Date:** 2026-08-07
+**Branch:** `22727-native-po-request`
+
+---
+
+## 1. Goal
+
+Replace the write path of the Purchase Order Request page
+(`pharmacy_purhcase_order_request.xhtml` / `PurchaseOrderRequestController`) with a
+native-SQL implementation, mirroring what `RetailSaleNativeSqlController` /
+`RetailSaleNativeSqlService` did for pharmacy retail sale (#20260).
+
+**Requirement: 100% functional replication.** Every button, validation message, and
+bill-number strategy on the legacy page carries over. Nothing is deferred to a
+follow-up. Any legacy behavior this spec does not explicitly mention is still in
+scope — the Playwright + second-agent review in §7 exists specifically to catch
+omissions.
+
+This phase does **not** touch:
+- `PurchaseOrderController` / the Approving page (Phase 2, #22726)
+- The List-to-Finalize or List-to-Approve list/search pages — both already query via
+  JPQL DTO constructors (`PharmacyPurchaseOrderDTO`), not raw entity graphs
+
+---
+
+## 2. What the Request page actually does
+
+Established by reading `PurchaseOrderRequestController.java` in full.
+
+**Bill lifecycle** — single bill, two atomic states, same row:
+- Created with `BillTypeAtomic.PHARMACY_ORDER_PRE` on first save (`saveBill()`)
+- Draft may be saved repeatedly (`saveRequest()` → `saveRequestWithoutMessage()` →
+  `saveBill()` + `saveBillComponent()`) — each call is create-if-new /
+  update-if-existing on the *same* bill row, not a new bill
+- Promoted in place to `BillTypeAtomic.PHARMACY_ORDER` on `finalizeRequest()` →
+  `finalizeBill()` + `finalizeBillComponent()`
+- No second bill is created at this phase — the requestedBill↔approvedBill two-bill
+  cross-link happens entirely in Phase 2 (`PurchaseOrderController.approve()`)
+
+**Guards enforced before any write** (must all be replicated):
+- `saveRequestWithoutMessage()`: cannot save once `currentBill.isChecked()`
+  (finalized); supplier (`toInstitution`) must be set
+- `finalizeRequest()`: supplier set; not already finalized; payment method set;
+  at least one bill item; every item has qty+price (`allBillItemsValid`); recalculated
+  total unit count > 0
+- `addItem()`: item selected; bill's `departmentType` auto-set from first item or
+  defaulted to `Pharmacy`; subsequent items must match bill's `departmentType`;
+  department type must be in `sessionController.getAvailableDepartmentTypesForPharmacyTransactions()`;
+  duplicate-item check gated on config `Prevent Duplicate Items in Purchase Orders`
+- `onEdit()`: integer-only qty/free-qty gated on config
+  `Pharmacy Purchase - Quantity Must Be Integer` (default true)
+- Privilege checks: `PurchaseOrderSave` (save/remove), `PurchaseOrderFinalize` (finalize)
+
+**Line items:**
+- `addItem()` — single add, auto-fills last purchase/retail rate via
+  `applyLastRatesToBillItem()`, sets serial number
+- `removeItem()` — soft-retires the `BillItem` + its `PharmaceuticalBillItem`
+  (`retired=true`, retirer, retiredAt); saves the request first
+  (`saveRequestWithoutMessage()`) so the retiring edit lands on a persisted row;
+  reloads `currentBill` via `billService.reloadBill()` afterward
+- `onEdit()` / `calculateLineValues()` — recomputes line gross/net from user-entered
+  qty/free-qty/rate
+- `generateBillComponentsForAllSupplierItems(items)` — bulk add: dedupes against
+  existing non-retired lines (same config gate), fetches last purchase/retail rates in
+  batch (`fetchLastPurchaseRatesForItems` / `fetchLastRetailRatesForItems`), assigns
+  serial numbers continuing from current list size
+- `addAllSupplierItems()` / `addAllSupplierItemsBelowRol()` — two entry points into the
+  bulk-add above, one unconditional, one filtered to items below reorder level
+- `finalizeBillComponent()` — on finalize, retires any line whose combined
+  qty+free-qty units is `<= 0` (comment: "Retired at Finalising PO"); sets
+  `remainingQty`/`remainingFreeQty` on the surviving `PharmaceuticalBillItem` to the
+  finalized qty/free-qty; accumulates `totalBillItemsCount`
+- `resyncPharmaceuticalBillItemIfEmpty()` — issue #21417 guard: if a duplicate-removal
+  left a `BillItem` with an all-zero PBI but its `BillItemFinanceDetails` still holds
+  real quantities, rebuild the PBI from BIFD before persisting. **Must be replicated
+  exactly** — this fixed a real production data-integrity bug
+
+**Bill-number generation** (`createAndAssignBillNumber()`) — 4 independently
+config-gated strategies for `deptId`, 1 for `insId`, with a legacy default fallback
+for each. All must be replicated verbatim; this is exactly the kind of intentional,
+configuration-driven branching CLAUDE.md's "never fix intentional complexity" rule
+protects.
+
+**Email** (`prepareEmailDialog()` / `sendPurchaseOrderEmail()`) — sends the PO to
+the supplier's configured recipient.
+
+**Totals** (`calculateBillTotals()`) — bill-level aggregate from line items.
+
+**Concurrency guards already in the legacy code** (must carry over, not redesigned):
+- `saveRequestWithoutMessage()` and `approve()`-adjacent methods are `synchronized` —
+  fixed issue #21417 (duplicate-submit double-persisted the same in-memory BillItem).
+  The native service's save/finalize entry points need the equivalent protection.
+
+---
+
+## 3. Approach
+
+**Chosen: new native service + controller, following the `PurchaseOrderNativeSqlService`
+package/DTO conventions already established by #20923, using
+`RetailSaleNativeSqlService` as the native-SQL-mechanics reference.**
+
+- New `PurchaseOrderRequestNativeSqlService` (`@Stateless`,
+  `com.divudi.service.pharmacy`) — owns native INSERT/UPDATE for:
+  - Bill row create (draft) / update (repeated draft save) / promote-in-place
+    (finalize)
+  - BillItem + PharmaceuticalBillItem INSERT/UPDATE per line, including the
+    resync-if-empty guard
+  - Bill-number assignment (reuses `BillNumberGenerator` — JPA-backed sequence
+    logic, not something to reimplement in raw SQL)
+- New `PurchaseOrderRequestNativeSqlController` (`@Named`, session-scoped to match
+  `PurchaseOrderNativeSqlController`'s existing scope choice for this bill family) —
+  owns validation/guard messages, item list state, autocomplete delegation, email
+  dialog state
+- New `pharmacy_purhcase_order_request_native.xhtml` — copies the legacy page's
+  layout and buttons 1:1, swapping entity EL bindings for the new controller
+
+Rationale:
+
+- There is no existing native *write* path for POs to extend — #20923/PR #20925 only
+  covers the read-only print page. Building fresh, closely modeled on
+  `RetailSaleNativeSqlService`'s INSERT/UPDATE mechanics, is the only option; there is
+  nothing to "convert in place."
+- Reusing `BillNumberGenerator` (not reimplementing bill-number sequences in native
+  SQL) follows the retail-sale precedent, where IDENTITY-PK-dependent or
+  sequence-dependent logic stayed on JPA (see migration guide §"Entities Written Per
+  Transaction").
+- The single-bill-row lifecycle here (no PreBill/BilledBill pair at this phase) is
+  simpler than retail sale's two-bill settle, so the migration guide's harder rules
+  (L2 cache eviction, cross-link via merge) are Phase 2's concern, not this one —
+  though this phase must still evict `Bill`/`BillItem`/`PharmaceuticalBillItem` from
+  L2 cache after any native UPDATE, per the guide's common-mistake #6.
+
+Rejected alternatives:
+
+- **Convert `PurchaseOrderController`'s existing native read-path service to also
+  handle writes.** Read and write concerns for different bill states (`PHARMACY_ORDER`
+  read-only print vs `PHARMACY_ORDER_PRE`/`PHARMACY_ORDER` in-progress draft) don't
+  share a natural home; conflating them risks the read service picking up
+  transactional side effects it wasn't designed for.
+- **Rewrite `PurchaseOrderRequestController` in place, swapping JPA calls for native
+  SQL line-by-line.** Loses the ability to keep the legacy page live as a fallback
+  during review (the retail-sale and PO-print precedents both keep a "Legacy View"
+  escape hatch until the native path is proven).
+
+---
+
+## 4. Function inventory (legacy → native, for the second-agent review)
+
+| Legacy method | Native equivalent | Notes |
+|---|---|---|
+| `saveBill()` | `PurchaseOrderRequestNativeSqlService.saveDraft()` | create-or-update same bill row |
+| `saveBillComponent()` | same service, item INSERT/UPDATE loop | |
+| `saveRequest()` / `saveRequestWithoutMessage()` | controller method, same guards | supplier-set, not-finalized checks |
+| `createAndAssignBillNumber()` | unchanged — delegates to `BillNumberGenerator` | not reimplemented in SQL |
+| `addItem()` | controller method, same guards | department-type matching, duplicate check |
+| `removeItem()` | controller method + native UPDATE (soft retire) | must save draft first, same as legacy |
+| `onEdit()` / `calculateLineValues()` | controller method, same math | |
+| `generateBillComponentsForAllSupplierItems()` | controller method | batch rate fetch |
+| `addAllSupplierItems()` / `addAllSupplierItemsBelowRol()` | controller methods | |
+| `finalizeBill()` / `finalizeRequest()` | `PurchaseOrderRequestNativeSqlService.finalize()` | in-place promote, same guards |
+| `finalizeBillComponent()` | same service | zero-qty retire, remainingQty set |
+| `resyncPharmaceuticalBillItemIfEmpty()` | same service, ported verbatim | issue #21417 fix — do not drop |
+| `prepareEmailDialog()` / `sendPurchaseOrderEmail()` | controller methods, unchanged (JPA/email infra, not settle-hot-path) | |
+| `calculateBillTotals()` | controller method, same math | |
+| `displayItemDetails()` / `closeItemHistory()` | controller methods, unchanged | |
+| Privilege checks (`PurchaseOrderSave`, `PurchaseOrderFinalize`) | same checks in new controller | |
+| `synchronized` guards on save/finalize | same on native controller/service entry points | issue #21417 pattern |
+
+---
+
+## 5. Data written (native SQL)
+
+Only the `bill`, `billitem`, `pharmaceuticalbillitem` tables are touched at this
+phase — there is no `billitemfinancedetails`/`billfinancedetails`/payment/stock
+involvement yet (POs don't move stock or money until GRN/approval). This is a
+narrower write surface than the retail-sale settle path.
+
+After any native INSERT/UPDATE, evict from L2 cache: `Bill`, `BillItem`,
+`PharmaceuticalBillItem` (guide's common-mistake #6).
+
+---
+
+## 6. Error handling
+
+All validation stays as user-facing `JsfUtil` error messages, matching legacy
+wording exactly where a message is user-visible (some are typo'd in the legacy code,
+e.g. "Please selectr a supplier" in `finalizeRequest()` — CLAUDE.md's backward-
+compatibility rule about not "fixing" intentional artifacts extends here: fix obvious
+typos in *new* code, but do not treat matching legacy message text as optional).
+
+---
+
+## 7. Testing
+
+- Playwright: create new PO request → add item (single) → add item (bulk, all
+  supplier items) → add item (bulk, below ROL) → edit line qty/rate → remove a line
+  → save draft (twice, confirm same bill row updates, not duplicated) → set payment
+  method → finalize → confirm zero-qty lines retired → email → confirm List-to-
+  Finalize picker still opens this bill correctly for further edits pre-finalize
+- DB verification: `bill` row (single row, `BILLTYPEATOMIC` transitions
+  `PHARMACY_ORDER_PRE` → `PHARMACY_ORDER`), `billitem`/`pharmaceuticalbillitem` rows
+  (no duplicates from the #21417 double-submit pattern), bill-number columns for at
+  least the default strategy
+- Second-agent review against §4's function inventory before this phase is
+  considered done and Phase 2 begins
+
+---
+
+## 8. Out of scope / explicitly deferred
+
+- Approving page (`PurchaseOrderController`) — Phase 2, separate spec
+- List-to-Finalize / List-to-Approve pages — already DTO-based, not touched
+- Multi-window concurrency (numbered controller copies) — not needed; PO request has
+  no multi-cashier-window precedent to match, unlike retail sale

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestNativeSqlController.java
@@ -126,12 +126,27 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
             return "";
         }
         resetBillValues();
-        this.billId = billId;
-        currentBill = billFacade.find(billId);
-        if (currentBill == null) {
+        Bill bill = billFacade.find(billId);
+        if (bill == null) {
             JsfUtil.addErrorMessage("Bill not found");
             return "";
         }
+        if (bill.getBillTypeAtomic() != BillTypeAtomic.PHARMACY_ORDER_PRE
+                && bill.getBillTypeAtomic() != BillTypeAtomic.PHARMACY_ORDER) {
+            JsfUtil.addErrorMessage("Bill is not a purchase order request");
+            return "";
+        }
+        if (bill.isRetired() || bill.isCancelled()) {
+            JsfUtil.addErrorMessage("Bill is retired or cancelled");
+            return "";
+        }
+        if (bill.getDepartment() == null || sessionController.getLoggedUser() == null
+                || !bill.getDepartment().equals(sessionController.getDepartment())) {
+            JsfUtil.addErrorMessage("You are not authorized to view this purchase order request");
+            return "";
+        }
+        this.billId = billId;
+        currentBill = bill;
         billItems = loadBillItems(currentBill);
         return "/pharmacy/pharmacy_purhcase_order_request_native?faces-redirect=true";
     }
@@ -277,22 +292,22 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
             return;
         }
 
-        if (currentBill.getDepartmentType() == null) {
-            currentBill.setDepartmentType(currentBillItem.getItem().getDepartmentType() != null
+        if (getCurrentBill().getDepartmentType() == null) {
+            getCurrentBill().setDepartmentType(currentBillItem.getItem().getDepartmentType() != null
                     ? currentBillItem.getItem().getDepartmentType() : DepartmentType.Pharmacy);
         }
 
         DepartmentType itemDepartmentType = currentBillItem.getItem().getDepartmentType();
-        if (itemDepartmentType != null && !itemDepartmentType.equals(currentBill.getDepartmentType())) {
+        if (itemDepartmentType != null && !itemDepartmentType.equals(getCurrentBill().getDepartmentType())) {
             JsfUtil.addErrorMessage("Cannot add items from different department types. "
-                    + "Bill is set for " + currentBill.getDepartmentType().getLabel()
+                    + "Bill is set for " + getCurrentBill().getDepartmentType().getLabel()
                     + " items, but you are trying to add a " + itemDepartmentType.getLabel() + " item.");
             return;
         }
 
         List<DepartmentType> allowedTypes = sessionController.getAvailableDepartmentTypesForPharmacyTransactions();
-        if (allowedTypes == null || !allowedTypes.contains(currentBill.getDepartmentType())) {
-            JsfUtil.addErrorMessage("Items are not allowed for the selected department type: " + currentBill.getDepartmentType().getLabel());
+        if (allowedTypes == null || !allowedTypes.contains(getCurrentBill().getDepartmentType())) {
+            JsfUtil.addErrorMessage("Items are not allowed for the selected department type: " + getCurrentBill().getDepartmentType().getLabel());
             return;
         }
 
@@ -320,6 +335,10 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
         if (currentBill == null || bi == null) {
             return;
         }
+        if (currentBill.isChecked()) {
+            JsfUtil.addErrorMessage("Cannot modify a finalized bill");
+            return;
+        }
         bi.setRetired(true);
         if (bi.getId() != null) {
             purchaseOrderRequestNativeSqlService.retireLine(bi.getId(), sessionController.getLoggedUser().getId());
@@ -339,7 +358,13 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
         if (selectedBillItems == null) {
             return;
         }
-        saveRequestWithoutMessage();
+        if (currentBill != null && currentBill.isChecked()) {
+            JsfUtil.addErrorMessage("Cannot modify a finalized bill");
+            return;
+        }
+        if (!saveRequestWithoutMessage()) {
+            return;
+        }
         for (BillItem b : selectedBillItems) {
             b.setBill(null);
             b.setRetired(true);
@@ -359,7 +384,8 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
     }
 
     public void onEdit(BillItem bi) {
-        if (configOptionController.getBooleanValueByKey("Pharmacy Purchase - Quantity Must Be Integer", true)) {
+        if (bi.getBillItemFinanceDetails() != null
+                && configOptionController.getBooleanValueByKey("Pharmacy Purchase - Quantity Must Be Integer", true)) {
             java.math.BigDecimal qty = bi.getBillItemFinanceDetails().getQuantity();
             java.math.BigDecimal freeQty = bi.getBillItemFinanceDetails().getFreeQuantity();
             if (qty != null && qty.remainder(java.math.BigDecimal.ONE).compareTo(java.math.BigDecimal.ZERO) != 0) {
@@ -620,16 +646,16 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
     }
 
     public void addAllSupplierItems() {
-        if (currentBill.getToInstitution() == null) {
+        if (getCurrentBill().getToInstitution() == null) {
             JsfUtil.addErrorMessage("Please Select Dealor");
             return;
         }
-        List<Item> allItems = pharmacyBillBean.getItemsForDealor(currentBill.getToInstitution());
+        List<Item> allItems = pharmacyBillBean.getItemsForDealor(getCurrentBill().getToInstitution());
         generateBillComponentsForAllSupplierItems(allItems);
     }
 
     public void addAllSupplierItemsBelowRol() {
-        if (currentBill.getToInstitution() == null) {
+        if (getCurrentBill().getToInstitution() == null) {
             JsfUtil.addErrorMessage("Please Select Dealer");
             return;
         }
@@ -642,7 +668,7 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
                 + "ORDER BY i.name";
 
         Map<String, Object> parameters = new HashMap<>();
-        parameters.put("supplier", currentBill.getToInstitution());
+        parameters.put("supplier", getCurrentBill().getToInstitution());
         parameters.put("department", sessionController.getDepartment());
         List<Item> itemsBelowReorderLevel = itemFacade.findByJpql(jpql, parameters);
 
@@ -668,14 +694,20 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
     }
 
     private boolean saveRequestWithoutMessage() {
-        if (currentBill.isChecked()) {
+        if (getCurrentBill().isChecked()) {
             JsfUtil.addErrorMessage("Cannot save a finalized bill");
             return false;
         }
-        if (currentBill.getToInstitution() == null) {
+        if (getCurrentBill().getToInstitution() == null) {
             JsfUtil.addErrorMessage("Please select a supplier");
             return false;
         }
+
+        Institution toInstitution = currentBill.getToInstitution();
+        PaymentMethod paymentMethod = currentBill.getPaymentMethod();
+        int creditDuration = currentBill.getCreditDuration();
+        boolean consignment = currentBill.isConsignment();
+        DepartmentType departmentType = currentBill.getDepartmentType();
 
         if (currentBill.getId() == null) {
             String[] billNumbers = createAndAssignBillNumber();
@@ -686,15 +718,24 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
                     billNumbers[0],
                     billNumbers[1]);
             currentBill = billFacade.find(newBillId);
+            // createDraftBill() only inserts department/institution/creater/deptId/insId --
+            // toInstitution/paymentMethod/consignment/creditDuration/departmentType are not
+            // yet in the DB, so the reload above comes back with those fields null/default.
+            // Re-apply the values the user actually entered before they're used below.
+            currentBill.setToInstitution(toInstitution);
+            currentBill.setPaymentMethod(paymentMethod);
+            currentBill.setCreditDuration(creditDuration);
+            currentBill.setConsignment(consignment);
+            currentBill.setDepartmentType(departmentType);
         }
 
         purchaseOrderRequestNativeSqlService.updateDraftBillHeader(
                 currentBill.getId(),
-                currentBill.getToInstitution().getId(),
-                currentBill.getPaymentMethod(),
-                currentBill.getCreditDuration(),
-                currentBill.isConsignment(),
-                currentBill.getDepartmentType(),
+                toInstitution.getId(),
+                paymentMethod,
+                creditDuration,
+                consignment,
+                departmentType,
                 sessionController.getLoggedUser().getId());
 
         for (BillItem bi : billItems) {
@@ -761,9 +802,9 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
             return;
         }
 
-        purchaseOrderRequestNativeSqlService.finalizeBill(currentBill.getId(), sessionController.getLoggedUser().getId());
-        // Per-line sweep for any zero-qty straggler that survived validation.
-        purchaseOrderRequestNativeSqlService.retireZeroQtyLines(currentBill.getId(), sessionController.getLoggedUser().getId());
+        // Finalize and the per-line zero-qty sweep run as one EJB call so both
+        // native writes share a single transaction (see finalizeAndRetireZeroQtyLines).
+        purchaseOrderRequestNativeSqlService.finalizeAndRetireZeroQtyLines(currentBill.getId(), sessionController.getLoggedUser().getId());
 
         currentBill = billFacade.find(currentBill.getId());
         billItems = loadBillItems(currentBill);

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestNativeSqlController.java
@@ -273,6 +273,12 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
             return;
         }
 
+        List<DepartmentType> allowedTypes = sessionController.getAvailableDepartmentTypesForPharmacyTransactions();
+        if (allowedTypes == null || !allowedTypes.contains(currentBill.getDepartmentType())) {
+            JsfUtil.addErrorMessage("Items are not allowed for the selected department type: " + currentBill.getDepartmentType().getLabel());
+            return;
+        }
+
         if (configOptionApplicationController.getBooleanValueByKey("Prevent Duplicate Items in Purchase Orders", false)) {
             for (BillItem existing : billItems) {
                 if (existing != null && !existing.isRetired() && existing.getItem() != null
@@ -298,6 +304,9 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
             return;
         }
         bi.setRetired(true);
+        if (bi.getId() != null) {
+            purchaseOrderRequestNativeSqlService.retireLine(bi.getId(), sessionController.getLoggedUser().getId());
+        }
         billItems.remove(bi);
         calculateBillTotals();
         itemHistoryVisible = false;

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestNativeSqlController.java
@@ -33,6 +33,7 @@ import com.divudi.core.util.JsfUtil;
 import com.divudi.ejb.BillNumberGenerator;
 import com.divudi.ejb.EmailManagerEjb;
 import com.divudi.ejb.PharmacyBean;
+import com.divudi.ejb.PharmacyCalculation;
 import com.divudi.service.pharmacy.PurchaseOrderRequestNativeSqlService;
 import java.io.Serializable;
 import java.math.BigDecimal;
@@ -73,6 +74,10 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
     private ConfigOptionController configOptionController;
     @Inject
     private ItemController itemController;
+    @Inject
+    private PharmacyController pharmacyController;
+    @Inject
+    private PharmacyCalculation pharmacyBillBean;
 
     @EJB
     private PurchaseOrderRequestNativeSqlService purchaseOrderRequestNativeSqlService;
@@ -341,6 +346,101 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
         }
         currentBill.setNetTotal(total);
         currentBill.setTotal(total);
+    }
+
+    public void generateBillComponentsForAllSupplierItems(List<Item> items) {
+        if (items == null || items.isEmpty()) {
+            return;
+        }
+
+        if (billItems == null) {
+            billItems = new ArrayList<>();
+        }
+
+        int serialStart = billItems.size();
+        boolean preventDuplicates = configOptionApplicationController.getBooleanValueByKey("Prevent Duplicate Items in Purchase Orders", false);
+        int skippedCount = 0;
+
+        List<Item> itemsToAdd = new ArrayList<>();
+        for (Item i : items) {
+            if (preventDuplicates) {
+                boolean isDuplicate = false;
+                for (BillItem existingItem : billItems) {
+                    if (existingItem != null && !existingItem.isRetired()
+                            && existingItem.getItem() != null
+                            && existingItem.getItem().equals(i)) {
+                        isDuplicate = true;
+                        skippedCount++;
+                        break;
+                    }
+                }
+                if (isDuplicate) {
+                    continue; // Skip this item as it already exists
+                }
+            }
+            itemsToAdd.add(i);
+        }
+
+        Map<Long, Double> purchaseRatesByItemId = fetchLastPurchaseRatesForItems(itemsToAdd);
+        Map<Long, Double> retailRatesByItemId = fetchLastRetailRatesForItems(itemsToAdd);
+
+        for (Item i : itemsToAdd) {
+            BillItem bi = new BillItem();
+            bi.setItem(i);
+
+            PharmaceuticalBillItem tmp = new PharmaceuticalBillItem();
+            tmp.setBillItem(bi);
+            bi.setPharmaceuticalBillItem(tmp);
+
+            bi.setSearialNo(serialStart++);
+
+            applyLastRatesToBillItem(
+                    bi,
+                    getRateForItem(purchaseRatesByItemId, i),
+                    getRateForItem(retailRatesByItemId, i));
+
+            billItems.add(bi);
+        }
+
+        if (preventDuplicates && skippedCount > 0) {
+            JsfUtil.addErrorMessage(skippedCount + " duplicate item(s) were skipped. Items already in the purchase order were not added again.");
+        }
+
+        calculateBillTotals();
+    }
+
+    public void addAllSupplierItems() {
+        if (currentBill.getToInstitution() == null) {
+            JsfUtil.addErrorMessage("Please Select Dealor");
+            return;
+        }
+        List<Item> allItems = pharmacyBillBean.getItemsForDealor(currentBill.getToInstitution());
+        generateBillComponentsForAllSupplierItems(allItems);
+    }
+
+    public void addAllSupplierItemsBelowRol() {
+        if (currentBill.getToInstitution() == null) {
+            JsfUtil.addErrorMessage("Please Select Dealer");
+            return;
+        }
+
+        String jpql = "SELECT i FROM Item i WHERE i IN "
+                + "(SELECT id.item FROM ItemsDistributors id WHERE id.institution = :supplier AND id.retired = false AND id.item.retired = false AND id.item.inactive = false) "
+                + "AND i IN "
+                + "(SELECT s.itemBatch.item FROM Stock s JOIN Reorder r ON r.item = s.itemBatch.item AND r.department = s.department "
+                + "WHERE s.department = :department AND s.stock < r.rol GROUP BY s.itemBatch.item) "
+                + "ORDER BY i.name";
+
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("supplier", currentBill.getToInstitution());
+        parameters.put("department", sessionController.getDepartment());
+        List<Item> itemsBelowReorderLevel = itemFacade.findByJpql(jpql, parameters);
+
+        if (itemsBelowReorderLevel == null || itemsBelowReorderLevel.isEmpty()) {
+            JsfUtil.addErrorMessage("No items found below reorder level for the selected supplier and department.");
+        } else {
+            generateBillComponentsForAllSupplierItems(itemsBelowReorderLevel);
+        }
     }
 
     // synchronized: a double-submit on the Save/Finalize button (Enter-key defaultCommand
@@ -1020,6 +1120,15 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
 
     public void setItemHistoryVisible(boolean itemHistoryVisible) {
         this.itemHistoryVisible = itemHistoryVisible;
+    }
+
+    public void displayItemDetails(BillItem bi) {
+        pharmacyController.fillItemDetails(bi.getItem());
+        itemHistoryVisible = true;
+    }
+
+    public void closeItemHistory() {
+        itemHistoryVisible = false;
     }
 
     public Long getBillId() {

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestNativeSqlController.java
@@ -343,6 +343,110 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
         currentBill.setTotal(total);
     }
 
+    public synchronized void saveRequest() {
+        if (!isAuthorized("SAVE", "PurchaseOrderSave")) {
+            return;
+        }
+        boolean saved = saveRequestWithoutMessage();
+        if (saved) {
+            JsfUtil.addSuccessMessage("Request Saved");
+        }
+    }
+
+    private boolean saveRequestWithoutMessage() {
+        if (currentBill.isChecked()) {
+            JsfUtil.addErrorMessage("Cannot save a finalized bill");
+            return false;
+        }
+        if (currentBill.getToInstitution() == null) {
+            JsfUtil.addErrorMessage("Please select a supplier");
+            return false;
+        }
+
+        if (currentBill.getId() == null) {
+            String[] billNumbers = createAndAssignBillNumber();
+            long newBillId = purchaseOrderRequestNativeSqlService.createDraftBill(
+                    sessionController.getLoggedUser().getDepartment().getId(),
+                    sessionController.getLoggedUser().getDepartment().getInstitution().getId(),
+                    sessionController.getLoggedUser().getId(),
+                    billNumbers[0],
+                    billNumbers[1]);
+            currentBill = billFacade.find(newBillId);
+        }
+
+        purchaseOrderRequestNativeSqlService.updateDraftBillHeader(
+                currentBill.getId(),
+                currentBill.getToInstitution().getId(),
+                currentBill.getPaymentMethod(),
+                currentBill.getCreditDuration(),
+                currentBill.isConsignment(),
+                currentBill.getDepartmentType(),
+                sessionController.getLoggedUser().getId());
+
+        for (BillItem bi : billItems) {
+            PurchaseOrderRequestLineData line = toLineData(bi);
+            long billItemId = purchaseOrderRequestNativeSqlService.saveLine(currentBill.getId(), line);
+            bi.setId(billItemId);
+        }
+
+        return true;
+    }
+
+    public synchronized void finalizeRequest() {
+        if (!isAuthorized("FINALIZE", "PurchaseOrderFinalize")) {
+            return;
+        }
+        if (currentBill == null) {
+            JsfUtil.addErrorMessage("No Bill");
+            return;
+        }
+        if (currentBill.getToInstitution() == null) {
+            JsfUtil.addErrorMessage("Please selectr a supplier");
+            return;
+        }
+        if (currentBill.isChecked()) {
+            JsfUtil.addErrorMessage("Cannot finalize an already finalized bill");
+            return;
+        }
+        if (currentBill.getPaymentMethod() == null) {
+            JsfUtil.addErrorMessage("Please select a payment method.");
+            return;
+        }
+        if (billItems == null || billItems.isEmpty()) {
+            JsfUtil.addErrorMessage("Please add bill items.");
+            return;
+        }
+        saveRequestWithoutMessage();
+
+        purchaseOrderRequestNativeSqlService.finalizeBill(currentBill.getId(), sessionController.getLoggedUser().getId());
+        int survivingCount = purchaseOrderRequestNativeSqlService.retireZeroQtyLines(currentBill.getId(), sessionController.getLoggedUser().getId());
+        if (survivingCount == 0) {
+            JsfUtil.addErrorMessage("Please enter item quantities for the bill.");
+            return;
+        }
+
+        currentBill = billFacade.find(currentBill.getId());
+        billItems = loadBillItems(currentBill);
+        JsfUtil.addSuccessMessage("Request successfully finalized.");
+        printPreview = true;
+    }
+
+    private PurchaseOrderRequestLineData toLineData(BillItem bi) {
+        PurchaseOrderRequestLineData line = new PurchaseOrderRequestLineData();
+        line.setBillItemId(bi.getId());
+        line.setPharmaceuticalBillItemId(bi.getPharmaceuticalBillItem() != null ? bi.getPharmaceuticalBillItem().getId() : null);
+        line.setItemId(bi.getItem().getId());
+        line.setAmpp(bi.getItem() instanceof com.divudi.core.entity.pharmacy.Ampp);
+        line.setQuantity(bi.getBillItemFinanceDetails().getQuantity());
+        line.setFreeQuantity(bi.getBillItemFinanceDetails().getFreeQuantity());
+        line.setPurchaseRate(bi.getBillItemFinanceDetails().getLineGrossRate());
+        line.setRetailRate(bi.getBillItemFinanceDetails().getRetailSaleRate());
+        line.setUnitsPerPack(bi.getBillItemFinanceDetails().getUnitsPerPack());
+        line.setSerialNo(bi.getSearialNo());
+        line.setCreaterId(sessionController.getLoggedUser().getId());
+        return line;
+    }
+
     private BigDecimal getUnitsPerPack(Item item) {
         if (item instanceof Ampp) {
             BigDecimal unitsPerPack = BigDecimal.valueOf(item.getDblValue());
@@ -631,7 +735,20 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
         private Institution institution;
     }
 
-    private void createAndAssignBillNumber() {
+    /**
+     * Computes the department-scoped and institution-scoped bill number
+     * strings in a single invocation. Returns {@code String[]{deptId, insId}}.
+     * <p>
+     * Adapted from legacy's mutate-{@code currentBill}-directly style: at the
+     * point this is called in the native flow, {@code createDraftBill()} has
+     * not run yet, so there is no bill row to mutate. The exact same strategy
+     * branching and the exact same deptId-to-insId fallback relationship
+     * (insId normally reuses the just-computed deptId, per legacy
+     * {@code PurchaseOrderRequestController.java:830-881}) are preserved.
+     * Must be called exactly once per save — deptId and insId are NOT
+     * independent draws from the sequence generator.
+     */
+    private String[] createAndAssignBillNumber() {
         // Check if bill number suffix is configured, if not set default "POR" for Purchase Order Requests
         String billSuffix = configOptionApplicationController.getLongTextValueByKey("Bill Number Suffix for " + BillTypeAtomic.PHARMACY_ORDER_PRE, "");
         if (billSuffix == null || billSuffix.trim().isEmpty()) {
@@ -639,49 +756,30 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
             configOptionApplicationController.setLongTextValueByKey("Bill Number Suffix for " + BillTypeAtomic.PHARMACY_ORDER_PRE, "POR");
         }
 
-        boolean billNumberGenerationStrategyForDepartmentIdIsPrefixDeptInsYearCount = configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Purchase Order Requests - Prefix + Department Code + Institution Code + Year + Yearly Number and Yearly Number", false);
-        boolean billNumberGenerationStrategyForDepartmentIdIsPrefixInsDeptYearCount = configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Purchase Order Requests - Prefix + Institution Code + Department Code + Year + Yearly Number and Yearly Number", false);
-        boolean billNumberGenerationStrategyForDepartmentIdIsPrefixInsYearCount = configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Purchase Order Requests - Prefix + Institution Code + Year + Yearly Number and Yearly Number", false);
-        boolean billNumberGenerationStrategyForInstitutionIdIsPrefixInsYearCount = configOptionApplicationController.getBooleanValueByKey("Institution Number Generation Strategy for Purchase Order Requests - Prefix + Institution Code + Year + Yearly Number and Yearly Number", false);
+        boolean stratDeptInsYear = configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Purchase Order Requests - Prefix + Department Code + Institution Code + Year + Yearly Number and Yearly Number", false);
+        boolean stratInsDeptYear = configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Purchase Order Requests - Prefix + Institution Code + Department Code + Year + Yearly Number and Yearly Number", false);
+        boolean stratInsYear = configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Purchase Order Requests - Prefix + Institution Code + Year + Yearly Number and Yearly Number", false);
+        boolean stratInsIdInsYear = configOptionApplicationController.getBooleanValueByKey("Institution Number Generation Strategy for Purchase Order Requests - Prefix + Institution Code + Year + Yearly Number and Yearly Number", false);
 
-        String billId = "";
-
-        if (billNumberGenerationStrategyForDepartmentIdIsPrefixDeptInsYearCount) {
-            if (getCurrentBill().getDeptId() == null || getCurrentBill().getDeptId().trim().equals("")) {
-                billId = billNumberBean.departmentBillNumberGeneratorYearlyWithPrefixDeptInsYearCount(sessionController.getDepartment(), BillTypeAtomic.PHARMACY_ORDER_PRE);
-                getCurrentBill().setDeptId(billId);
-            }
-        } else if (billNumberGenerationStrategyForDepartmentIdIsPrefixInsDeptYearCount) {
-            if (getCurrentBill().getDeptId() == null || getCurrentBill().getDeptId().trim().equals("")) {
-                billId = billNumberBean.departmentBillNumberGeneratorYearlyWithPrefixInsDeptYearCount(sessionController.getDepartment(), BillTypeAtomic.PHARMACY_ORDER_PRE);
-                getCurrentBill().setDeptId(billId);
-            }
-        } else if (billNumberGenerationStrategyForDepartmentIdIsPrefixInsYearCount) {
-            if (getCurrentBill().getDeptId() == null || getCurrentBill().getDeptId().trim().equals("")) {
-                billId = billNumberBean.departmentBillNumberGeneratorYearlyWithPrefixInsYearCountInstitutionWide(sessionController.getDepartment(), BillTypeAtomic.PHARMACY_ORDER_PRE);
-                getCurrentBill().setDeptId(billId);
-            }
+        String deptId;
+        if (stratDeptInsYear) {
+            deptId = billNumberBean.departmentBillNumberGeneratorYearlyWithPrefixDeptInsYearCount(sessionController.getDepartment(), BillTypeAtomic.PHARMACY_ORDER_PRE);
+        } else if (stratInsDeptYear) {
+            deptId = billNumberBean.departmentBillNumberGeneratorYearlyWithPrefixInsDeptYearCount(sessionController.getDepartment(), BillTypeAtomic.PHARMACY_ORDER_PRE);
+        } else if (stratInsYear) {
+            deptId = billNumberBean.departmentBillNumberGeneratorYearlyWithPrefixInsYearCountInstitutionWide(sessionController.getDepartment(), BillTypeAtomic.PHARMACY_ORDER_PRE);
         } else {
-            //Keep Legacy Method intact without any changes
-            if (getCurrentBill().getDeptId() == null || getCurrentBill().getDeptId().trim().equals("")) {
-                billId = billNumberBean.departmentBillNumberGeneratorYearly(sessionController.getDepartment(), BillTypeAtomic.PHARMACY_ORDER_PRE);
-                getCurrentBill().setDeptId(billId);
-            }
+            deptId = billNumberBean.departmentBillNumberGeneratorYearly(sessionController.getDepartment(), BillTypeAtomic.PHARMACY_ORDER_PRE);
         }
 
-        if (billNumberGenerationStrategyForInstitutionIdIsPrefixInsYearCount) {
-            if (getCurrentBill().getInsId() == null || getCurrentBill().getInsId().trim().equals("")) {
-                String insId = billNumberBean.institutionBillNumberGeneratorYearlyWithPrefixInsYearCountInstitutionWide(sessionController.getDepartment(), BillTypeAtomic.PHARMACY_ORDER_PRE);
-                getCurrentBill().setInsId(insId);
-            }
+        String insId;
+        if (stratInsIdInsYear) {
+            insId = billNumberBean.institutionBillNumberGeneratorYearlyWithPrefixInsYearCountInstitutionWide(sessionController.getDepartment(), BillTypeAtomic.PHARMACY_ORDER_PRE);
         } else {
-            //Keep Legacy Method intact without any changes
-            if (getCurrentBill().getInsId() == null || getCurrentBill().getInsId().trim().equals("")) {
-                if (billId != null && !billId.trim().isEmpty()) {
-                    getCurrentBill().setInsId(billId);
-                }
-            }
+            insId = (deptId != null && !deptId.trim().isEmpty()) ? deptId : null;
         }
+
+        return new String[]{deptId, insId};
     }
 
     public void prepareEmailDialog() {

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestNativeSqlController.java
@@ -269,6 +269,9 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
     }
 
     public void addItem() {
+        if (!isAuthorized("SAVE", "PurchaseOrderSave")) {
+            return;
+        }
         if (currentBillItem.getItem() == null) {
             JsfUtil.addErrorMessage("Please select and item from the list");
             return;
@@ -1191,6 +1194,16 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
         }
     }
 
+    /**
+     * HTML-escapes free-text values (item/institution/person names, addresses,
+     * phone numbers) before they are concatenated into the email body — those
+     * fields are staff-editable and would otherwise let stray HTML/script
+     * markup reach the outbound email unescaped.
+     */
+    private static String esc(String value) {
+        return value != null ? org.apache.commons.text.StringEscapeUtils.escapeHtml4(value) : "";
+    }
+
     private String generatePurchaseOrderHtml() {
         try {
             if (currentBill == null) {
@@ -1205,12 +1218,12 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
             // Institution header
             if (currentBill.getCreater() != null && currentBill.getCreater().getInstitution() != null) {
                 html.append("<div style='text-align: center; margin-bottom: 20px;'>");
-                html.append("<h2>").append(currentBill.getCreater().getInstitution().getName() != null ? currentBill.getCreater().getInstitution().getName() : "").append("</h2>");
+                html.append("<h2>").append(esc(currentBill.getCreater().getInstitution().getName())).append("</h2>");
                 if (currentBill.getCreater().getInstitution().getAddress() != null) {
-                    html.append("<p>").append(currentBill.getCreater().getInstitution().getAddress()).append("</p>");
+                    html.append("<p>").append(esc(currentBill.getCreater().getInstitution().getAddress())).append("</p>");
                 }
                 if (currentBill.getCreater().getInstitution().getPhone() != null) {
-                    html.append("<p>Phone: ").append(currentBill.getCreater().getInstitution().getPhone()).append("</p>");
+                    html.append("<p>Phone: ").append(esc(currentBill.getCreater().getInstitution().getPhone())).append("</p>");
                 }
                 html.append("</div>");
             }
@@ -1219,18 +1232,18 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
 
             // Order details
             html.append("<table style='width: 100%; margin-bottom: 20px;'>");
-            html.append("<tr><td><strong>Order No:</strong></td><td>").append(currentBill.getDeptId() != null ? currentBill.getDeptId() : "").append("</td></tr>");
+            html.append("<tr><td><strong>Order No:</strong></td><td>").append(esc(currentBill.getDeptId())).append("</td></tr>");
             if (currentBill.getDepartment() != null) {
-                html.append("<tr><td><strong>Order Department:</strong></td><td>").append(currentBill.getDepartment().getName() != null ? currentBill.getDepartment().getName() : "").append("</td></tr>");
+                html.append("<tr><td><strong>Order Department:</strong></td><td>").append(esc(currentBill.getDepartment().getName())).append("</td></tr>");
             }
             if (currentBill.getToInstitution() != null) {
-                html.append("<tr><td><strong>Supplier:</strong></td><td>").append(currentBill.getToInstitution().getName() != null ? currentBill.getToInstitution().getName() : "").append("</td></tr>");
-                html.append("<tr><td><strong>Supplier Code:</strong></td><td>").append(currentBill.getToInstitution().getCode() != null ? currentBill.getToInstitution().getCode() : "").append("</td></tr>");
+                html.append("<tr><td><strong>Supplier:</strong></td><td>").append(esc(currentBill.getToInstitution().getName())).append("</td></tr>");
+                html.append("<tr><td><strong>Supplier Code:</strong></td><td>").append(esc(currentBill.getToInstitution().getCode())).append("</td></tr>");
                 if (currentBill.getToInstitution().getPhone() != null) {
-                    html.append("<tr><td><strong>Supplier Phone:</strong></td><td>").append(currentBill.getToInstitution().getPhone()).append("</td></tr>");
+                    html.append("<tr><td><strong>Supplier Phone:</strong></td><td>").append(esc(currentBill.getToInstitution().getPhone())).append("</td></tr>");
                 }
                 if (currentBill.getToInstitution().getAddress() != null) {
-                    html.append("<tr><td><strong>Supplier Address:</strong></td><td>").append(currentBill.getToInstitution().getAddress()).append("</td></tr>");
+                    html.append("<tr><td><strong>Supplier Address:</strong></td><td>").append(esc(currentBill.getToInstitution().getAddress())).append("</td></tr>");
                 }
             }
             html.append("<tr><td><strong>Payment Method:</strong></td><td>").append(currentBill.getPaymentMethod() != null ? currentBill.getPaymentMethod().toString() : "").append("</td></tr>");
@@ -1253,8 +1266,8 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
                 for (BillItem bi : billItems) {
                     if (bi != null && !bi.isRetired() && bi.getItem() != null) {
                         html.append("<tr>");
-                        html.append("<td style='padding: 8px;'>").append(bi.getItem().getCode() != null ? bi.getItem().getCode() : "").append("</td>");
-                        html.append("<td style='padding: 8px;'>").append(bi.getItem().getName() != null ? bi.getItem().getName() : "").append("</td>");
+                        html.append("<td style='padding: 8px;'>").append(esc(bi.getItem().getCode())).append("</td>");
+                        html.append("<td style='padding: 8px;'>").append(esc(bi.getItem().getName())).append("</td>");
                         html.append("<td style='padding: 8px; text-align: right;'>");
                         if (bi.getPharmaceuticalBillItem() != null) {
                             html.append(String.format("%,.0f", bi.getPharmaceuticalBillItem().getQty()));
@@ -1286,10 +1299,10 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
             // Footer details
             html.append("<div style='margin-top: 20px;'>");
             if (currentBill.getCreater() != null && currentBill.getCreater().getWebUserPerson() != null) {
-                html.append("<p><strong>Order Initiated By:</strong> ").append(currentBill.getCreater().getWebUserPerson().getName() != null ? currentBill.getCreater().getWebUserPerson().getName() : "").append("</p>");
+                html.append("<p><strong>Order Initiated By:</strong> ").append(esc(currentBill.getCreater().getWebUserPerson().getName())).append("</p>");
             }
             if (currentBill.getCheckedBy() != null) {
-                html.append("<p><strong>Order Finalized By:</strong> ").append(currentBill.getCheckedBy().getName() != null ? currentBill.getCheckedBy().getName() : "").append("</p>");
+                html.append("<p><strong>Order Finalized By:</strong> ").append(esc(currentBill.getCheckedBy().getName())).append("</p>");
             }
             if (currentBill.getCheckeAt() != null) {
                 html.append("<p><strong>Order Finalized At:</strong> ").append(CommonFunctions.formatDate(currentBill.getCheckeAt(), "dd/MM/yyyy HH:mm:ss")).append("</p>");

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestNativeSqlController.java
@@ -346,18 +346,54 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
             java.math.BigDecimal freeQty = bi.getBillItemFinanceDetails().getFreeQuantity();
             if (qty != null && qty.remainder(java.math.BigDecimal.ONE).compareTo(java.math.BigDecimal.ZERO) != 0) {
                 bi.getBillItemFinanceDetails().setQuantity(java.math.BigDecimal.ZERO);
+                recalculateLineValues(bi);
                 JsfUtil.addErrorMessage("Please enter only whole numbers (integers) for quantity. Decimal values are not allowed.");
                 calculateBillTotals();
                 return;
             }
             if (freeQty != null && freeQty.remainder(java.math.BigDecimal.ONE).compareTo(java.math.BigDecimal.ZERO) != 0) {
                 bi.getBillItemFinanceDetails().setFreeQuantity(java.math.BigDecimal.ZERO);
+                recalculateLineValues(bi);
                 JsfUtil.addErrorMessage("Please enter only whole numbers (integers) for free quantity. Decimal values are not allowed.");
                 calculateBillTotals();
                 return;
             }
         }
+        recalculateLineValues(bi);
         calculateBillTotals();
+    }
+
+    /**
+     * Recomputes the BillItem-level rate/value fields (rate, netRate, grossValue,
+     * netValue) from the current BillItemFinanceDetails quantity/rate after an
+     * in-place edit on the page. BillItemFinanceDetails and PharmaceuticalBillItem
+     * fields are already correctly bound via two-way JSF EL on the qty/freeQty/rate
+     * inputs (see pharmacy_purhcase_order_request_native.xhtml), so only the
+     * BillItem-level fields — which calculateBillTotals() sums for the on-screen
+     * total — need recalculating here. Mirrors the BillItem-level subset of legacy
+     * PurchaseOrderRequestController.calculateLineValues() (no discount/tax/expense
+     * in purchase order requests, so net == gross).
+     */
+    private void recalculateLineValues(BillItem bi) {
+        if (bi == null || bi.getBillItemFinanceDetails() == null) {
+            return;
+        }
+        java.math.BigDecimal qty = bi.getBillItemFinanceDetails().getQuantity();
+        java.math.BigDecimal purchaseRate = bi.getBillItemFinanceDetails().getLineGrossRate();
+        if (qty == null) {
+            qty = java.math.BigDecimal.ZERO;
+        }
+        if (purchaseRate == null) {
+            purchaseRate = java.math.BigDecimal.ZERO;
+        }
+
+        java.math.BigDecimal grossValue = purchaseRate.multiply(qty);
+        java.math.BigDecimal netValue = grossValue;
+
+        bi.setRate(purchaseRate.doubleValue());
+        bi.setNetRate(purchaseRate.doubleValue());
+        bi.setGrossValue(grossValue.doubleValue());
+        bi.setNetValue(netValue.doubleValue());
     }
 
     private void calculateBillTotals() {
@@ -515,6 +551,15 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
             long billItemId = purchaseOrderRequestNativeSqlService.saveLine(currentBill.getId(), line);
             bi.setId(billItemId);
         }
+
+        // Persist bill-level netTotal/total: calculateBillTotals() only mutates
+        // the in-memory Bill, and nothing else in the native save path writes
+        // these two columns back to the DB (unlike legacy's billFacade.edit()
+        // full-entity merge). Recompute from ALL current lines (not just the
+        // one being edited) since removeSelected()/finalizeRequest() also
+        // route through this method.
+        calculateBillTotals();
+        purchaseOrderRequestNativeSqlService.updateBillTotals(currentBill.getId(), currentBill.getNetTotal(), currentBill.getTotal());
 
         return true;
     }

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestNativeSqlController.java
@@ -254,6 +254,86 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
         financeDetails.setRetailSaleRate(BigDecimal.valueOf(retailRate));
     }
 
+    public void addItem() {
+        if (currentBillItem.getItem() == null) {
+            JsfUtil.addErrorMessage("Please select and item from the list");
+            return;
+        }
+
+        if (currentBill.getDepartmentType() == null) {
+            currentBill.setDepartmentType(currentBillItem.getItem().getDepartmentType() != null
+                    ? currentBillItem.getItem().getDepartmentType() : DepartmentType.Pharmacy);
+        }
+
+        DepartmentType itemDepartmentType = currentBillItem.getItem().getDepartmentType();
+        if (itemDepartmentType != null && !itemDepartmentType.equals(currentBill.getDepartmentType())) {
+            JsfUtil.addErrorMessage("Cannot add items from different department types. "
+                    + "Bill is set for " + currentBill.getDepartmentType().getLabel()
+                    + " items, but you are trying to add a " + itemDepartmentType.getLabel() + " item.");
+            return;
+        }
+
+        if (configOptionApplicationController.getBooleanValueByKey("Prevent Duplicate Items in Purchase Orders", false)) {
+            for (BillItem existing : billItems) {
+                if (existing != null && !existing.isRetired() && existing.getItem() != null
+                        && existing.getItem().equals(currentBillItem.getItem())) {
+                    JsfUtil.addErrorMessage("This item has already been added to the purchase order. Please update the quantity of the existing item instead of adding it again.");
+                    return;
+                }
+            }
+        }
+
+        currentBillItem.setSearialNo(billItems.size());
+        applyLastRatesToBillItem(currentBillItem);
+        billItems.add(currentBillItem);
+        calculateBillTotals();
+        currentBillItem = new BillItem();
+    }
+
+    public void removeItem(BillItem bi) {
+        if (!isAuthorized("SAVE", "PurchaseOrderSave")) {
+            return;
+        }
+        if (currentBill == null || bi == null) {
+            return;
+        }
+        bi.setRetired(true);
+        billItems.remove(bi);
+        calculateBillTotals();
+        itemHistoryVisible = false;
+    }
+
+    public void onEdit(BillItem bi) {
+        if (configOptionController.getBooleanValueByKey("Pharmacy Purchase - Quantity Must Be Integer", true)) {
+            java.math.BigDecimal qty = bi.getBillItemFinanceDetails().getQuantity();
+            java.math.BigDecimal freeQty = bi.getBillItemFinanceDetails().getFreeQuantity();
+            if (qty != null && qty.remainder(java.math.BigDecimal.ONE).compareTo(java.math.BigDecimal.ZERO) != 0) {
+                bi.getBillItemFinanceDetails().setQuantity(java.math.BigDecimal.ZERO);
+                JsfUtil.addErrorMessage("Please enter only whole numbers (integers) for quantity. Decimal values are not allowed.");
+                calculateBillTotals();
+                return;
+            }
+            if (freeQty != null && freeQty.remainder(java.math.BigDecimal.ONE).compareTo(java.math.BigDecimal.ZERO) != 0) {
+                bi.getBillItemFinanceDetails().setFreeQuantity(java.math.BigDecimal.ZERO);
+                JsfUtil.addErrorMessage("Please enter only whole numbers (integers) for free quantity. Decimal values are not allowed.");
+                calculateBillTotals();
+                return;
+            }
+        }
+        calculateBillTotals();
+    }
+
+    private void calculateBillTotals() {
+        double total = 0.0;
+        for (BillItem bi : billItems) {
+            if (bi != null && !bi.isRetired()) {
+                total += bi.getNetValue();
+            }
+        }
+        currentBill.setNetTotal(total);
+        currentBill.setTotal(total);
+    }
+
     private BigDecimal getUnitsPerPack(Item item) {
         if (item instanceof Ampp) {
             BigDecimal unitsPerPack = BigDecimal.valueOf(item.getDblValue());

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestNativeSqlController.java
@@ -6,7 +6,6 @@ package com.divudi.bean.pharmacy;
 
 import com.divudi.bean.common.ConfigOptionApplicationController;
 import com.divudi.bean.common.ConfigOptionController;
-import com.divudi.bean.common.EnumController;
 import com.divudi.bean.common.ItemController;
 import com.divudi.bean.common.SessionController;
 import com.divudi.bean.common.WebUserController;
@@ -72,8 +71,6 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
     private ConfigOptionApplicationController configOptionApplicationController;
     @Inject
     private ConfigOptionController configOptionController;
-    @Inject
-    private EnumController enumController;
     @Inject
     private ItemController itemController;
 

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestNativeSqlController.java
@@ -348,6 +348,7 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
         if (currentBill.getId() != null) {
             purchaseOrderRequestNativeSqlService.updateBillTotals(currentBill.getId(), currentBill.getNetTotal(), currentBill.getTotal());
         }
+        persistSurvivingSerialNumbers();
         itemHistoryVisible = false;
     }
 
@@ -380,7 +381,22 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
         if (currentBill.getId() != null) {
             purchaseOrderRequestNativeSqlService.updateBillTotals(currentBill.getId(), currentBill.getNetTotal(), currentBill.getTotal());
         }
+        persistSurvivingSerialNumbers();
         selectedBillItems = null;
+    }
+
+    /**
+     * Persists the searialNo calculateBillTotals() just renumbered in memory,
+     * for every surviving line that's already been saved (has an id). Called
+     * after a removal, where calculateBillTotals() can shift a persisted
+     * survivor's serial to fill the gap left by a retired line.
+     */
+    private void persistSurvivingSerialNumbers() {
+        for (BillItem bi : billItems) {
+            if (bi != null && !bi.isRetired() && bi.getId() != null) {
+                purchaseOrderRequestNativeSqlService.updateBillItemSerialNo(bi.getId(), bi.getSearialNo());
+            }
+        }
     }
 
     public void onEdit(BillItem bi) {
@@ -596,9 +612,23 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
         int serialStart = billItems.size();
         boolean preventDuplicates = configOptionApplicationController.getBooleanValueByKey("Prevent Duplicate Items in Purchase Orders", false);
         int skippedCount = 0;
+        int skippedDepartmentTypeCount = 0;
+
+        List<DepartmentType> allowedTypes = sessionController.getAvailableDepartmentTypesForPharmacyTransactions();
 
         List<Item> itemsToAdd = new ArrayList<>();
         for (Item i : items) {
+            DepartmentType itemDepartmentType = i != null ? i.getDepartmentType() : null;
+            DepartmentType billDepartmentType = getCurrentBill().getDepartmentType() != null
+                    ? getCurrentBill().getDepartmentType()
+                    : (itemDepartmentType != null ? itemDepartmentType : DepartmentType.Pharmacy);
+            boolean departmentTypeMismatch = itemDepartmentType != null && !itemDepartmentType.equals(billDepartmentType);
+            boolean departmentTypeNotAllowed = allowedTypes == null || !allowedTypes.contains(billDepartmentType);
+            if (departmentTypeMismatch || departmentTypeNotAllowed) {
+                skippedDepartmentTypeCount++;
+                continue;
+            }
+
             if (preventDuplicates) {
                 boolean isDuplicate = false;
                 for (BillItem existingItem : billItems) {
@@ -614,7 +644,14 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
                     continue; // Skip this item as it already exists
                 }
             }
+            if (getCurrentBill().getDepartmentType() == null) {
+                getCurrentBill().setDepartmentType(billDepartmentType);
+            }
             itemsToAdd.add(i);
+        }
+
+        if (skippedDepartmentTypeCount > 0) {
+            JsfUtil.addErrorMessage(skippedDepartmentTypeCount + " item(s) of a different or disallowed department type were skipped.");
         }
 
         Map<Long, Double> purchaseRatesByItemId = fetchLastPurchaseRatesForItems(itemsToAdd);
@@ -708,6 +745,7 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
         int creditDuration = currentBill.getCreditDuration();
         boolean consignment = currentBill.isConsignment();
         DepartmentType departmentType = currentBill.getDepartmentType();
+        String comments = currentBill.getComments();
 
         if (currentBill.getId() == null) {
             String[] billNumbers = createAndAssignBillNumber();
@@ -719,14 +757,16 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
                     billNumbers[1]);
             currentBill = billFacade.find(newBillId);
             // createDraftBill() only inserts department/institution/creater/deptId/insId --
-            // toInstitution/paymentMethod/consignment/creditDuration/departmentType are not
-            // yet in the DB, so the reload above comes back with those fields null/default.
-            // Re-apply the values the user actually entered before they're used below.
+            // toInstitution/paymentMethod/consignment/creditDuration/departmentType/comments
+            // are not yet in the DB, so the reload above comes back with those fields
+            // null/default. Re-apply the values the user actually entered before they're
+            // used below.
             currentBill.setToInstitution(toInstitution);
             currentBill.setPaymentMethod(paymentMethod);
             currentBill.setCreditDuration(creditDuration);
             currentBill.setConsignment(consignment);
             currentBill.setDepartmentType(departmentType);
+            currentBill.setComments(comments);
         }
 
         purchaseOrderRequestNativeSqlService.updateDraftBillHeader(
@@ -736,6 +776,7 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
                 creditDuration,
                 consignment,
                 departmentType,
+                comments,
                 sessionController.getLoggedUser().getId());
 
         for (BillItem bi : billItems) {

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestNativeSqlController.java
@@ -1,0 +1,852 @@
+/*
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.bean.pharmacy;
+
+import com.divudi.bean.common.ConfigOptionApplicationController;
+import com.divudi.bean.common.ConfigOptionController;
+import com.divudi.bean.common.EnumController;
+import com.divudi.bean.common.ItemController;
+import com.divudi.bean.common.SessionController;
+import com.divudi.bean.common.WebUserController;
+import com.divudi.core.data.BillType;
+import com.divudi.core.data.BillTypeAtomic;
+import com.divudi.core.data.DepartmentType;
+import com.divudi.core.data.PaymentMethod;
+import com.divudi.core.data.dto.PharmacyPurchaseOrderRateDTO;
+import com.divudi.core.data.dto.pharmacy.PurchaseOrderRequestLineData;
+import com.divudi.core.entity.AppEmail;
+import com.divudi.core.data.MessageType;
+import com.divudi.core.entity.Bill;
+import com.divudi.core.entity.BillItem;
+import com.divudi.core.entity.Department;
+import com.divudi.core.entity.Institution;
+import com.divudi.core.entity.Item;
+import com.divudi.core.entity.pharmacy.Ampp;
+import com.divudi.core.entity.pharmacy.PharmaceuticalBillItem;
+import com.divudi.core.facade.BillFacade;
+import com.divudi.core.facade.BillItemFacade;
+import com.divudi.core.facade.EmailFacade;
+import com.divudi.core.facade.ItemFacade;
+import com.divudi.core.util.CommonFunctions;
+import com.divudi.core.util.JsfUtil;
+import com.divudi.ejb.BillNumberGenerator;
+import com.divudi.ejb.EmailManagerEjb;
+import com.divudi.ejb.PharmacyBean;
+import com.divudi.service.pharmacy.PurchaseOrderRequestNativeSqlService;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.ejb.EJB;
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+/**
+ * SessionScoped controller for the native-SQL Purchase Order Request page.
+ * Native SQL: bill create/update, billitem+PBI writes (via the service).
+ * JPA (unchanged): rate lookups, bill-number generation, email — see
+ * docs/superpowers/specs/2026-08-07-po-request-native-design.md §3.
+ * Related issue: #22727
+ */
+@Named
+@SessionScoped
+public class PurchaseOrderRequestNativeSqlController implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final Logger LOGGER = Logger.getLogger(PurchaseOrderRequestNativeSqlController.class.getName());
+
+    @Inject
+    private SessionController sessionController;
+    @Inject
+    private WebUserController webUserController;
+    @Inject
+    private ConfigOptionApplicationController configOptionApplicationController;
+    @Inject
+    private ConfigOptionController configOptionController;
+    @Inject
+    private EnumController enumController;
+    @Inject
+    private ItemController itemController;
+
+    @EJB
+    private PurchaseOrderRequestNativeSqlService purchaseOrderRequestNativeSqlService;
+    @EJB
+    private BillNumberGenerator billNumberBean;
+    @EJB
+    private BillFacade billFacade;
+    @EJB
+    private BillItemFacade billItemFacade;
+    @EJB
+    private ItemFacade itemFacade;
+    @EJB
+    private PharmacyBean pharmacyBean;
+    @EJB
+    private EmailFacade emailFacade;
+    @EJB
+    private EmailManagerEjb emailManagerEjb;
+
+    private Bill currentBill;
+    private BillItem currentBillItem;
+    private List<BillItem> billItems;
+    private List<BillItem> selectedBillItems;
+    private boolean printPreview;
+    private boolean itemHistoryVisible;
+    private Long billId;
+    private String emailRecipient;
+
+    public String navigateToCreateNewPurchaseOrder() {
+        resetBillValues();
+        currentBill = new Bill();
+        return "/pharmacy/pharmacy_purhcase_order_request_native?faces-redirect=true";
+    }
+
+    public String navigateToUpdatePurchaseOrder(Long billId) {
+        if (billId == null) {
+            JsfUtil.addErrorMessage("No Bill");
+            return "";
+        }
+        resetBillValues();
+        this.billId = billId;
+        currentBill = billFacade.find(billId);
+        if (currentBill == null) {
+            JsfUtil.addErrorMessage("Bill not found");
+            return "";
+        }
+        billItems = loadBillItems(currentBill);
+        return "/pharmacy/pharmacy_purhcase_order_request_native?faces-redirect=true";
+    }
+
+    private List<BillItem> loadBillItems(Bill bill) {
+        String jpql = "select bi from BillItem bi where bi.retired=:ret and bi.bill=:bill order by bi.searialNo";
+        Map<String, Object> m = new HashMap<>();
+        m.put("ret", false);
+        m.put("bill", bill);
+        List<BillItem> result = billItemFacade.findByJpql(jpql, m);
+        return result != null ? result : new ArrayList<>();
+    }
+
+    private void resetBillValues() {
+        currentBill = null;
+        currentBillItem = new BillItem();
+        billItems = new ArrayList<>();
+        selectedBillItems = null;
+        printPreview = false;
+        itemHistoryVisible = false;
+        billId = null;
+    }
+
+    /**
+     * Authorization helper method to check Purchase Order privileges and
+     * audit denied access
+     *
+     * @param action The action being attempted (SAVE, FINALIZE)
+     * @param requiredPrivilege The specific privilege required
+     * @return true if authorized, false if not
+     */
+    private boolean isAuthorized(String action, String requiredPrivilege) {
+        if (webUserController == null || sessionController == null) {
+            LOGGER.log(Level.SEVERE, "Authorization failed - missing controllers: action={0}, userId=null, billId={1}",
+                    new Object[]{action, currentBill != null ? currentBill.getId() : "null"});
+            return false;
+        }
+
+        if (!webUserController.hasPrivilege(requiredPrivilege)) {
+            Long userId = sessionController.getLoggedUser() != null ? sessionController.getLoggedUser().getId() : null;
+            Long billIdForLog = currentBill != null ? currentBill.getId() : null;
+
+            LOGGER.log(Level.WARNING, "SECURITY: Unauthorized Purchase Order access attempt - action={0}, userId={1}, billId={2}, requiredPrivilege={3}",
+                    new Object[]{action, userId, billIdForLog, requiredPrivilege});
+
+            JsfUtil.addErrorMessage("You don't have permission to " + action.toLowerCase() + " purchase order requests.");
+            return false;
+        }
+
+        return true;
+    }
+
+    public List<Item> getDealorItems() {
+        List<Item> lst;
+        String sql;
+        HashMap hm = new HashMap();
+        sql = "select c.item "
+                + " from ItemsDistributors c"
+                + " where c.retired=false "
+                + " and c.item.retired=false "
+                + " and c.item.inactive=false "
+                + " and c.institution=:ins "
+                + " order by c.item.name";
+        hm.put("ins", getCurrentBill().getToInstitution());
+        lst = itemFacade.findByJpql(sql, hm, 200);
+
+        // Filter by department type if set
+        if (getCurrentBill().getDepartmentType() != null && lst != null) {
+            lst = filterItemsByDepartmentType(lst, getCurrentBill().getDepartmentType());
+        }
+
+        return lst;
+    }
+
+    private List<Item> filterItemsByDepartmentType(List<Item> items, DepartmentType departmentType) {
+        if (items == null || departmentType == null) {
+            return items;
+        }
+
+        // Check if the department type is allowed for pharmacy transactions
+        List<DepartmentType> allowedTypes = sessionController.getAvailableDepartmentTypesForPharmacyTransactions();
+        if (allowedTypes == null || !allowedTypes.contains(departmentType)) {
+            return new ArrayList<>(); // Return empty list if department type not allowed
+        }
+
+        // For now, return all items if department type is allowed
+        // Additional item-specific filtering can be added here if needed
+        return items;
+    }
+
+    public List<Item> completeItemForSelectedDepartmentType(String query) {
+        // Get items from the ItemController
+        List<Item> allItems;
+        if (getCurrentBill().getDepartmentType() == null) {
+            allItems = itemController.completeAmpAndAmppItemForLoggedDepartment(query);
+        } else {
+            allItems = itemController.completeAmpAndAmppItemForLoggedDepartment(query, getCurrentBill().getDepartmentType());
+        }
+
+        // Filter by department type if set
+        if (getCurrentBill().getDepartmentType() != null && allItems != null) {
+            return filterItemsByDepartmentType(allItems, getCurrentBill().getDepartmentType());
+        }
+
+        return allItems;
+    }
+
+    private void applyLastRatesToBillItem(BillItem billItem) {
+        if (billItem == null || billItem.getItem() == null) {
+            return;
+        }
+
+        List<Item> items = new ArrayList<>();
+        items.add(billItem.getItem());
+
+        Map<Long, Double> purchaseRates = fetchLastPurchaseRatesForItems(items);
+        Map<Long, Double> retailRates = fetchLastRetailRatesForItems(items);
+
+        applyLastRatesToBillItem(
+                billItem,
+                getRateForItem(purchaseRates, billItem.getItem()),
+                getRateForItem(retailRates, billItem.getItem()));
+    }
+
+    private void applyLastRatesToBillItem(BillItem billItem, double purchaseRate, double retailRate) {
+        PharmaceuticalBillItem pharmaceuticalBillItem = billItem.getPharmaceuticalBillItem();
+        pharmaceuticalBillItem.setPurchaseRate(purchaseRate);
+        pharmaceuticalBillItem.setRetailRate(retailRate);
+
+        com.divudi.core.entity.BillItemFinanceDetails financeDetails = billItem.getBillItemFinanceDetails();
+        financeDetails.setUnitsPerPack(getUnitsPerPack(billItem.getItem()));
+        financeDetails.setLineGrossRate(BigDecimal.valueOf(purchaseRate));
+        financeDetails.setLineNetRate(financeDetails.getLineGrossRate());
+        financeDetails.setRetailSaleRate(BigDecimal.valueOf(retailRate));
+    }
+
+    private BigDecimal getUnitsPerPack(Item item) {
+        if (item instanceof Ampp) {
+            BigDecimal unitsPerPack = BigDecimal.valueOf(item.getDblValue());
+            if (unitsPerPack.doubleValue() > 0) {
+                return unitsPerPack;
+            }
+        }
+        return BigDecimal.ONE;
+    }
+
+    private Map<Long, Double> fetchLastPurchaseRatesForItems(List<Item> items) {
+        Map<Long, Double> ratesByItemId = fetchLastRatesForItems(items,
+                "billItemFinanceDetails.lineGrossRate",
+                "pharmaceuticalBillItem.itemBatch.purcahseRate",
+                "purchase");
+
+        Department dept = getDepartmentLookupScope().department;
+        if (dept != null) {
+            for (Item item : getItemsMissingRates(getUniqueItemsWithIds(items), ratesByItemId)) {
+                double rate = pharmacyBean.getLastPurchaseRate(item, dept, true);
+                if (rate > 0.0) {
+                    ratesByItemId.put(item.getId(), rate);
+                }
+            }
+        }
+
+        return ratesByItemId;
+    }
+
+    private Map<Long, Double> fetchLastRetailRatesForItems(List<Item> items) {
+        Map<Long, Double> ratesByItemId = fetchLastRatesForItems(items,
+                "billItemFinanceDetails.retailSaleRate",
+                "pharmaceuticalBillItem.itemBatch.retailsaleRate",
+                "retail");
+
+        Department dept = getDepartmentLookupScope().department;
+        if (dept != null) {
+            for (Item item : getItemsMissingRates(getUniqueItemsWithIds(items), ratesByItemId)) {
+                double rate = pharmacyBean.getLastRetailRate(item, dept, true);
+                if (rate > 0.0) {
+                    ratesByItemId.put(item.getId(), rate);
+                }
+            }
+        }
+
+        return ratesByItemId;
+    }
+
+    private Map<Long, Double> fetchLastRatesForItems(List<Item> items, String financeRatePath, String itemBatchRatePath, String rateLabel) {
+        List<Item> lookupItems = getUniqueItemsWithIds(items);
+        Map<Long, Double> ratesByItemId = new HashMap<>();
+        if (lookupItems.isEmpty()) {
+            return ratesByItemId;
+        }
+
+        DepartmentLookupScope scope = getDepartmentLookupScope();
+
+        mergeMissingRates(ratesByItemId, fetchScopedFinanceRatesForItems(lookupItems, financeRatePath, rateLabel, "department", scope.department));
+        mergeMissingRates(ratesByItemId, fetchScopedFinanceRatesForItems(getItemsMissingRates(lookupItems, ratesByItemId), financeRatePath, rateLabel, "institution", scope.institution));
+        mergeMissingRates(ratesByItemId, fetchScopedFinanceRatesForItems(getItemsMissingRates(lookupItems, ratesByItemId), financeRatePath, rateLabel, "global", null));
+
+        mergeMissingItemBatchRates(ratesByItemId, lookupItems, itemBatchRatePath, rateLabel, "department", scope.department);
+        mergeMissingItemBatchRates(ratesByItemId, lookupItems, itemBatchRatePath, rateLabel, "institution", scope.institution);
+        mergeMissingItemBatchRates(ratesByItemId, lookupItems, itemBatchRatePath, rateLabel, "global", null);
+
+        return ratesByItemId;
+    }
+
+    private List<Item> getUniqueItemsWithIds(List<Item> items) {
+        Map<Long, Item> uniqueItems = new HashMap<>();
+        if (items == null) {
+            return new ArrayList<>();
+        }
+        for (Item item : items) {
+            if (item != null && item.getId() != null && !uniqueItems.containsKey(item.getId())) {
+                uniqueItems.put(item.getId(), item);
+            }
+        }
+        return new ArrayList<>(uniqueItems.values());
+    }
+
+    private List<Item> getItemsMissingRates(List<Item> items, Map<Long, Double> ratesByItemId) {
+        List<Item> missingItems = new ArrayList<>();
+        if (items == null) {
+            return missingItems;
+        }
+        for (Item item : items) {
+            if (item != null && item.getId() != null && getRateForItem(ratesByItemId, item) <= 0.0) {
+                missingItems.add(item);
+            }
+        }
+        return missingItems;
+    }
+
+    private void mergeMissingRates(Map<Long, Double> ratesByItemId, Map<Long, Double> newRatesByItemId) {
+        if (newRatesByItemId == null || newRatesByItemId.isEmpty()) {
+            return;
+        }
+        for (Map.Entry<Long, Double> rateEntry : newRatesByItemId.entrySet()) {
+            if (rateEntry.getKey() != null && rateEntry.getValue() != null && rateEntry.getValue() > 0.0
+                    && getRateByItemId(ratesByItemId, rateEntry.getKey()) <= 0.0) {
+                ratesByItemId.put(rateEntry.getKey(), rateEntry.getValue());
+            }
+        }
+    }
+
+    private Map<Long, Double> fetchScopedFinanceRatesForItems(List<Item> items, String ratePath, String rateLabel, String scope, Object scopeValue) {
+        Map<Long, Double> ratesByItemId = new HashMap<>();
+        if (items == null || items.isEmpty() || (scopeValue == null && !"global".equals(scope))) {
+            return ratesByItemId;
+        }
+
+        String rateExpression = "bi." + ratePath;
+
+        String jpql = "SELECT new com.divudi.core.data.dto.PharmacyPurchaseOrderRateDTO("
+                + "bi.item.id, " + rateExpression + ", bi.id) "
+                + "FROM BillItem bi "
+                + "WHERE bi.item.id IN :itemIds "
+                + "AND bi.retired = false "
+                + "AND bi.bill.cancelled = false "
+                + "AND bi.billItemFinanceDetails IS NOT NULL "
+                + "AND " + rateExpression + " IS NOT NULL "
+                + "AND " + rateExpression + " > 0 "
+                + "AND bi.bill.billType IN :billTypes "
+                + getScopeCondition(scope, "bi")
+                + "ORDER BY bi.id DESC";
+
+        Map<String, Object> params = createRateLookupParameters(items);
+        addScopeParameter(params, scope, scopeValue);
+        return fetchRateDtos(jpql, params, rateLabel);
+    }
+
+    private void mergeMissingItemBatchRates(Map<Long, Double> ratesByItemId, List<Item> originalItems, String ratePath, String rateLabel, String scope, Object scopeValue) {
+        List<Item> missingItems = getItemsMissingRates(originalItems, ratesByItemId);
+        if (missingItems.isEmpty() || (scopeValue == null && !"global".equals(scope))) {
+            return;
+        }
+
+        List<Item> batchItems = new ArrayList<>();
+        Map<Long, Long> batchItemIdByOriginalItemId = new HashMap<>();
+        for (Item item : missingItems) {
+            Item batchItem = getItemForItemBatchRate(item);
+            if (batchItem != null && batchItem.getId() != null) {
+                batchItems.add(batchItem);
+                batchItemIdByOriginalItemId.put(item.getId(), batchItem.getId());
+            }
+        }
+
+        Map<Long, Double> batchRatesByBatchItemId = fetchScopedItemBatchRatesForItems(getUniqueItemsWithIds(batchItems), ratePath, rateLabel, scope, scopeValue);
+        for (Item item : missingItems) {
+            Long batchItemId = batchItemIdByOriginalItemId.get(item.getId());
+            Double rate = batchRatesByBatchItemId.get(batchItemId);
+            if (rate != null && rate > 0.0 && getRateForItem(ratesByItemId, item) <= 0.0) {
+                ratesByItemId.put(item.getId(), rate);
+            }
+        }
+    }
+
+    private Map<Long, Double> fetchScopedItemBatchRatesForItems(List<Item> items, String ratePath, String rateLabel, String scope, Object scopeValue) {
+        Map<Long, Double> ratesByItemId = new HashMap<>();
+        if (items == null || items.isEmpty() || (scopeValue == null && !"global".equals(scope))) {
+            return ratesByItemId;
+        }
+
+        String rateExpression = "bi." + ratePath;
+
+        String jpql = "SELECT new com.divudi.core.data.dto.PharmacyPurchaseOrderRateDTO("
+                + "bi.pharmaceuticalBillItem.itemBatch.item.id, " + rateExpression + ", bi.id) "
+                + "FROM BillItem bi "
+                + "WHERE bi.retired = false "
+                + "AND bi.bill.cancelled = false "
+                + "AND bi.pharmaceuticalBillItem IS NOT NULL "
+                + "AND bi.pharmaceuticalBillItem.itemBatch IS NOT NULL "
+                + "AND bi.pharmaceuticalBillItem.itemBatch.item.id IN :itemIds "
+                + "AND " + rateExpression + " > 0 "
+                + "AND bi.bill.billType IN :billTypes "
+                + getScopeCondition(scope, "bi")
+                + "ORDER BY bi.id DESC";
+
+        Map<String, Object> params = createRateLookupParameters(items);
+        addScopeParameter(params, scope, scopeValue);
+        return fetchRateDtos(jpql, params, rateLabel);
+    }
+
+    private Map<String, Object> createRateLookupParameters(List<Item> items) {
+        List<BillType> purchaseBillTypes = new ArrayList<>();
+        purchaseBillTypes.add(BillType.PharmacyGrnBill);
+        purchaseBillTypes.add(BillType.PharmacyPurchaseBill);
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("itemIds", getItemIds(items));
+        params.put("billTypes", purchaseBillTypes);
+        return params;
+    }
+
+    private List<Long> getItemIds(List<Item> items) {
+        List<Long> itemIds = new ArrayList<>();
+        if (items == null) {
+            return itemIds;
+        }
+        for (Item item : items) {
+            if (item != null && item.getId() != null && !itemIds.contains(item.getId())) {
+                itemIds.add(item.getId());
+            }
+        }
+        return itemIds;
+    }
+
+    private String getScopeCondition(String scope, String alias) {
+        if ("department".equals(scope)) {
+            return "AND " + alias + ".bill.department = :department ";
+        }
+        if ("institution".equals(scope)) {
+            return "AND " + alias + ".bill.department.institution = :institution ";
+        }
+        return "";
+    }
+
+    private void addScopeParameter(Map<String, Object> params, String scope, Object scopeValue) {
+        if ("department".equals(scope)) {
+            params.put("department", scopeValue);
+        } else if ("institution".equals(scope)) {
+            params.put("institution", scopeValue);
+        }
+    }
+
+    private Map<Long, Double> fetchRateDtos(String jpql, Map<String, Object> params, String rateLabel) {
+        Map<Long, Double> ratesByItemId = new HashMap<>();
+        try {
+            @SuppressWarnings("unchecked")
+            List<PharmacyPurchaseOrderRateDTO> results = (List<PharmacyPurchaseOrderRateDTO>) billItemFacade.findLightsByJpql(jpql, params);
+            if (results == null) {
+                return ratesByItemId;
+            }
+            for (PharmacyPurchaseOrderRateDTO result : results) {
+                if (result != null && result.getItemId() != null && result.getRate() != null && result.getRate() > 0.0
+                        && getRateByItemId(ratesByItemId, result.getItemId()) <= 0.0) {
+                    ratesByItemId.put(result.getItemId(), result.getRate());
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, "Failed to fetch last " + rateLabel + " rates for purchase order request", e);
+        }
+        return ratesByItemId;
+    }
+
+    private Item getItemForItemBatchRate(Item item) {
+        if (item instanceof Ampp) {
+            return ((Ampp) item).getAmp();
+        }
+        return item;
+    }
+
+    private double getRateForItem(Map<Long, Double> ratesByItemId, Item item) {
+        if (item == null || item.getId() == null) {
+            return 0.0;
+        }
+        return getRateByItemId(ratesByItemId, item.getId());
+    }
+
+    private double getRateByItemId(Map<Long, Double> ratesByItemId, Long itemId) {
+        if (ratesByItemId == null || itemId == null) {
+            return 0.0;
+        }
+        Double rate = ratesByItemId.get(itemId);
+        if (rate == null || rate <= 0.0) {
+            return 0.0;
+        }
+        return rate;
+    }
+
+    private DepartmentLookupScope getDepartmentLookupScope() {
+        DepartmentLookupScope scope = new DepartmentLookupScope();
+        if (sessionController != null && sessionController.getDepartment() != null) {
+            scope.department = sessionController.getDepartment();
+            scope.institution = sessionController.getDepartment().getInstitution();
+        }
+        return scope;
+    }
+
+    private static class DepartmentLookupScope implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        private Department department;
+        private Institution institution;
+    }
+
+    private void createAndAssignBillNumber() {
+        // Check if bill number suffix is configured, if not set default "POR" for Purchase Order Requests
+        String billSuffix = configOptionApplicationController.getLongTextValueByKey("Bill Number Suffix for " + BillTypeAtomic.PHARMACY_ORDER_PRE, "");
+        if (billSuffix == null || billSuffix.trim().isEmpty()) {
+            // Set default suffix for Purchase Order Requests if not configured
+            configOptionApplicationController.setLongTextValueByKey("Bill Number Suffix for " + BillTypeAtomic.PHARMACY_ORDER_PRE, "POR");
+        }
+
+        boolean billNumberGenerationStrategyForDepartmentIdIsPrefixDeptInsYearCount = configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Purchase Order Requests - Prefix + Department Code + Institution Code + Year + Yearly Number and Yearly Number", false);
+        boolean billNumberGenerationStrategyForDepartmentIdIsPrefixInsDeptYearCount = configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Purchase Order Requests - Prefix + Institution Code + Department Code + Year + Yearly Number and Yearly Number", false);
+        boolean billNumberGenerationStrategyForDepartmentIdIsPrefixInsYearCount = configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Purchase Order Requests - Prefix + Institution Code + Year + Yearly Number and Yearly Number", false);
+        boolean billNumberGenerationStrategyForInstitutionIdIsPrefixInsYearCount = configOptionApplicationController.getBooleanValueByKey("Institution Number Generation Strategy for Purchase Order Requests - Prefix + Institution Code + Year + Yearly Number and Yearly Number", false);
+
+        String billId = "";
+
+        if (billNumberGenerationStrategyForDepartmentIdIsPrefixDeptInsYearCount) {
+            if (getCurrentBill().getDeptId() == null || getCurrentBill().getDeptId().trim().equals("")) {
+                billId = billNumberBean.departmentBillNumberGeneratorYearlyWithPrefixDeptInsYearCount(sessionController.getDepartment(), BillTypeAtomic.PHARMACY_ORDER_PRE);
+                getCurrentBill().setDeptId(billId);
+            }
+        } else if (billNumberGenerationStrategyForDepartmentIdIsPrefixInsDeptYearCount) {
+            if (getCurrentBill().getDeptId() == null || getCurrentBill().getDeptId().trim().equals("")) {
+                billId = billNumberBean.departmentBillNumberGeneratorYearlyWithPrefixInsDeptYearCount(sessionController.getDepartment(), BillTypeAtomic.PHARMACY_ORDER_PRE);
+                getCurrentBill().setDeptId(billId);
+            }
+        } else if (billNumberGenerationStrategyForDepartmentIdIsPrefixInsYearCount) {
+            if (getCurrentBill().getDeptId() == null || getCurrentBill().getDeptId().trim().equals("")) {
+                billId = billNumberBean.departmentBillNumberGeneratorYearlyWithPrefixInsYearCountInstitutionWide(sessionController.getDepartment(), BillTypeAtomic.PHARMACY_ORDER_PRE);
+                getCurrentBill().setDeptId(billId);
+            }
+        } else {
+            //Keep Legacy Method intact without any changes
+            if (getCurrentBill().getDeptId() == null || getCurrentBill().getDeptId().trim().equals("")) {
+                billId = billNumberBean.departmentBillNumberGeneratorYearly(sessionController.getDepartment(), BillTypeAtomic.PHARMACY_ORDER_PRE);
+                getCurrentBill().setDeptId(billId);
+            }
+        }
+
+        if (billNumberGenerationStrategyForInstitutionIdIsPrefixInsYearCount) {
+            if (getCurrentBill().getInsId() == null || getCurrentBill().getInsId().trim().equals("")) {
+                String insId = billNumberBean.institutionBillNumberGeneratorYearlyWithPrefixInsYearCountInstitutionWide(sessionController.getDepartment(), BillTypeAtomic.PHARMACY_ORDER_PRE);
+                getCurrentBill().setInsId(insId);
+            }
+        } else {
+            //Keep Legacy Method intact without any changes
+            if (getCurrentBill().getInsId() == null || getCurrentBill().getInsId().trim().equals("")) {
+                if (billId != null && !billId.trim().isEmpty()) {
+                    getCurrentBill().setInsId(billId);
+                }
+            }
+        }
+    }
+
+    public void prepareEmailDialog() {
+        if (currentBill == null) {
+            JsfUtil.addErrorMessage("No Bill");
+            return;
+        }
+
+        // Set default email if available
+        if (currentBill.getToInstitution() != null && currentBill.getToInstitution().getEmail() != null) {
+            emailRecipient = currentBill.getToInstitution().getEmail();
+        } else {
+            emailRecipient = "";
+        }
+    }
+
+    public void sendPurchaseOrderEmail() {
+        if (currentBill == null) {
+            JsfUtil.addErrorMessage("No Bill");
+            return;
+        }
+
+        if (emailRecipient == null || emailRecipient.trim().isEmpty()) {
+            JsfUtil.addErrorMessage("Please enter recipient email");
+            return;
+        }
+
+        String recipient = emailRecipient.trim();
+        if (!CommonFunctions.isValidEmail(recipient)) {
+            JsfUtil.addErrorMessage("Please enter a valid email address");
+            return;
+        }
+
+        String body = generatePurchaseOrderHtml();
+        if (body == null) {
+            JsfUtil.addErrorMessage("Could not generate email body");
+            return;
+        }
+
+        AppEmail email = new AppEmail();
+        email.setCreatedAt(new Date());
+        email.setCreater(sessionController.getLoggedUser());
+        email.setReceipientEmail(recipient);
+        email.setMessageSubject("Purchase Order Request");
+        email.setMessageBody(body);
+        email.setDepartment(sessionController.getLoggedUser().getDepartment());
+        email.setInstitution(sessionController.getLoggedUser().getInstitution());
+        email.setBill(currentBill);
+        email.setMessageType(MessageType.Marketing);
+        email.setSentSuccessfully(false);
+        email.setPending(true);
+        emailFacade.create(email);
+
+        try {
+            boolean success = emailManagerEjb.sendEmail(
+                    java.util.Collections.singletonList(recipient),
+                    body,
+                    "Purchase Order Request",
+                    true
+            );
+            email.setSentSuccessfully(success);
+            email.setPending(!success);
+            if (success) {
+                email.setSentAt(new Date());
+                JsfUtil.addSuccessMessage("Email Sent Successfully");
+            } else {
+                JsfUtil.addErrorMessage("Sending Email Failed");
+            }
+            emailFacade.edit(email);
+        } catch (Exception ex) {
+            JsfUtil.addErrorMessage("Sending Email Failed");
+        }
+    }
+
+    private String generatePurchaseOrderHtml() {
+        try {
+            if (currentBill == null) {
+                LOGGER.log(Level.SEVERE, "Current bill is null when generating purchase order HTML");
+                return null;
+            }
+
+            StringBuilder html = new StringBuilder();
+            html.append("<html><head><title>Purchase Order Request</title></head><body>");
+            html.append("<div style='font-family: Arial, sans-serif; padding: 20px;'>");
+
+            // Institution header
+            if (currentBill.getCreater() != null && currentBill.getCreater().getInstitution() != null) {
+                html.append("<div style='text-align: center; margin-bottom: 20px;'>");
+                html.append("<h2>").append(currentBill.getCreater().getInstitution().getName() != null ? currentBill.getCreater().getInstitution().getName() : "").append("</h2>");
+                if (currentBill.getCreater().getInstitution().getAddress() != null) {
+                    html.append("<p>").append(currentBill.getCreater().getInstitution().getAddress()).append("</p>");
+                }
+                if (currentBill.getCreater().getInstitution().getPhone() != null) {
+                    html.append("<p>Phone: ").append(currentBill.getCreater().getInstitution().getPhone()).append("</p>");
+                }
+                html.append("</div>");
+            }
+
+            html.append("<h3 style='text-align: center; text-decoration: underline;'>Purchase Order Request</h3>");
+
+            // Order details
+            html.append("<table style='width: 100%; margin-bottom: 20px;'>");
+            html.append("<tr><td><strong>Order No:</strong></td><td>").append(currentBill.getDeptId() != null ? currentBill.getDeptId() : "").append("</td></tr>");
+            if (currentBill.getDepartment() != null) {
+                html.append("<tr><td><strong>Order Department:</strong></td><td>").append(currentBill.getDepartment().getName() != null ? currentBill.getDepartment().getName() : "").append("</td></tr>");
+            }
+            if (currentBill.getToInstitution() != null) {
+                html.append("<tr><td><strong>Supplier:</strong></td><td>").append(currentBill.getToInstitution().getName() != null ? currentBill.getToInstitution().getName() : "").append("</td></tr>");
+                html.append("<tr><td><strong>Supplier Code:</strong></td><td>").append(currentBill.getToInstitution().getCode() != null ? currentBill.getToInstitution().getCode() : "").append("</td></tr>");
+                if (currentBill.getToInstitution().getPhone() != null) {
+                    html.append("<tr><td><strong>Supplier Phone:</strong></td><td>").append(currentBill.getToInstitution().getPhone()).append("</td></tr>");
+                }
+                if (currentBill.getToInstitution().getAddress() != null) {
+                    html.append("<tr><td><strong>Supplier Address:</strong></td><td>").append(currentBill.getToInstitution().getAddress()).append("</td></tr>");
+                }
+            }
+            html.append("<tr><td><strong>Payment Method:</strong></td><td>").append(currentBill.getPaymentMethod() != null ? currentBill.getPaymentMethod().toString() : "").append("</td></tr>");
+            html.append("<tr><td><strong>Consignment:</strong></td><td>").append(currentBill.isConsignment() ? "Yes" : "No").append("</td></tr>");
+            html.append("</table>");
+
+            // Items table
+            html.append("<table border='1' style='width: 100%; border-collapse: collapse; margin-bottom: 20px;'>");
+            html.append("<thead style='background-color: #f0f0f0;'>");
+            html.append("<tr>");
+            html.append("<th style='padding: 8px;'>Item Code</th>");
+            html.append("<th style='padding: 8px;'>Item Name</th>");
+            html.append("<th style='padding: 8px;'>Qty</th>");
+            html.append("<th style='padding: 8px;'>Free Qty</th>");
+            html.append("<th style='padding: 8px;'>Purchase Rate</th>");
+            html.append("<th style='padding: 8px;'>Purchase Value</th>");
+            html.append("</tr></thead><tbody>");
+
+            if (billItems != null) {
+                for (BillItem bi : billItems) {
+                    if (bi != null && !bi.isRetired() && bi.getItem() != null) {
+                        html.append("<tr>");
+                        html.append("<td style='padding: 8px;'>").append(bi.getItem().getCode() != null ? bi.getItem().getCode() : "").append("</td>");
+                        html.append("<td style='padding: 8px;'>").append(bi.getItem().getName() != null ? bi.getItem().getName() : "").append("</td>");
+                        html.append("<td style='padding: 8px; text-align: right;'>");
+                        if (bi.getPharmaceuticalBillItem() != null) {
+                            html.append(String.format("%,.0f", bi.getPharmaceuticalBillItem().getQty()));
+                        }
+                        html.append("</td>");
+                        html.append("<td style='padding: 8px; text-align: right;'>");
+                        if (bi.getPharmaceuticalBillItem() != null) {
+                            html.append(String.format("%,.0f", bi.getPharmaceuticalBillItem().getFreeQty()));
+                        }
+                        html.append("</td>");
+                        html.append("<td style='padding: 8px; text-align: right;'>");
+                        if (bi.getPharmaceuticalBillItem() != null) {
+                            html.append(String.format("%,.2f", bi.getPharmaceuticalBillItem().getPurchaseRate()));
+                        }
+                        html.append("</td>");
+                        html.append("<td style='padding: 8px; text-align: right;'>").append(String.format("%,.2f", bi.getNetValue())).append("</td>");
+                        html.append("</tr>");
+                    }
+                }
+            }
+
+            html.append("</tbody>");
+            html.append("<tfoot style='font-weight: bold;'>");
+            html.append("<tr>");
+            html.append("<td colspan='5' style='padding: 8px; text-align: right;'>Net Total:</td>");
+            html.append("<td style='padding: 8px; text-align: right;'>").append(String.format("%,.2f", currentBill.getNetTotal())).append("</td>");
+            html.append("</tr></tfoot></table>");
+
+            // Footer details
+            html.append("<div style='margin-top: 20px;'>");
+            if (currentBill.getCreater() != null && currentBill.getCreater().getWebUserPerson() != null) {
+                html.append("<p><strong>Order Initiated By:</strong> ").append(currentBill.getCreater().getWebUserPerson().getName() != null ? currentBill.getCreater().getWebUserPerson().getName() : "").append("</p>");
+            }
+            if (currentBill.getCheckedBy() != null) {
+                html.append("<p><strong>Order Finalized By:</strong> ").append(currentBill.getCheckedBy().getName() != null ? currentBill.getCheckedBy().getName() : "").append("</p>");
+            }
+            if (currentBill.getCheckeAt() != null) {
+                html.append("<p><strong>Order Finalized At:</strong> ").append(CommonFunctions.formatDate(currentBill.getCheckeAt(), "dd/MM/yyyy HH:mm:ss")).append("</p>");
+            }
+            html.append("<p><strong>Generated At:</strong> ").append(CommonFunctions.formatDate(new Date(), "dd/MM/yyyy HH:mm:ss")).append("</p>");
+            html.append("<p><strong>Total:</strong> ").append(String.format("%,.2f", currentBill.getNetTotal())).append("</p>");
+            html.append("</div>");
+
+            html.append("</div></body></html>");
+            return html.toString();
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, "Error generating purchase order HTML", e);
+            return null;
+        }
+    }
+
+    // Getters/setters
+    public Bill getCurrentBill() {
+        return currentBill;
+    }
+
+    public void setCurrentBill(Bill currentBill) {
+        this.currentBill = currentBill;
+    }
+
+    public BillItem getCurrentBillItem() {
+        return currentBillItem;
+    }
+
+    public void setCurrentBillItem(BillItem currentBillItem) {
+        this.currentBillItem = currentBillItem;
+    }
+
+    public List<BillItem> getBillItems() {
+        return billItems;
+    }
+
+    public void setBillItems(List<BillItem> billItems) {
+        this.billItems = billItems;
+    }
+
+    public List<BillItem> getSelectedBillItems() {
+        return selectedBillItems;
+    }
+
+    public void setSelectedBillItems(List<BillItem> selectedBillItems) {
+        this.selectedBillItems = selectedBillItems;
+    }
+
+    public boolean isPrintPreview() {
+        return printPreview;
+    }
+
+    public void setPrintPreview(boolean printPreview) {
+        this.printPreview = printPreview;
+    }
+
+    public boolean isItemHistoryVisible() {
+        return itemHistoryVisible;
+    }
+
+    public void setItemHistoryVisible(boolean itemHistoryVisible) {
+        this.itemHistoryVisible = itemHistoryVisible;
+    }
+
+    public Long getBillId() {
+        return billId;
+    }
+
+    public void setBillId(Long billId) {
+        this.billId = billId;
+    }
+
+    public String getEmailRecipient() {
+        return emailRecipient;
+    }
+
+    public void setEmailRecipient(String emailRecipient) {
+        this.emailRecipient = emailRecipient;
+    }
+}

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestNativeSqlController.java
@@ -136,7 +136,7 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
         return result != null ? result : new ArrayList<>();
     }
 
-    private void resetBillValues() {
+    public void resetBillValues() {
         currentBill = null;
         currentBillItem = new BillItem();
         billItems = new ArrayList<>();
@@ -315,6 +315,29 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
         billItems.remove(bi);
         calculateBillTotals();
         itemHistoryVisible = false;
+    }
+
+    public void removeSelected() {
+        if (!isAuthorized("SAVE", "PurchaseOrderSave")) {
+            return;
+        }
+        if (selectedBillItems == null) {
+            return;
+        }
+        saveRequestWithoutMessage();
+        for (BillItem b : selectedBillItems) {
+            b.setBill(null);
+            b.setRetired(true);
+            b.setRetirer(sessionController.getLoggedUser());
+            b.setRetiredAt(new Date());
+            if (b.getId() != null) {
+                purchaseOrderRequestNativeSqlService.retireLine(b.getId(), sessionController.getLoggedUser().getId());
+            }
+        }
+
+        billItems.removeAll(selectedBillItems);
+        calculateBillTotals();
+        selectedBillItems = null;
     }
 
     public void onEdit(BillItem bi) {

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestNativeSqlController.java
@@ -6,6 +6,7 @@ package com.divudi.bean.pharmacy;
 
 import com.divudi.bean.common.ConfigOptionApplicationController;
 import com.divudi.bean.common.ConfigOptionController;
+import com.divudi.bean.common.EnumController;
 import com.divudi.bean.common.ItemController;
 import com.divudi.bean.common.SessionController;
 import com.divudi.bean.common.WebUserController;
@@ -64,6 +65,9 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
 
     private static final Logger LOGGER = Logger.getLogger(PurchaseOrderRequestNativeSqlController.class.getName());
 
+    /** Smallest purchase rate a line may carry and still be finalizable. */
+    private static final double MIN_PURCHASE_RATE = 0.00001;
+
     @Inject
     private SessionController sessionController;
     @Inject
@@ -72,6 +76,8 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
     private ConfigOptionApplicationController configOptionApplicationController;
     @Inject
     private ConfigOptionController configOptionController;
+    @Inject
+    private EnumController enumController;
     @Inject
     private ItemController itemController;
     @Inject
@@ -107,7 +113,10 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
 
     public String navigateToCreateNewPurchaseOrder() {
         resetBillValues();
-        currentBill = new Bill();
+        // getCurrentBill() rebuilds the draft with the configured default
+        // payment method and consignment flag, so the entry path and the page's
+        // "New Order" buttons produce an identically initialised bill.
+        getCurrentBill();
         return "/pharmacy/pharmacy_purhcase_order_request_native?faces-redirect=true";
     }
 
@@ -402,15 +411,148 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
         bi.setNetValue(netValue.doubleValue());
     }
 
+    /**
+     * Recomputes the on-screen bill total AND renumbers the surviving lines'
+     * serial numbers so they stay contiguous from 0.
+     * <p>
+     * Renumbering matters because the page's dataTable uses
+     * {@code rowKey="#{bi.searialNo}"} (see
+     * pharmacy_purhcase_order_request_native.xhtml) and both {@code addItem()}
+     * and {@code generateBillComponentsForAllSupplierItems()} seed a new line's
+     * serial from {@code billItems.size()}. After a removal the size shrinks
+     * back over a serial already held by a survivor, so the next added line
+     * would collide with it and PrimeFaces would bind edits to the wrong row.
+     * Mirrors legacy PurchaseOrderRequestController.calculateBillTotals().
+     */
     private void calculateBillTotals() {
         double total = 0.0;
+        int serialNo = 0;
         for (BillItem bi : billItems) {
-            if (bi != null && !bi.isRetired()) {
-                total += bi.getNetValue();
+            if (bi == null || bi.isRetired()) {
+                continue;
             }
+            bi.setSearialNo(serialNo++);
+            total += bi.getNetValue();
         }
         currentBill.setNetTotal(total);
         currentBill.setTotal(total);
+    }
+
+    /**
+     * Total quantity (in atomic units) across all non-retired lines. Used as
+     * the in-memory pre-check that a finalize is allowed at all, before any
+     * native mutation touches the DB. Mirrors legacy
+     * PurchaseOrderRequestController.calculateTotalBillItemsCount().
+     */
+    private double calculateTotalBillItemsCount(List<BillItem> items) {
+        double total = 0d;
+        if (items == null) {
+            return total;
+        }
+        for (BillItem b : items) {
+            if (b == null || b.isRetired()) {
+                continue;
+            }
+            BigDecimal totalUnits = totalUnitsForLine(b);
+            if (totalUnits.compareTo(BigDecimal.ZERO) > 0) {
+                total += totalUnits.doubleValue();
+            }
+        }
+        return total;
+    }
+
+    /**
+     * True only when every non-retired line carries at least one atomic unit of
+     * quantity and a usable purchase rate. Mirrors legacy
+     * PurchaseOrderRequestController.allBillItemsValid().
+     */
+    private boolean allBillItemsValid(List<BillItem> items) {
+        if (items == null || items.isEmpty()) {
+            return false;
+        }
+        boolean sawLine = false;
+        for (BillItem bi : items) {
+            if (bi == null || bi.isRetired()) {
+                continue;
+            }
+            sawLine = true;
+            com.divudi.core.entity.BillItemFinanceDetails fd = bi.getBillItemFinanceDetails();
+            if (fd == null) {
+                return false;
+            }
+            // Require at least one atomic unit (e.g., tablet)
+            if (totalUnitsForLine(bi).compareTo(BigDecimal.ONE) < 0) {
+                return false;
+            }
+            BigDecimal rate = fd.getLineGrossRate();
+            if (rate == null || rate.compareTo(BigDecimal.valueOf(MIN_PURCHASE_RATE)) < 0) {
+                return false;
+            }
+        }
+        return sawLine;
+    }
+
+    /**
+     * Quantity + free quantity for a line, expressed in atomic units.
+     * <p>
+     * Legacy reads {@code BillItemFinanceDetails.quantityByUnits} /
+     * {@code freeQuantityByUnits} directly, because legacy's
+     * {@code calculateLineValues()} refreshes those two in-memory fields on
+     * every edit. The native flow deliberately does NOT: {@code quantityByUnits}
+     * is computed server-side inside
+     * {@code PurchaseOrderRequestNativeSqlService.saveBillItemFinanceDetails()},
+     * and the page binds only {@code quantity} / {@code freeQuantity} /
+     * {@code lineGrossRate}. A freshly added, not-yet-saved line therefore has
+     * a null {@code quantityByUnits}, so reading it directly would reject every
+     * valid new order. Derive it here from the same inputs and the same formula
+     * the service uses (pack quantity x unitsPerPack), so validation matches
+     * what will actually be persisted.
+     */
+    private BigDecimal totalUnitsForLine(BillItem bi) {
+        com.divudi.core.entity.BillItemFinanceDetails fd = bi.getBillItemFinanceDetails();
+        if (fd == null) {
+            return BigDecimal.ZERO;
+        }
+        BigDecimal qty = fd.getQuantity() != null ? fd.getQuantity() : BigDecimal.ZERO;
+        BigDecimal freeQty = fd.getFreeQuantity() != null ? fd.getFreeQuantity() : BigDecimal.ZERO;
+        BigDecimal unitsPerPack = (fd.getUnitsPerPack() != null && fd.getUnitsPerPack().compareTo(BigDecimal.ZERO) > 0)
+                ? fd.getUnitsPerPack() : BigDecimal.ONE;
+        if (bi.getItem() instanceof Ampp) {
+            return qty.multiply(unitsPerPack).add(freeQty.multiply(unitsPerPack));
+        }
+        return qty.add(freeQty);
+    }
+
+    /**
+     * A duplicate-line removal can leave the surviving BillItem with a lazily
+     * created all-zero PharmaceuticalBillItem while its BillItemFinanceDetails
+     * still holds the real quantities; downstream approval/GRN reads the PBI,
+     * so rebuild the derived line values from the finance details before
+     * persisting (issue #21417).
+     * <p>
+     * The native flow rebuilds the persisted PBI qty/freeQty from the line's
+     * BillItemFinanceDetails on every save (see
+     * {@code toLineData()} -> {@code PurchaseOrderRequestNativeSqlService.saveLine()}),
+     * so the PBI columns self-heal. What does NOT self-heal is the in-memory
+     * BillItem's own rate/netValue fields, which {@code calculateBillTotals()}
+     * sums for the on-screen and persisted bill total. Recalculate them here,
+     * matching legacy's {@code calculateLineValues(b)} call.
+     */
+    private void resyncPharmaceuticalBillItemIfEmpty(BillItem b) {
+        if (b == null || b.isRetired() || b.getBillItemFinanceDetails() == null) {
+            return;
+        }
+        PharmaceuticalBillItem pbi = b.getPharmaceuticalBillItem();
+        if (pbi == null || pbi.getQty() != 0 || pbi.getFreeQty() != 0) {
+            return;
+        }
+        BigDecimal qtyByUnits = b.getBillItemFinanceDetails().getQuantity();
+        BigDecimal freeQtyByUnits = b.getBillItemFinanceDetails().getFreeQuantity();
+        boolean financeDetailsHaveQty = (qtyByUnits != null && qtyByUnits.compareTo(BigDecimal.ZERO) > 0)
+                || (freeQtyByUnits != null && freeQtyByUnits.compareTo(BigDecimal.ZERO) > 0);
+        if (financeDetailsHaveQty) {
+            recalculateLineValues(b);
+        }
     }
 
     public void generateBillComponentsForAllSupplierItems(List<Item> items) {
@@ -553,6 +695,7 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
                 sessionController.getLoggedUser().getId());
 
         for (BillItem bi : billItems) {
+            resyncPharmaceuticalBillItemIfEmpty(bi);
             PurchaseOrderRequestLineData line = toLineData(bi);
             long billItemId = purchaseOrderRequestNativeSqlService.saveLine(currentBill.getId(), line);
             bi.setId(billItemId);
@@ -594,14 +737,30 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
             JsfUtil.addErrorMessage("Please add bill items.");
             return;
         }
-        saveRequestWithoutMessage();
-
-        purchaseOrderRequestNativeSqlService.finalizeBill(currentBill.getId(), sessionController.getLoggedUser().getId());
-        int survivingCount = purchaseOrderRequestNativeSqlService.retireZeroQtyLines(currentBill.getId(), sessionController.getLoggedUser().getId());
-        if (survivingCount == 0) {
+        // Every guard below runs against the IN-MEMORY line list, before any
+        // native mutation reaches the DB. finalizeBill() sets checked=1 and
+        // promotes BILLTYPEATOMIC, and retireZeroQtyLines() retires lines --
+        // both commit immediately. Letting them run first and only then
+        // discovering the bill had no real quantity left the bill permanently
+        // checked=1 with every line retired, and the page disables Save and
+        // Finalize once checked=true, so it could never be recovered.
+        if (!allBillItemsValid(billItems)) {
+            JsfUtil.addErrorMessage("Please ensure each item has quantity and purchase price.");
+            return;
+        }
+        if (calculateTotalBillItemsCount(billItems) == 0) {
             JsfUtil.addErrorMessage("Please enter item quantities for the bill.");
             return;
         }
+
+        // Validation passed -- safe to persist, then promote.
+        if (!saveRequestWithoutMessage()) {
+            return;
+        }
+
+        purchaseOrderRequestNativeSqlService.finalizeBill(currentBill.getId(), sessionController.getLoggedUser().getId());
+        // Per-line sweep for any zero-qty straggler that survived validation.
+        purchaseOrderRequestNativeSqlService.retireZeroQtyLines(currentBill.getId(), sessionController.getLoggedUser().getId());
 
         currentBill = billFacade.find(currentBill.getId());
         billItems = loadBillItems(currentBill);
@@ -1148,7 +1307,33 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
     }
 
     // Getters/setters
+    /**
+     * Lazily rebuilds a fresh draft bill when the field is null.
+     * <p>
+     * The three "New Order" buttons on the page bind straight to
+     * {@code resetBillValues()}, which nulls {@code currentBill} without
+     * recreating it. Every writable header binding on the page
+     * ({@code currentBill.toInstitution}, {@code .paymentMethod},
+     * {@code .consignment}, {@code .comments}, {@code .departmentType},
+     * {@code .creditDuration}) then resolves against null and fails on the next
+     * form interaction. Reconstructing here — with the same config-driven
+     * defaults legacy applies — makes "New Order" leave the page immediately
+     * usable. Mirrors legacy PurchaseOrderRequestController.getCurrentBill().
+     */
     public Bill getCurrentBill() {
+        if (currentBill == null) {
+            currentBill = new Bill();
+            currentBill.setBillType(BillType.PharmacyOrder);
+            currentBill.setBillTypeAtomic(BillTypeAtomic.PHARMACY_ORDER);
+
+            String strEnumValue = configOptionApplicationController.getEnumValueByKey("Pharmacy Purchase Order Default Payment Method");
+            PaymentMethod pm = enumController.getEnumValue(PaymentMethod.class, strEnumValue);
+            currentBill.setPaymentMethod(pm);
+
+            boolean consignmentEnabled = configOptionApplicationController.getBooleanValueByKey(
+                    "Consignment Option is checked in new Pharmacy Purchasing Bills", false);
+            currentBill.setConsignment(consignmentEnabled);
+        }
         return currentBill;
     }
 

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestNativeSqlController.java
@@ -343,6 +343,10 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
         currentBill.setTotal(total);
     }
 
+    // synchronized: a double-submit on the Save/Finalize button (Enter-key defaultCommand
+    // racing a button click, or a resubmitted form) let two requests race through the same
+    // in-memory billItems list before either had persisted, so both saw BillItem.id == null
+    // and created every line twice, sharing one BillItemFinanceDetails (issue #21417).
     public synchronized void saveRequest() {
         if (!isAuthorized("SAVE", "PurchaseOrderSave")) {
             return;

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestNativeSqlController.java
@@ -314,6 +314,9 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
         }
         billItems.remove(bi);
         calculateBillTotals();
+        if (currentBill.getId() != null) {
+            purchaseOrderRequestNativeSqlService.updateBillTotals(currentBill.getId(), currentBill.getNetTotal(), currentBill.getTotal());
+        }
         itemHistoryVisible = false;
     }
 
@@ -337,6 +340,9 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
 
         billItems.removeAll(selectedBillItems);
         calculateBillTotals();
+        if (currentBill.getId() != null) {
+            purchaseOrderRequestNativeSqlService.updateBillTotals(currentBill.getId(), currentBill.getNetTotal(), currentBill.getTotal());
+        }
         selectedBillItems = null;
     }
 

--- a/src/main/java/com/divudi/core/data/dto/pharmacy/PurchaseOrderRequestLineData.java
+++ b/src/main/java/com/divudi/core/data/dto/pharmacy/PurchaseOrderRequestLineData.java
@@ -1,0 +1,54 @@
+package com.divudi.core.data.dto.pharmacy;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+
+public class PurchaseOrderRequestLineData implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Long billItemId;
+    private Long pharmaceuticalBillItemId;
+    private Long itemId;
+    private boolean ampp;
+    private BigDecimal quantity;
+    private BigDecimal freeQuantity;
+    private BigDecimal purchaseRate;
+    private BigDecimal retailRate;
+    private BigDecimal unitsPerPack;
+    private int serialNo;
+    private Long createrId;
+
+    public Long getBillItemId() { return billItemId; }
+    public void setBillItemId(Long billItemId) { this.billItemId = billItemId; }
+
+    public Long getPharmaceuticalBillItemId() { return pharmaceuticalBillItemId; }
+    public void setPharmaceuticalBillItemId(Long pharmaceuticalBillItemId) { this.pharmaceuticalBillItemId = pharmaceuticalBillItemId; }
+
+    public Long getItemId() { return itemId; }
+    public void setItemId(Long itemId) { this.itemId = itemId; }
+
+    public boolean isAmpp() { return ampp; }
+    public void setAmpp(boolean ampp) { this.ampp = ampp; }
+
+    public BigDecimal getQuantity() { return quantity; }
+    public void setQuantity(BigDecimal quantity) { this.quantity = quantity; }
+
+    public BigDecimal getFreeQuantity() { return freeQuantity; }
+    public void setFreeQuantity(BigDecimal freeQuantity) { this.freeQuantity = freeQuantity; }
+
+    public BigDecimal getPurchaseRate() { return purchaseRate; }
+    public void setPurchaseRate(BigDecimal purchaseRate) { this.purchaseRate = purchaseRate; }
+
+    public BigDecimal getRetailRate() { return retailRate; }
+    public void setRetailRate(BigDecimal retailRate) { this.retailRate = retailRate; }
+
+    public BigDecimal getUnitsPerPack() { return unitsPerPack; }
+    public void setUnitsPerPack(BigDecimal unitsPerPack) { this.unitsPerPack = unitsPerPack; }
+
+    public int getSerialNo() { return serialNo; }
+    public void setSerialNo(int serialNo) { this.serialNo = serialNo; }
+
+    public Long getCreaterId() { return createrId; }
+    public void setCreaterId(Long createrId) { this.createrId = createrId; }
+}

--- a/src/main/java/com/divudi/service/pharmacy/PurchaseOrderRequestNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PurchaseOrderRequestNativeSqlService.java
@@ -374,4 +374,27 @@ public class PurchaseOrderRequestNativeSqlService {
         evictLineCache();
         return survivingCount;
     }
+
+    /**
+     * Retires a single billitem line (used when a user removes a line from
+     * an in-progress purchase order request) and its associated
+     * pharmacybillitem row. Mirrors legacy PurchaseOrderRequestController's
+     * removeItem() persisting the retirement via billItemFacade.edit(bi).
+     */
+    public void retireLine(long billItemId, long retirerId) {
+        Timestamp now = new Timestamp(new Date().getTime());
+        em.createNativeQuery(
+            "UPDATE " + billItemTable() + " SET retired=1, retirer_ID=?, retiredAt=? WHERE ID=?")
+            .setParameter(1, retirerId)
+            .setParameter(2, now)
+            .setParameter(3, billItemId)
+            .executeUpdate();
+        em.createNativeQuery(
+            "UPDATE " + pharmBillItemTable() + " SET retired=1, retirer_ID=?, retiredAt=? WHERE billItem_ID=?")
+            .setParameter(1, retirerId)
+            .setParameter(2, now)
+            .setParameter(3, billItemId)
+            .executeUpdate();
+        evictLineCache();
+    }
 }

--- a/src/main/java/com/divudi/service/pharmacy/PurchaseOrderRequestNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PurchaseOrderRequestNativeSqlService.java
@@ -55,20 +55,21 @@ public class PurchaseOrderRequestNativeSqlService {
 
     public void updateDraftBillHeader(long billId, Long toInstitutionId, PaymentMethod paymentMethod,
                                        int creditDuration, boolean consignment, DepartmentType departmentType,
-                                       Long editorId) {
+                                       String comments, Long editorId) {
         em.createNativeQuery(
             "UPDATE " + billTable()
             + " SET toInstitution_ID=?, paymentMethod=?, creditDuration=?, consignment=?,"
-            + " departmentType=?, editor_ID=?, editedAt=?"
+            + " departmentType=?, comments=?, editor_ID=?, editedAt=?"
             + " WHERE ID=?")
             .setParameter(1, toInstitutionId)
             .setParameter(2, paymentMethod != null ? paymentMethod.toString() : null)
             .setParameter(3, creditDuration)
             .setParameter(4, consignment ? 1 : 0)
             .setParameter(5, departmentType != null ? departmentType.toString() : null)
-            .setParameter(6, editorId)
-            .setParameter(7, new Timestamp(new Date().getTime()))
-            .setParameter(8, billId)
+            .setParameter(6, comments)
+            .setParameter(7, editorId)
+            .setParameter(8, new Timestamp(new Date().getTime()))
+            .setParameter(9, billId)
             .executeUpdate();
         evictCache();
     }
@@ -90,6 +91,23 @@ public class PurchaseOrderRequestNativeSqlService {
             .setParameter(3, billId)
             .executeUpdate();
         evictCache();
+    }
+
+    /**
+     * Persists a single BillItem's renumbered searialNo. calculateBillTotals()
+     * in the controller renumbers surviving lines' serials in memory after a
+     * removal, but nothing else in the native save path wrote that column back
+     * to the DB -- a reload (loadBillItems, ordered by searialNo) could then
+     * see gaps left by the retired line, and a later-added line reusing that
+     * gap's serial would collide with a persisted survivor.
+     */
+    public void updateBillItemSerialNo(long billItemId, int serialNo) {
+        em.createNativeQuery(
+            "UPDATE " + billItemTable() + " SET searialNo=? WHERE ID=?")
+            .setParameter(1, serialNo)
+            .setParameter(2, billItemId)
+            .executeUpdate();
+        evictLineCache();
     }
 
     public boolean isBillChecked(long billId) {

--- a/src/main/java/com/divudi/service/pharmacy/PurchaseOrderRequestNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PurchaseOrderRequestNativeSqlService.java
@@ -73,6 +73,25 @@ public class PurchaseOrderRequestNativeSqlService {
         evictCache();
     }
 
+    /**
+     * Persists the bill-level netTotal/total columns. calculateBillTotals()
+     * in the controller only mutates the in-memory Bill entity — nothing else
+     * in the native save path wrote these columns back to the DB, so totals
+     * went stale in the database after the first edit-then-save cycle.
+     * Legacy relied on billFacade.edit(currentBill) (a full JPA merge) to
+     * persist whatever calculateBillTotals() computed; this is the native
+     * equivalent for just these two columns.
+     */
+    public void updateBillTotals(long billId, double netTotal, double total) {
+        em.createNativeQuery(
+            "UPDATE " + billTable() + " SET netTotal=?, total=? WHERE ID=?")
+            .setParameter(1, netTotal)
+            .setParameter(2, total)
+            .setParameter(3, billId)
+            .executeUpdate();
+        evictCache();
+    }
+
     public boolean isBillChecked(long billId) {
         Object result = em.createNativeQuery(
             "SELECT checked FROM " + billTable() + " WHERE ID=?")

--- a/src/main/java/com/divudi/service/pharmacy/PurchaseOrderRequestNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PurchaseOrderRequestNativeSqlService.java
@@ -1,0 +1,115 @@
+package com.divudi.service.pharmacy;
+
+import com.divudi.core.data.BillTypeAtomic;
+import com.divudi.core.data.BillType;
+import com.divudi.core.data.DepartmentType;
+import com.divudi.core.data.PaymentMethod;
+import javax.ejb.Stateless;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.sql.Timestamp;
+import java.util.Date;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Native SQL write path for the Purchase Order Request draft bill.
+ * Only bill / billitem / pharmaceuticalbillitem are touched here —
+ * BillItemFinanceDetails stays JPA (IDENTITY PK, calculation-heavy),
+ * matching RetailSaleNativeSqlService's split.
+ * Related issue: #22727
+ */
+@Stateless
+public class PurchaseOrderRequestNativeSqlService {
+
+    private static final Logger LOGGER = Logger.getLogger(PurchaseOrderRequestNativeSqlService.class.getName());
+
+    @PersistenceContext(unitName = "hmisPU")
+    private EntityManager em;
+
+    private String tBill;
+    private String tBillItem;
+    private String tPharmBillItem;
+
+    public long createDraftBill(long departmentId, long institutionId, long createrId, String deptId, String insId) {
+        Date now = new Date();
+        em.createNativeQuery(
+            "INSERT INTO " + billTable()
+            + " (BILLTYPEATOMIC, billType, department_ID, institution_ID, fromDepartment_ID, fromInstitution_ID,"
+            + " creater_ID, createdAt, checked, retired, cancelled, deptId, insId, netTotal, total)"
+            + " VALUES (?,?,?,?,?,?,?,?,0,0,0,?,?,0,0)")
+            .setParameter(1, BillTypeAtomic.PHARMACY_ORDER_PRE.toString())
+            .setParameter(2, BillType.PharmacyOrder.toString())
+            .setParameter(3, departmentId)
+            .setParameter(4, institutionId)
+            .setParameter(5, departmentId)
+            .setParameter(6, institutionId)
+            .setParameter(7, createrId)
+            .setParameter(8, new Timestamp(now.getTime()))
+            .setParameter(9, deptId)
+            .setParameter(10, insId)
+            .executeUpdate();
+        long billId = ((Number) em.createNativeQuery("SELECT LAST_INSERT_ID()").getSingleResult()).longValue();
+        evictCache();
+        return billId;
+    }
+
+    public void updateDraftBillHeader(long billId, Long toInstitutionId, PaymentMethod paymentMethod,
+                                       int creditDuration, boolean consignment, DepartmentType departmentType,
+                                       Long editorId) {
+        em.createNativeQuery(
+            "UPDATE " + billTable()
+            + " SET toInstitution_ID=?, paymentMethod=?, creditDuration=?, consignment=?,"
+            + " departmentType=?, editor_ID=?, editedAt=?"
+            + " WHERE ID=?")
+            .setParameter(1, toInstitutionId)
+            .setParameter(2, paymentMethod != null ? paymentMethod.toString() : null)
+            .setParameter(3, creditDuration)
+            .setParameter(4, consignment ? 1 : 0)
+            .setParameter(5, departmentType != null ? departmentType.toString() : null)
+            .setParameter(6, editorId)
+            .setParameter(7, new Timestamp(new Date().getTime()))
+            .setParameter(8, billId)
+            .executeUpdate();
+        evictCache();
+    }
+
+    public boolean isBillChecked(long billId) {
+        Object result = em.createNativeQuery(
+            "SELECT checked FROM " + billTable() + " WHERE ID=?")
+            .setParameter(1, billId)
+            .getSingleResult();
+        if (result instanceof Boolean) return (Boolean) result;
+        if (result instanceof Number) return ((Number) result).intValue() != 0;
+        return false;
+    }
+
+    private void evictCache() {
+        javax.persistence.Cache cache = em.getEntityManagerFactory().getCache();
+        cache.evict(com.divudi.core.entity.Bill.class);
+    }
+
+    private String resolveTable(String upperName) {
+        Object name = em.createNativeQuery(
+            "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES "
+            + "WHERE TABLE_SCHEMA = DATABASE() AND UPPER(TABLE_NAME) = ? LIMIT 1")
+            .setParameter(1, upperName)
+            .getSingleResult();
+        return name.toString();
+    }
+
+    private String billTable() {
+        if (tBill == null) tBill = resolveTable("BILL");
+        return tBill;
+    }
+
+    private String billItemTable() {
+        if (tBillItem == null) tBillItem = resolveTable("BILLITEM");
+        return tBillItem;
+    }
+
+    private String pharmBillItemTable() {
+        if (tPharmBillItem == null) tPharmBillItem = resolveTable("PHARMACEUTICALBILLITEM");
+        return tPharmBillItem;
+    }
+}

--- a/src/main/java/com/divudi/service/pharmacy/PurchaseOrderRequestNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PurchaseOrderRequestNativeSqlService.java
@@ -4,9 +4,12 @@ import com.divudi.core.data.BillTypeAtomic;
 import com.divudi.core.data.BillType;
 import com.divudi.core.data.DepartmentType;
 import com.divudi.core.data.PaymentMethod;
+import com.divudi.core.data.dto.pharmacy.PurchaseOrderRequestLineData;
+import com.divudi.core.entity.BillItemFinanceDetails;
 import javax.ejb.Stateless;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.util.Date;
 
@@ -109,5 +112,191 @@ public class PurchaseOrderRequestNativeSqlService {
     private String pharmBillItemTable() {
         if (tPharmBillItem == null) tPharmBillItem = resolveTable("PHARMACEUTICALBILLITEM");
         return tPharmBillItem;
+    }
+
+    /**
+     * Pure calculation extracted from legacy calculateLineValues() — no em access,
+     * unit tested directly. AMPP items store rates per-pack on BillItemFinanceDetails
+     * but per-unit on PharmaceuticalBillItem; non-AMPP items use the same rate for both.
+     */
+    static final class LineValues {
+        final BigDecimal qty, freeQty, purchaseRate, retailRate, unitsPerPack;
+        final BigDecimal grossValue, netValue, purchaseValue, retailValue, netRate;
+        final double pbiQty, pbiFreeQty, pbiPurchaseRate, pbiRetailRate;
+
+        LineValues(BigDecimal qty, BigDecimal freeQty, BigDecimal purchaseRate, BigDecimal retailRate,
+                   BigDecimal unitsPerPack, BigDecimal grossValue, BigDecimal netValue,
+                   BigDecimal purchaseValue, BigDecimal retailValue, BigDecimal netRate,
+                   double pbiQty, double pbiFreeQty, double pbiPurchaseRate, double pbiRetailRate) {
+            this.qty = qty; this.freeQty = freeQty; this.purchaseRate = purchaseRate; this.retailRate = retailRate;
+            this.unitsPerPack = unitsPerPack; this.grossValue = grossValue; this.netValue = netValue;
+            this.purchaseValue = purchaseValue; this.retailValue = retailValue; this.netRate = netRate;
+            this.pbiQty = pbiQty; this.pbiFreeQty = pbiFreeQty;
+            this.pbiPurchaseRate = pbiPurchaseRate; this.pbiRetailRate = pbiRetailRate;
+        }
+    }
+
+    LineValues computeLineValues(PurchaseOrderRequestLineData line) {
+        BigDecimal qty = line.getQuantity() != null ? line.getQuantity() : BigDecimal.ZERO;
+        BigDecimal freeQty = line.getFreeQuantity() != null ? line.getFreeQuantity() : BigDecimal.ZERO;
+        BigDecimal purchaseRate = line.getPurchaseRate() != null ? line.getPurchaseRate() : BigDecimal.ZERO;
+        BigDecimal retailRate = line.getRetailRate() != null ? line.getRetailRate() : BigDecimal.ZERO;
+        BigDecimal unitsPerPack = (line.getUnitsPerPack() != null && line.getUnitsPerPack().doubleValue() > 0)
+                ? line.getUnitsPerPack() : BigDecimal.ONE;
+
+        BigDecimal grossValue = purchaseRate.multiply(qty);
+        BigDecimal netValue = grossValue;
+        BigDecimal purchaseValue = purchaseRate.multiply(qty.add(freeQty));
+        BigDecimal retailValue = retailRate.multiply(qty.add(freeQty));
+        BigDecimal netRate = qty.doubleValue() > 0
+                ? netValue.divide(qty, 2, java.math.RoundingMode.HALF_UP) : BigDecimal.ZERO;
+
+        double pbiQty = line.isAmpp() ? qty.doubleValue() * unitsPerPack.doubleValue() : qty.doubleValue();
+        double pbiFreeQty = line.isAmpp() ? freeQty.doubleValue() * unitsPerPack.doubleValue() : freeQty.doubleValue();
+        double pbiPurchaseRate = line.isAmpp() ? purchaseRate.doubleValue() / unitsPerPack.doubleValue() : purchaseRate.doubleValue();
+        double pbiRetailRate = line.isAmpp() ? retailRate.doubleValue() / unitsPerPack.doubleValue() : retailRate.doubleValue();
+
+        return new LineValues(qty, freeQty, purchaseRate, retailRate, unitsPerPack, grossValue, netValue,
+                purchaseValue, retailValue, netRate, pbiQty, pbiFreeQty, pbiPurchaseRate, pbiRetailRate);
+    }
+
+    public long saveLine(long billId, PurchaseOrderRequestLineData line) {
+        LineValues v = computeLineValues(line);
+        BigDecimal qty = v.qty, freeQty = v.freeQty, purchaseRate = v.purchaseRate, retailRate = v.retailRate;
+        BigDecimal grossValue = v.grossValue, netValue = v.netValue, netRate = v.netRate;
+        BigDecimal purchaseValue = v.purchaseValue, retailValue = v.retailValue, unitsPerPack = v.unitsPerPack;
+
+        long billItemId;
+        if (line.getBillItemId() == null) {
+            em.createNativeQuery(
+                "INSERT INTO " + billItemTable()
+                + " (bill_ID, item_ID, qty, netValue, grossValue, Rate, netRate,"
+                + " createdAt, creater_ID, retired, refunded, billItemRefunded,"
+                + " consideredForCosting, inwardChargeType, searialNo)"
+                + " VALUES (?,?,?,?,?,?,?,?,?,0,0,0,1,'Medicine',?)")
+                .setParameter(1, billId)
+                .setParameter(2, line.getItemId())
+                .setParameter(3, qty.doubleValue())
+                .setParameter(4, netValue.doubleValue())
+                .setParameter(5, grossValue.doubleValue())
+                .setParameter(6, purchaseRate.doubleValue())
+                .setParameter(7, netRate.doubleValue())
+                .setParameter(8, new Timestamp(new Date().getTime()))
+                .setParameter(9, line.getCreaterId())
+                .setParameter(10, line.getSerialNo())
+                .executeUpdate();
+            billItemId = ((Number) em.createNativeQuery("SELECT LAST_INSERT_ID()").getSingleResult()).longValue();
+        } else {
+            billItemId = line.getBillItemId();
+            em.createNativeQuery(
+                "UPDATE " + billItemTable()
+                + " SET qty=?, netValue=?, grossValue=?, Rate=?, netRate=? WHERE ID=?")
+                .setParameter(1, qty.doubleValue())
+                .setParameter(2, netValue.doubleValue())
+                .setParameter(3, grossValue.doubleValue())
+                .setParameter(4, purchaseRate.doubleValue())
+                .setParameter(5, netRate.doubleValue())
+                .setParameter(6, billItemId)
+                .executeUpdate();
+        }
+
+        double pbiQty = v.pbiQty, pbiFreeQty = v.pbiFreeQty, pbiPurchaseRate = v.pbiPurchaseRate, pbiRetailRate = v.pbiRetailRate;
+
+        if (line.getPharmaceuticalBillItemId() == null) {
+            em.createNativeQuery(
+                "INSERT INTO " + pharmBillItemTable()
+                + " (billItem_ID, qty, freeQty, purchaseRate, purchaseRatePack, purchaseValue,"
+                + " retailRate, retailRatePack, retailRateInUnit, retailValue, costRate, costRatePack, costValue,"
+                + " createdAt, creater_ID)"
+                + " VALUES (?,?,?,?,?,?,?,?,?,?,0,0,0,?,?)")
+                .setParameter(1, billItemId)
+                .setParameter(2, pbiQty)
+                .setParameter(3, pbiFreeQty)
+                .setParameter(4, pbiPurchaseRate)
+                .setParameter(5, purchaseRate.doubleValue())
+                .setParameter(6, purchaseValue.doubleValue())
+                .setParameter(7, pbiRetailRate)
+                .setParameter(8, retailRate.doubleValue())
+                .setParameter(9, pbiRetailRate)
+                .setParameter(10, retailValue.doubleValue())
+                .setParameter(11, new Timestamp(new Date().getTime()))
+                .setParameter(12, line.getCreaterId())
+                .executeUpdate();
+        } else {
+            em.createNativeQuery(
+                "UPDATE " + pharmBillItemTable()
+                + " SET qty=?, freeQty=?, purchaseRate=?, purchaseRatePack=?, purchaseValue=?,"
+                + " retailRate=?, retailRatePack=?, retailRateInUnit=?, retailValue=? WHERE billItem_ID=?")
+                .setParameter(1, pbiQty)
+                .setParameter(2, pbiFreeQty)
+                .setParameter(3, pbiPurchaseRate)
+                .setParameter(4, purchaseRate.doubleValue())
+                .setParameter(5, purchaseValue.doubleValue())
+                .setParameter(6, pbiRetailRate)
+                .setParameter(7, retailRate.doubleValue())
+                .setParameter(8, pbiRetailRate)
+                .setParameter(9, retailValue.doubleValue())
+                .setParameter(10, billItemId)
+                .executeUpdate();
+        }
+
+        saveBillItemFinanceDetails(billItemId, line, qty, freeQty, purchaseRate, retailRate, netValue, grossValue,
+                netRate, unitsPerPack, pbiQty, pbiFreeQty);
+
+        evictLineCache();
+        return billItemId;
+    }
+
+    private void saveBillItemFinanceDetails(long billItemId, PurchaseOrderRequestLineData line,
+            BigDecimal qty, BigDecimal freeQty, BigDecimal purchaseRate, BigDecimal retailRate,
+            BigDecimal netValue, BigDecimal grossValue, BigDecimal netRate, BigDecimal unitsPerPack,
+            double quantityByUnits, double freeQuantityByUnits) {
+        BillItemFinanceDetails bifd;
+        if (line.getBillItemId() != null) {
+            String jpql = "SELECT bi.billItemFinanceDetails FROM BillItem bi WHERE bi.id = :id";
+            java.util.List<BillItemFinanceDetails> existing = em.createQuery(jpql, BillItemFinanceDetails.class)
+                    .setParameter("id", billItemId)
+                    .getResultList();
+            bifd = (existing != null && !existing.isEmpty() && existing.get(0) != null) ? existing.get(0) : new BillItemFinanceDetails();
+        } else {
+            bifd = new BillItemFinanceDetails();
+        }
+
+        bifd.setLineNetRate(purchaseRate);
+        bifd.setLineGrossRate(purchaseRate);
+        bifd.setGrossRate(purchaseRate);
+        bifd.setLineNetTotal(netValue);
+        bifd.setLineGrossTotal(grossValue);
+        bifd.setGrossTotal(grossValue);
+        bifd.setQuantity(qty);
+        bifd.setFreeQuantity(freeQty);
+        bifd.setQuantityByUnits(BigDecimal.valueOf(quantityByUnits));
+        bifd.setFreeQuantityByUnits(BigDecimal.valueOf(freeQuantityByUnits));
+        bifd.setRetailSaleRate(retailRate);
+        bifd.setUnitsPerPack(unitsPerPack);
+        bifd.setValueAtPurchaseRate(purchaseRate.multiply(qty.add(freeQty)));
+        bifd.setValueAtRetailRate(retailRate.multiply(qty.add(freeQty)));
+        bifd.setLineCost(BigDecimal.ZERO);
+        bifd.setLineCostRate(BigDecimal.ZERO);
+        bifd.setValueAtCostRate(BigDecimal.ZERO);
+
+        if (bifd.getId() == null) {
+            bifd.setCreatedAt(new Date());
+            em.persist(bifd);
+            em.flush();
+            em.createNativeQuery("UPDATE " + billItemTable() + " SET BILLITEMFINANCEDETAILS_ID=? WHERE ID=?")
+                    .setParameter(1, bifd.getId())
+                    .setParameter(2, billItemId)
+                    .executeUpdate();
+        } else {
+            em.merge(bifd);
+        }
+    }
+
+    private void evictLineCache() {
+        javax.persistence.Cache cache = em.getEntityManagerFactory().getCache();
+        cache.evict(com.divudi.core.entity.BillItem.class);
+        cache.evict(com.divudi.core.entity.pharmacy.PharmaceuticalBillItem.class);
+        cache.evict(BillItemFinanceDetails.class);
     }
 }

--- a/src/main/java/com/divudi/service/pharmacy/PurchaseOrderRequestNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PurchaseOrderRequestNativeSqlService.java
@@ -221,7 +221,28 @@ public class PurchaseOrderRequestNativeSqlService {
 
         double pbiQty = v.pbiQty, pbiFreeQty = v.pbiFreeQty, pbiPurchaseRate = v.pbiPurchaseRate, pbiRetailRate = v.pbiRetailRate;
 
-        if (line.getPharmaceuticalBillItemId() == null) {
+        // Branch on whether a PBI row already exists for this billItem_ID rather than
+        // on line.getPharmaceuticalBillItemId(): the controller never learns the
+        // generated PBI id back from an insert, so that DTO field stays null across
+        // every subsequent save of the same line and a field-based branch would insert
+        // a duplicate PHARMACEUTICALBILLITEM row on every save after the first.
+        int updated = em.createNativeQuery(
+                "UPDATE " + pharmBillItemTable()
+                + " SET qty=?, freeQty=?, purchaseRate=?, purchaseRatePack=?, purchaseValue=?,"
+                + " retailRate=?, retailRatePack=?, retailRateInUnit=?, retailValue=? WHERE billItem_ID=?")
+                .setParameter(1, pbiQty)
+                .setParameter(2, pbiFreeQty)
+                .setParameter(3, pbiPurchaseRate)
+                .setParameter(4, purchaseRate.doubleValue())
+                .setParameter(5, purchaseValue.doubleValue())
+                .setParameter(6, pbiRetailRate)
+                .setParameter(7, retailRate.doubleValue())
+                .setParameter(8, pbiRetailRate)
+                .setParameter(9, retailValue.doubleValue())
+                .setParameter(10, billItemId)
+                .executeUpdate();
+
+        if (updated == 0) {
             em.createNativeQuery(
                 "INSERT INTO " + pharmBillItemTable()
                 + " (billItem_ID, qty, freeQty, purchaseRate, purchaseRatePack, purchaseValue,"
@@ -240,22 +261,6 @@ public class PurchaseOrderRequestNativeSqlService {
                 .setParameter(10, retailValue.doubleValue())
                 .setParameter(11, new Timestamp(new Date().getTime()))
                 .setParameter(12, line.getCreaterId())
-                .executeUpdate();
-        } else {
-            em.createNativeQuery(
-                "UPDATE " + pharmBillItemTable()
-                + " SET qty=?, freeQty=?, purchaseRate=?, purchaseRatePack=?, purchaseValue=?,"
-                + " retailRate=?, retailRatePack=?, retailRateInUnit=?, retailValue=? WHERE billItem_ID=?")
-                .setParameter(1, pbiQty)
-                .setParameter(2, pbiFreeQty)
-                .setParameter(3, pbiPurchaseRate)
-                .setParameter(4, purchaseRate.doubleValue())
-                .setParameter(5, purchaseValue.doubleValue())
-                .setParameter(6, pbiRetailRate)
-                .setParameter(7, retailRate.doubleValue())
-                .setParameter(8, pbiRetailRate)
-                .setParameter(9, retailValue.doubleValue())
-                .setParameter(10, billItemId)
                 .executeUpdate();
         }
 
@@ -314,6 +319,7 @@ public class PurchaseOrderRequestNativeSqlService {
 
     private void evictLineCache() {
         javax.persistence.Cache cache = em.getEntityManagerFactory().getCache();
+        cache.evict(com.divudi.core.entity.Bill.class);
         cache.evict(com.divudi.core.entity.BillItem.class);
         cache.evict(com.divudi.core.entity.pharmacy.PharmaceuticalBillItem.class);
         cache.evict(BillItemFinanceDetails.class);
@@ -344,6 +350,18 @@ public class PurchaseOrderRequestNativeSqlService {
             .setParameter(6, billId)
             .executeUpdate();
         evictCache();
+    }
+
+    /**
+     * Finalizes the bill and retires zero-qty lines as one EJB call, so both
+     * native writes share the same container-managed transaction. Calling
+     * finalizeBill() and retireZeroQtyLines() as two separate EJB invocations
+     * from the controller let the first commit even if the second later
+     * failed, leaving the bill checked=1 with stale/unretired zero-qty lines.
+     */
+    public int finalizeAndRetireZeroQtyLines(long billId, long editorId) {
+        finalizeBill(billId, editorId);
+        return retireZeroQtyLines(billId, editorId);
     }
 
     /**

--- a/src/main/java/com/divudi/service/pharmacy/PurchaseOrderRequestNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PurchaseOrderRequestNativeSqlService.java
@@ -9,8 +9,6 @@ import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 import java.sql.Timestamp;
 import java.util.Date;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Native SQL write path for the Purchase Order Request draft bill.
@@ -21,8 +19,6 @@ import java.util.logging.Logger;
  */
 @Stateless
 public class PurchaseOrderRequestNativeSqlService {
-
-    private static final Logger LOGGER = Logger.getLogger(PurchaseOrderRequestNativeSqlService.class.getName());
 
     @PersistenceContext(unitName = "hmisPU")
     private EntityManager em;
@@ -103,11 +99,13 @@ public class PurchaseOrderRequestNativeSqlService {
         return tBill;
     }
 
+    // Forward-declared table helpers; used by line-item and finalization methods added in Task 3/4
     private String billItemTable() {
         if (tBillItem == null) tBillItem = resolveTable("BILLITEM");
         return tBillItem;
     }
 
+    // Forward-declared table helpers; used by line-item and finalization methods added in Task 3/4
     private String pharmBillItemTable() {
         if (tPharmBillItem == null) tPharmBillItem = resolveTable("PHARMACEUTICALBILLITEM");
         return tPharmBillItem;

--- a/src/main/java/com/divudi/service/pharmacy/PurchaseOrderRequestNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PurchaseOrderRequestNativeSqlService.java
@@ -299,4 +299,79 @@ public class PurchaseOrderRequestNativeSqlService {
         cache.evict(com.divudi.core.entity.pharmacy.PharmaceuticalBillItem.class);
         cache.evict(BillItemFinanceDetails.class);
     }
+
+    /**
+     * Pure predicate extracted from legacy finalizeBillComponent()'s
+     * totalUnits.compareTo(BigDecimal.ZERO) <= 0 check.
+     * No em access, unit tested.
+     */
+    boolean isZeroQtyLine(double qty, double freeQty) {
+        return (qty + freeQty) <= 0;
+    }
+
+    /**
+     * Promotes BILLTYPEATOMIC to PHARMACY_ORDER and marks bill as checked.
+     * Sets checked=1, checkeAt=now, checkedBy_ID=editorId, editor_ID=editorId, editedAt=now.
+     */
+    public void finalizeBill(long billId, long editorId) {
+        em.createNativeQuery(
+            "UPDATE " + billTable()
+            + " SET BILLTYPEATOMIC=?, checked=1, checkeAt=?, checkedBy_ID=?, editor_ID=?, editedAt=? WHERE ID=?")
+            .setParameter(1, BillTypeAtomic.PHARMACY_ORDER.toString())
+            .setParameter(2, new Timestamp(new Date().getTime()))
+            .setParameter(3, editorId)
+            .setParameter(4, editorId)
+            .setParameter(5, new Timestamp(new Date().getTime()))
+            .setParameter(6, billId)
+            .executeUpdate();
+        evictCache();
+    }
+
+    /**
+     * Retires any line where qty + freeQty <= 0 (zero-qty lines).
+     * For surviving (non-retired) lines, sets remainingQty=qty and remainingFreeQty=freeQty.
+     * Returns count of surviving lines with qty > 0.
+     * Mirrors legacy finalizeBillComponent()'s totalBillItemsCount accumulation.
+     */
+    @SuppressWarnings("unchecked")
+    public int retireZeroQtyLines(long billId, long retirerId) {
+        java.util.List<Object[]> rows = em.createNativeQuery(
+            "SELECT bi.ID, pbi.qty, pbi.freeQty FROM " + billItemTable() + " bi "
+            + "JOIN " + pharmBillItemTable() + " pbi ON pbi.billItem_ID = bi.ID "
+            + "WHERE bi.bill_ID = ? AND bi.retired = 0")
+            .setParameter(1, billId)
+            .getResultList();
+
+        int survivingCount = 0;
+        Timestamp now = new Timestamp(new Date().getTime());
+        for (Object[] row : rows) {
+            long billItemId = ((Number) row[0]).longValue();
+            double qty = row[1] != null ? ((Number) row[1]).doubleValue() : 0.0;
+            double freeQty = row[2] != null ? ((Number) row[2]).doubleValue() : 0.0;
+
+            if (isZeroQtyLine(qty, freeQty)) {
+                em.createNativeQuery(
+                    "UPDATE " + billItemTable() + " SET retired=1, retirer_ID=?, retiredAt=?, retireComments=? WHERE ID=?")
+                    .setParameter(1, retirerId)
+                    .setParameter(2, now)
+                    .setParameter(3, "Retired at Finalising PO")
+                    .setParameter(4, billItemId)
+                    .executeUpdate();
+                em.createNativeQuery(
+                    "UPDATE " + pharmBillItemTable() + " SET retired=1, retirer_ID=?, retiredAt=? WHERE billItem_ID=?")
+                    .setParameter(1, retirerId)
+                    .setParameter(2, now)
+                    .setParameter(3, billItemId)
+                    .executeUpdate();
+            } else {
+                em.createNativeQuery(
+                    "UPDATE " + pharmBillItemTable() + " SET remainingQty=qty, remainingFreeQty=freeQty WHERE billItem_ID=?")
+                    .setParameter(1, billItemId)
+                    .executeUpdate();
+                survivingCount++;
+            }
+        }
+        evictLineCache();
+        return survivingCount;
+    }
 }

--- a/src/main/webapp/pharmacy/pharmacy_purhcase_order_list_to_finalize.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purhcase_order_list_to_finalize.xhtml
@@ -281,10 +281,9 @@
                                                 icon="fas #{b.cancelled eq true ? 'fa-ban' : 'fa-clipboard-check'}"
                                                 class="#{b.cancelled eq true ? 'ui-button-secondary ui-button-outlined' : 'ui-button-success'}"
                                                 value="#{b.cancelled eq true ? 'Cancelled' : 'Finalize'}"
-                                                action="#{purchaseOrderRequestController.navigateToUpdatePurchaseOrder()}"
+                                                action="#{purchaseOrderRequestNativeSqlController.navigateToUpdatePurchaseOrder(b.billId)}"
                                                 disabled="#{b.cancelled eq true}"
                                                 style="min-width: 100px;">
-                                                <f:setPropertyActionListener target="#{purchaseOrderRequestController.billId}" value="#{b.billId}"/>
                                             </p:commandButton>
 
                                             <!-- Status indicators below button -->

--- a/src/main/webapp/pharmacy/pharmacy_purhcase_order_request_native.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purhcase_order_request_native.xhtml
@@ -1,0 +1,729 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/resources/template/template.xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:p="http://primefaces.org/ui"
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns:ph="http://xmlns.jcp.org/jsf/composite/pharmacy"
+                xmlns:pa="http://xmlns.jcp.org/jsf/composite/paymentMethod"
+                xmlns:po="http://xmlns.jcp.org/jsf/composite/pharmacy">
+    <ui:define name="content">
+        <h:form id="form">
+            <h:panelGroup rendered="#{!webUserController.hasPrivilege('CreatePurchaseOrder')}" >
+                You are NOT authorized
+            </h:panelGroup>
+            <h:panelGroup id="gpOrder" rendered="#{webUserController.hasPrivilege('CreatePurchaseOrder')}" >
+                <div class="d-flex justify-content-end">
+                    <!-- Small non-prominent fallback to legacy entity-based page -->
+                    <p:commandButton
+                        ajax="false"
+                        value="Legacy View"
+                        title="Open original entity-based Purchase Order Request page"
+                        action="pharmacy_purhcase_order_request?faces-redirect=true"
+                        class="ui-button-secondary ms-3"
+                        icon="fas fa-history"
+                        style="font-size: 0.75rem; padding: 0.2rem 0.5rem;"/>
+                </div>
+                <p:defaultCommand target="btnSave" ></p:defaultCommand>
+                <p:messages id="pageMessages" ></p:messages>
+                <h:panelGroup id="notPrintPreview"  rendered="#{not purchaseOrderRequestNativeSqlController.printPreview}" class="w-100 p-0 m-0">
+
+                    <h:panelGroup rendered="#{not purchaseOrderRequestNativeSqlController.currentBill.checked}">
+                        <div class="row">
+                            <div class="col-9">
+
+                                <h:panelGroup id="itemHistoryAboveWrapper" layout="block">
+                                    <h:panelGroup rendered="#{purchaseOrderRequestNativeSqlController.itemHistoryVisible and configOptionApplicationController.getBooleanValueByKey('Pharmacy PO - Show Item History Above Items', false)}" layout="block">
+                                        <ph:history id="itemHistoryAbove"
+                                            closeActionListener="#{purchaseOrderRequestNativeSqlController.closeItemHistory()}"
+                                            updateOnClose=":form:itemHistoryAboveWrapper"/>
+                                    </h:panelGroup>
+                                </h:panelGroup>
+
+                                <p:dataTable
+                                    styleClass="noBorder" 
+                                    rowIndexVar="i" 
+                                    style="padding: 0;"
+                                    var="bi" 
+                                    scrollable="true"
+                                    scrollHeight="350px"
+                                    rowKey="#{bi.searialNo}"
+                                    value="#{purchaseOrderRequestNativeSqlController.billItems}" 
+                                    selection="#{purchaseOrderRequestNativeSqlController.selectedBillItems}"
+                                    id="itemList" >  
+
+                                    <f:facet name="header">
+                                        <div class="d-flex justify-content-between">
+                                            <h:outputLabel  value="Purchase Order Items"/>
+                                            <div class="d-flex gap-1">
+                                                <h:panelGroup rendered="#{webUserController.hasPrivilege('Admin')}">
+                                                    <p:commandButton
+                                                        value="Config"
+                                                        icon="fa fa-cog"
+                                                        title="Page Configuration Management"
+                                                        action="#{pageAdminController.navigateToPageAdmin('pharmacy/pharmacy_purhcase_order_request')}"
+                                                        ajax="false"
+                                                        styleClass="ui-button-secondary"/>
+                                                </h:panelGroup>
+                                                <p:commandButton ajax="false" class="ui-button-danger" value="Remove Selected"
+                                                                 disabled="#{not webUserController.hasPrivilege('PurchaseOrderSave')}"
+                                                                 action="#{purchaseOrderRequestNativeSqlController.removeSelected()}"/>
+                                            </div>
+                                        </div>
+                                    </f:facet>  
+
+                                    <p:column selectionBox="true" width="2em"  style="padding: 0;" />
+
+                                    <p:column headerText="No" width="2em" style="padding: 0;" >
+                                        <h:outputLabel value="#{bi.searialNo+1}" >
+                                            <f:convertNumber pattern="00" ></f:convertNumber>
+                                        </h:outputLabel>
+                                    </p:column>
+
+                                    <p:column headerText="Item"  style=" padding: 0;">
+                                        <h:outputLabel value="#{bi.item.name}  - #{bi.item.code}" ></h:outputLabel>
+                                        <p:commandButton
+                                            icon="pi pi-search"
+                                            id="btnViewSelectedItemDetails"
+                                            title="View Item Details"
+                                            action="#{purchaseOrderRequestNativeSqlController.displayItemDetails(bi)}"
+                                            update=":form:itemHistoryAboveWrapper :form:itemHistoryBelowWrapper"
+                                            process="@this"
+                                            class="ui-button-icon-only mx-3"/>
+                                    </p:column>
+
+                                    <p:column 
+                                        headerText="Qty" 
+                                        width="6em"
+                                        class="text-end px-1"
+                                        style="padding: 0px;"> 
+                                        <p:inputText
+                                            autocomplete="off"
+                                            id="qty"
+                                            value="#{bi.billItemFinanceDetails.quantity}"
+                                            style="padding: 0;"
+                                            label="Qty"
+                                            class="text-end w-100"
+                                            onkeydown="if (event.keyCode === 13) { event.preventDefault(); }"
+                                            onkeyup="if (event.keyCode === 13) { event.preventDefault(); this.blur(); }"
+                                            onfocus="this.select()">
+                                            <f:convertNumber pattern="0.#" ></f:convertNumber>
+                                            <p:ajax 
+                                                event="blur" 
+                                                update="total :#{p:resolveFirstComponentWithId('tot',view).clientId} @this :#{p:resolveFirstComponentWithId('pageMessages',view).clientId}"  
+                                                process="@this price" 
+                                                listener="#{purchaseOrderRequestNativeSqlController.onEdit(bi)}" ></p:ajax>
+                                        </p:inputText>
+                                    </p:column> 
+
+                                    <p:column 
+                                        width="5em"
+                                        headerText="Free Qty"
+                                        class="text-end px-1"
+                                        style="padding: 0px;"> 
+                                        <p:inputText
+                                            autocomplete="off"
+                                            id="freeQty"
+                                            onfocus="this.select()"
+                                            class="text-end w-100"
+                                            onkeydown="if (event.keyCode === 13) { event.preventDefault(); }"
+                                            onkeyup="if (event.keyCode === 13) { event.preventDefault(); this.blur(); }"
+                                            value="#{bi.billItemFinanceDetails.freeQuantity}"
+                                            style="padding: 0;"
+                                            label="Qty">
+                                            <f:convertNumber pattern="0.#" ></f:convertNumber>
+                                            <f:ajax 
+                                                event="blur" 
+                                                render="total :#{p:resolveFirstComponentWithId('tot',view).clientId}  @this :#{p:resolveFirstComponentWithId('pageMessages',view).clientId}" 
+                                                execute="@this price" 
+                                                listener="#{purchaseOrderRequestNativeSqlController.onEdit(bi)}" >
+                                            </f:ajax>
+                                        </p:inputText>
+                                    </p:column>
+
+                                    <p:column 
+                                        headerText="P Price"
+                                        class="text-end px-1"
+                                        style="padding: 0px;"
+                                        width="6em">  
+                                        <h:panelGroup id="price">
+                                            <p:inputText
+                                                id="txtRetailRate"
+                                                onfocus="this.select()"
+                                                autocomplete="off"
+                                                style="padding: 0;"
+                                                onkeydown="if (event.keyCode === 13) { event.preventDefault(); }"
+                                                onkeyup="if (event.keyCode === 13) { event.preventDefault(); this.blur(); }"
+                                                value="#{bi.billItemFinanceDetails.lineGrossRate}"
+                                                class="w-100 text-end">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                                <f:ajax event="blur" render="total :#{p:resolveFirstComponentWithId('tot',view).clientId}"  execute="@this qty" listener="#{purchaseOrderRequestNativeSqlController.onEdit(bi)}" ></f:ajax>
+                                            </p:inputText>
+                                        </h:panelGroup>
+                                    </p:column>  
+
+                                    <p:column 
+                                        headerText="Total" 
+                                        class="text-end px-1"
+                                        style="padding: 0;" 
+                                        width="6em">  
+                                        <h:panelGroup id="total">
+                                            <h:outputText 
+                                                id="lblTotal"
+                                                value="#{bi.netValue}" >
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputText>
+                                        </h:panelGroup>
+                                    </p:column>  
+
+                                    <p:column 
+                                        headerText="Stock in Units" 
+                                        width="6em" 
+                                        style="padding: 0;" 
+                                        class="text-end px-1">
+                                        <h:outputText 
+                                            value="#{stockController.findStock(bi.item)}">
+                                        </h:outputText>
+                                    </p:column>
+
+                                    <!--                                    <p:column headerText="Expiring" 
+                                                                                  width="6em" 
+                                                                                  style="padding: 0;" 
+                                                                                  class="text-end px-1">
+                                                                            <p:commandLink value="#{stockController.findExpiaringStock(bi.item)}"
+                                                                                           oncomplete="PF('expStockDetailsDialog').show();"
+                                                                                           process="itemList"
+                                                                                           update="expStockDetailsForm"
+                                                                                           actionListener="#{stockController.listExpiaringStocks(bi.item)}"
+                                                                                           style="#{stockController.findExpiaringStock(bi.item) > 0 ? 'color: red;' : 'color: #02e05f;'}">
+                                                                            </p:commandLink>
+                                                                        </p:column>
+                                    -->
+
+                                    <p:column 
+                                        headerText="Usage" width="6em" 
+                                        style="padding: 0;" 
+                                        class="text-end px-1">
+                                        <p:outputLabel value="#{pharmacyController.findAllOutTransactions(bi.item)}" style="width:4em; text-align: right;"/>                            
+                                    </p:column>
+
+                                    <p:column  style="width:5em; text-align: right; padding: 0;">
+                                        <p:commandButton 
+                                            class="ui-button-danger" 
+                                            icon="fas fa-trash"
+                                            process="itemList"
+                                            update="itemList :#{p:resolveFirstComponentWithId('tot',view).clientId} :form:itemHistoryAboveWrapper :form:itemHistoryBelowWrapper"
+                                            tabindex="-1"
+                                            style="padding: 0;"
+                                            disabled="#{not webUserController.hasPrivilege('PurchaseOrderSave')}"
+                                            action="#{purchaseOrderRequestNativeSqlController.removeItem(bi)}"/>
+                                    </p:column>
+
+                                </p:dataTable> 
+
+                                <h:panelGroup id="itemHistoryBelowWrapper" layout="block">
+                                    <h:panelGroup rendered="#{purchaseOrderRequestNativeSqlController.itemHistoryVisible and !configOptionApplicationController.getBooleanValueByKey('Pharmacy PO - Show Item History Above Items', false)}" layout="block">
+                                        <ph:history id="itemHistoryBelow"
+                                            closeActionListener="#{purchaseOrderRequestNativeSqlController.closeItemHistory()}"
+                                            updateOnClose=":form:itemHistoryBelowWrapper"/>
+                                    </h:panelGroup>
+                                </h:panelGroup>
+
+
+                            </div>
+                            <div class="col-3">
+                                <p:panel header="Purchase Order" id="po">
+
+
+                                    <p:outputLabel value="Supplier"
+                                                   class="form-label"
+                                                   for="acSupplier"></p:outputLabel>
+                                    <p:autoComplete
+                                        id="acSupplier"
+                                        converter="deal"
+                                        value="#{purchaseOrderRequestNativeSqlController.currentBill.toInstitution}"
+                                        forceSelection="true"
+                                        onkeydown="if (event.keyCode === 13) { var pnl = document.getElementById(this.id.replace(/_input$/, '_panel')); var panelOpen = pnl &amp;&amp; pnl.style.display !== 'none'; event.preventDefault(); if (!panelOpen) { return false; } }"
+                                        class="w-100"
+                                        inputStyleClass="w-100"
+                                        completeMethod="#{dealerController.completeActiveDealor}"
+                                        var="vt" itemLabel="#{vt.name}" itemValue="#{vt}" >
+                                        <f:ajax
+                                            event="itemSelect" 
+                                            execute="@this" 
+                                            render=":#{p:resolveFirstComponentWithId('exDItem',view).clientId}" 
+                                            />
+                                    </p:autoComplete>
+
+                                    <p:outputLabel value="Payment Method"
+                                                   class="form-label"
+                                                   for="cmbPs"></p:outputLabel>
+                                    <p:selectOneMenu class="w-100"  id="cmbPs" value="#{purchaseOrderRequestNativeSqlController.currentBill.paymentMethod}">    
+                                        <f:selectItem itemLabel="Select Payment method"/>
+                                        <f:selectItems value="#{enumController.paymentMethodsForGrn}" var="pm" itemLabel="#{pm.label}" itemValue="#{pm}">
+                                        </f:selectItems>
+                                        <p:ajax process="@this" update="po" event="change"/>
+                                        <p:ajax process="@this" update="duration" event="itemSelect" />
+                                    </p:selectOneMenu>
+
+
+                                    <h:panelGroup rendered="#{purchaseOrderRequestNativeSqlController.currentBill.paymentMethod eq 'Credit'}" id="duration" >
+                                        <div class="d-flex" >
+                                            <div class="ui-inputgroup mx-1 my-1">
+                                                <p:inputText  
+                                                    onfocus="this.select();"  
+                                                    value="#{purchaseOrderRequestNativeSqlController.currentBill.creditDuration}"
+                                                    style="width: 10em;">
+                                                </p:inputText>
+                                                <div class="ui-inputgroup-addon">Days</div>
+                                            </div>
+                                        </div>
+                                    </h:panelGroup>
+
+                                    <p:spacer 
+                                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable Consignment in Pharmacy Purchasing', true)}"
+                                        class="my-4"></p:spacer>
+                                    <h:panelGroup
+                                        class="my-4"
+                                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable Consignment in Pharmacy Purchasing', true)}">
+                                        <p:selectBooleanCheckbox value="#{purchaseOrderRequestNativeSqlController.currentBill.consignment}" itemLabel="Consignment"/>
+                                    </h:panelGroup>
+
+                                    <p:outputLabel 
+                                        value="Comments"
+                                        class="form-label w-100">
+                                    </p:outputLabel>
+                                    <p:inputTextarea 
+                                        value="#{purchaseOrderRequestNativeSqlController.currentBill.comments}" 
+                                        class="form-control w-100" ></p:inputTextarea>
+
+                                    <p:outputLabel value="Department Type"
+                                                   class="form-label"
+                                                   for="selDepartmentType"></p:outputLabel>
+                                    <p:selectOneMenu
+                                        id="selDepartmentType"
+                                        value="#{purchaseOrderRequestNativeSqlController.currentBill.departmentType}"
+                                        class="w-100"
+                                        disabled="#{not empty purchaseOrderRequestNativeSqlController.billItems and purchaseOrderRequestNativeSqlController.billItems.size() > 0}">
+                                        <f:selectItem itemLabel="Select Department Type" itemValue="#{null}"/>
+                                        <f:selectItems value="#{sessionController.availableDepartmentTypesForPharmacyTransactions}"
+                                                       var="dt"
+                                                       itemLabel="#{dt.label}"
+                                                       itemValue="#{dt}"/>
+                                        <p:ajax process="po" update="po exDItem exItem" event="change"/>
+                                    </p:selectOneMenu>
+
+                                    <p:outputLabel 
+                                        value="Total Value"
+                                        class="form-label w-100"></p:outputLabel>
+                                    <p:outputLabel 
+                                        class="m-1 w-100" 
+                                        id="tot" 
+                                        style="font-weight: bold;" 
+                                        value="#{purchaseOrderRequestNativeSqlController.currentBill.netTotal}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </p:outputLabel>
+                                    <p:commandButton 
+                                        id="btnSave"
+                                        ajax="false" 
+                                        value="Save" 
+                                        action="#{purchaseOrderRequestNativeSqlController.saveRequest}"
+                                        icon="pi pi-save"
+                                        class="ui-button-success m-1"
+                                        disabled="#{purchaseOrderRequestNativeSqlController.currentBill.checked or not webUserController.hasPrivilege('PurchaseOrderSave')}"/>
+                                    <p:commandButton
+                                        id="btnFinalize"
+                                        ajax="false"
+                                        value="Finalize"
+                                        action="#{purchaseOrderRequestNativeSqlController.finalizeRequest()}"
+                                        icon="pi pi-check"
+                                        class="ui-button-warning m-1"
+                                        onclick="return confirm('Are you sure you want to finalize this purchase order? This action cannot be undone.');"
+                                        disabled="#{purchaseOrderRequestNativeSqlController.currentBill.checked or not webUserController.hasPrivilege('PurchaseOrderFinalize')}"/>
+                                    <p:commandButton 
+                                        ajax="false"  
+                                        value="New Order" 
+                                        action="#{purchaseOrderRequestNativeSqlController.resetBillValues}"
+                                        icon="pi pi-plus" 
+                                        class="ui-button-danger m-1"/>
+
+                                    <h:panelGroup>                            
+
+                                    </h:panelGroup>
+                                </p:panel>
+                                <p:panel header="Add Items" >
+                                    <p:outputLabel 
+                                        class="form-label w-100"
+                                        value="Add supplier Items" ></p:outputLabel>
+                                    <p:commandButton 
+                                        class="m-1 ui-button-success"  
+                                        ajax="false" 
+                                        value="Add All" 
+                                        action="#{purchaseOrderRequestNativeSqlController.addAllSupplierItems}"/>
+                                    <p:commandButton 
+                                        class="m-1 ui-button-success "  
+                                        ajax="false" 
+                                        value="Add Items Below ROL" 
+                                        action="#{purchaseOrderRequestNativeSqlController.addAllSupplierItemsBelowRol()}"/>
+
+                                    <hr/>
+                                    <p:outputLabel 
+                                        for="exDItem" 
+                                        class="form-label w-100"
+                                        value="Select and Add a supplier Item" ></p:outputLabel>
+                                    <p:selectOneMenu 
+                                        id="exDItem" 
+                                        value="#{purchaseOrderRequestNativeSqlController.currentBillItem.item}"
+                                        class="w-75"
+                                        filterMatchMode="contains"
+                                        filter="true"
+                                        height="500"
+                                        var="vt" >
+                                        <p:column headerText="Item"  style="width: 350px; padding: 6px;">
+                                            <h:outputLabel value="#{vt.name}"></h:outputLabel>
+                                        </p:column>
+                                        <p:column headerText="Code"  style="padding: 6px;">
+                                            <h:outputLabel value="#{vt.code}"></h:outputLabel>
+                                        </p:column>
+                                        <p:column headerText="Department Stock"  style="padding: 6px; text-align: right;">
+                                            <p:outputLabel value="#{stockController.departmentItemStock(sessionController.department , vt)}">
+                                                <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                            </p:outputLabel>                            
+                                        </p:column>
+                                        <f:selectItems value="#{purchaseOrderRequestNativeSqlController.dealorItems}" var="di" itemLabel="#{di.name}" itemValue="#{di}" ></f:selectItems>
+                                    </p:selectOneMenu>
+                                    <p:commandButton
+                                        class="m-1 ui-button-success"
+                                        value="Add"
+                                        action="#{purchaseOrderRequestNativeSqlController.addItem}"
+                                        process="exDItem @this po"
+                                        update="exDItem :#{p:resolveFirstComponentWithId('itemList',view).clientId} tot po pageMessages" />
+                                    <hr/>
+                                    <p:outputLabel 
+                                        for="exItem" 
+                                        class="form-label w-100"
+                                        value="Select Any Item and Add" ></p:outputLabel>
+                                    <p:autoComplete
+                                        id="exItem"
+                                        value="#{purchaseOrderRequestNativeSqlController.currentBillItem.item}"
+                                        forceSelection="true"
+                                        onkeydown="if (event.keyCode === 13) { var pnl = document.getElementById(this.id.replace(/_input$/, '_panel')); var panelOpen = pnl &amp;&amp; pnl.style.display !== 'none'; event.preventDefault(); if (!panelOpen) { return false; } }"
+                                        class="w-75"
+                                        maxResults="50"
+                                        scrollHeight="600"
+                                        minQueryLength="#{configOptionApplicationController.getShortTextValueByKey('Minimum Number of Characters to Search for Item','4')}"
+                                        inputStyleClass="w-100"
+                                        completeMethod="#{purchaseOrderRequestNativeSqlController.completeItemForSelectedDepartmentType}" var="vt" itemLabel="#{vt.name}" itemValue="#{vt}" >
+                                        <p:column headerText="ID" rendered="#{webUserController.hasPrivilege('Developers')}" >
+                                            <h:outputLabel value="#{vt.id}"></h:outputLabel>
+                                        </p:column>
+                                        <p:column headerText="Item" style="width: 350px; padding: 6px;">
+                                            <h:outputLabel value="#{vt.name}"></h:outputLabel>
+                                        </p:column>
+                                        <p:column headerText="Code" style="padding: 6px;">
+                                            <h:outputLabel value="#{vt.code}"></h:outputLabel>
+                                        </p:column>
+                                        <p:column headerText="Department Stock" style="padding: 6px; text-align: right;">
+                                            <p:outputLabel value="#{stockController.departmentItemStock(sessionController.department , vt)}">
+                                                <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                            </p:outputLabel>                            
+                                        </p:column>
+                                    </p:autoComplete>
+                                    <p:commandButton
+                                        class="mx-1 ui-button-success"
+                                        value="Add"
+                                        action="#{purchaseOrderRequestNativeSqlController.addItem}"
+                                        process="exItem @this po"
+                                        update="exItem :#{p:resolveFirstComponentWithId('itemList',view).clientId} tot po pageMessages" />
+
+                                </p:panel>
+                            </div>
+                        </div>
+                    </h:panelGroup>
+
+                    <h:panelGroup rendered="#{purchaseOrderRequestNativeSqlController.currentBill.checked}" class="w-100 p-3">
+                        <div class="alert alert-warning" role="alert">
+                            <h:outputText value="This purchase order request has been finalized and cannot be modified." />
+                        </div>
+                    </h:panelGroup>
+
+                    <h:panelGroup rendered="#{purchaseOrderRequestNativeSqlController.currentBill.checked}" class="w-100 p-3">
+                        <div class="d-flex justify-content-center gap-2">
+                            <p:commandButton 
+                                ajax="false" 
+                                value="View Print Preview" 
+                                action="#{purchaseOrderRequestNativeSqlController.setPrintPreview(true)}"
+                                icon="pi pi-eye" 
+                                class="ui-button-info"/>
+                            <p:commandButton 
+                                ajax="false"  
+                                value="New Order" 
+                                action="#{purchaseOrderRequestNativeSqlController.resetBillValues}"
+                                icon="pi pi-plus" 
+                                class="ui-button-success"/>
+                        </div>
+                    </h:panelGroup>
+
+                </h:panelGroup>  
+
+
+                <p:panel 
+                    rendered="#{purchaseOrderRequestNativeSqlController.printPreview}"
+                    styleClass="print-preview"
+                    class="w-100">
+                    <f:facet name="header">
+                        <div class="d-flex justify-content-between">
+                            <div>
+                                <h:outputLabel value="Purchase Order Request" class="mt-2"/>
+                            </div>
+                            <div class="d-flex gap-2">
+                                <p:commandButton
+                                    rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
+                                    value="Settings"
+                                    icon="fas fa-cog"
+                                    class="ui-button-secondary"
+                                    type="button"
+                                    onclick="PF('purchaseOrderConfigDialog').show();" >
+                                </p:commandButton>
+                                <p:commandButton
+                                    ajax="false"
+                                    value="Print"
+                                    icon="fas fa-print"
+                                    class="ui-button-info">
+                                    <p:printer target=":form:printPaper" />
+                                </p:commandButton>
+                                <p:commandButton
+                                    value="Send Email"
+                                    icon="fas fa-envelope"
+                                    action="#{purchaseOrderRequestNativeSqlController.prepareEmailDialog}"
+                                    styleClass="ui-button-secondary"
+                                    oncomplete="PF('emailDialog').show();"
+                                    update="emailDialogForm"/>
+                                <p:commandButton
+                                    ajax="false"
+                                    value="New Order"
+                                    action="#{purchaseOrderRequestNativeSqlController.resetBillValues}"
+                                    icon="fas fa-plus"
+                                    styleClass="ui-button-success"/>
+                            </div>
+                        </div>
+                    </f:facet>
+
+                    <div class="d-flex justify-content-center">
+
+
+                        <h:panelGroup style="width: 212mm; height: 275mm;" id="printPaper" layout="block">
+
+                            <po:purchase_order_request_custom_1
+                                rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Purchase Order Request Print - A4 Paper Custom 1', true)}"
+                                bill="#{purchaseOrderRequestNativeSqlController.currentBill}"
+                                billItems="#{purchaseOrderRequestNativeSqlController.billItems}">
+                            </po:purchase_order_request_custom_1>
+
+                            <po:purchase_order_request_custom_2
+                                rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Purchase Order Request Print - A4 Paper Custom 2', false)}"
+                                bill="#{purchaseOrderRequestNativeSqlController.currentBill}"
+                                billItems="#{purchaseOrderRequestNativeSqlController.billItems}">
+                            </po:purchase_order_request_custom_2>
+
+                        </h:panelGroup>
+
+                    </div>
+                </p:panel>
+
+            </h:panelGroup>
+
+        </h:form>
+
+
+        <p:dialog widgetVar="stockDetailsDialog" modal="true" header="Stock Details" width="50%" height="auto">
+            <h:form id="stockDetailsForm">
+
+                <p:dataTable id="stockList" value="#{stockController.selectedItemStocks}" var="s" scrollable="true" scrollHeight="250px;">
+
+                    <f:facet name="header">
+                        <h:outputText id="stockItemName" value="Item: #{stockController.selectedItem.name}" />
+                    </f:facet>
+
+                    <p:column headerText="Expiry Date">
+                        <h:outputText value="#{s.itemBatch.dateOfExpire}">
+                            <f:convertDateTime pattern="dd MMMM yyyy" />
+                        </h:outputText>
+                    </p:column>
+
+                    <p:column headerText="Department">
+                        <h:outputText value="#{s.department.name}" />
+                    </p:column>
+
+                    <p:column headerText="Stock">
+                        <h:outputText value="#{s.stock}">
+                            <f:convertNumber pattern="#.#" />
+                        </h:outputText>
+                    </p:column>
+
+                    <f:facet name="footer">
+                        <h:outputText value="Total Stock Quantity: " />
+                        <h:outputText id="stockQty" value="#{stockController.totalStockQty}">
+                            <f:convertNumber pattern="#.#" />
+                        </h:outputText>
+                    </f:facet>
+
+                </p:dataTable>
+            </h:form>
+        </p:dialog>
+
+
+
+        <p:dialog widgetVar="expStockDetailsDialog" modal="true" header="Expiring Stock Details" width="50%" height="auto">
+            <h:form id="expStockDetailsForm">
+
+                <p:dataTable id="expStockList" value="#{stockController.selectedItemExpiaringStocks}" var="s">
+
+                    <f:facet name="header">
+                        <h:outputText id="expItemName" value="#{stockController.selectedItem.name}" />
+                    </f:facet>
+
+                    <p:column headerText="Expiry Date">
+                        <h:outputText value="#{s.itemBatch.dateOfExpire}">
+                            <f:convertDateTime pattern="dd MMMM yyyy" />
+                        </h:outputText>
+                    </p:column>
+
+                    <p:column headerText="Department">
+                        <h:outputText value="#{s.department.name}">
+                        </h:outputText>
+                    </p:column>
+
+                    <p:column headerText="Stock">
+                        <h:outputText value="#{s.stock}" >
+                            <f:convertNumber pattern="#.#" ></f:convertNumber>
+                        </h:outputText>
+                    </p:column>
+
+                    <f:facet name="footer">
+                        <h:outputText value="Total Expiaring Quentity by " />
+                        <h:outputText value="#{stockController.shortExpiaryDate}" >
+                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}" ></f:convertDateTime>
+                        </h:outputText>
+                        <h:outputText value=" : " />
+                        <h:outputText id="expQty" value="#{stockController.expiaringStockQty}" >
+                            <f:convertNumber pattern="#.#" ></f:convertNumber>
+                        </h:outputText>
+                    </f:facet>
+
+                </p:dataTable>
+
+            </h:form>
+        </p:dialog>
+
+        <p:dialog widgetVar="emailDialog" modal="true" header="Send Purchase Order Email" width="400px" height="auto" resizable="false">
+            <h:form id="emailDialogForm">
+                <div class="p-3">
+                    <div class="mb-3">
+                        <p:outputLabel value="Supplier: " style="font-weight: bold;"/>
+                        <p:outputLabel value="#{purchaseOrderRequestNativeSqlController.currentBill.toInstitution.name}"/>
+                    </div>
+
+                    <div class="mb-3">
+                        <p:outputLabel for="emailRecipient" value="Email Address:" class="form-label"/>
+                        <p:inputText 
+                            id="emailRecipient" 
+                            value="#{purchaseOrderRequestNativeSqlController.emailRecipient}" 
+                            class="w-100"
+                            placeholder="Enter email address"
+                            required="true"
+                            requiredMessage="Email address is required"/>
+                    </div>
+
+                    <div class="d-flex justify-content-end gap-2">
+                        <p:commandButton 
+                            value="Cancel" 
+                            onclick="PF('emailDialog').hide();"
+                            class="ui-button-secondary"
+                            type="button"/>
+                        <p:commandButton 
+                            value="Send Email" 
+                            action="#{purchaseOrderRequestNativeSqlController.sendPurchaseOrderEmail}"
+                            class="ui-button-success"
+                            icon="fas fa-envelope"
+                            ajax="false"
+                            oncomplete="PF('emailDialog').hide();"/>
+                    </div>
+                </div>
+            </h:form>
+        </p:dialog>
+
+        <!-- Purchase Order Configuration Dialog -->
+        <p:dialog id="purchaseOrderConfigDialog" 
+                  header="Purchase Order Request Printer Configuration" 
+                  widgetVar="purchaseOrderConfigDialog" 
+                  modal="true" 
+                  width="800" 
+                  height="500"
+                  resizable="true" 
+                  maximizable="true"
+                  closeOnEscape="true">
+
+            <p:ajax event="open" listener="#{purchaseOrderConfigController.loadCurrentConfig}" update="purchaseOrderConfigForm" />
+
+            <h:form id="purchaseOrderConfigForm">
+
+                <div class="row">
+                    <div class="col-md-12">
+                        <div class="card config-section">
+                            <div class="card-header">
+                                <h6><i class="fas fa-file-alt"></i> Purchase Order Paper Settings</h6>
+                            </div>
+                            <div class="card-body">
+                                <div class="mb-3">
+                                    <p:selectBooleanCheckbox 
+                                        id="custom1Paper"
+                                        value="#{purchaseOrderConfigController.custom1Paper}" />
+                                    <p:outputLabel for="custom1Paper" value="A4 Paper Custom Format 1" class="ms-2" />
+                                    <small class="form-text text-muted d-block">A4 purchase order format - Custom 1</small>
+                                </div>
+
+                                <div class="mb-3">
+                                    <p:selectBooleanCheckbox 
+                                        id="custom2Paper"
+                                        value="#{purchaseOrderConfigController.custom2Paper}" />
+                                    <p:outputLabel for="custom2Paper" value="A4 Paper Custom Format 2" class="ms-2" />
+                                    <small class="form-text text-muted d-block">A4 purchase order format - Custom 2</small>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="row mt-4">
+                    <div class="col-12">
+                        <div class="card">
+                            <div class="card-body">
+                                <p:messages id="purchaseOrderConfigMessages" showDetail="true" closable="true" />
+                                <div class="d-flex justify-content-between align-items-center">
+                                    <div class="d-flex gap-2">
+                                        <p:commandButton 
+                                            value="Apply &amp; Close" 
+                                            icon="fas fa-save"
+                                            class="ui-button-success"
+                                            ajax="false"
+                                            action="#{purchaseOrderConfigController.saveConfig}" />
+                                        <p:commandButton 
+                                            value="Cancel" 
+                                            icon="fas fa-times"
+                                            class="ui-button-secondary"
+                                            onclick="PF('purchaseOrderConfigDialog').hide(); return false;" 
+                                            type="button" />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+            </h:form>
+        </p:dialog>
+
+    </ui:define>  
+</ui:composition>

--- a/src/test/java/com/divudi/core/data/dto/pharmacy/PurchaseOrderRequestLineDataTest.java
+++ b/src/test/java/com/divudi/core/data/dto/pharmacy/PurchaseOrderRequestLineDataTest.java
@@ -1,0 +1,35 @@
+package com.divudi.core.data.dto.pharmacy;
+
+import org.junit.jupiter.api.Test;
+import java.math.BigDecimal;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PurchaseOrderRequestLineDataTest {
+    @Test
+    void gettersReturnValuesSetByConstructorArgs() {
+        var d = new PurchaseOrderRequestLineData();
+        d.setBillItemId(5L);
+        d.setPharmaceuticalBillItemId(7L);
+        d.setItemId(100L);
+        d.setAmpp(true);
+        d.setQuantity(BigDecimal.TEN);
+        d.setFreeQuantity(BigDecimal.ONE);
+        d.setPurchaseRate(BigDecimal.valueOf(12.5));
+        d.setRetailRate(BigDecimal.valueOf(15.0));
+        d.setUnitsPerPack(BigDecimal.valueOf(10));
+        d.setSerialNo(2);
+        d.setCreaterId(1L);
+
+        assertEquals(Long.valueOf(5L), d.getBillItemId());
+        assertEquals(Long.valueOf(7L), d.getPharmaceuticalBillItemId());
+        assertEquals(Long.valueOf(100L), d.getItemId());
+        assertEquals(true, d.isAmpp());
+        assertEquals(BigDecimal.TEN, d.getQuantity());
+        assertEquals(BigDecimal.ONE, d.getFreeQuantity());
+        assertEquals(BigDecimal.valueOf(12.5), d.getPurchaseRate());
+        assertEquals(BigDecimal.valueOf(15.0), d.getRetailRate());
+        assertEquals(BigDecimal.valueOf(10), d.getUnitsPerPack());
+        assertEquals(2, d.getSerialNo());
+        assertEquals(Long.valueOf(1L), d.getCreaterId());
+    }
+}

--- a/src/test/java/com/divudi/service/pharmacy/PurchaseOrderRequestNativeSqlServiceTest.java
+++ b/src/test/java/com/divudi/service/pharmacy/PurchaseOrderRequestNativeSqlServiceTest.java
@@ -1,0 +1,76 @@
+package com.divudi.service.pharmacy;
+
+import com.divudi.core.data.dto.pharmacy.PurchaseOrderRequestLineData;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PurchaseOrderRequestNativeSqlServiceTest {
+
+    private final PurchaseOrderRequestNativeSqlService service = new PurchaseOrderRequestNativeSqlService();
+
+    @Test
+    void computeLineValues_nonAmpp_purchaseRateTimesQtyIsGrossAndNetValue() {
+        PurchaseOrderRequestLineData line = new PurchaseOrderRequestLineData();
+        line.setAmpp(false);
+        line.setQuantity(new BigDecimal("10"));
+        line.setFreeQuantity(new BigDecimal("1"));
+        line.setPurchaseRate(new BigDecimal("25.50"));
+        line.setRetailRate(new BigDecimal("30.00"));
+        line.setUnitsPerPack(BigDecimal.ONE);
+
+        PurchaseOrderRequestNativeSqlService.LineValues v = service.computeLineValues(line);
+
+        assertEquals(new BigDecimal("255.00"), v.grossValue.setScale(2));
+        assertEquals(new BigDecimal("255.00"), v.netValue.setScale(2));
+        assertEquals(new BigDecimal("280.50"), v.purchaseValue.setScale(2)); // 25.50 * (10+1)
+        assertEquals(new BigDecimal("330.00"), v.retailValue.setScale(2));  // 30.00 * (10+1)
+        assertEquals(25.50, v.pbiPurchaseRate, 0.0001); // non-AMPP: no pack conversion
+        assertEquals(10.0, v.pbiQty, 0.0001);
+    }
+
+    @Test
+    void computeLineValues_ampp_convertsQtyAndRateByUnitsPerPack() {
+        PurchaseOrderRequestLineData line = new PurchaseOrderRequestLineData();
+        line.setAmpp(true);
+        line.setQuantity(new BigDecimal("2")); // 2 packs
+        line.setFreeQuantity(BigDecimal.ZERO);
+        line.setPurchaseRate(new BigDecimal("100")); // rate per pack
+        line.setRetailRate(new BigDecimal("120"));
+        line.setUnitsPerPack(new BigDecimal("10")); // 10 units per pack
+
+        PurchaseOrderRequestNativeSqlService.LineValues v = service.computeLineValues(line);
+
+        assertEquals(20.0, v.pbiQty, 0.0001); // 2 packs * 10 units/pack
+        assertEquals(10.0, v.pbiPurchaseRate, 0.0001); // 100 / 10 units per pack
+        assertEquals(12.0, v.pbiRetailRate, 0.0001); // 120 / 10
+    }
+
+    @Test
+    void computeLineValues_zeroQuantity_netRateIsZeroNotDivideByZero() {
+        PurchaseOrderRequestLineData line = new PurchaseOrderRequestLineData();
+        line.setAmpp(false);
+        line.setQuantity(BigDecimal.ZERO);
+        line.setFreeQuantity(BigDecimal.ZERO);
+        line.setPurchaseRate(new BigDecimal("50"));
+        line.setRetailRate(new BigDecimal("60"));
+        line.setUnitsPerPack(BigDecimal.ONE);
+
+        PurchaseOrderRequestNativeSqlService.LineValues v = service.computeLineValues(line);
+
+        assertEquals(BigDecimal.ZERO.setScale(2), v.netRate.setScale(2));
+    }
+
+    @Test
+    void computeLineValues_nullFields_defaultToZeroOrOne() {
+        PurchaseOrderRequestLineData line = new PurchaseOrderRequestLineData();
+        // quantity, freeQuantity, purchaseRate, retailRate, unitsPerPack all left null
+
+        PurchaseOrderRequestNativeSqlService.LineValues v = service.computeLineValues(line);
+
+        assertEquals(BigDecimal.ZERO.setScale(2), v.grossValue.setScale(2));
+        assertEquals(BigDecimal.ONE, v.unitsPerPack);
+    }
+}

--- a/src/test/java/com/divudi/service/pharmacy/PurchaseOrderRequestNativeSqlServiceTest.java
+++ b/src/test/java/com/divudi/service/pharmacy/PurchaseOrderRequestNativeSqlServiceTest.java
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.Test;
 import java.math.BigDecimal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class PurchaseOrderRequestNativeSqlServiceTest {
 
@@ -72,5 +74,27 @@ class PurchaseOrderRequestNativeSqlServiceTest {
 
         assertEquals(BigDecimal.ZERO.setScale(2), v.grossValue.setScale(2));
         assertEquals(BigDecimal.ONE, v.unitsPerPack);
+    }
+
+    @Test
+    void isZeroQtyLine_trueWhenQtyAndFreeQtyBothZero() {
+        assertTrue(service.isZeroQtyLine(0.0, 0.0));
+    }
+
+    @Test
+    void isZeroQtyLine_falseWhenQtyPositive() {
+        assertFalse(service.isZeroQtyLine(5.0, 0.0));
+    }
+
+    @Test
+    void isZeroQtyLine_falseWhenOnlyFreeQtyPositive() {
+        assertFalse(service.isZeroQtyLine(0.0, 3.0));
+    }
+
+    @Test
+    void isZeroQtyLine_trueWhenNegativeTotal() {
+        // Defensive: legacy compares totalUnits <= 0, so a negative sum (shouldn't
+        // happen in practice but the guard must match) also counts as zero-qty.
+        assertTrue(service.isZeroQtyLine(-1.0, 0.5));
     }
 }


### PR DESCRIPTION
## Summary

Migrates the Purchase Order Request page (`pharmacy_purhcase_order_request.xhtml` / `PurchaseOrderRequestController`) from JPA-entity persistence to a native-SQL write path, per Phase 1 of the master migration issue #22726.

- New `PurchaseOrderRequestNativeSqlService` (`@Stateless`) — native `INSERT`/`UPDATE` for `bill`/`billitem`/`pharmaceuticalbillitem`; `BillItemFinanceDetails` stays JPA (`IDENTITY` PK), matching the established `RetailSaleNativeSqlService` pattern.
- New `PurchaseOrderRequestNativeSqlController` (`@Named @SessionScoped`) — full feature parity with the legacy controller: create, repeated draft save, item add/remove/edit, bulk-add, finalize, email, bill-number generation (all 4 strategies), "New Order" reset.
- New `pharmacy_purhcase_order_request_native.xhtml` — copy of the legacy page with a "Legacy View" escape-hatch link during the review window.
- `pharmacy_purhcase_order_list_to_finalize.xhtml`'s Edit action now routes to the native page.
- Legacy page/controller are untouched and continue to work.

List/search pages (`pharmacy_purhcase_order_list_to_finalize.xhtml`, `..._list_to_approve_dto.xhtml`) were already JPQL-DTO-based and are out of scope for this migration.

## Process

Built via the `subagent-driven-development` workflow: design spec → implementation plan (11 tasks) → per-task implement/review/fix loops → a final whole-branch review → three rounds of post-task bugfixes for defects the per-task reviews and initial live testing didn't surface. Full history in `.superpowers/sdd/2026-08-07-po-request-native/progress.md` (not part of this PR — local workspace only).

Three defect classes were found and fixed via live Playwright + direct MySQL verification after the 11 planned tasks:

1. **Line-value / totals recalculation on edit** — editing a quantity didn't recompute the on-screen or persisted bill total.
2. **Bill-totals persistence on every mutating path** — `saveRequestWithoutMessage()`, `removeItem()`, and `removeSelected()` all needed their own `updateBillTotals()` call; only the first had it initially.
3. **Five defects from the final whole-branch review**, none exercised by the "edit an existing draft" test path:
   - `finalizeRequest()` promoted the bill (`checked=1`, `BILLTYPEATOMIC=PHARMACY_ORDER`) and retired every line **before** checking whether any line had real quantity — an all-zero-qty PO became permanently, unrecoverably finalized-and-empty. Fixed by running all validation against the in-memory line list before any native mutation.
   - The `allBillItemsValid()` guard (qty + purchase-rate check) was missing entirely.
   - `resyncPharmaceuticalBillItemIfEmpty()` (issue #21417's fix) was absent. Ported — see note below.
   - `calculateBillTotals()` didn't renumber `searialNo` after removals, risking serial collisions (the dataTable keys rows on it).
   - The three "New Order" buttons called `resetBillValues()`, which nulled `currentBill` with no re-init — every writable header binding then failed on the next interaction. `getCurrentBill()` now lazily rebuilds with the same config-driven defaults legacy applies.

Both critical scenarios (all-zero-qty finalize, fresh "New Order") were re-verified live after the fix: the zero-qty finalize now correctly rejects with **no bill row ever created** (validated entirely in-memory before any DB write), and "New Order" resets cleanly with immediately-usable header fields.

**Known non-blocking observation:** `resyncPharmaceuticalBillItemIfEmpty()` is a faithful port of the legacy #21417 fix, but is currently inert in this architecture — `PharmaceuticalBillItem.qty`/`freeQty` are never mutated in-memory anywhere in the native controller (only written as DB columns by the service's `saveLine()`), so the guard's trigger condition can't occur via the native path today. Kept for future-proofing and documented in code comments.

Closes #22727

## Test plan

- [x] Full test suite passes (`mvn test`, 194/194 including 8 new tests for `PurchaseOrderRequestNativeSqlService`'s pure calculation methods)
- [x] Create → add item(s) → save draft (repeated) → edit qty/rate (live total recalc) → finalize → verified via DB: correct `bill.netTotal`/`total`, `billitem`/`pharmaceuticalbillitem` values, no duplicate rows, `BILLTYPEATOMIC` promotion, `checked=1`
- [x] Remove single item / bulk-remove selected items → verified totals persist correctly without requiring an explicit Save
- [x] Send Email → `AppEmail` record created correctly
- [x] "New Order" → page resets cleanly, all header fields immediately usable
- [x] All-zero-quantity finalize attempt → correctly rejected, zero DB footprint (bill never created)
- [x] List-to-Finalize picker's Edit button correctly routes to the native page
- [x] Legacy page/controller confirmed untouched and still functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a native pharmacy purchase order workflow for creating, editing, saving, and finalizing orders.
  * Added item selection, duplicate prevention, quantity and rate validation, supplier/payment details, item history, stock views, print preview, and email sending.
  * Added options to add supplier items or items below reorder levels.
  * Added automatic totals, bill numbering, zero-quantity handling, and finalized-order restrictions.
  * Added direct navigation from the finalization list to order editing.

* **Tests**
  * Added coverage for line data and quantity calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->