### PR TITLE
Add self-service Favorites tab to EMR Analytics reports page

### DIFF
--- a/src/main/webapp/emr/reports/index.xhtml
+++ b/src/main/webapp/emr/reports/index.xhtml
@@ -3,7 +3,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
       xmlns:h="http://xmlns.jcp.org/jsf/html"
-      xmlns:p="http://primefaces.org/ui">
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:fav="http://xmlns.jcp.org/jsf/composite/ezcomp/reports">
 
 
     <ui:composition template="/resources/template/template.xhtml">
@@ -14,34 +15,102 @@
                     <div class="col-md-3" >
                         <h:form>
 
-                            <p:accordionPanel widgetVar="basic"  
-                                              activeIndex="#{emrController.activeIndexOfReports}" 
+                            <p:accordionPanel widgetVar="basic"
+                                              activeIndex="#{emrController.activeIndexOfReports}"
                                               >
+                                <p:tab title="⭐ Favorites">
+                                    <!--
+                                        Each report button below is intentionally duplicated from its
+                                        category tab further down this file (same reportKey, label,
+                                        category, action), gated on isFavorite() instead of always
+                                        rendering. See developer_docs/feature/report-favorites.md.
+                                        If you add or rename a report button below, update BOTH copies -
+                                        the reportKey ties them together.
+                                    -->
+                                    <h:panelGroup id="favoritesPanel" layout="block">
+                                        <h:panelGroup layout="block" styleClass="text-muted p-2" rendered="#{not userFavoriteReportController.hasAnyFavoriteWithKeyPrefix('emrAnalytics_')}">
+                                            <h:outputText value="No favorite reports yet — click the star next to any report to add it here." />
+                                        </h:panelGroup>
+                                        <div class="d-grid gap-2">
+                                            <h:panelGroup layout="block" styleClass="d-flex align-items-center gap-1 w-100" rendered="#{userFavoriteReportController.isFavorite('emrAnalytics_listVisits')}">
+                                                <p:commandButton value="List Visits" class="w-100" ajax="false"
+                                                                 action="#{patientEncounterController.navigateToListInstitutionEncounters()}" />
+                                                <fav:favoriteStar reportKey="emrAnalytics_listVisits" label="List Visits" category="Clinical Data" />
+                                            </h:panelGroup>
+                                            <h:panelGroup layout="block" styleClass="d-flex align-items-center gap-1 w-100" rendered="#{userFavoriteReportController.isFavorite('emrAnalytics_dailyVisits')}">
+                                                <p:commandButton value="Daily Visits" class="w-100" ajax="false"
+                                                                 action="#{patientEncounterController.listAllEncounters()}" />
+                                                <fav:favoriteStar reportKey="emrAnalytics_dailyVisits" label="Daily Visits" category="Clinical Data" />
+                                            </h:panelGroup>
+                                            <h:panelGroup layout="block" styleClass="d-flex align-items-center gap-1 w-100" rendered="#{userFavoriteReportController.isFavorite('emrAnalytics_diagnosis')}">
+                                                <p:commandButton value="Diagnosis" class="w-100" ajax="false" action="#{diagnosisController.navigateToListDiagnoses()}" />
+                                                <fav:favoriteStar reportKey="emrAnalytics_diagnosis" label="Diagnosis" category="Clinical Metadata" />
+                                            </h:panelGroup>
+                                            <h:panelGroup layout="block" styleClass="d-flex align-items-center gap-1 w-100" rendered="#{userFavoriteReportController.isFavorite('emrAnalytics_genericNamesVtms')}">
+                                                <p:commandButton value="Generic Names (VTMs)" class="w-100" ajax="false" action="#{vtmController.navigateToListAllVtms()}" />
+                                                <fav:favoriteStar reportKey="emrAnalytics_genericNamesVtms" label="Generic Names (VTMs)" category="Pharmaceutical Metadata" />
+                                            </h:panelGroup>
+                                            <h:panelGroup layout="block" styleClass="d-flex align-items-center gap-1 w-100" rendered="#{userFavoriteReportController.isFavorite('emrAnalytics_tradeNamesAtms')}">
+                                                <p:commandButton value="Trade Names (ATMs)" class="w-100" ajax="false" action="#{atmController.navigateToListAllAtms()}" />
+                                                <fav:favoriteStar reportKey="emrAnalytics_tradeNamesAtms" label="Trade Names (ATMs)" category="Pharmaceutical Metadata" />
+                                            </h:panelGroup>
+                                            <h:panelGroup layout="block" styleClass="d-flex align-items-center gap-1 w-100" rendered="#{userFavoriteReportController.isFavorite('emrAnalytics_productNamesVmps')}">
+                                                <p:commandButton value="Product Names (VMPs)" class="w-100" ajax="false" action="#{vmpController.navigateToListAllVmps()}" />
+                                                <fav:favoriteStar reportKey="emrAnalytics_productNamesVmps" label="Product Names (VMPs)" category="Pharmaceutical Metadata" />
+                                            </h:panelGroup>
+                                            <h:panelGroup layout="block" styleClass="d-flex align-items-center gap-1 w-100" rendered="#{userFavoriteReportController.isFavorite('emrAnalytics_itemsAmps')}">
+                                                <p:commandButton value="Items (AMPs)" class="w-100" ajax="false" action="#{ampController.navigateToListAllAmps()}" />
+                                                <fav:favoriteStar reportKey="emrAnalytics_itemsAmps" label="Items (AMPs)" category="Pharmaceutical Metadata" />
+                                            </h:panelGroup>
+                                        </div>
+                                    </h:panelGroup>
+                                </p:tab>
                                 <p:tab title="Clinical">
                                     <div class="d-grid gap-2">
                                     </div>
                                 </p:tab>
                                 <p:tab title="Clinical Data">
                                     <div class="d-grid gap-2">
