### PR TITLE
Report Favorites: add self-service Favorites tab to Membership Analytics

### DIFF
--- a/src/main/webapp/membership/analytics/index.xhtml
+++ b/src/main/webapp/membership/analytics/index.xhtml
@@ -3,7 +3,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
       xmlns:p="http://primefaces.org/ui"
-      xmlns:h="http://xmlns.jcp.org/jsf/html">
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:fav="http://xmlns.jcp.org/jsf/composite/ezcomp/reports">
     <h:body>
         <ui:composition template="/resources/template/template.xhtml">
             <ui:define name="content">
@@ -11,20 +12,55 @@
                     <div class="row">
                         <div class="col-2 p-1">
                             <h:form >
-                                <p:accordionPanel>
+                                <p:accordionPanel id="reportsAccordion">
+                                    <p:tab title="⭐ Favorites">
+                                        <h:panelGroup id="favoritesPanel" layout="block">
+                                            <h:panelGroup layout="block" styleClass="text-muted p-2" rendered="#{not userFavoriteReportController.hasAnyFavoriteWithKeyPrefix('membershipAnalytics_')}">
+                                                <h:outputText value="No favorite reports yet — click the star next to any report to add it here." />
+                                            </h:panelGroup>
+                                            <div class="d-grid gap-2">
+                                                <h:panelGroup layout="block" styleClass="d-flex align-items-center gap-1 w-100"
+                                                              rendered="#{webUserController.hasPrivilege('MemberShipInwardMemberShipInwardMemberShipReport') and userFavoriteReportController.isFavorite('membershipAnalytics_families')}">
+                                                    <p:commandButton
+                                                        class="w-100 my-1"
+                                                        action="#{familyController.navigateToListFamilies()}"
+                                                        value="Families"
+                                                        ajax="false"/>
+                                                    <fav:favoriteStar reportKey="membershipAnalytics_families" label="Families" category="Lists" />
+                                                </h:panelGroup>
+                                                <h:panelGroup layout="block" styleClass="d-flex align-items-center gap-1 w-100"
+                                                              rendered="#{webUserController.hasPrivilege('MemberShipOpdMemberShipDisOpdMemberShipReport') and userFavoriteReportController.isFavorite('membershipAnalytics_members')}">
+                                                    <p:commandButton
+                                                        class="w-100 my-1"
+                                                        action="#{familyController.navigateToListFamilyMembers()}"
+                                                        value="Members"
+                                                        ajax="false"/>
+                                                    <fav:favoriteStar reportKey="membershipAnalytics_members" label="Members" category="Lists" />
+                                                </h:panelGroup>
+                                            </div>
+                                        </h:panelGroup>
+                                    </p:tab>
                                     <p:tab title="Lists" class="p-1">
-                                        <p:commandButton  
-                                            class="w-100 my-1"
-                                            action="#{familyController.navigateToListFamilies()}"
-                                            value="Families"  
-                                            ajax="false"
-                                            rendered="#{webUserController.hasPrivilege('MemberShipInwardMemberShipInwardMemberShipReport')}"/>
-                                        <p:commandButton
-                                            class="w-100 my-1"
-                                            action="#{familyController.navigateToListFamilyMembers()}"
-                                            value="Members" 
-                                            ajax="false"
-                                            rendered="#{webUserController.hasPrivilege('MemberShipOpdMemberShipDisOpdMemberShipReport')}"/>
+                                        <div class="d-flex align-items-center gap-1 w-100">
+                                            <p:commandButton
+                                                class="w-100 my-1"
+                                                action="#{familyController.navigateToListFamilies()}"
+                                                value="Families"
+                                                ajax="false"
+                                                rendered="#{webUserController.hasPrivilege('MemberShipInwardMemberShipInwardMemberShipReport')}"/>
+                                            <fav:favoriteStar reportKey="membershipAnalytics_families" label="Families" category="Lists"
+                                                               visible="#{webUserController.hasPrivilege('MemberShipInwardMemberShipInwardMemberShipReport')}" />
+                                        </div>
+                                        <div class="d-flex align-items-center gap-1 w-100">
+                                            <p:commandButton
+                                                class="w-100 my-1"
+                                                action="#{familyController.navigateToListFamilyMembers()}"
+                                                value="Members"
+                                                ajax="false"
+                                                rendered="#{webUserController.hasPrivilege('MemberShipOpdMemberShipDisOpdMemberShipReport')}"/>
+                                            <fav:favoriteStar reportKey="membershipAnalytics_members" label="Members" category="Lists"
+                                                               visible="#{webUserController.hasPrivilege('MemberShipOpdMemberShipDisOpdMemberShipReport')}" />
+                                        </div>
                                     </p:tab>
                                 </p:accordionPanel>
                             </h:form>


### PR DESCRIPTION
## Summary
- Add a pinned **⭐ Favorites** tab as the first tab on `membership/analytics/index.xhtml` (Membership menu → Analytics)
- Add a `<fav:favoriteStar>` toggle beside each existing report button (Families, Members), using the `membershipAnalytics_` reportKey prefix (`membershipAnalytics_families`, `membershipAnalytics_members`)
- Duplicate both report button rows into the Favorites tab, each wrapped in `<h:panelGroup layout="block" rendered="...">` (never a raw `<div>`), gated on `isFavorite(...)` and the existing privilege checks
- Use the page-scoped empty-state check `#{not userFavoriteReportController.hasAnyFavoriteWithKeyPrefix('membershipAnalytics_')}` instead of the global `#{empty userFavoriteReportController.favorites}`
- Added `id="reportsAccordion"` to the page's `p:accordionPanel` so `favoriteStar`'s AJAX `update` (which targets that fixed id) resolves to this page's own accordion

This follows the pattern documented in [Report Favorites Implementation Guide](https://github.com/hmislk/hmis/blob/development/developer_docs/feature/report-favorites.md), reusing the shared `hasAnyFavoriteWithKeyPrefix` helper landed in #22739.

## Test plan
- [x] Verified the modified XHTML is well-formed XML
- [ ] Playwright: star 2-3 reports on this page, confirm the Favorites tab shows them stacked tightly, confirm navigation from the Favorites tab works, confirm unfavoriting + empty-state message both work (not run in this environment — no running app server to verify against)
- [ ] DB: confirm `USERFAVORITEREPORT` rows are created/soft-deleted with the `membershipAnalytics_` key prefix
- [ ] Wiki: update [Report Favorites](https://github.com/hmislk/hmis/wiki/Report-Favorites) to mention this page (wiki repo not available in this session's repo scope — needs a follow-up edit)

Since this is an XHTML-only change with no Java modifications, per project convention it does not require compilation.

Closes #22743

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0114wRbzsHZooay2RGW1rQYm)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Favorites tab to the Analytics section for quickly accessing favorited Family and Member reports.
  * Added favorite-star controls to supported report lists, shown based on access privileges.
  * Favorites are displayed only when the relevant reports have been marked as favorites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->