### PR TITLE
feat(report): add key-prefix-scoped favorite check for per-page Favorites tabs

### DIFF
--- a/src/main/java/com/divudi/bean/common/UserFavoriteReportController.java
+++ b/src/main/java/com/divudi/bean/common/UserFavoriteReportController.java
@@ -71,6 +71,32 @@ public class UserFavoriteReportController implements Serializable {
     }
 
     /**
+     * True if the current logged-in user has any non-retired favorite whose
+     * reportKey starts with the given prefix. Lets each report/analytics
+     * index page (e.g. Pharmacy Analytics, using the "pharmacyAnalytics_"
+     * reportKey prefix) show its own page-scoped "no favorites yet"
+     * empty-state message, instead of {@link #getFavorites()}, which
+     * returns favorites across the whole app and would incorrectly suppress
+     * the message on a page where the user has no favorites of their own,
+     * just because they have a favorite on a different page. See
+     * developer_docs/feature/report-favorites.md - Gotcha 3.
+     */
+    public boolean hasAnyFavoriteWithKeyPrefix(String prefix) {
+        if (sessionController == null || sessionController.getLoggedUser() == null) {
+            return false;
+        }
+        if (prefix == null) {
+            return false;
+        }
+        for (UserFavoriteReport f : getCachedFavorites()) {
+            if (f.getReportKey() != null && f.getReportKey().startsWith(prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Toggles the favorite state of a report for the current logged-in
      * user: retires the existing favorite (soft-delete) if one exists,
      * otherwise creates a new one. Refreshes the cached list afterwards so


### PR DESCRIPTION
Closes #22739. Shared prerequisite for the [Report Favorites rollout](https://github.com/hmislk/hmis/issues/22750) to other Analytics pages.

## Summary

Adds `UserFavoriteReportController.hasAnyFavoriteWithKeyPrefix(String prefix)`.

`UserFavoriteReportController` is `@SessionScoped` and shared across the whole app, with no page context. `reports/index.xhtml`'s Favorites tab currently checks emptiness with `#{empty userFavoriteReportController.favorites}` — the user's favorites across the *entire app*, not just that page. Once a second page (e.g. Pharmacy Analytics) adopts Favorites, a user whose only favorite is on that other page would incorrectly suppress the "no favorites yet" message on a page where they actually have none.

Each Analytics page in the rollout uses its own `reportKey` prefix (see [the implementation guide](https://github.com/hmislk/hmis/blob/development/developer_docs/feature/report-favorites.md)), so this method lets each page scope its own empty-state check with a one-line XHTML change and a plain string literal — no new Java needed per page:

```xml
rendered="#{not userFavoriteReportController.hasAnyFavoriteWithKeyPrefix('pharmacyAnalytics_')}"
```

This makes `UserFavoriteReportController.java` the only file shared across the whole rollout, and only for this one method — every one of the 9 per-page sub-issues under #22750 is a self-contained, single-XHTML-file change, safe to build fully in parallel now that this has landed.

## Scope note

`reports/index.xhtml` is intentionally left unchanged — its existing `reportKey`s have no prefix (by design, to avoid orphaning already-persisted favorites), so this method doesn't apply there unless that page is retrofitted with a prefix later.

## Testing

- `mvn clean package` — build succeeds, all 194 existing tests pass, no regressions
- No existing test coverage exists for `UserFavoriteReportController` (DI-heavy `@SessionScoped`/`@EJB` bean); the new method mirrors the existing, already-proven `isFavorite(String)` method's exact null-guard and loop pattern
- No page calls this method yet (that's the follow-up per-page sub-issues), so there is nothing to exercise end-to-end in the browser for this PR alone

🤖 Generated with [Claude Code](https://claude.com/claude-code)