-                                        <p:commandButton value="List Visits"  class="w-100" 
-                                                         action="#{patientEncounterController.navigateToListInstitutionEncounters()}"  >
-                                        </p:commandButton>
-                                        <p:commandButton  value="Daily Visits"  class="w-100" 
-                                                          action="#{patientEncounterController.listAllEncounters()}" >
-                                        </p:commandButton><!-- comment -->
+                                        <div class="d-flex align-items-center gap-1 w-100">
+                                            <p:commandButton value="List Visits"  class="w-100"
+                                                              action="#{patientEncounterController.navigateToListInstitutionEncounters()}"  >
+                                            </p:commandButton>
+                                            <fav:favoriteStar reportKey="emrAnalytics_listVisits" label="List Visits" category="Clinical Data" />
+                                        </div>
+                                        <div class="d-flex align-items-center gap-1 w-100">
+                                            <p:commandButton  value="Daily Visits"  class="w-100"
+                                                               action="#{patientEncounterController.listAllEncounters()}" >
+                                            </p:commandButton><!-- comment -->
+                                            <fav:favoriteStar reportKey="emrAnalytics_dailyVisits" label="Daily Visits" category="Clinical Data" />
+                                        </div>
                                     </div>
                                 </p:tab>
                                 <p:tab title="Clinical Metadata">
                                     <div class="d-grid gap-2">
-                                        <p:commandButton value="Diagnosis" action="#{diagnosisController.navigateToListDiagnoses()}" class="w-100"  />
+                                        <div class="d-flex align-items-center gap-1 w-100">
+                                            <p:commandButton value="Diagnosis" action="#{diagnosisController.navigateToListDiagnoses()}" class="w-100"  />
+                                            <fav:favoriteStar reportKey="emrAnalytics_diagnosis" label="Diagnosis" category="Clinical Metadata" />
+                                        </div>
                                     </div>
                                 </p:tab>
                                 <p:tab title="Pharmaceutical Metadata">
                                     <div class="d-grid gap-2">
