### PR TITLE
Add general-purpose admission search REST API

### DIFF
--- a/developer_docs/api/using-apis/API_ADMISSION_DETAILS.md
+++ b/developer_docs/api/using-apis/API_ADMISSION_DETAILS.md
@@ -1,0 +1,211 @@
+# Getting Admission Details — Consolidated Guide
+
+There is **no single endpoint** that returns one admission's full detail (demographics + clinical + billing) by ID. Admission-related data is split across three separate APIs, each covering a different slice. This guide indexes all three with worked examples so you can pick the right one instead of guessing.
+
+| Need | Endpoint | Doc |
+|---|---|---|
+| List all currently active (not-discharged) admissions, or search past/current admissions by BHT/name/MRN/phone/NIC | `GET /api/inward/admissions` | below |
+| Which admissions still owe money (financial worklist) | `GET /api/apiInward/admissions` | below |
+| Find a patient's open/unpaid admission by phone | `GET /api/apiInward/admissions/byPhone/{phone}` | below |
+| Confirm a BHT number + phone combo is valid before taking payment | `GET /api/apiInward/validateAdmission/{bht_no}/{phone}` | [API_INWARD.md](API_INWARD.md) |
+| Take an online payment against a BHT | `POST /api/apiInward/payment` | [API_INWARD.md](API_INWARD.md) |
+| Bank list for the payment form | `GET /api/apiInward/banks` | [API_INWARD.md](API_INWARD.md) |
+| View/reset the BHT/OPD-card number sequence counter | `GET`/`PUT /api/admission-numbers` | [API_ADMISSION_NUMBERS.md](API_ADMISSION_NUMBERS.md) |
+| Clinical form entries recorded against an admission | `GET /api/forms/entries/{admissionId}` | below |
+
+All endpoints use the `Finance` header for authentication unless noted.
+
+---
+
+## 1. General-purpose admission search — `AdmissionSearchApi`
+
+`GET /api/inward/admissions` mirrors the staff-facing search page (`/inward/inpatient_search.xhtml`, `AdmissionController.searchAdmissions()`) — unlike `ApiInward`'s worklist endpoints below, it is **not** scoped to unpaid/open admissions and has no row cap (paginated instead).
+
+All query params are optional:
+
+| Param | Description |
+|---|---|
+| `status` | `ADMITTED_BUT_NOT_DISCHARGED` (default), `DISCHARGED_BUT_FINAL_BILL_NOT_COMPLETED`, `DISCHARGED_AND_FINAL_BILL_COMPLETED`, `ANY_STATUS` |
+| `bhtNo` | Bed Head Ticket number (partial match) |
+| `patientName` | Patient name (partial match) |
+| `mrn` | Patient MRN/PHN or patient code (exact match) |
+| `phone` | Patient or guardian phone/mobile (exact match) |
+| `nic` | Patient NIC/passport (exact match) |
+| `admissionTypeId` | Numeric `AdmissionType` ID |
+| `institutionId` | Numeric `Institution` ID |
+| `departmentId` | Numeric `Department` ID |
+| `fromDate` / `toDate` | Admission date range, `yyyy-MM-dd HH:mm:ss` — must be supplied together |
+| `page` | Default 1 |
+| `size` | Default 50, max 200 |
+
+### List currently active (not-discharged) admissions
+
+```bash
+curl -H "Finance: YOUR_API_KEY" \
+  https://hmis.example.com/api/inward/admissions
+```
+
+### Search past or current admissions by phone or MRN
+
+```bash
+curl -H "Finance: YOUR_API_KEY" \
+  "https://hmis.example.com/api/inward/admissions?status=ANY_STATUS&mrn=P00012345"
+
+curl -H "Finance: YOUR_API_KEY" \
+  "https://hmis.example.com/api/inward/admissions?status=ANY_STATUS&phone=0771234567"
+```
+
+Example response:
+```json
+{
+  "status": "success",
+  "code": 200,
+  "data": {
+    "admissions": [
+      {
+        "patientEncounterId": 384021,
+        "bhtNo": "BHT2026001",
+        "patientMrn": "P00012345",
+        "patientCode": "PC00123",
+        "patientName": "K. G. Perera",
+        "patientPhone": "0112345678",
+        "patientMobile": "0771234567",
+        "patientNic": "901234567V",
+        "patientAddress": "12 Main St, Galle",
+        "patientArea": "Galle",
+        "referringDoctor": "Dr. J. Silva",
+        "admissionType": "Ward Admission",
+        "institution": "Ruhunu Hospital",
+        "department": "Medical Ward 1",
+        "currentRoom": "Ward 1 - Bed 4",
+        "dateOfAdmission": "2026-08-01 10:15:00",
+        "dateOfDischarge": null,
+        "discharged": false,
+        "paymentFinalized": false,
+        "netTotal": 45000.0,
+        "paidAmount": 20000.0,
+        "balance": 25000.0
+      }
+    ],
+    "page": 1,
+    "size": 50,
+    "totalCount": 128
+  }
+}
+```
+
+`netTotal`/`paidAmount`/`balance` are only present once a final bill exists for the admission, matching `ApiInward`'s behavior. `totalCount` reflects the full matching set independent of pagination.
+
+---
+
+## 2. Financial worklist — `ApiInward`
+
+Full reference: [API_INWARD.md](API_INWARD.md). These two endpoints don't return *all* admissions — they return admissions that still need attention: not-yet-finalized/discharged admissions, plus finalized-and-discharged ones with an outstanding balance greater than 0.1 (capped at 20 of each kind, newest first).
+
+### List admissions with money owed
+
+```bash
+curl -H "Finance: YOUR_API_KEY" \
+  https://hmis.example.com/api/apiInward/admissions
+```
+
+```json
+{
+  "admission": [
+    {
+      "patient_encounter_id": 384021,
+      "bht_no": "BHT2026001",
+      "patient_mrn": "P00012345",
+      "patient_name": "K. G. Perera",
+      "patient_home_phone": "0112345678",
+      "patient_mobile": "0771234567",
+      "patient_nic": "901234567V",
+      "net_total": 45000.0,
+      "paid_amount": 20000.0,
+      "balance": 25000.0
+    }
+  ],
+  "error": "0",
+  "error_description": ""
+}
+```
+
+### Find by patient/guardian phone
+
+```bash
+curl -H "Finance: YOUR_API_KEY" \
+  https://hmis.example.com/api/apiInward/admissions/byPhone/0771234567
+```
+
+Same field shape, filtered to admissions where the patient's or guardian's mobile/home phone matches. Returns `{"admission": "", "error": "1", "error_description": "No Data."}` when nothing matches.
+
+---
+
+## 3. BHT number sequence — `AdmissionNumberApi`
+
+Full reference: [API_ADMISSION_NUMBERS.md](API_ADMISSION_NUMBERS.md). This is **not** admission content — it manages the counter that generates the next BHT/OPD-card number for a given admission type.
+
+```bash
+curl -H "Finance: YOUR_API_KEY" \
+  "https://hmis.example.com/api/admission-numbers?admissionTypeId=1192"
+```
+
+```json
+{
+  "status": "success",
+  "code": 200,
+  "data": {
+    "admissionTypeId": 1192,
+    "admissionTypeName": "OPD Card",
+    "institutionId": null,
+    "institutionBased": false,
+    "lastAdmissionNumber": 48213,
+    "nextAdmissionNumber": 48214
+  }
+}
+```
+
+Resetting the counter (`PUT`) requires an `expectedLastAdmissionNumber` compare-and-set guard — see the full doc for the request body and error codes.
+
+---
+
+## 4. Clinical form entries — `FormApi`
+
+Full reference: [`developer_docs/forms/form-api-guide.md`](../../forms/form-api-guide.md). Returns the filled-in clinical forms (ward assessments, nursing notes, etc.) recorded against an admission — not demographic or billing data.
+
+```bash
+curl -H "Finance: YOUR_API_KEY" \
+  https://hmis.example.com/api/forms/entries/384021
+```
+
+`384021` is the `PatientEncounter`/`Admission` primary key (same `patient_encounter_id` returned by `/api/apiInward/admissions`).
+
+```json
+[
+  {
+    "id": 9021,
+    "formTemplateId": 12,
+    "formTemplateName": "Ward Assessment",
+    "comments": "Stable, no complaints",
+    "createdAt": "2026-08-05T09:30:00.000+0000",
+    "createdBy": "nurse.silva"
+  }
+]
+```
+
+To get the actual field values captured on a specific entry, follow up with:
+
+```bash
+curl -H "Finance: YOUR_API_KEY" \
+  https://hmis.example.com/api/forms/entries/9021/values
+```
+
+---
+
+## Getting full admission demographics/clinical fields
+
+`/api/inward/admissions` (section 1) now covers the common demographic/status/location fields a caller typically needs (patient identity, admission type, institution/department, current room, discharge status, financials). If you need fields it still doesn't expose — e.g. detailed vitals (`weight`, `sbp`, `dbp`, `bmi`, etc.), discharge condition/instructions, guardian relationship — these live on the `PatientEncounter` entity (`src/main/java/com/divudi/core/entity/PatientEncounter.java`) but are **not currently exposed via REST**. If a caller needs one of these fields, file a GitHub issue describing the specific fields required rather than reaching for direct DB/entity access — see [api-development](../building-apis/) for the pattern to follow when adding a new endpoint.
+
+## History
+
+[hmislk/hmis#22754](https://github.com/hmislk/hmis/issues/22754) tracked the original gap — no endpoint could list all currently active admissions or search past/current admissions by phone or MRN, only the `ApiInward` financial worklist existed. `AdmissionSearchApi` (`GET /api/inward/admissions`, section 1) closed this gap.

--- a/developer_docs/api/using-apis/API_ADMISSION_DETAILS.md
+++ b/developer_docs/api/using-apis/API_ADMISSION_DETAILS.md
@@ -5,7 +5,7 @@ There is **no single endpoint** that returns one admission's full detail (demogr
 | Need | Endpoint | Doc |
 |---|---|---|
 | List all currently active (not-discharged) admissions, or search past/current admissions by BHT/name/MRN/phone/NIC | `GET /api/inward/admissions` | below |
-| Which admissions still owe money (financial worklist) | `GET /api/apiInward/admissions` | below |
+| Admissions needing billing attention (financial worklist) | `GET /api/apiInward/admissions` | below |
 | Find a patient's open/unpaid admission by phone | `GET /api/apiInward/admissions/byPhone/{phone}` | below |
 | Confirm a BHT number + phone combo is valid before taking payment | `GET /api/apiInward/validateAdmission/{bht_no}/{phone}` | [API_INWARD.md](API_INWARD.md) |
 | Take an online payment against a BHT | `POST /api/apiInward/payment` | [API_INWARD.md](API_INWARD.md) |
@@ -102,7 +102,7 @@ Example response:
 
 Full reference: [API_INWARD.md](API_INWARD.md). These two endpoints don't return *all* admissions — they return admissions that still need attention: not-yet-finalized/discharged admissions, plus finalized-and-discharged ones with an outstanding balance greater than 0.1 (capped at 20 of each kind, newest first).
 
-### List admissions with money owed
+### List admissions needing billing attention
 
 ```bash
 curl -H "Finance: YOUR_API_KEY" \

--- a/developer_docs/api/using-apis/API_INWARD.md
+++ b/developer_docs/api/using-apis/API_INWARD.md
@@ -8,27 +8,86 @@ Provides access to inpatient admission data and payment processing for admitted 
 
 ## Endpoints
 
-### GET `/api/apiInward/admissions` — List active admissions
+### GET `/api/apiInward/admissions` — List admissions with money owed
 
-Returns current inpatient admissions.
+Returns admissions that still need to be paid: admissions that are **not yet finalized/discharged**, plus finalized-and-discharged admissions that still have an **outstanding balance > 0.1**. Not a full admission-detail record — it's a financial worklist (up to 20 of each kind, most recent first).
 
 ```bash
 GET /api/apiInward/admissions
 Header: Finance: YOUR_API_KEY
 ```
 
-Response fields per admission: `bhtNo`, `patientName`, `patientPhone`, `admittedAt`, `ward`, `bed`, `doctor`, `diagnosis`
+Response fields per admission:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `patient_encounter_id` | long | `PatientEncounter`/`Admission` primary key |
+| `bht_no` | string | Bed Head Ticket number |
+| `patient_mrn` | string | Patient's PHN (medical record number) |
+| `patient_name` | string | Patient's full name (or `"No Person Details"` if unavailable) |
+| `patient_home_phone` | string | Patient's home phone |
+| `patient_mobile` | string | Patient's mobile number |
+| `patient_nic` | string | Patient's NIC |
+| `net_total` | double | Final bill net total (only present once a final bill exists) |
+| `paid_amount` | double | Amount paid so far, including credit payments |
+| `balance` | double | `net_total - paid_amount` |
+
+Example response:
+```json
+{
+  "admission": [
+    {
+      "patient_encounter_id": 384021,
+      "bht_no": "BHT2026001",
+      "patient_mrn": "P00012345",
+      "patient_name": "K. G. Perera",
+      "patient_home_phone": "0112345678",
+      "patient_mobile": "0771234567",
+      "patient_nic": "901234567V",
+      "net_total": 45000.0,
+      "paid_amount": 20000.0,
+      "balance": 25000.0
+    }
+  ],
+  "error": "0",
+  "error_description": ""
+}
+```
+
+If there are no matching admissions:
+```json
+{ "admission": "", "error": "1", "error_description": "No Data." }
+```
 
 ---
 
 ### GET `/api/apiInward/admissions/byPhone/{phone}` — Find admission by patient phone
+
+Same field shape and filtering rules as `/admissions` above (not-yet-finalized, or finalized-with-balance), restricted to admissions where the patient's or guardian's mobile/phone matches `{phone}`.
 
 ```bash
 GET /api/apiInward/admissions/byPhone/0771234567
 Header: Finance: YOUR_API_KEY
 ```
 
-Returns the active admission(s) for the patient with this mobile number.
+Example response:
+```json
+{
+  "admission": [
+    {
+      "patient_encounter_id": 384021,
+      "bht_no": "BHT2026001",
+      "patient_mrn": "P00012345",
+      "patient_name": "K. G. Perera",
+      "net_total": 45000.0,
+      "paid_amount": 20000.0,
+      "balance": 25000.0
+    }
+  ],
+  "error": "0",
+  "error_description": ""
+}
+```
 
 ---
 
@@ -124,3 +183,10 @@ Header: Finance: YOUR_API_KEY
 - `bht_no` is the Bed Head Ticket number assigned at admission
 - Payment is processed as an **online settlement** — use `/api/apiInward/banks` to get valid `bank_id` values
 - It is recommended to call `/api/apiInward/validateAdmission` before processing payment as a best practice; however `POST /payment` does not enforce this as a hard precondition and will accept requests without a prior validate call
+- `/admissions` and `/admissions/byPhone/{phone}` are financial worklists (unpaid/open admissions), not general admission search or a full-detail lookup by ID — for that, use `GET /api/inward/admissions` (see [API_ADMISSION_DETAILS.md](API_ADMISSION_DETAILS.md))
+
+## See also
+
+- [Admission Search API](API_ADMISSION_DETAILS.md) — `GET /api/inward/admissions` lists all currently active admissions, or searches past/current admissions by BHT/name/MRN/phone/NIC, with no financial scoping or row cap
+- [Admission Number Counters API](API_ADMISSION_NUMBERS.md) — view/reset the BHT/OPD-card number sequence (not admission content)
+- [Forms API](../../forms/form-api-guide.md) — `GET /api/forms/entries/{admissionId}` returns clinical form entries recorded against an admission

--- a/developer_docs/api/using-apis/API_INWARD.md
+++ b/developer_docs/api/using-apis/API_INWARD.md
@@ -8,9 +8,9 @@ Provides access to inpatient admission data and payment processing for admitted 
 
 ## Endpoints
 
-### GET `/api/apiInward/admissions` — List admissions with money owed
+### GET `/api/apiInward/admissions` — Financial worklist: admissions needing billing attention
 
-Returns admissions that still need to be paid: admissions that are **not yet finalized/discharged**, plus finalized-and-discharged admissions that still have an **outstanding balance > 0.1**. Not a full admission-detail record — it's a financial worklist (up to 20 of each kind, most recent first).
+Returns admissions that need billing attention: admissions that are **not yet finalized/discharged** (open, regardless of balance), plus finalized-and-discharged admissions that still have an **outstanding balance > 0.1**. Not a full admission-detail record — it's a financial worklist (up to 20 of each kind, most recent first).
 
 ```bash
 GET /api/apiInward/admissions
@@ -183,7 +183,7 @@ Header: Finance: YOUR_API_KEY
 - `bht_no` is the Bed Head Ticket number assigned at admission
 - Payment is processed as an **online settlement** — use `/api/apiInward/banks` to get valid `bank_id` values
 - It is recommended to call `/api/apiInward/validateAdmission` before processing payment as a best practice; however `POST /payment` does not enforce this as a hard precondition and will accept requests without a prior validate call
-- `/admissions` and `/admissions/byPhone/{phone}` are financial worklists (unpaid/open admissions), not general admission search or a full-detail lookup by ID — for that, use `GET /api/inward/admissions` (see [API_ADMISSION_DETAILS.md](API_ADMISSION_DETAILS.md))
+- `/admissions` and `/admissions/byPhone/{phone}` are financial worklists (unpaid/open admissions), not general admission search — `GET /api/inward/admissions` (see [API_ADMISSION_DETAILS.md](API_ADMISSION_DETAILS.md)) supports general admission list/search by BHT/name/MRN/phone/NIC/status, but it is not a full-detail lookup by admission ID either — it has no ID path parameter and does not expose every `PatientEncounter` field
 
 ## See also
 

--- a/developer_docs/api/using-apis/README.md
+++ b/developer_docs/api/using-apis/README.md
@@ -13,6 +13,7 @@ All standard endpoints use the `Finance` header unless noted otherwise below.
 
 | File | Module | Auth |
 |---|---|---|
+| [API_ADMISSION_DETAILS.md](API_ADMISSION_DETAILS.md) | Consolidated index: which API to call for admission worklist/BHT numbers/clinical forms | `Finance` |
 | [API_ADMISSION_NUMBERS.md](API_ADMISSION_NUMBERS.md) | View/reset BHT/OPD admission-number sequence counters | `Finance` |
 | [API_BALANCE_HISTORY.md](API_BALANCE_HISTORY.md) | Drawer/patient-deposit/agent balance change history | `Finance` |
 | [API_BILL_DATA_CORRECTION.md](API_BILL_DATA_CORRECTION.md) | Correct saved bill finance-detail fields (UPDATE only) | `Finance` |

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -375,6 +375,64 @@ public class AnthropicApiService implements Serializable {
                         .add("required", Json.createArrayBuilder().add("method").add("admissionTypeId")))
                 .build();
 
+        JsonObject admissionSearchTool = Json.createObjectBuilder()
+                .add("name", "search_admissions")
+                .add("description",
+                        "Search or list hospital admissions. Unlike the inward payment worklist, this is "
+                        + "not scoped to unpaid/open admissions — it can list all currently active "
+                        + "(not-discharged) admissions, or find a patient's past or current admissions by "
+                        + "BHT number, name, MRN/PHN, phone, or NIC. All parameters are optional; omitting "
+                        + "status defaults to currently-admitted (not-discharged) patients only.")
+                .add("input_schema", Json.createObjectBuilder()
+                        .add("type", "object")
+                        .add("properties", Json.createObjectBuilder()
+                                .add("status", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("enum", Json.createArrayBuilder()
+                                                .add("ADMITTED_BUT_NOT_DISCHARGED")
+                                                .add("DISCHARGED_BUT_FINAL_BILL_NOT_COMPLETED")
+                                                .add("DISCHARGED_AND_FINAL_BILL_COMPLETED")
+                                                .add("ANY_STATUS"))
+                                        .add("description", "Admission status filter. Default ADMITTED_BUT_NOT_DISCHARGED (currently active patients). Use ANY_STATUS to search past admissions too."))
+                                .add("bhtNo", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Bed Head Ticket number (partial match)."))
+                                .add("patientName", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Patient name (partial match)."))
+                                .add("mrn", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Patient MRN/PHN or patient code (exact match)."))
+                                .add("phone", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Patient or guardian phone/mobile number (exact match)."))
+                                .add("nic", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Patient NIC/passport number (exact match)."))
+                                .add("admissionTypeId", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Numeric AdmissionType ID filter."))
+                                .add("institutionId", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Numeric Institution ID filter."))
+                                .add("departmentId", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Numeric Department ID filter."))
+                                .add("fromDate", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Admission date range start, format yyyy-MM-dd HH:mm:ss. Must be supplied together with toDate."))
+                                .add("toDate", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Admission date range end, format yyyy-MM-dd HH:mm:ss. Must be supplied together with fromDate."))
+                                .add("page", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Page number, default 1."))
+                                .add("size", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Page size, default 50, max 200.")))
+                        .add("required", Json.createArrayBuilder()))
+                .build();
+
         JsonObject clinicalMetadataTool = Json.createObjectBuilder()
                 .add("name", "manage_clinical_metadata")
                 .add("description",
@@ -1938,6 +1996,7 @@ public class AnthropicApiService implements Serializable {
                 .add(searchConfigTool)
                 .add(manageConfigOptionTool)
                 .add(admissionNumberTool)
+                .add(admissionSearchTool)
                 .add(clinicalMetadataTool)
                 .add(itemRequestTool)
                 .add(collectingCentreFeesTool)
@@ -2014,6 +2073,16 @@ public class AnthropicApiService implements Serializable {
                     String lastAdmissionNumber = toolInput.containsKey("lastAdmissionNumber") ? toolInput.getString("lastAdmissionNumber", "") : "";
                     String expectedLastAdmissionNumber = toolInput.containsKey("expectedLastAdmissionNumber") ? toolInput.getString("expectedLastAdmissionNumber", "") : "";
                     return callAdmissionNumberApi(method, admissionTypeId, institutionId, lastAdmissionNumber, expectedLastAdmissionNumber, hmisBaseUrl, hmisApiKey);
+                }
+                case "search_admissions": {
+                    Map<String, String> params = new HashMap<>();
+                    for (String key : new String[]{"status", "bhtNo", "patientName", "mrn", "phone", "nic",
+                        "admissionTypeId", "institutionId", "departmentId", "fromDate", "toDate", "page", "size"}) {
+                        if (toolInput.containsKey(key)) {
+                            params.put(key, toolInput.getString(key, ""));
+                        }
+                    }
+                    return callAdmissionSearchApi(params, hmisBaseUrl, hmisApiKey);
                 }
                 case "manage_clinical_metadata": {
                     String method = toolInput.getString("method", "GET");
@@ -2799,6 +2868,50 @@ public class AnthropicApiService implements Serializable {
             return "Error: lastAdmissionNumber and expectedLastAdmissionNumber must be whole numbers.";
         } catch (Exception e) {
             return "Admission number API error: " + e.getMessage();
+        }
+    }
+
+    private String callAdmissionSearchApi(Map<String, String> params, String hmisBaseUrl, String hmisApiKey) {
+        if (hmisBaseUrl == null || hmisBaseUrl.trim().isEmpty()) {
+            return "Error: HMIS base URL is not configured. Cannot call admission search API.";
+        }
+        if (hmisApiKey == null || hmisApiKey.trim().isEmpty()) {
+            return "Error: No active HMIS API key found for the current user.";
+        }
+        try {
+            HttpClient client = HttpClient.newBuilder()
+                    .connectTimeout(Duration.ofSeconds(10))
+                    .build();
+
+            StringBuilder urlBuilder = new StringBuilder(
+                    hmisBaseUrl.trim().replaceAll("/+$", "") + "/api/inward/admissions");
+            boolean first = true;
+            for (Map.Entry<String, String> entry : params.entrySet()) {
+                if (entry.getValue() == null || entry.getValue().trim().isEmpty()) {
+                    continue;
+                }
+                urlBuilder.append(first ? "?" : "&")
+                        .append(entry.getKey())
+                        .append("=")
+                        .append(URLEncoder.encode(entry.getValue().trim(), StandardCharsets.UTF_8));
+                first = false;
+            }
+
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(urlBuilder.toString()))
+                    .timeout(Duration.ofSeconds(15))
+                    .header("Finance", hmisApiKey)
+                    .GET()
+                    .build();
+
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            return "HTTP " + response.statusCode() + "\n" + response.body();
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return "Admission search API call interrupted.";
+        } catch (Exception e) {
+            return "Admission search API error: " + e.getMessage();
         }
     }
 
@@ -6391,6 +6504,21 @@ public class AnthropicApiService implements Serializable {
                     {"GET",  "/apiInward/validateAdmission/{bht_no}/{phone}",                    "Validate BHT number and phone before payment"},
                     {"POST", "/apiInward/payment",                                                "Process online settlement payment for admitted patient (fields: bht_no, bank_id, reference_no, amount, payment_date)"},
                     {"GET",  "/apiInward/payment/{bht_no}/{bank_id}/{credit_card_ref}/{amount}", "Legacy GET-based payment endpoint"}
+                });
+
+        // ── Admission Search ──────────────────────────────────────────────────
+        appendModule(sb, "Admission Search", "/inward/admissions",
+                "General-purpose admission search — unlike /apiInward/admissions (a financial worklist "
+                + "scoped to unpaid/open admissions, capped at 20 rows), this lists all currently active "
+                + "(not-discharged) admissions, or searches past or current admissions by BHT, patient "
+                + "name, MRN/PHN, phone, or NIC, with no financial scoping and no row cap (paginated).",
+                githubUrl(branch, "developer_docs/api/using-apis/API_ADMISSION_DETAILS.md"),
+                new String[][]{
+                    {"GET", "/inward/admissions", "Search/list admissions. Params: status (default "
+                        + "ADMITTED_BUT_NOT_DISCHARGED; also DISCHARGED_BUT_FINAL_BILL_NOT_COMPLETED, "
+                        + "DISCHARGED_AND_FINAL_BILL_COMPLETED, ANY_STATUS), bhtNo, patientName, mrn, "
+                        + "phone, nic, admissionTypeId, institutionId, departmentId, fromDate, toDate "
+                        + "(yyyy-MM-dd HH:mm:ss, both required together), page (default 1), size (default 50, max 200)"}
                 });
 
         // ── Inward Discount Matrix ────────────────────────────────────────────

--- a/src/main/java/com/divudi/ws/common/ApplicationConfig.java
+++ b/src/main/java/com/divudi/ws/common/ApplicationConfig.java
@@ -68,6 +68,7 @@ public class ApplicationConfig extends Application {
         resources.add(com.divudi.ws.investigation.InvestigationFullApi.class);
         resources.add(com.divudi.ws.investigation.InvestigationValidatorApi.class);
         resources.add(com.divudi.ws.inward.AdmissionNumberApi.class);
+        resources.add(com.divudi.ws.inward.AdmissionSearchApi.class);
         resources.add(com.divudi.ws.inward.ApiInward.class);
         resources.add(com.divudi.ws.inward.InwardDiscountMatrixApi.class);
         resources.add(com.divudi.ws.inward.InwardDocumentTemplateApi.class);

--- a/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
+++ b/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
@@ -149,6 +149,16 @@ public class CapabilityStatementResource {
                 .add(resource("Admission Number Counters", "/api/admission-numbers",
                         "View or reset the BHT/OPD-card admission-number sequence counter for an admission type.",
                         "API Key (Finance header)", "GET", "PUT"))
+                .add(resource("Admission Search", "/api/inward/admissions",
+                        "General-purpose admission search — list all currently active (not-discharged) "
+                        + "admissions, or search past or current admissions by BHT no, patient name, "
+                        + "MRN/PHN, phone, or NIC. Unlike /api/apiInward/admissions this is not scoped to "
+                        + "unpaid/open admissions and has no row cap (paginated via page/size). "
+                        + "Params: status (ADMITTED_BUT_NOT_DISCHARGED default, "
+                        + "DISCHARGED_BUT_FINAL_BILL_NOT_COMPLETED, DISCHARGED_AND_FINAL_BILL_COMPLETED, "
+                        + "ANY_STATUS), bhtNo, patientName, mrn, phone, nic, admissionTypeId, institutionId, "
+                        + "departmentId, fromDate, toDate, page, size.",
+                        "API Key (Finance header)", "GET"))
                 .add(resource("Inward Discount Matrix", "/api/inward-discount-matrix",
                         "Manage inward discount matrix entries for services/investigations and pharmacy. "
                         + "Supports scope=service|pharmacy to restrict category types. "

--- a/src/main/java/com/divudi/ws/inward/AdmissionSearchApi.java
+++ b/src/main/java/com/divudi/ws/inward/AdmissionSearchApi.java
@@ -1,0 +1,372 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.ws.inward;
+
+import com.divudi.bean.common.ApiKeyController;
+import com.divudi.core.data.BillType;
+import com.divudi.core.data.inward.AdmissionStatus;
+import com.divudi.core.entity.ApiKey;
+import com.divudi.core.entity.PatientEncounter;
+import com.divudi.core.entity.WebUser;
+import com.divudi.core.entity.inward.Admission;
+import com.divudi.core.facade.BillItemFacade;
+import com.divudi.core.facade.PatientEncounterFacade;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.ejb.EJB;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+/**
+ * General-purpose admission search — unlike ApiInward's /admissions
+ * endpoints (a financial worklist scoped to unpaid/open admissions, capped
+ * at 20 rows), this endpoint mirrors AdmissionController.searchAdmissions()
+ * (the /inward/inpatient_search.xhtml backing query): it can list all
+ * currently-admitted (not-discharged) patients, or search past or current
+ * admissions by BHT, name, MRN/PHN, phone, or NIC — with no financial
+ * scoping and no row cap (paginated instead).
+ *
+ * @author Dr M H B Ariyaratne <buddhika.ari at gmail.com>
+ */
+@Path("inward/admissions")
+@RequestScoped
+public class AdmissionSearchApi {
+
+    @Context
+    private HttpServletRequest requestContext;
+
+    @Context
+    private UriInfo uriInfo;
+
+    @Inject
+    private ApiKeyController apiKeyController;
+
+    @EJB
+    private PatientEncounterFacade patientEncounterFacade;
+
+    @EJB
+    private BillItemFacade billItemFacade;
+
+    private static final Gson gson = new GsonBuilder().setDateFormat("yyyy-MM-dd HH:mm:ss").create();
+    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+    private static final int DEFAULT_PAGE_SIZE = 50;
+    private static final int MAX_PAGE_SIZE = 200;
+
+    /**
+     * GET /api/inward/admissions
+     *
+     * Query params (all optional):
+     * status (AdmissionStatus name, default ADMITTED_BUT_NOT_DISCHARGED),
+     * bhtNo, patientName, mrn, phone, nic, admissionTypeId, institutionId,
+     * departmentId, fromDate, toDate (yyyy-MM-dd HH:mm:ss, both required
+     * together), page (default 1), size (default 50, max 200).
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response searchAdmissions() {
+        WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+        if (user == null) {
+            return errorResponse("Not a valid key", 401);
+        }
+
+        try {
+            Map<String, String> q = new HashMap<>();
+            for (String key : uriInfo.getQueryParameters().keySet()) {
+                q.put(key, uriInfo.getQueryParameters().getFirst(key));
+            }
+
+            AdmissionStatus status = AdmissionStatus.ADMITTED_BUT_NOT_DISCHARGED;
+            if (nonEmpty(q.get("status"))) {
+                try {
+                    status = AdmissionStatus.valueOf(q.get("status").trim());
+                } catch (IllegalArgumentException e) {
+                    return errorResponse("Invalid status. Valid values: ADMITTED_BUT_NOT_DISCHARGED, "
+                            + "DISCHARGED_BUT_FINAL_BILL_NOT_COMPLETED, DISCHARGED_AND_FINAL_BILL_COMPLETED, "
+                            + "ANY_STATUS", 400);
+                }
+            }
+
+            Date fromDate = null;
+            Date toDate = null;
+            if (nonEmpty(q.get("fromDate")) || nonEmpty(q.get("toDate"))) {
+                if (!nonEmpty(q.get("fromDate")) || !nonEmpty(q.get("toDate"))) {
+                    return errorResponse("fromDate and toDate must both be supplied together.", 400);
+                }
+                try {
+                    fromDate = DATE_FORMAT.parse(q.get("fromDate").trim());
+                    toDate = DATE_FORMAT.parse(q.get("toDate").trim());
+                } catch (Exception e) {
+                    return errorResponse("Invalid fromDate/toDate format. Expected: yyyy-MM-dd HH:mm:ss", 400);
+                }
+            }
+
+            Long admissionTypeId = parseLongParam(q.get("admissionTypeId"));
+            Long institutionId = parseLongParam(q.get("institutionId"));
+            Long departmentId = parseLongParam(q.get("departmentId"));
+
+            int page = 1;
+            if (nonEmpty(q.get("page"))) {
+                try {
+                    page = Math.max(1, Integer.parseInt(q.get("page").trim()));
+                } catch (NumberFormatException e) {
+                    return errorResponse("Invalid page value.", 400);
+                }
+            }
+            int size = DEFAULT_PAGE_SIZE;
+            if (nonEmpty(q.get("size"))) {
+                try {
+                    size = Math.min(MAX_PAGE_SIZE, Math.max(1, Integer.parseInt(q.get("size").trim())));
+                } catch (NumberFormatException e) {
+                    return errorResponse("Invalid size value.", 400);
+                }
+            }
+
+            Map<String, Object> params = new HashMap<>();
+            String where = buildWhereClause(params, status, q.get("bhtNo"), q.get("patientName"),
+                    q.get("mrn"), q.get("phone"), q.get("nic"), admissionTypeId, institutionId,
+                    departmentId, fromDate, toDate);
+
+            long totalCount = getPatientEncounterFacade().findLongByJpql(
+                    "select count(c) from Admission c " + where, params);
+
+            int fromRecord = (page - 1) * size;
+            int toRecord = fromRecord + size - 1;
+            List<PatientEncounter> encounters = getPatientEncounterFacade().findByJpql(
+                    "select c from Admission c " + where + " order by c.id desc", params, fromRecord, toRecord);
+
+            List<Map<String, Object>> admissions = new ArrayList<>();
+            for (PatientEncounter pe : encounters) {
+                admissions.add(toResponseMap(pe));
+            }
+
+            Map<String, Object> data = new LinkedHashMap<>();
+            data.put("admissions", admissions);
+            data.put("page", page);
+            data.put("size", size);
+            data.put("totalCount", totalCount);
+
+            return successResponse(data);
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    // =========================================================================
+    // Private helpers
+    // =========================================================================
+
+    private String buildWhereClause(Map<String, Object> params, AdmissionStatus status, String bhtNo,
+            String patientName, String mrn, String phone, String nic, Long admissionTypeId,
+            Long institutionId, Long departmentId, Date fromDate, Date toDate) {
+        StringBuilder j = new StringBuilder("where c.retired=:ret and type(c)=:class ");
+        params.put("ret", false);
+        params.put("class", Admission.class);
+
+        if (fromDate != null && toDate != null) {
+            j.append(" and c.dateOfAdmission between :fd and :td ");
+            params.put("fd", fromDate);
+            params.put("td", toDate);
+        }
+
+        if (nonEmpty(bhtNo)) {
+            j.append(" and c.bhtNo like :bht ");
+            params.put("bht", "%" + bhtNo.trim() + "%");
+        }
+
+        if (nonEmpty(patientName)) {
+            j.append(" and c.patient.person.name like :name ");
+            params.put("name", "%" + patientName.trim() + "%");
+        }
+
+        if (nonEmpty(mrn)) {
+            j.append(" and (c.patient.code =:mrn or c.patient.phn =:mrn) ");
+            params.put("mrn", mrn.trim());
+        }
+
+        if (nonEmpty(phone)) {
+            j.append(" and (c.patient.person.phone =:phone or c.patient.person.mobile =:phone"
+                    + " or c.guardian.phone =:phone or c.guardian.mobile =:phone) ");
+            params.put("phone", phone.trim());
+        }
+
+        if (nonEmpty(nic)) {
+            j.append(" and c.patient.person.nic =:nic ");
+            params.put("nic", nic.trim());
+        }
+
+        if (admissionTypeId != null) {
+            j.append(" and c.admissionType.id =:atId ");
+            params.put("atId", admissionTypeId);
+        }
+
+        if (institutionId != null) {
+            j.append(" and c.institution.id =:insId ");
+            params.put("insId", institutionId);
+        }
+
+        if (departmentId != null) {
+            j.append(" and c.department.id =:deptId ");
+            params.put("deptId", departmentId);
+        }
+
+        switch (status) {
+            case ADMITTED_BUT_NOT_DISCHARGED:
+                j.append(" and c.discharged=:dis ");
+                params.put("dis", false);
+                break;
+            case DISCHARGED_BUT_FINAL_BILL_NOT_COMPLETED:
+                j.append(" and c.discharged=:dis and c.paymentFinalized=:bf ");
+                params.put("dis", true);
+                params.put("bf", false);
+                break;
+            case DISCHARGED_AND_FINAL_BILL_COMPLETED:
+                j.append(" and c.discharged=:dis and c.paymentFinalized=:bf ");
+                params.put("dis", true);
+                params.put("bf", true);
+                break;
+            case ANY_STATUS:
+            default:
+                break;
+        }
+
+        return j.toString();
+    }
+
+    private Map<String, Object> toResponseMap(PatientEncounter pe) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("patientEncounterId", pe.getId());
+        m.put("bhtNo", pe.getBhtNo());
+
+        if (pe.getPatient() != null) {
+            m.put("patientMrn", pe.getPatient().getPhn());
+            m.put("patientCode", pe.getPatient().getCode());
+            if (pe.getPatient().getPerson() != null) {
+                m.put("patientName", pe.getPatient().getPerson().getName());
+                m.put("patientPhone", pe.getPatient().getPerson().getPhone());
+                m.put("patientMobile", pe.getPatient().getPerson().getMobile());
+                m.put("patientNic", pe.getPatient().getPerson().getNic());
+                m.put("patientAddress", pe.getPatient().getPerson().getAddress());
+                m.put("patientArea", pe.getPatient().getPerson().getArea() != null
+                        ? pe.getPatient().getPerson().getArea().getName() : null);
+            }
+        }
+
+        m.put("referringDoctor", pe.getReferringDoctor() != null ? pe.getReferringDoctor().getName() : null);
+        m.put("admissionType", pe.getAdmissionType() != null ? pe.getAdmissionType().getName() : null);
+        m.put("institution", pe.getInstitution() != null ? pe.getInstitution().getName() : null);
+        m.put("department", pe.getDepartment() != null ? pe.getDepartment().getName() : null);
+        m.put("currentRoom", pe.getCurrentPatientRoom() != null ? pe.getCurrentPatientRoom().getName() : null);
+        m.put("dateOfAdmission", pe.getDateOfAdmission());
+        m.put("dateOfDischarge", pe.getDateOfDischarge());
+        m.put("discharged", pe.getDischarged() != null && pe.getDischarged());
+        m.put("paymentFinalized", pe.isPaymentFinalized());
+
+        if (pe.getFinalBill() != null) {
+            double netTotal = pe.getFinalBill().getNetTotal();
+            double paidAmount = pe.getFinalBill().getPaidAmount() + fetchCreditPaymentTotal(pe);
+            m.put("netTotal", netTotal);
+            m.put("paidAmount", paidAmount);
+            m.put("balance", netTotal - paidAmount);
+        }
+
+        return m;
+    }
+
+    private double fetchCreditPaymentTotal(PatientEncounter pe) {
+        String sql = "SELECT sum(bi.netValue) FROM BillItem bi "
+                + " WHERE bi.retired=false "
+                + " and bi.bill.billType=:bty"
+                + " and bi.patientEncounter=:bhtno";
+        Map<String, Object> m = new HashMap<>();
+        m.put("bty", BillType.CashRecieveBill);
+        m.put("bhtno", pe);
+        return getBillItemFacade().findDoubleByJpql(sql, m);
+    }
+
+    private boolean nonEmpty(String s) {
+        return s != null && !s.trim().isEmpty();
+    }
+
+    private Long parseLongParam(String s) {
+        if (!nonEmpty(s)) {
+            return null;
+        }
+        try {
+            return Long.parseLong(s.trim());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private WebUser validateApiKey(String key) {
+        if (key == null || key.trim().isEmpty()) {
+            return null;
+        }
+
+        ApiKey apiKey = apiKeyController.findApiKey(key);
+        if (apiKey == null) {
+            return null;
+        }
+
+        WebUser user = apiKey.getWebUser();
+        if (user == null) {
+            return null;
+        }
+
+        if (user.isRetired()) {
+            return null;
+        }
+
+        if (!user.isActivated()) {
+            return null;
+        }
+
+        if (apiKey.getDateOfExpiary() == null || apiKey.getDateOfExpiary().before(new Date())) {
+            return null;
+        }
+
+        return user;
+    }
+
+    private Response errorResponse(String message, int code) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("status", "error");
+        response.put("code", code);
+        response.put("message", message);
+        return Response.status(code).entity(gson.toJson(response)).build();
+    }
+
+    private Response successResponse(Object data) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("status", "success");
+        response.put("code", 200);
+        response.put("data", data);
+        return Response.status(200).entity(gson.toJson(response)).build();
+    }
+
+    public PatientEncounterFacade getPatientEncounterFacade() {
+        return patientEncounterFacade;
+    }
+
+    public BillItemFacade getBillItemFacade() {
+        return billItemFacade;
+    }
+}

--- a/src/main/java/com/divudi/ws/inward/AdmissionSearchApi.java
+++ b/src/main/java/com/divudi/ws/inward/AdmissionSearchApi.java
@@ -66,7 +66,7 @@ public class AdmissionSearchApi {
     private BillItemFacade billItemFacade;
 
     private static final Gson gson = new GsonBuilder().setDateFormat("yyyy-MM-dd HH:mm:ss").create();
-    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+    private static final String DATE_PATTERN = "yyyy-MM-dd HH:mm:ss";
     private static final int DEFAULT_PAGE_SIZE = 50;
     private static final int MAX_PAGE_SIZE = 200;
 
@@ -111,16 +111,23 @@ public class AdmissionSearchApi {
                     return errorResponse("fromDate and toDate must both be supplied together.", 400);
                 }
                 try {
-                    fromDate = DATE_FORMAT.parse(q.get("fromDate").trim());
-                    toDate = DATE_FORMAT.parse(q.get("toDate").trim());
+                    fromDate = new SimpleDateFormat(DATE_PATTERN).parse(q.get("fromDate").trim());
+                    toDate = new SimpleDateFormat(DATE_PATTERN).parse(q.get("toDate").trim());
                 } catch (Exception e) {
                     return errorResponse("Invalid fromDate/toDate format. Expected: yyyy-MM-dd HH:mm:ss", 400);
                 }
             }
 
-            Long admissionTypeId = parseLongParam(q.get("admissionTypeId"));
-            Long institutionId = parseLongParam(q.get("institutionId"));
-            Long departmentId = parseLongParam(q.get("departmentId"));
+            Long admissionTypeId;
+            Long institutionId;
+            Long departmentId;
+            try {
+                admissionTypeId = parseRequiredLongParam(q.get("admissionTypeId"));
+                institutionId = parseRequiredLongParam(q.get("institutionId"));
+                departmentId = parseRequiredLongParam(q.get("departmentId"));
+            } catch (NumberFormatException e) {
+                return errorResponse("Invalid admissionTypeId/institutionId/departmentId value. Must be numeric.", 400);
+            }
 
             int page = 1;
             if (nonEmpty(q.get("page"))) {
@@ -165,7 +172,9 @@ public class AdmissionSearchApi {
 
             return successResponse(data);
         } catch (Exception e) {
-            return errorResponse("An error occurred: " + e.getMessage(), 500);
+            java.util.logging.Logger.getLogger(AdmissionSearchApi.class.getName())
+                    .log(java.util.logging.Level.SEVERE, "Admission search failed", e);
+            return errorResponse("An error occurred while searching admissions.", 500);
         }
     }
 
@@ -305,15 +314,16 @@ public class AdmissionSearchApi {
         return s != null && !s.trim().isEmpty();
     }
 
-    private Long parseLongParam(String s) {
+    /**
+     * Parses an optional numeric filter param. Returns null when absent/blank;
+     * throws NumberFormatException (rather than silently dropping the filter)
+     * when present but not numeric.
+     */
+    private Long parseRequiredLongParam(String s) {
         if (!nonEmpty(s)) {
             return null;
         }
-        try {
-            return Long.parseLong(s.trim());
-        } catch (NumberFormatException e) {
-            return null;
-        }
+        return Long.parseLong(s.trim());
     }
 
     private WebUser validateApiKey(String key) {


### PR DESCRIPTION
## Summary

- `ApiInward`'s `/apiInward/admissions*` endpoints are a financial worklist — scoped to unpaid/open admissions, capped at 20 rows, and with no MRN search. There was no REST equivalent of the staff-facing search page (`inpatient_search.xhtml` / `AdmissionController.searchAdmissions()`).
- Adds `GET /api/inward/admissions` (new `AdmissionSearchApi`), mirroring that search page's filter set — `status`, `bhtNo`, `patientName`, `mrn`, `phone`, `nic`, `admissionTypeId`, `institutionId`, `departmentId`, `fromDate`/`toDate` — with pagination (`page`/`size`) instead of a hard row cap.
- Default `status=ADMITTED_BUT_NOT_DISCHARGED` lists all currently active patients; `status=ANY_STATUS` + `mrn`/`phone` searches past **or** current admissions.
- Registered in `ApplicationConfig` and `CapabilityStatementResource`; wired into `AnthropicApiService` (system prompt module + `search_admissions` tool + HTTP-call handler) so the AI chat assistant can call it.
- Updated `developer_docs/api/using-apis/API_ADMISSION_DETAILS.md` and `API_INWARD.md` with the new endpoint reference and examples.

Closes #22754

## Test plan

No UI changes — verified locally via curl against a local Payara + MySQL `coop` DB after `mvn clean package` + `asadmin redeploy`:

- [x] `GET /api/inward/admissions` (no params) → returns only not-discharged admissions, matches DB query for the same filter, `totalCount` correct
- [x] `GET /api/inward/admissions?status=ANY_STATUS&phone=<mobile>` → found a **discharged** admission by phone (proves past-admission search)
- [x] `GET /api/inward/admissions?status=ANY_STATUS&mrn=<phn>` and `?mrn=<patient code>` → both sides of the MRN OR-filter (`patient.phn` / `patient.code`) return the correct admission
- [x] `GET /api/inward/admissions?bhtNo=<partial>` → correct single-match filtering
- [x] `?page=1&size=1` vs `?page=2&size=1` → correct offset, stable `totalCount` across pages
- [x] Invalid `status` value → `400` with valid-values message
- [x] `fromDate` supplied without `toDate` → `400`
- [x] Missing/invalid `Finance` header → `401`
- [x] `GET /api/capabilities` → new "Admission Search" resource entry present
- [x] Server log checked clean (no `SEVERE`/exceptions) through redeploy and all test requests
- [x] `mvn compile` clean after each wiring change (REST class, `ApplicationConfig`, `CapabilityStatementResource`, `AnthropicApiService`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added admission search with filters for status, patient details, location, dates, and pagination.
  * Search results include admission, patient, billing, payment, and balance information.
  * Added structured validation and error responses for unauthorized or invalid requests.
  * Added AI-assisted admission search support.
* **Documentation**
  * Added comprehensive admission API guidance, examples, response formats, filtering, pagination, and authentication details.
  * Clarified the distinction between full admission search and financial worklists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->