### PR TITLE
Extract wiki DDL version check to async background service

### DIFF
--- a/src/main/java/com/divudi/bean/common/DataAdministrationController.java
+++ b/src/main/java/com/divudi/bean/common/DataAdministrationController.java
@@ -280,6 +280,8 @@ public class DataAdministrationController implements Serializable {
     @EJB
     private DatabaseMigrationService databaseMigrationService;
     @EJB
+    private com.divudi.service.DatabaseMigrationVersionCheckService databaseMigrationVersionCheckService;
+    @EJB
     private DatabaseMigrationFacade databaseMigrationFacade;
     @EJB
     private com.divudi.core.facade.BillFinanceDetailsFacade billFinanceDetailsFacade;
@@ -338,7 +340,6 @@ public class DataAdministrationController implements Serializable {
     private String auditDatabaseExecutionFeedback;
 
     // Wiki DDL version tracking
-    private static final String WIKI_DDL_URL = "https://github.com/hmislk/hmis/wiki/Database-Schema-DDL-Generation-Guide";
     private static final String WIKI_DDL_RAW_URL = "https://raw.githubusercontent.com/wiki/hmislk/hmis/files/createDDL.sql";
     private static final String CONFIG_KEY_DDL_VERSION = "DATABASE_DDL_VERSION";
     private String wikiDdlVersion;
@@ -2453,38 +2454,14 @@ public class DataAdministrationController implements Serializable {
         }
     }
 
+    /**
+     * Delegates to {@link com.divudi.service.DatabaseMigrationVersionCheckService},
+     * which also backs {@link DatabaseMigrationService}'s automatic
+     * post-startup check — kept as a shared method so the wiki-fetch/regex
+     * logic isn't duplicated between the manual and automatic paths.
+     */
     public String fetchWikiDdlVersion() {
-        java.net.HttpURLConnection conn = null;
-        try {
-            java.net.URL url = new java.net.URL(WIKI_DDL_URL);
-            conn = (java.net.HttpURLConnection) url.openConnection();
-            conn.setRequestMethod("GET");
-            conn.setConnectTimeout(5000);
-            conn.setReadTimeout(10000);
-            conn.setRequestProperty("User-Agent", "HMIS-Schema-Checker/1.0");
-            int status = conn.getResponseCode();
-            if (status == 200) {
-                try (java.io.BufferedReader reader = new java.io.BufferedReader(
-                        new java.io.InputStreamReader(conn.getInputStream(), java.nio.charset.StandardCharsets.UTF_8))) {
-                    String line;
-                    // Wiki page writes the time as HH.MM (dot); accept both dot and colon
-                    Pattern versionPattern = Pattern.compile("Last Update\\s*-\\s*(\\d{4}\\.\\d{2}\\.\\d{2}\\s+\\d{2}[.:]\\d{2})");
-                    while ((line = reader.readLine()) != null) {
-                        Matcher m = versionPattern.matcher(line);
-                        if (m.find()) {
-                            return m.group(1).trim();
-                        }
-                    }
-                }
-            }
-        } catch (Exception e) {
-            // Network or parse failure — return null so caller falls back to legacy
-        } finally {
-            if (conn != null) {
-                conn.disconnect();
-            }
-        }
-        return null;
+        return databaseMigrationVersionCheckService.fetchWikiDdlVersion();
     }
 
     /**

--- a/src/main/java/com/divudi/service/DatabaseMigrationService.java
+++ b/src/main/java/com/divudi/service/DatabaseMigrationService.java
@@ -7,8 +7,10 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.PostConstruct;
+import javax.annotation.Resource;
 import javax.annotation.security.PermitAll;
 import javax.ejb.EJB;
+import javax.ejb.SessionContext;
 import javax.ejb.Singleton;
 import javax.ejb.Startup;
 import javax.ejb.TransactionAttribute;
@@ -48,6 +50,9 @@ public class DatabaseMigrationService {
     @EJB
     private DatabaseMigrationVersionCheckService databaseMigrationVersionCheckService;
 
+    @Resource
+    private SessionContext sessionContext;
+
     private volatile boolean migrationPending = true;
 
     @PostConstruct
@@ -66,16 +71,23 @@ public class DatabaseMigrationService {
         LOGGER.info("DatabaseMigrationService: Migration page is open to all users until marked as complete or not necessary.");
         try {
             // Fire-and-forget: runs on a background thread via @Asynchronous.
-            // Must go through the injected proxy, not a self-invocation, or
-            // @Asynchronous would be silently ignored and this would block
-            // startup exactly like the code removed in c32868a9f5.
-            databaseMigrationVersionCheckService.checkAndUpdateMigrationStatus(this);
+            // Pass the container-managed no-interface business proxy (via
+            // SessionContext.getBusinessObject), never raw "this" — the
+            // callback's calls back into this bean must go through the
+            // proxy so singleton concurrency locking applies. Also, the
+            // outbound call itself must go through the injected
+            // databaseMigrationVersionCheckService proxy, not a
+            // self-invocation, or @Asynchronous would be silently ignored
+            // and this would block startup exactly like the code removed
+            // in c32868a9f5.
+            DatabaseMigrationService self = sessionContext.getBusinessObject(DatabaseMigrationService.class);
+            databaseMigrationVersionCheckService.checkAndUpdateMigrationStatus(self);
         } catch (Exception e) {
             LOGGER.log(Level.FINE, "DatabaseMigrationService: Could not schedule background DDL version check.", e);
         }
     }
 
-    String readStoredDdlVersion() {
+    public String readStoredDdlVersion() {
         try {
             Map<String, Object> params = new HashMap<>();
             params.put("key", CONFIG_KEY_DDL_VERSION);

--- a/src/main/java/com/divudi/service/DatabaseMigrationService.java
+++ b/src/main/java/com/divudi/service/DatabaseMigrationService.java
@@ -20,12 +20,17 @@ import javax.ejb.TransactionAttributeType;
  * On every deployment/restart, migrationPending starts as true, making the
  * page accessible to anyone. If the stored DATABASE_DDL_VERSION config option
  * is set to "CONFIRMED", migration is automatically marked as not necessary
- * and the banner is suppressed. Otherwise, the banner remains until an admin
- * visits mf.xhtml and marks the migration as complete or not necessary.
+ * and the banner is suppressed. Otherwise, a background check (see
+ * {@link DatabaseMigrationVersionCheckService}) compares the stored version
+ * against the wiki's current DDL version shortly after startup and clears
+ * the banner automatically if they already match. Failing that, the banner
+ * remains until an admin visits mf.xhtml and marks the migration as
+ * complete or not necessary.
  *
- * The wiki DDL version check has been removed to avoid blocking the deploy
- * thread with an outbound HTTP request at startup. Admins can confirm the
- * migration status manually via the admin interface.
+ * The wiki DDL version check runs asynchronously (never inline in
+ * {@code @PostConstruct}) to avoid blocking the deploy thread with an
+ * outbound HTTP request at startup — see commit c32868a9f5, which removed
+ * an earlier synchronous version of this check for exactly that reason.
  *
  * @author Dr M H B Ariyaratne
  */
@@ -39,6 +44,9 @@ public class DatabaseMigrationService {
 
     @EJB
     private ConfigOptionFacade configOptionFacade;
+
+    @EJB
+    private DatabaseMigrationVersionCheckService databaseMigrationVersionCheckService;
 
     private volatile boolean migrationPending = true;
 
@@ -56,9 +64,18 @@ public class DatabaseMigrationService {
             LOGGER.log(Level.WARNING, "DatabaseMigrationService: Could not read stored DDL version at startup.", e);
         }
         LOGGER.info("DatabaseMigrationService: Migration page is open to all users until marked as complete or not necessary.");
+        try {
+            // Fire-and-forget: runs on a background thread via @Asynchronous.
+            // Must go through the injected proxy, not a self-invocation, or
+            // @Asynchronous would be silently ignored and this would block
+            // startup exactly like the code removed in c32868a9f5.
+            databaseMigrationVersionCheckService.checkAndUpdateMigrationStatus(this);
+        } catch (Exception e) {
+            LOGGER.log(Level.FINE, "DatabaseMigrationService: Could not schedule background DDL version check.", e);
+        }
     }
 
-    private String readStoredDdlVersion() {
+    String readStoredDdlVersion() {
         try {
             Map<String, Object> params = new HashMap<>();
             params.put("key", CONFIG_KEY_DDL_VERSION);

--- a/src/main/java/com/divudi/service/DatabaseMigrationVersionCheckService.java
+++ b/src/main/java/com/divudi/service/DatabaseMigrationVersionCheckService.java
@@ -1,0 +1,109 @@
+package com.divudi.service;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.ejb.Asynchronous;
+import javax.ejb.Stateless;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+
+/**
+ * Fetches the wiki-hosted DDL "Last Update" version string used to detect
+ * whether a deployed schema is current, and runs the version comparison in
+ * the background so callers never block on the outbound HTTP request.
+ *
+ * Shared by {@link DatabaseMigrationService}'s automatic post-startup check
+ * and by the manual "Check Missing Fields" flow in
+ * {@code DataAdministrationController} — both used to duplicate this
+ * fetch/regex logic independently.
+ *
+ * @author Dr M H B Ariyaratne
+ */
+@Stateless
+public class DatabaseMigrationVersionCheckService {
+
+    private static final Logger LOGGER = Logger.getLogger(DatabaseMigrationVersionCheckService.class.getName());
+    private static final String WIKI_DDL_URL = "https://github.com/hmislk/hmis/wiki/Database-Schema-DDL-Generation-Guide";
+    private static final Pattern WIKI_DDL_VERSION_PATTERN
+            = Pattern.compile("Last Update\\s*-\\s*(\\d{4}\\.\\d{2}\\.\\d{2}\\s+\\d{2}[.:]\\d{2})");
+
+    /**
+     * Fetches the wiki page and extracts the "Last Update" DDL version
+     * string, e.g. "2026.08.07 04.00". Returns null on any network or parse
+     * failure — callers must treat null as "unknown, fall back to the
+     * legacy check" rather than raising an error.
+     */
+    @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
+    public String fetchWikiDdlVersion() {
+        HttpURLConnection conn = null;
+        try {
+            URL url = new URL(WIKI_DDL_URL);
+            conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("GET");
+            conn.setConnectTimeout(5000);
+            conn.setReadTimeout(10000);
+            conn.setRequestProperty("User-Agent", "HMIS-Schema-Checker/1.0");
+            int status = conn.getResponseCode();
+            if (status == 200) {
+                try (BufferedReader reader = new BufferedReader(
+                        new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8))) {
+                    String line;
+                    while ((line = reader.readLine()) != null) {
+                        Matcher m = WIKI_DDL_VERSION_PATTERN.matcher(line);
+                        if (m.find()) {
+                            return m.group(1).trim();
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            // Network or parse failure — return null so caller falls back to legacy check
+        } finally {
+            if (conn != null) {
+                conn.disconnect();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Compares the wiki's current DDL version against the caller's stored
+     * version and, on a match, marks migration complete. Runs on a
+     * container-managed background thread — {@code @Asynchronous} only
+     * takes effect when this method is invoked through an injected
+     * (proxied) reference to this bean, never via self-invocation.
+     *
+     * Any failure (wiki unreachable, timeout, parse error) is swallowed at
+     * FINE level: this is a best-effort convenience check, and it must
+     * never surface an error to end users or affect the migrationPending
+     * default the caller already has.
+     */
+    @Asynchronous
+    @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
+    public void checkAndUpdateMigrationStatus(DatabaseMigrationService migrationService) {
+        if (migrationService == null) {
+            return;
+        }
+        try {
+            String wikiVersion = fetchWikiDdlVersion();
+            if (wikiVersion == null) {
+                LOGGER.fine("DatabaseMigrationVersionCheckService: wiki DDL version unreachable during background check.");
+                return;
+            }
+            if (wikiVersion.equals(migrationService.readStoredDdlVersion())) {
+                migrationService.markMigrationComplete();
+                LOGGER.info("DatabaseMigrationVersionCheckService: background check confirmed schema is up to date "
+                        + "(version " + wikiVersion + ") — migration banner cleared.");
+            }
+        } catch (Exception e) {
+            LOGGER.log(Level.FINE, "DatabaseMigrationVersionCheckService: background DDL version check failed.", e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Refactors the wiki DDL version-checking logic into a dedicated `DatabaseMigrationVersionCheckService` to eliminate code duplication and enable asynchronous, non-blocking version checks at startup.

## Key Changes
- **New service**: `DatabaseMigrationVersionCheckService` encapsulates wiki-fetch and regex-parsing logic
  - `fetchWikiDdlVersion()` — synchronous HTTP fetch with timeout and error handling
  - `checkAndUpdateMigrationStatus()` — asynchronous wrapper that compares versions and clears the migration banner if they match
  - Marked `@Asynchronous` to run on a background thread, preventing startup blocking
  
- **DatabaseMigrationService** now delegates to the new service
  - Calls `databaseMigrationVersionCheckService.checkAndUpdateMigrationStatus(this)` in `@PostConstruct` to fire-and-forget the background check
  - Made `readStoredDdlVersion()` package-private so the service can access it
  - Updated class-level documentation to explain the asynchronous flow
  
- **DataAdministrationController** now delegates to the shared service
  - Removed duplicate HTTP-fetch and regex logic from `fetchWikiDdlVersion()`
  - Now simply calls `databaseMigrationVersionCheckService.fetchWikiDdlVersion()`
  - Removed unused `WIKI_DDL_URL` constant (kept `WIKI_DDL_RAW_URL` for other purposes)

## Implementation Details
- The `@Asynchronous` method must be invoked through the injected proxy reference, not via self-invocation, or the annotation is silently ignored and the call blocks synchronously
- Any network or parse failure is logged at `FINE` level and swallowed — this is a best-effort convenience check that must never surface errors to end users or affect the default `migrationPending` state
- Timeouts are set conservatively (5s connect, 10s read) to fail fast if the wiki is unreachable
- The regex pattern accepts both dot and colon separators in the time portion (e.g., `04.00` or `04:00`)

Closes #[issue-number-if-applicable]

https://claude.ai/code/session_01Hf6CeZ5eR2cEveRcnwsaeB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automatic startup check for the latest database migration version.
  * Migration status is updated in the background when the stored version matches the latest available version.

* **Bug Fixes**
  * Startup is no longer blocked when the version check fails.
  * Version lookup failures are handled gracefully without disrupting deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->