-                                        <p:commandButton value="Generic Names (VTMs)" action="#{vtmController.navigateToListAllVtms()}" class="w-100"  />
-                                        <p:commandButton value="Trade Names (ATMs)" action="#{atmController.navigateToListAllAtms()}" class="w-100"  />
-                                        <p:commandButton value="Product Names (VMPs)" action="#{vmpController.navigateToListAllVmps()}" class="w-100"  />
-                                        <p:commandButton value="Items (AMPs)" action="#{ampController.navigateToListAllAmps()}" class="w-100"  />
+                                        <div class="d-flex align-items-center gap-1 w-100">
+                                            <p:commandButton value="Generic Names (VTMs)" action="#{vtmController.navigateToListAllVtms()}" class="w-100"  />
+                                            <fav:favoriteStar reportKey="emrAnalytics_genericNamesVtms" label="Generic Names (VTMs)" category="Pharmaceutical Metadata" />
+                                        </div>
+                                        <div class="d-flex align-items-center gap-1 w-100">
+                                            <p:commandButton value="Trade Names (ATMs)" action="#{atmController.navigateToListAllAtms()}" class="w-100"  />
+                                            <fav:favoriteStar reportKey="emrAnalytics_tradeNamesAtms" label="Trade Names (ATMs)" category="Pharmaceutical Metadata" />
+                                        </div>
+                                        <div class="d-flex align-items-center gap-1 w-100">
+                                            <p:commandButton value="Product Names (VMPs)" action="#{vmpController.navigateToListAllVmps()}" class="w-100"  />
+                                            <fav:favoriteStar reportKey="emrAnalytics_productNamesVmps" label="Product Names (VMPs)" category="Pharmaceutical Metadata" />
+                                        </div>
+                                        <div class="d-flex align-items-center gap-1 w-100">
+                                            <p:commandButton value="Items (AMPs)" action="#{ampController.navigateToListAllAmps()}" class="w-100"  />
+                                            <fav:favoriteStar reportKey="emrAnalytics_itemsAmps" label="Items (AMPs)" category="Pharmaceutical Metadata" />
+                                        </div>
                                     </div>
                                 </p:tab>
                             </p:accordionPanel>


### PR DESCRIPTION
## What changed

Adds a pinned **⭐ Favorites** tab to `emr/reports/index.xhtml` (Clinical/EMR menu → EMR Analytics), following the [Report Favorites Implementation Guide](https://github.com/hmislk/hmis/blob/development/developer_docs/feature/report-favorites.md).

- Added a `<fav:favoriteStar>` toggle beside every existing report button, using the `emrAnalytics_` reportKey prefix:
  - `emrAnalytics_listVisits`, `emrAnalytics_dailyVisits` (Clinical Data)
  - `emrAnalytics_diagnosis` (Clinical Metadata)
  - `emrAnalytics_genericNamesVtms`, `emrAnalytics_tradeNamesAtms`, `emrAnalytics_productNamesVmps`, `emrAnalytics_itemsAmps` (Pharmaceutical Metadata)
- Duplicated every report button into the new Favorites tab (first tab in the accordion), each row wrapped in `<h:panelGroup layout="block">` with `rendered` on the wrapper — never a raw `<div>` (per issue #22736, the spacing-gap gotcha)
- Empty-state message uses the page-scoped `userFavoriteReportController.hasAnyFavoriteWithKeyPrefix('emrAnalytics_')` check (added in the shared prerequisite, #22739) instead of the app-wide `#{empty userFavoriteReportController.favorites}` expression

No Java changes were needed — `hasAnyFavoriteWithKeyPrefix` already exists on `UserFavoriteReportController` from the prerequisite issue (#22739), and every reportKey used here was confirmed unique across the codebase (`grep -rn` on each key returned no other hits).

## Testing

This is a JSF-only change (XHTML only, no Java), so per project convention it doesn't require compilation. This session runs in an isolated cloud container without local Payara/Playwright access, so browser-driven verification wasn't performed here — the change follows the exact reviewed pattern already shipped and verified on `reports/index.xhtml` (PR #22728, spacing fix #22737). Recommend a Playwright pass (star 2-3 reports across tabs, confirm the Favorites tab stacks tightly with no blank gap, confirm navigation and unfavoriting work, confirm the empty-state message) before merge, per the issue's testing checklist.

## Out of scope

Other Analytics pages are tracked as separate sub-issues under the Report Favorites rollout master issue.

Closes #22748

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wf5sRxGsZefxjWPVQRnjJc)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Favorites tab to the reports section.
  * Users can mark reports as favorites using star controls.
  * Favorite reports are displayed in a dedicated list.
  * Added an empty-state message when no reports have been favorited.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->