### PR TITLE
feat(pharmacy): native SQL Purchase Order Approving page (Phase 2 of #22726)

### DIFF
--- a/docs/superpowers/plans/2026-08-08-po-approving-native.md
+++ b/docs/superpowers/plans/2026-08-08-po-approving-native.md
@@ -12,7 +12,8 @@ owns native INSERT/UPDATE for the approved bill's own `bill`/`billitem`/
 `pharmaceuticalbillitem` rows, reusing Phase 1's `PurchaseOrderRequestNativeSqlService`
 for line-value math and `PurchaseOrderRequestLineData` as the shared DTO shape.
 New `PurchaseOrderApprovingNativeSqlController` (`@Named @SessionScoped`) owns
-page state, guards, and the JPA-only cross-link write. New page
+page state, guards, and (as revised during PR review — see note below) the
+native cross-link write. New page
 `pharmacy_purhcase_order_approving_native.xhtml` is a 1:1 layout port.
 
 **Tech Stack:** JPA (EclipseLink) native queries via `EntityManager`, JSF/PrimeFaces, JUnit 5.
@@ -21,10 +22,18 @@ page state, guards, and the JPA-only cross-link write. New page
 
 - **Requirement: 100% functional replication.** Every button, validation
   message, and guard on the legacy page carries over.
-- **`requestedBill.referenceBill = approvedBill` cross-link write stays JPA
-  merge, never native SQL** — L2-cache-coherence rule from master issue #22726.
-- **`requestedBill` entity itself stays on JPA throughout** — only the new
-  `approvedBill`'s own rows go through native SQL.
+- **`requestedBill.referenceBill = approvedBill` cross-link write: originally
+  JPA merge only (L2-cache-coherence rule from master issue #22726),
+  superseded during PR review.** Both cross-link directions
+  (`approvedBill.referenceBill` and `requestedBill.referenceBill`) are now
+  native `UPDATE` writes — see the design spec §2/§7 for why: a
+  `billFacade.edit()` merge on a bill whose lines were written by native SQL
+  through a sibling EJB risks EclipseLink orphan-removal deleting those
+  lines, and this applies to `requestedBill`'s merge exactly as it did to
+  `approvedBill`'s. Confirmed working live via Playwright + direct DB query.
+- **`requestedBill` entity itself stays read-only via JPA for guard checks
+  and header seeding** — only its persisted cross-link write moved to native
+  SQL; it is never merged via `billFacade.edit()`.
 - **Recompute line values from 5 raw inputs, never copy legacy's ~25 BIFD
   fields verbatim.** Reuse `PurchaseOrderRequestNativeSqlService.computeLineValues()`
   and `LineValues` directly (both package-private in `com.divudi.service.pharmacy`,

--- a/docs/superpowers/plans/2026-08-08-po-approving-native.md
+++ b/docs/superpowers/plans/2026-08-08-po-approving-native.md
@@ -1,0 +1,1561 @@
+# Native Purchase Order Approving Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the write path of the Purchase Order Approving page
+(`pharmacy_purhcase_order_approving.xhtml` / `PurchaseOrderController`) with a
+native-SQL implementation, per
+`docs/superpowers/specs/2026-08-08-po-approving-native-design.md`.
+
+**Architecture:** New `PurchaseOrderApprovingNativeSqlService` (`@Stateless`)
+owns native INSERT/UPDATE for the approved bill's own `bill`/`billitem`/
+`pharmaceuticalbillitem` rows, reusing Phase 1's `PurchaseOrderRequestNativeSqlService`
+for line-value math and `PurchaseOrderRequestLineData` as the shared DTO shape.
+New `PurchaseOrderApprovingNativeSqlController` (`@Named @SessionScoped`) owns
+page state, guards, and the JPA-only cross-link write. New page
+`pharmacy_purhcase_order_approving_native.xhtml` is a 1:1 layout port.
+
+**Tech Stack:** JPA (EclipseLink) native queries via `EntityManager`, JSF/PrimeFaces, JUnit 5.
+
+## Global Constraints
+
+- **Requirement: 100% functional replication.** Every button, validation
+  message, and guard on the legacy page carries over.
+- **`requestedBill.referenceBill = approvedBill` cross-link write stays JPA
+  merge, never native SQL** — L2-cache-coherence rule from master issue #22726.
+- **`requestedBill` entity itself stays on JPA throughout** — only the new
+  `approvedBill`'s own rows go through native SQL.
+- **Recompute line values from 5 raw inputs, never copy legacy's ~25 BIFD
+  fields verbatim.** Reuse `PurchaseOrderRequestNativeSqlService.computeLineValues()`
+  and `LineValues` directly (both package-private in `com.divudi.service.pharmacy`,
+  visible to the new service in the same package) rather than duplicating the logic.
+- **Reuse `PurchaseOrderRequestLineData`** as both the write-side line DTO
+  (as Phase 1 uses it) and the read-side projection returned by
+  `loadRequestedLines()` — do not create a second, near-identical DTO class.
+- Both `navigateToPurchaseOrderApproval()` and `approve()` must be
+  `synchronized`, with an already-approved re-check inside `approve()` even
+  though `navigateToPurchaseOrderApproval()` already checked it — this is the
+  fix for a real production incident (GRN item duplication,
+  PO/RH/GSK/26/01093), not defensive boilerplate to be simplified away.
+- Evict `Bill`, `BillItem`, `PharmaceuticalBillItem`, `BillItemFinanceDetails`
+  from L2 cache after every native INSERT/UPDATE.
+- HTML-escape every free-text field in `generatePurchaseOrderHtml()` from the
+  start (institution/supplier name, address, phone, item code/name, person
+  names) — Phase 1 had to fix this after review; do it correctly here first.
+- `navigateToPurchaseOrderApproval(Long requestedBillId)` must guard the
+  loaded bill: reject if not `BillTypeAtomic.PHARMACY_ORDER`, retired,
+  cancelled, or not owned by the logged-in user's department — same fix
+  Phase 1 needed after review, applied here from the start.
+- Apache Commons Text (`org.apache.commons.text.StringEscapeUtils`) is
+  already a project dependency (used in Phase 1) — reuse it, don't add a new
+  escaping utility.
+
+---
+
+### Task 1: `PurchaseOrderApprovingNativeSqlService` — bill and line persistence
+
+**Files:**
+- Create: `src/main/java/com/divudi/service/pharmacy/PurchaseOrderApprovingNativeSqlService.java`
+- Test: `src/test/java/com/divudi/service/pharmacy/PurchaseOrderApprovingNativeSqlServiceTest.java`
+
+**Interfaces:**
+- Consumes: `PurchaseOrderRequestNativeSqlService.computeLineValues(PurchaseOrderRequestLineData)`
+  → `PurchaseOrderRequestNativeSqlService.LineValues` (package-private, same
+  package `com.divudi.service.pharmacy`); `PurchaseOrderRequestNativeSqlService.isZeroQtyLine(double, double)`
+  (package-private). `PurchaseOrderRequestLineData` (`com.divudi.core.data.dto.pharmacy`)
+  as both the line-write DTO and the `loadRequestedLines()` return type.
+- Produces: `long createApprovedBill(long requestedBillId, long departmentId, long institutionId, long fromDepartmentId, long fromInstitutionId, long createrId, String deptId, String insId)`,
+  `void updateApprovedBillHeader(long approvedBillId, Long toInstitutionId, PaymentMethod paymentMethod, int creditDuration, boolean consignment, DepartmentType departmentType, String comments, Long editorId)`,
+  `long saveApprovedLine(long approvedBillId, PurchaseOrderRequestLineData line)`,
+  `int retireZeroQtyApprovedLines(long approvedBillId, long retirerId)`,
+  `List<PurchaseOrderRequestLineData> loadRequestedLines(long requestedBillId)`
+  — used by later tasks (Task 3 controller).
+
+This service owns only the **approved** bill's own rows. It never reads or
+writes the requested bill (that stays JPA, owned by the controller in Task 3).
+
+- [ ] **Step 1: Scaffold the service class and table-name resolution**
+
+Mirror `PurchaseOrderRequestNativeSqlService`'s `resolveTable`/`billTable`/
+`billItemTable`/`pharmBillItemTable` pattern exactly (case-insensitive table
+name resolution via `INFORMATION_SCHEMA`, cached in instance fields) — this
+project's migration guide requires it for cross-deployment case sensitivity.
+
+```java
+package com.divudi.service.pharmacy;
+
+import com.divudi.core.data.BillTypeAtomic;
+import com.divudi.core.data.BillType;
+import com.divudi.core.data.DepartmentType;
+import com.divudi.core.data.PaymentMethod;
+import com.divudi.core.data.dto.pharmacy.PurchaseOrderRequestLineData;
+import com.divudi.core.entity.BillItemFinanceDetails;
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * Native SQL write path for the Purchase Order Approving bill.
+ * Only the APPROVED bill's own bill / billitem / pharmaceuticalbillitem rows
+ * are touched here -- the requested bill stays JPA (see
+ * PurchaseOrderApprovingNativeSqlController). BillItemFinanceDetails stays
+ * JPA (IDENTITY PK, calculation-heavy), matching
+ * PurchaseOrderRequestNativeSqlService's split.
+ * Related issue: #22738
+ */
+@Stateless
+public class PurchaseOrderApprovingNativeSqlService {
+
+    @PersistenceContext(unitName = "hmisPU")
+    private EntityManager em;
+
+    @EJB
+    private PurchaseOrderRequestNativeSqlService purchaseOrderRequestNativeSqlService;
+
+    private String tBill;
+    private String tBillItem;
+    private String tPharmBillItem;
+
+    private String resolveTable(String upperName) {
+        Object name = em.createNativeQuery(
+            "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES "
+            + "WHERE TABLE_SCHEMA = DATABASE() AND UPPER(TABLE_NAME) = ? LIMIT 1")
+            .setParameter(1, upperName)
+            .getSingleResult();
+        return name.toString();
+    }
+
+    private String billTable() {
+        if (tBill == null) tBill = resolveTable("BILL");
+        return tBill;
+    }
+
+    private String billItemTable() {
+        if (tBillItem == null) tBillItem = resolveTable("BILLITEM");
+        return tBillItem;
+    }
+
+    private String pharmBillItemTable() {
+        if (tPharmBillItem == null) tPharmBillItem = resolveTable("PHARMACEUTICALBILLITEM");
+        return tPharmBillItem;
+    }
+
+    private void evictCache() {
+        javax.persistence.Cache cache = em.getEntityManagerFactory().getCache();
+        cache.evict(com.divudi.core.entity.Bill.class);
+    }
+
+    private void evictLineCache() {
+        javax.persistence.Cache cache = em.getEntityManagerFactory().getCache();
+        cache.evict(com.divudi.core.entity.Bill.class);
+        cache.evict(com.divudi.core.entity.BillItem.class);
+        cache.evict(com.divudi.core.entity.pharmacy.PharmaceuticalBillItem.class);
+        cache.evict(BillItemFinanceDetails.class);
+    }
+}
+```
+
+- [ ] **Step 2: `createApprovedBill` — native INSERT for the approved bill row**
+
+Sets the cross-link FKs (`referenceBill_ID` on this row points nowhere yet —
+the *requested* bill's `referenceBill_ID` points here, written later in JPA
+by the controller; this row's own `backwardReferenceBill_ID` points at the
+requested bill, matching legacy's `setBackwardReferenceBill(getRequestedBill())`).
+`billClassType` is `BilledBill` per legacy's `new BilledBill()` — write it as
+a literal column too, matching how `BillTypeAtomic`/`BillType` are written as
+`.toString()` elsewhere in Phase 1's service.
+
+```java
+public long createApprovedBill(long requestedBillId, long departmentId, long institutionId,
+        long fromDepartmentId, long fromInstitutionId, long createrId, String deptId, String insId) {
+    Date now = new Date();
+    em.createNativeQuery(
+        "INSERT INTO " + billTable()
+        + " (BILLTYPEATOMIC, billType, billClassType, department_ID, institution_ID,"
+        + " fromDepartment_ID, fromInstitution_ID, backwardReferenceBill_ID,"
+        + " creater_ID, createdAt, checked, retired, cancelled, deptId, insId, netTotal, total)"
+        + " VALUES (?,?,?,?,?,?,?,?,?,?,0,0,0,?,?,0,0)")
+        .setParameter(1, BillTypeAtomic.PHARMACY_ORDER_APPROVAL.toString())
+        .setParameter(2, BillType.PharmacyOrderApprove.toString())
+        .setParameter(3, com.divudi.core.data.BillClassType.BilledBill.toString())
+        .setParameter(4, departmentId)
+        .setParameter(5, institutionId)
+        .setParameter(6, fromDepartmentId)
+        .setParameter(7, fromInstitutionId)
+        .setParameter(8, requestedBillId)
+        .setParameter(9, createrId)
+        .setParameter(10, new Timestamp(now.getTime()))
+        .setParameter(11, deptId)
+        .setParameter(12, insId)
+        .executeUpdate();
+    long billId = ((Number) em.createNativeQuery("SELECT LAST_INSERT_ID()").getSingleResult()).longValue();
+    evictCache();
+    return billId;
+}
+```
+
+Note: verify `BillClassType` is a plain Java `enum` (not a JPA-only
+converter-backed type) before writing `.toString()` — check
+`src/main/java/com/divudi/core/data/BillClassType.java` (or wherever it
+lives; grep first) the same way `BillTypeAtomic`/`BillType`/`PaymentMethod`
+were confirmed as plain enums in Phase 1. If `billClassType` turns out to be
+set automatically by the `BilledBill` JPA subclass discriminator rather than
+a plain column, drop it from this INSERT and rely on `BILLTYPEATOMIC`/
+`billType` alone, matching whichever pattern the existing `Bill`/`BilledBill`
+mapping actually uses.
+
+- [ ] **Step 3: `updateApprovedBillHeader` — native UPDATE for payment method / supplier / etc.**
+
+Mirrors `PurchaseOrderRequestNativeSqlService.updateDraftBillHeader` exactly
+(including the `comments` column, present in that method after Phase 1's
+post-merge review fix — do not omit it here).
+
+```java
+public void updateApprovedBillHeader(long approvedBillId, Long toInstitutionId, PaymentMethod paymentMethod,
+        int creditDuration, boolean consignment, DepartmentType departmentType, String comments, Long editorId) {
+    em.createNativeQuery(
+        "UPDATE " + billTable()
+        + " SET toInstitution_ID=?, paymentMethod=?, creditDuration=?, consignment=?,"
+        + " departmentType=?, comments=?, editor_ID=?, editedAt=?"
+        + " WHERE ID=?")
+        .setParameter(1, toInstitutionId)
+        .setParameter(2, paymentMethod != null ? paymentMethod.toString() : null)
+        .setParameter(3, creditDuration)
+        .setParameter(4, consignment ? 1 : 0)
+        .setParameter(5, departmentType != null ? departmentType.toString() : null)
+        .setParameter(6, comments)
+        .setParameter(7, editorId)
+        .setParameter(8, new Timestamp(new Date().getTime()))
+        .setParameter(9, approvedBillId)
+        .executeUpdate();
+    evictCache();
+}
+```
+
+- [ ] **Step 4: `saveApprovedLine` — native INSERT/UPDATE for billitem + pharmaceuticalbillitem**
+
+Copy `PurchaseOrderRequestNativeSqlService.saveLine()` verbatim, including
+its post-review upsert-by-existence fix for the PBI row (UPDATE first,
+INSERT only if 0 rows affected — never branch on
+`line.getPharmaceuticalBillItemId()`), and its `saveBillItemFinanceDetails`
+helper for the JPA-persisted `BillItemFinanceDetails`. The only difference
+from Phase 1: `billItemId`'s owning `bill_ID` is the **approved** bill, and
+the `computeLineValues()` call delegates to
+`purchaseOrderRequestNativeSqlService.computeLineValues(line)` (injected
+`@EJB`) instead of a local copy — do not duplicate that method's logic here.
+
+```java
+public long saveApprovedLine(long approvedBillId, PurchaseOrderRequestLineData line) {
+    PurchaseOrderRequestNativeSqlService.LineValues v = purchaseOrderRequestNativeSqlService.computeLineValues(line);
+    BigDecimal qty = v.qty, freeQty = v.freeQty, purchaseRate = v.purchaseRate, retailRate = v.retailRate;
+    BigDecimal grossValue = v.grossValue, netValue = v.netValue, netRate = v.netRate;
+    BigDecimal purchaseValue = v.purchaseValue, retailValue = v.retailValue, unitsPerPack = v.unitsPerPack;
+
+    long billItemId;
+    if (line.getBillItemId() == null) {
+        em.createNativeQuery(
+            "INSERT INTO " + billItemTable()
+            + " (bill_ID, item_ID, qty, netValue, grossValue, Rate, netRate,"
+            + " createdAt, creater_ID, retired, refunded, billItemRefunded,"
+            + " consideredForCosting, inwardChargeType, searialNo)"
+            + " VALUES (?,?,?,?,?,?,?,?,?,0,0,0,1,'Medicine',?)")
+            .setParameter(1, approvedBillId)
+            .setParameter(2, line.getItemId())
+            .setParameter(3, qty.doubleValue())
+            .setParameter(4, netValue.doubleValue())
+            .setParameter(5, grossValue.doubleValue())
+            .setParameter(6, purchaseRate.doubleValue())
+            .setParameter(7, netRate.doubleValue())
+            .setParameter(8, new Timestamp(new Date().getTime()))
+            .setParameter(9, line.getCreaterId())
+            .setParameter(10, line.getSerialNo())
+            .executeUpdate();
+        billItemId = ((Number) em.createNativeQuery("SELECT LAST_INSERT_ID()").getSingleResult()).longValue();
+    } else {
+        billItemId = line.getBillItemId();
+        em.createNativeQuery(
+            "UPDATE " + billItemTable()
+            + " SET qty=?, netValue=?, grossValue=?, Rate=?, netRate=? WHERE ID=?")
+            .setParameter(1, qty.doubleValue())
+            .setParameter(2, netValue.doubleValue())
+            .setParameter(3, grossValue.doubleValue())
+            .setParameter(4, purchaseRate.doubleValue())
+            .setParameter(5, netRate.doubleValue())
+            .setParameter(6, billItemId)
+            .executeUpdate();
+    }
+
+    double pbiQty = v.pbiQty, pbiFreeQty = v.pbiFreeQty, pbiPurchaseRate = v.pbiPurchaseRate, pbiRetailRate = v.pbiRetailRate;
+
+    int updated = em.createNativeQuery(
+            "UPDATE " + pharmBillItemTable()
+            + " SET qty=?, freeQty=?, purchaseRate=?, purchaseRatePack=?, purchaseValue=?,"
+            + " retailRate=?, retailRatePack=?, retailRateInUnit=?, retailValue=?,"
+            + " remainingQty=?, remainingFreeQty=? WHERE billItem_ID=?")
+            .setParameter(1, pbiQty)
+            .setParameter(2, pbiFreeQty)
+            .setParameter(3, pbiPurchaseRate)
+            .setParameter(4, purchaseRate.doubleValue())
+            .setParameter(5, purchaseValue.doubleValue())
+            .setParameter(6, pbiRetailRate)
+            .setParameter(7, retailRate.doubleValue())
+            .setParameter(8, pbiRetailRate)
+            .setParameter(9, retailValue.doubleValue())
+            .setParameter(10, pbiQty)
+            .setParameter(11, pbiFreeQty)
+            .setParameter(12, billItemId)
+            .executeUpdate();
+
+    if (updated == 0) {
+        em.createNativeQuery(
+            "INSERT INTO " + pharmBillItemTable()
+            + " (billItem_ID, qty, freeQty, purchaseRate, purchaseRatePack, purchaseValue,"
+            + " retailRate, retailRatePack, retailRateInUnit, retailValue, remainingQty, remainingFreeQty,"
+            + " costRate, costRatePack, costValue, createdAt, creater_ID)"
+            + " VALUES (?,?,?,?,?,?,?,?,?,?,?,?,0,0,0,?,?)")
+            .setParameter(1, billItemId)
+            .setParameter(2, pbiQty)
+            .setParameter(3, pbiFreeQty)
+            .setParameter(4, pbiPurchaseRate)
+            .setParameter(5, purchaseRate.doubleValue())
+            .setParameter(6, purchaseValue.doubleValue())
+            .setParameter(7, pbiRetailRate)
+            .setParameter(8, retailRate.doubleValue())
+            .setParameter(9, pbiRetailRate)
+            .setParameter(10, retailValue.doubleValue())
+            .setParameter(11, pbiQty)
+            .setParameter(12, pbiFreeQty)
+            .setParameter(13, new Timestamp(new Date().getTime()))
+            .setParameter(14, line.getCreaterId())
+            .executeUpdate();
+    }
+
+    saveBillItemFinanceDetails(billItemId, line, qty, freeQty, purchaseRate, retailRate, netValue, grossValue,
+            netRate, unitsPerPack, pbiQty, pbiFreeQty);
+
+    evictLineCache();
+    return billItemId;
+}
+
+private void saveBillItemFinanceDetails(long billItemId, PurchaseOrderRequestLineData line,
+        BigDecimal qty, BigDecimal freeQty, BigDecimal purchaseRate, BigDecimal retailRate,
+        BigDecimal netValue, BigDecimal grossValue, BigDecimal netRate, BigDecimal unitsPerPack,
+        double quantityByUnits, double freeQuantityByUnits) {
+    BillItemFinanceDetails bifd;
+    if (line.getBillItemId() != null) {
+        String jpql = "SELECT bi.billItemFinanceDetails FROM BillItem bi WHERE bi.id = :id";
+        List<BillItemFinanceDetails> existing = em.createQuery(jpql, BillItemFinanceDetails.class)
+                .setParameter("id", billItemId)
+                .getResultList();
+        bifd = (existing != null && !existing.isEmpty() && existing.get(0) != null) ? existing.get(0) : new BillItemFinanceDetails();
+    } else {
+        bifd = new BillItemFinanceDetails();
+    }
+
+    bifd.setLineNetRate(purchaseRate);
+    bifd.setLineGrossRate(purchaseRate);
+    bifd.setGrossRate(purchaseRate);
+    bifd.setLineNetTotal(netValue);
+    bifd.setLineGrossTotal(grossValue);
+    bifd.setGrossTotal(grossValue);
+    bifd.setQuantity(qty);
+    bifd.setFreeQuantity(freeQty);
+    bifd.setQuantityByUnits(BigDecimal.valueOf(quantityByUnits));
+    bifd.setFreeQuantityByUnits(BigDecimal.valueOf(freeQuantityByUnits));
+    bifd.setRetailSaleRate(retailRate);
+    bifd.setUnitsPerPack(unitsPerPack);
+    bifd.setValueAtPurchaseRate(purchaseRate.multiply(qty.add(freeQty)));
+    bifd.setValueAtRetailRate(retailRate.multiply(qty.add(freeQty)));
+    bifd.setLineCost(BigDecimal.ZERO);
+    bifd.setLineCostRate(BigDecimal.ZERO);
+    bifd.setValueAtCostRate(BigDecimal.ZERO);
+
+    if (bifd.getId() == null) {
+        bifd.setCreatedAt(new Date());
+        em.persist(bifd);
+        em.flush();
+        em.createNativeQuery("UPDATE " + billItemTable() + " SET BILLITEMFINANCEDETAILS_ID=? WHERE ID=?")
+                .setParameter(1, bifd.getId())
+                .setParameter(2, billItemId)
+                .executeUpdate();
+    } else {
+        em.merge(bifd);
+    }
+}
+```
+
+Note the two differences from Phase 1's `saveLine`, both intentional and
+required by this spec (§2 "remainingQty/remainingFreeQty" note): the PBI
+UPDATE/INSERT here also sets `remainingQty=pbiQty, remainingFreeQty=pbiFreeQty`
+inline (legacy's `saveBillComponent()` sets these explicitly on approve;
+Phase 1's Request-side `saveLine` never needed them because a request line
+has no "remaining" concept until it's approved).
+
+- [ ] **Step 5: `retireZeroQtyApprovedLines` — copy verbatim from Phase 1, adjusted retire comment**
+
+Copy `PurchaseOrderRequestNativeSqlService.retireZeroQtyLines()` exactly,
+delegating the zero-qty predicate to
+`purchaseOrderRequestNativeSqlService.isZeroQtyLine(qty, freeQty)` instead of
+a local copy, and changing the retire comment string to `"Retired at
+Approving PO"` (matching legacy's `saveBillComponent()` comment, distinct
+from the Request page's `"Retired at Finalising PO"`).
+
+```java
+@SuppressWarnings("unchecked")
+public int retireZeroQtyApprovedLines(long approvedBillId, long retirerId) {
+    List<Object[]> rows = em.createNativeQuery(
+        "SELECT bi.ID, pbi.qty, pbi.freeQty FROM " + billItemTable() + " bi "
+        + "JOIN " + pharmBillItemTable() + " pbi ON pbi.billItem_ID = bi.ID "
+        + "WHERE bi.bill_ID = ? AND bi.retired = 0")
+        .setParameter(1, approvedBillId)
+        .getResultList();
+
+    int survivingCount = 0;
+    Timestamp now = new Timestamp(new Date().getTime());
+    for (Object[] row : rows) {
+        long billItemId = ((Number) row[0]).longValue();
+        double qty = row[1] != null ? ((Number) row[1]).doubleValue() : 0.0;
+        double freeQty = row[2] != null ? ((Number) row[2]).doubleValue() : 0.0;
+
+        if (purchaseOrderRequestNativeSqlService.isZeroQtyLine(qty, freeQty)) {
+            em.createNativeQuery(
+                "UPDATE " + billItemTable() + " SET retired=1, retirer_ID=?, retiredAt=?, retireComments=? WHERE ID=?")
+                .setParameter(1, retirerId)
+                .setParameter(2, now)
+                .setParameter(3, "Retired at Approving PO")
+                .setParameter(4, billItemId)
+                .executeUpdate();
+            em.createNativeQuery(
+                "UPDATE " + pharmBillItemTable() + " SET retired=1, retirer_ID=?, retiredAt=? WHERE billItem_ID=?")
+                .setParameter(1, retirerId)
+                .setParameter(2, now)
+                .setParameter(3, billItemId)
+                .executeUpdate();
+        } else {
+            survivingCount++;
+        }
+    }
+    evictLineCache();
+    return survivingCount;
+}
+```
+
+Note: unlike Phase 1's `retireZeroQtyLines`, the surviving branch here does
+**not** re-set `remainingQty=qty, remainingFreeQty=freeQty` — Step 4 already
+wrote those at save time (see the note above), so there is nothing left to
+do for survivors here.
+
+- [ ] **Step 6: `loadRequestedLines` — JPQL projection reading the requested bill's lines**
+
+Returns `PurchaseOrderRequestLineData` per non-retired
+`PharmaceuticalBillItem` on the requested bill. The `ampp` flag needs
+`TYPE(bi.item)` — use a `CASE WHEN` JPQL expression (EclipseLink supports
+this in a `SELECT NEW` constructor argument).
+
+```java
+public List<PurchaseOrderRequestLineData> loadRequestedLines(long requestedBillId) {
+    String jpql = "SELECT NEW com.divudi.core.data.dto.pharmacy.PurchaseOrderRequestLineData("
+            + "bi.item.id, "
+            + "CASE WHEN TYPE(bi.item) = com.divudi.core.entity.pharmacy.Ampp THEN true ELSE false END, "
+            + "bi.billItemFinanceDetails.quantity, "
+            + "bi.billItemFinanceDetails.freeQuantity, "
+            + "bi.billItemFinanceDetails.lineGrossRate, "
+            + "bi.billItemFinanceDetails.retailSaleRate, "
+            + "bi.billItemFinanceDetails.unitsPerPack, "
+            + "bi.searialNo) "
+            + "FROM PharmaceuticalBillItem p JOIN p.billItem bi "
+            + "WHERE bi.bill.id = :billId AND bi.retired = false "
+            + "ORDER BY bi.searialNo";
+    return em.createQuery(jpql, PurchaseOrderRequestLineData.class)
+            .setParameter("billId", requestedBillId)
+            .getResultList();
+}
+```
+
+This requires a matching constructor on `PurchaseOrderRequestLineData` —
+Task 2 adds it (Phase 1's existing DTO only has a no-arg constructor +
+setters; per CLAUDE.md, add a new constructor, never modify the existing
+no-arg one).
+
+If `CASE WHEN TYPE(...) = X` in a `SELECT NEW` constructor argument turns
+out not to be supported by the EclipseLink version this project pins (verify
+by running Step 8's test against a real DB before assuming it works), fall
+back to: project `bi.item.id` only (drop the `ampp` boolean from the
+`SELECT NEW`), then resolve `ampp` in the controller via `itemFacade.find(itemId) instanceof Ampp`
+for each returned line before calling `saveApprovedLine`. Note whichever
+approach is used in the task's completion report so Task 3 knows which
+constructor shape to call.
+
+- [ ] **Step 7: Compile**
+
+Run: `mvn -q -o compile` (see build tool path notes in project memory /
+`developer_docs/deployment/persistence-verification.md` if `mvn` is not on
+PATH)
+Expected: no errors. If Step 6's `CASE WHEN TYPE(...)` fails to compile/run
+against a real query, apply the fallback noted in Step 6 and re-verify.
+
+- [ ] **Step 8: Unit tests for the parts with no `EntityManager` dependency**
+
+`saveApprovedLine`'s math is entirely covered by
+`purchaseOrderRequestNativeSqlService.computeLineValues()`, already tested
+in Phase 1 (`PurchaseOrderRequestNativeSqlServiceTest`) — do not re-test that
+math here. This class's own testable surface is thin (everything else needs
+a live `EntityManager`). Write one test confirming the zero-qty retire
+delegation is wired correctly:
+
+```java
+package com.divudi.service.pharmacy;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class PurchaseOrderApprovingNativeSqlServiceTest {
+
+    private final PurchaseOrderRequestNativeSqlService requestService = new PurchaseOrderRequestNativeSqlService();
+
+    @Test
+    void isZeroQtyLine_deferredToRequestService_trueWhenBothZero() {
+        assertTrue(requestService.isZeroQtyLine(0.0, 0.0));
+    }
+
+    @Test
+    void isZeroQtyLine_deferredToRequestService_falseWhenQtyPositive() {
+        assertFalse(requestService.isZeroQtyLine(5.0, 0.0));
+    }
+}
+```
+
+Run: `mvn -q -o test "-Dtest=PurchaseOrderApprovingNativeSqlServiceTest" -DfailIfNoTests=false`
+Expected: PASS. (This confirms the delegation target's behavior is stable;
+`PurchaseOrderApprovingNativeSqlService` itself has no pure-logic surface
+worth mocking an `EntityManager` for — its correctness is verified end-to-end
+in Task 5's Playwright pass, matching Phase 1's own test-coverage shape.)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/main/java/com/divudi/service/pharmacy/PurchaseOrderApprovingNativeSqlService.java src/test/java/com/divudi/service/pharmacy/PurchaseOrderApprovingNativeSqlServiceTest.java
+git commit -m "feat(pharmacy): native SQL service for PO Approving bill/line writes"
+```
+
+---
+
+### Task 2: `PurchaseOrderRequestLineData` — add the read-side constructor
+
+**Files:**
+- Modify: `src/main/java/com/divudi/core/data/dto/pharmacy/PurchaseOrderRequestLineData.java`
+- Test: `src/test/java/com/divudi/core/data/dto/pharmacy/PurchaseOrderRequestLineDataTest.java`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `PurchaseOrderRequestLineData(Long itemId, boolean ampp, BigDecimal quantity, BigDecimal freeQuantity, BigDecimal purchaseRate, BigDecimal retailRate, BigDecimal unitsPerPack, int serialNo)`
+  — used by Task 1 Step 6's JPQL `SELECT NEW`.
+
+Per CLAUDE.md: **never modify the existing no-arg constructor** — this class
+currently has only the implicit default constructor (all fields set via
+setters). Add a new constructor; do not touch existing getters/setters.
+
+- [ ] **Step 1: Add the new constructor**
+
+```java
+public PurchaseOrderRequestLineData(Long itemId, boolean ampp, BigDecimal quantity, BigDecimal freeQuantity,
+        BigDecimal purchaseRate, BigDecimal retailRate, BigDecimal unitsPerPack, int serialNo) {
+    this.itemId = itemId;
+    this.ampp = ampp;
+    this.quantity = quantity;
+    this.freeQuantity = freeQuantity;
+    this.purchaseRate = purchaseRate;
+    this.retailRate = retailRate;
+    this.unitsPerPack = unitsPerPack;
+    this.serialNo = serialNo;
+}
+```
+
+Place it immediately after the field declarations, before the getters —
+matching the class's existing layout.
+
+- [ ] **Step 2: Add a test for the new constructor**
+
+Append to the existing test class (do not remove or modify
+`gettersReturnValuesSetByConstructorArgs`, which tests the setter path):
+
+```java
+@Test
+void projectionConstructorSetsOnlyProjectedFields() {
+    var d = new PurchaseOrderRequestLineData(100L, true, BigDecimal.TEN, BigDecimal.ONE,
+            BigDecimal.valueOf(12.5), BigDecimal.valueOf(15.0), BigDecimal.valueOf(10), 3);
+
+    assertEquals(Long.valueOf(100L), d.getItemId());
+    assertTrue(d.isAmpp());
+    assertEquals(BigDecimal.TEN, d.getQuantity());
+    assertEquals(BigDecimal.ONE, d.getFreeQuantity());
+    assertEquals(BigDecimal.valueOf(12.5), d.getPurchaseRate());
+    assertEquals(BigDecimal.valueOf(15.0), d.getRetailRate());
+    assertEquals(BigDecimal.valueOf(10), d.getUnitsPerPack());
+    assertEquals(3, d.getSerialNo());
+    assertNull(d.getBillItemId());
+    assertNull(d.getPharmaceuticalBillItemId());
+    assertNull(d.getCreaterId());
+}
+```
+
+Add `import static org.junit.jupiter.api.Assertions.assertTrue;` and
+`import static org.junit.jupiter.api.Assertions.assertNull;` to the test
+file's existing import block if not already present.
+
+- [ ] **Step 3: Run the test**
+
+Run: `mvn -q -o test "-Dtest=PurchaseOrderRequestLineDataTest" -DfailIfNoTests=false`
+Expected: PASS (both the pre-existing test and the new one).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/java/com/divudi/core/data/dto/pharmacy/PurchaseOrderRequestLineData.java src/test/java/com/divudi/core/data/dto/pharmacy/PurchaseOrderRequestLineDataTest.java
+git commit -m "feat(pharmacy): add projection constructor to PurchaseOrderRequestLineData"
+```
+
+---
+
+### Task 3: `PurchaseOrderApprovingNativeSqlController` — page state, guards, approve flow
+
+**Files:**
+- Create: `src/main/java/com/divudi/bean/pharmacy/PurchaseOrderApprovingNativeSqlController.java`
+
+**Interfaces:**
+- Consumes: `PurchaseOrderApprovingNativeSqlService` (Task 1) — all its public
+  methods. `PurchaseOrderRequestLineData` (Task 2) — both constructors.
+  `BillFacade.find(Long)` / `BillFacade.edit(Bill)` for the requested-bill
+  JPA read and the cross-link write. `BillNumberGenerator` (existing,
+  unchanged) for approval bill-number generation. `WebUserController.hasPrivilege(String)`
+  for the `PurchaseOrdersApprovel` privilege check.
+- Produces: `String navigateToPurchaseOrderApproval(Long requestedBillId)`,
+  `void removeItem(BillItem)`, `void removeSelected()`, `void onEdit(BillItem)`,
+  `void approve()`, `void prepareEmailDialog()`, `void sendPurchaseOrderEmail()`,
+  plus getters/setters for `requestedBill`, `approvedBill`, `billItems`,
+  `selectedItems`, `printPreview`, `emailRecipient` — all bound by Task 4's page.
+
+This class never calls the native service for anything touching
+`requestedBill` — only `approvedBill`.
+
+- [ ] **Step 1: Scaffold the controller class, fields, and authorization helper**
+
+Copy the `isAuthorized(String action, String requiredPrivilege)` helper
+pattern verbatim from `PurchaseOrderRequestNativeSqlController` (privilege
+check + audit logging via `LOGGER.log(Level.WARNING, ...)` on denial), scoped
+to the `PurchaseOrdersApprovel` privilege for the `APPROVE` action.
+
+```java
+package com.divudi.bean.pharmacy;
+
+import com.divudi.bean.common.SessionController;
+import com.divudi.bean.common.WebUserController;
+import com.divudi.bean.common.ConfigOptionApplicationController;
+import com.divudi.bean.common.ConfigOptionController;
+import com.divudi.core.data.BillType;
+import com.divudi.core.data.BillTypeAtomic;
+import com.divudi.core.data.DepartmentType;
+import com.divudi.core.data.PaymentMethod;
+import com.divudi.core.data.dto.pharmacy.PurchaseOrderRequestLineData;
+import com.divudi.core.entity.AppEmail;
+import com.divudi.core.data.MessageType;
+import com.divudi.core.entity.Bill;
+import com.divudi.core.entity.BilledBill;
+import com.divudi.core.entity.BillItem;
+import com.divudi.core.entity.Item;
+import com.divudi.core.entity.pharmacy.Ampp;
+import com.divudi.core.entity.pharmacy.PharmaceuticalBillItem;
+import com.divudi.core.facade.BillFacade;
+import com.divudi.core.facade.EmailFacade;
+import com.divudi.core.util.CommonFunctions;
+import com.divudi.core.util.JsfUtil;
+import com.divudi.ejb.BillNumberGenerator;
+import com.divudi.ejb.EmailManagerEjb;
+import com.divudi.service.pharmacy.PurchaseOrderApprovingNativeSqlService;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.ejb.EJB;
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+/**
+ * SessionScoped controller for the native-SQL Purchase Order Approving page.
+ * Native SQL: the APPROVED bill's own create/update, billitem+PBI writes
+ * (via the service). JPA (unchanged): the requested bill (read-only except
+ * for the referenceBill cross-link write), rate/email infra.
+ * Related issue: #22738
+ */
+@Named
+@SessionScoped
+public class PurchaseOrderApprovingNativeSqlController implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final Logger LOGGER = Logger.getLogger(PurchaseOrderApprovingNativeSqlController.class.getName());
+
+    @Inject
+    private SessionController sessionController;
+    @Inject
+    private WebUserController webUserController;
+    @Inject
+    private ConfigOptionApplicationController configOptionApplicationController;
+    @Inject
+    private ConfigOptionController configOptionController;
+    @Inject
+    private PharmacyController pharmacyController;
+
+    @EJB
+    private PurchaseOrderApprovingNativeSqlService purchaseOrderApprovingNativeSqlService;
+    @EJB
+    private BillNumberGenerator billNumberBean;
+    @EJB
+    private BillFacade billFacade;
+    @EJB
+    private EmailFacade emailFacade;
+    @EJB
+    private EmailManagerEjb emailManagerEjb;
+
+    private Bill requestedBill;
+    private Bill approvedBill;
+    private List<BillItem> billItems;
+    private List<BillItem> selectedItems;
+    private boolean printPreview;
+    private String emailRecipient;
+
+    private boolean isAuthorized(String action, String requiredPrivilege) {
+        if (webUserController == null || sessionController == null) {
+            LOGGER.log(Level.SEVERE, "Authorization failed - missing controllers: action={0}, userId=null, billId={1}",
+                    new Object[]{action, requestedBill != null ? requestedBill.getId() : "null"});
+            return false;
+        }
+        if (!webUserController.hasPrivilege(requiredPrivilege)) {
+            Long userId = sessionController.getLoggedUser() != null ? sessionController.getLoggedUser().getId() : null;
+            Long billId = requestedBill != null ? requestedBill.getId() : null;
+            LOGGER.log(Level.WARNING, "SECURITY: Unauthorized Purchase Order Approving access attempt - action={0}, userId={1}, billId={2}, requiredPrivilege={3}",
+                    new Object[]{action, userId, billId, requiredPrivilege});
+            JsfUtil.addErrorMessage("You don't have permission to " + action.toLowerCase() + " purchase orders.");
+            return false;
+        }
+        return true;
+    }
+}
+```
+
+- [ ] **Step 2: `navigateToPurchaseOrderApproval` with scope guard, `getApprovedBill`, `resetBillValues`**
+
+The scope guard mirrors Phase 1's post-review fix on
+`navigateToUpdatePurchaseOrder`: reject if not `BillTypeAtomic.PHARMACY_ORDER`,
+retired, cancelled, or not owned by the caller's department. The
+already-approved check (`referenceBill != null`) and `synchronized` come
+directly from legacy — do not drop either.
+
+```java
+public void resetBillValues() {
+    requestedBill = null;
+    approvedBill = null;
+    billItems = new ArrayList<>();
+    selectedItems = null;
+    printPreview = false;
+}
+
+public Bill getApprovedBill() {
+    if (approvedBill == null) {
+        approvedBill = new BilledBill();
+        approvedBill.setBillType(BillType.PharmacyOrderApprove);
+        approvedBill.setBillTypeAtomic(BillTypeAtomic.PHARMACY_ORDER_APPROVAL);
+        if (requestedBill != null) {
+            approvedBill.setConsignment(requestedBill.isConsignment());
+            approvedBill.setDepartmentType(requestedBill.getDepartmentType());
+        }
+    }
+    return approvedBill;
+}
+
+// synchronized: see Task 3 doc comment on approve() for the production
+// incident (GRN item duplication, PO/RH/GSK/26/01093) this guards against.
+public synchronized String navigateToPurchaseOrderApproval(Long requestedBillId) {
+    if (requestedBillId == null) {
+        JsfUtil.addErrorMessage("No Bill");
+        return "";
+    }
+    Bill bill = billFacade.find(requestedBillId);
+    if (bill == null) {
+        JsfUtil.addErrorMessage("Bill not found");
+        return "";
+    }
+    if (bill.getBillTypeAtomic() != BillTypeAtomic.PHARMACY_ORDER) {
+        JsfUtil.addErrorMessage("Bill is not a finalized purchase order request");
+        return "";
+    }
+    if (bill.isRetired() || bill.isCancelled()) {
+        JsfUtil.addErrorMessage("Bill is retired or cancelled");
+        return "";
+    }
+    if (bill.getDepartment() == null || sessionController.getLoggedUser() == null
+            || !bill.getDepartment().equals(sessionController.getDepartment())) {
+        JsfUtil.addErrorMessage("You are not authorized to view this purchase order");
+        return "";
+    }
+    if (bill.getReferenceBill() != null) {
+        JsfUtil.addErrorMessage("This purchase order is already approved");
+        return "";
+    }
+
+    resetBillValues();
+    requestedBill = bill;
+    getApprovedBill().setPaymentMethod(requestedBill.getPaymentMethod());
+    getApprovedBill().setToInstitution(requestedBill.getToInstitution());
+    getApprovedBill().setCreditDuration(requestedBill.getCreditDuration());
+    generateBillComponent();
+    printPreview = false;
+    return "/pharmacy/pharmacy_purhcase_order_approving_native?faces-redirect=true";
+}
+```
+
+- [ ] **Step 3: `generateBillComponent` — seed billItems from the requested bill's lines**
+
+Calls `purchaseOrderApprovingNativeSqlService.loadRequestedLines(requestedBill.getId())`
+and builds in-memory `BillItem`/`PharmaceuticalBillItem`/`BillItemFinanceDetails`
+from each returned `PurchaseOrderRequestLineData`. This step only seeds raw
+inputs into fresh entities for display — it does not need
+`computeLineValues()`; `saveApprovedLine` (Task 1 Step 4) does the actual
+computation when `approve()` persists. Resolve `Item` by id via `itemFacade`
+(inject `ItemFacade` alongside the other EJBs from Step 1).
+
+```java
+@EJB
+private com.divudi.core.facade.ItemFacade itemFacade;
+
+public void generateBillComponent() {
+    billItems = new ArrayList<>();
+    if (requestedBill == null) {
+        return;
+    }
+    List<PurchaseOrderRequestLineData> lines = purchaseOrderApprovingNativeSqlService.loadRequestedLines(requestedBill.getId());
+    for (PurchaseOrderRequestLineData line : lines) {
+        Item item = itemFacade.find(line.getItemId());
+        if (item == null) {
+            continue;
+        }
+        BillItem bi = new BillItem();
+        bi.setItem(item);
+        bi.setSearialNo(line.getSerialNo());
+
+        PharmaceuticalBillItem pbi = new PharmaceuticalBillItem();
+        pbi.setBillItem(bi);
+        pbi.setCreatedAt(new Date());
+        pbi.setCreater(sessionController.getLoggedUser());
+        bi.setPharmaceuticalBillItem(pbi);
+
+        bi.getBillItemFinanceDetails().setQuantity(line.getQuantity());
+        bi.getBillItemFinanceDetails().setFreeQuantity(line.getFreeQuantity());
+        bi.getBillItemFinanceDetails().setLineGrossRate(line.getPurchaseRate());
+        bi.getBillItemFinanceDetails().setRetailSaleRate(line.getRetailRate());
+        bi.getBillItemFinanceDetails().setUnitsPerPack(line.getUnitsPerPack());
+
+        recalculateLineValues(bi);
+        billItems.add(bi);
+    }
+    calculateBillTotals();
+}
+```
+
+- [ ] **Step 4: `onEdit`, `recalculateLineValues`, `calculateBillTotals` — line editing**
+
+Mirrors Phase 1's `PurchaseOrderRequestNativeSqlController.onEdit()`/
+`recalculateLineValues()`/`calculateBillTotals()` exactly (integer-qty gate
+on the same config key, null-safe `getBillItemFinanceDetails()` guard per
+Phase 1's post-review fix, serial renumbering). Per the design spec's §3
+decision, there is **no** `updateCalculatedValues()` lighter path — always
+call the single recompute helper.
+
+```java
+public void onEdit(BillItem bi) {
+    if (bi.getBillItemFinanceDetails() != null
+            && configOptionController.getBooleanValueByKey("Pharmacy Purchase - Quantity Must Be Integer", true)) {
+        BigDecimal qty = bi.getBillItemFinanceDetails().getQuantity();
+        BigDecimal freeQty = bi.getBillItemFinanceDetails().getFreeQuantity();
+        if (qty != null && qty.remainder(BigDecimal.ONE).compareTo(BigDecimal.ZERO) != 0) {
+            bi.getBillItemFinanceDetails().setQuantity(BigDecimal.ZERO);
+            recalculateLineValues(bi);
+            JsfUtil.addErrorMessage("Please enter only whole numbers (integers) for quantity. Decimal values are not allowed.");
+            calculateBillTotals();
+            return;
+        }
+        if (freeQty != null && freeQty.remainder(BigDecimal.ONE).compareTo(BigDecimal.ZERO) != 0) {
+            bi.getBillItemFinanceDetails().setFreeQuantity(BigDecimal.ZERO);
+            recalculateLineValues(bi);
+            JsfUtil.addErrorMessage("Please enter only whole numbers (integers) for free quantity. Decimal values are not allowed.");
+            calculateBillTotals();
+            return;
+        }
+    }
+    recalculateLineValues(bi);
+    calculateBillTotals();
+}
+
+private void recalculateLineValues(BillItem bi) {
+    if (bi == null || bi.getBillItemFinanceDetails() == null) {
+        return;
+    }
+    BigDecimal qty = bi.getBillItemFinanceDetails().getQuantity();
+    BigDecimal purchaseRate = bi.getBillItemFinanceDetails().getLineGrossRate();
+    if (qty == null) qty = BigDecimal.ZERO;
+    if (purchaseRate == null) purchaseRate = BigDecimal.ZERO;
+
+    BigDecimal grossValue = purchaseRate.multiply(qty);
+    bi.setRate(purchaseRate.doubleValue());
+    bi.setNetRate(purchaseRate.doubleValue());
+    bi.setGrossValue(grossValue.doubleValue());
+    bi.setNetValue(grossValue.doubleValue());
+    bi.getBillItemFinanceDetails().setLineGrossTotal(grossValue);
+    bi.getBillItemFinanceDetails().setLineNetTotal(grossValue);
+}
+
+private void calculateBillTotals() {
+    double total = 0.0;
+    int serialNo = 0;
+    for (BillItem bi : billItems) {
+        if (bi == null || bi.isRetired()) {
+            continue;
+        }
+        bi.setSearialNo(serialNo++);
+        total += bi.getNetValue();
+    }
+    getApprovedBill().setNetTotal(total);
+    getApprovedBill().setTotal(total);
+}
+```
+
+- [ ] **Step 5: `removeItem`, `removeSelected` — in-memory only**
+
+Unlike Phase 1's Request page, there is no persisted intermediate state to
+keep in sync (per the design spec §2/§3) — these mutate only the in-memory
+`billItems` list, matching legacy exactly.
+
+```java
+public void removeItem(BillItem billItem) {
+    if (billItem == null || !billItems.contains(billItem)) {
+        JsfUtil.addErrorMessage("Item not found or already removed");
+        return;
+    }
+    billItems.remove(billItem);
+    calculateBillTotals();
+}
+
+public void removeSelected() {
+    if (selectedItems == null || selectedItems.isEmpty()) {
+        JsfUtil.addErrorMessage("No items selected to remove");
+        return;
+    }
+    billItems.removeAll(selectedItems);
+    calculateBillTotals();
+    selectedItems = null;
+}
+```
+
+- [ ] **Step 6: `approve` — validation, native bill+line writes, JPA cross-link**
+
+This is the task's central method. Validation happens entirely in memory
+before any write (matching the ordering-safety lesson from Phase 1's
+review). The cross-link write (`requestedBill.setReferenceBill(approvedBill); billFacade.edit(requestedBill)`)
+is the **only** JPA write to a native-owned bill row's FK in this whole
+phase — do this exactly as shown, do not attempt to fold it into the native
+service.
+
+```java
+// synchronized: a double-submit on the Approve button (no confirm-then-review
+// gap, or a resubmitted ajax="false" postback) let two requests race through
+// the same in-memory billItems list before either had persisted -- both saw
+// BillItem.id == null and created every line twice, duplicating every GRN
+// item (Ruhunu PO/RH/GSK/26/01093, same bug class as Phase 1's #21417 guard).
+public synchronized void approve() {
+    if (!isAuthorized("APPROVE", "PurchaseOrdersApprovel")) {
+        return;
+    }
+    if (requestedBill == null) {
+        JsfUtil.addErrorMessage("No Bill");
+        return;
+    }
+    if (requestedBill.getReferenceBill() != null) {
+        JsfUtil.addErrorMessage("This purchase order is already approved");
+        return;
+    }
+    if (getApprovedBill().getPaymentMethod() == null) {
+        JsfUtil.addErrorMessage("Select Paymentmethod");
+        return;
+    }
+    if (billItems == null || billItems.isEmpty()) {
+        JsfUtil.addErrorMessage("Please add bill items");
+        return;
+    }
+    for (BillItem bi : billItems) {
+        PharmaceuticalBillItem pbi = bi.getPharmaceuticalBillItem();
+        if (pbi == null) {
+            JsfUtil.addErrorMessage("Missing pharmaceutical details for item: " + bi.getItem().getName());
+            return;
+        }
+        double totalQty = bi.getBillItemFinanceDetails().getQuantity().doubleValue()
+                + bi.getBillItemFinanceDetails().getFreeQuantity().doubleValue();
+        if (totalQty <= 0) {
+            JsfUtil.addErrorMessage("Item '" + bi.getItem().getName() + "' has zero quantity and free quantity");
+            return;
+        }
+        if (bi.getBillItemFinanceDetails().getLineGrossRate() == null
+                || bi.getBillItemFinanceDetails().getLineGrossRate().doubleValue() <= 0) {
+            JsfUtil.addErrorMessage("Item '" + bi.getItem().getName() + "' has invalid purchase price");
+            return;
+        }
+    }
+
+    calculateBillTotals();
+
+    String[] billNumbers = createAndAssignBillNumber();
+    long approvedBillId = purchaseOrderApprovingNativeSqlService.createApprovedBill(
+            requestedBill.getId(),
+            sessionController.getLoggedUser().getDepartment().getId(),
+            sessionController.getLoggedUser().getDepartment().getInstitution().getId(),
+            requestedBill.getDepartment().getId(),
+            requestedBill.getInstitution().getId(),
+            sessionController.getLoggedUser().getId(),
+            billNumbers[0],
+            billNumbers[1]);
+    approvedBill = billFacade.find(approvedBillId);
+    approvedBill.setPaymentMethod(getApprovedBill().getPaymentMethod());
+    approvedBill.setToInstitution(getApprovedBill().getToInstitution());
+    approvedBill.setCreditDuration(getApprovedBill().getCreditDuration());
+    approvedBill.setConsignment(getApprovedBill().isConsignment());
+    approvedBill.setDepartmentType(getApprovedBill().getDepartmentType());
+
+    purchaseOrderApprovingNativeSqlService.updateApprovedBillHeader(
+            approvedBillId,
+            approvedBill.getToInstitution() != null ? approvedBill.getToInstitution().getId() : null,
+            approvedBill.getPaymentMethod(),
+            approvedBill.getCreditDuration(),
+            approvedBill.isConsignment(),
+            approvedBill.getDepartmentType(),
+            approvedBill.getComments(),
+            sessionController.getLoggedUser().getId());
+
+    for (BillItem bi : billItems) {
+        PurchaseOrderRequestLineData line = new PurchaseOrderRequestLineData();
+        line.setItemId(bi.getItem().getId());
+        line.setAmpp(bi.getItem() instanceof Ampp);
+        line.setQuantity(bi.getBillItemFinanceDetails().getQuantity());
+        line.setFreeQuantity(bi.getBillItemFinanceDetails().getFreeQuantity());
+        line.setPurchaseRate(bi.getBillItemFinanceDetails().getLineGrossRate());
+        line.setRetailRate(bi.getBillItemFinanceDetails().getRetailSaleRate());
+        line.setUnitsPerPack(bi.getBillItemFinanceDetails().getUnitsPerPack());
+        line.setSerialNo(bi.getSearialNo());
+        line.setCreaterId(sessionController.getLoggedUser().getId());
+        purchaseOrderApprovingNativeSqlService.saveApprovedLine(approvedBillId, line);
+    }
+
+    purchaseOrderApprovingNativeSqlService.retireZeroQtyApprovedLines(approvedBillId, sessionController.getLoggedUser().getId());
+
+    approvedBill = billFacade.find(approvedBillId);
+    approvedBill.setApproveAt(new Date());
+    approvedBill.setApproveUser(sessionController.getLoggedUser());
+    billFacade.edit(approvedBill);
+
+    // The one JPA write in this phase that touches a bill this controller
+    // does not own the writes for -- required to stay JPA merge, never
+    // native SQL, per the master issue's L2-cache-coherence rule.
+    requestedBill.setReferenceBill(approvedBill);
+    billFacade.edit(requestedBill);
+
+    printPreview = true;
+    JsfUtil.addSuccessMessage("Purchase order approved successfully.");
+}
+
+private String[] createAndAssignBillNumber() {
+    String billSuffix = configOptionApplicationController.getLongTextValueByKey("Bill Number Suffix for " + BillTypeAtomic.PHARMACY_ORDER_APPROVAL, "");
+    if (billSuffix == null || billSuffix.trim().isEmpty()) {
+        configOptionApplicationController.setLongTextValueByKey("Bill Number Suffix for " + BillTypeAtomic.PHARMACY_ORDER_APPROVAL, "POA");
+    }
+
+    boolean stratInsDeptYear = configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Purchase Order Approvals - Prefix + Institution Code + Department Code + Year + Yearly Number and Yearly Number", false);
+    boolean stratInsYear = configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Purchase Order Approvals - Prefix + Institution Code + Year + Yearly Number and Yearly Number", false);
+    boolean stratInsIdInsYear = configOptionApplicationController.getBooleanValueByKey("Institution Number Generation Strategy for Purchase Order Approvals - Prefix + Institution Code + Year + Yearly Number and Yearly Number", false);
+
+    String deptId;
+    if (stratInsDeptYear) {
+        deptId = billNumberBean.departmentBillNumberGeneratorYearlyWithPrefixInsDeptYearCount(sessionController.getDepartment(), BillTypeAtomic.PHARMACY_ORDER_APPROVAL);
+    } else if (stratInsYear) {
+        deptId = billNumberBean.departmentBillNumberGeneratorYearlyWithPrefixInsYearCountInstitutionWide(sessionController.getDepartment(), BillTypeAtomic.PHARMACY_ORDER_APPROVAL);
+    } else {
+        deptId = billNumberBean.departmentBillNumberGeneratorYearly(sessionController.getDepartment(), BillTypeAtomic.PHARMACY_ORDER_APPROVAL);
+    }
+
+    String insId;
+    if (stratInsIdInsYear) {
+        insId = billNumberBean.institutionBillNumberGeneratorYearlyWithPrefixInsYearCountInstitutionWide(sessionController.getDepartment(), BillTypeAtomic.PHARMACY_ORDER_APPROVAL);
+    } else {
+        insId = deptId;
+    }
+
+    return new String[]{deptId, insId};
+}
+```
+
+Note on `approveAt`/`approveUser`: legacy sets these directly on the entity
+before a single `billFacade.edit(aprovedBill)` call (no native column for
+them was written in Task 1's `createApprovedBill`/`updateApprovedBillHeader`
+— intentionally, since this is a low-frequency, non-hot-path write happening
+exactly once per approve). This is the same pragmatic pattern Phase 1 used
+for fields not on the hot native-write path; do not add
+`approveAt`/`approveUser` columns to the native INSERT/UPDATE in Task 1 to
+"complete" the native conversion — that would be scope creep against the
+spec's own reasoning.
+
+- [ ] **Step 7: Email — `prepareEmailDialog`, `sendPurchaseOrderEmail`, `generatePurchaseOrderHtml`**
+
+Copy Phase 1's final (post-review) `generatePurchaseOrderHtml()` +
+`esc()` helper structure exactly, retargeted to `approvedBill` instead of
+`currentBill`, with subject `"Purchase Order"` (matching legacy's
+`PurchaseOrderController`, not `"Purchase Order Request"`).
+
+```java
+private static String esc(String value) {
+    return value != null ? org.apache.commons.text.StringEscapeUtils.escapeHtml4(value) : "";
+}
+
+public void prepareEmailDialog() {
+    if (approvedBill == null) {
+        JsfUtil.addErrorMessage("No Bill");
+        return;
+    }
+    if (approvedBill.getToInstitution() != null && approvedBill.getToInstitution().getEmail() != null) {
+        emailRecipient = approvedBill.getToInstitution().getEmail();
+    } else {
+        emailRecipient = "";
+    }
+}
+
+public void sendPurchaseOrderEmail() {
+    if (approvedBill == null) {
+        JsfUtil.addErrorMessage("No Bill");
+        return;
+    }
+    if (emailRecipient == null || emailRecipient.trim().isEmpty()) {
+        JsfUtil.addErrorMessage("Please enter recipient email");
+        return;
+    }
+    String recipient = emailRecipient.trim();
+    if (!CommonFunctions.isValidEmail(recipient)) {
+        JsfUtil.addErrorMessage("Please enter a valid email address");
+        return;
+    }
+    String body = generatePurchaseOrderHtml();
+    if (body == null) {
+        JsfUtil.addErrorMessage("Could not generate email body");
+        return;
+    }
+
+    AppEmail email = new AppEmail();
+    email.setCreatedAt(new Date());
+    email.setCreater(sessionController.getLoggedUser());
+    email.setReceipientEmail(recipient);
+    email.setMessageSubject("Purchase Order");
+    email.setMessageBody(body);
+    email.setDepartment(sessionController.getLoggedUser().getDepartment());
+    email.setInstitution(sessionController.getLoggedUser().getInstitution());
+    email.setBill(approvedBill);
+    email.setMessageType(MessageType.Marketing);
+    email.setSentSuccessfully(false);
+    email.setPending(true);
+    emailFacade.create(email);
+
+    try {
+        boolean success = emailManagerEjb.sendEmail(
+                java.util.Collections.singletonList(recipient), body, "Purchase Order", true);
+        email.setSentSuccessfully(success);
+        email.setPending(!success);
+        if (success) {
+            email.setSentAt(new Date());
+            JsfUtil.addSuccessMessage("Email Sent Successfully");
+        } else {
+            JsfUtil.addErrorMessage("Sending Email Failed");
+        }
+        emailFacade.edit(email);
+    } catch (Exception ex) {
+        JsfUtil.addErrorMessage("Sending Email Failed");
+    }
+}
+
+private String generatePurchaseOrderHtml() {
+    try {
+        if (approvedBill == null) {
+            return null;
+        }
+        StringBuilder html = new StringBuilder();
+        html.append("<html><head><title>Purchase Order</title></head><body>");
+        html.append("<div style='font-family: Arial, sans-serif; padding: 20px;'>");
+
+        if (approvedBill.getCreater() != null && approvedBill.getCreater().getInstitution() != null) {
+            html.append("<div style='text-align: center; margin-bottom: 20px;'>");
+            html.append("<h2>").append(esc(approvedBill.getCreater().getInstitution().getName())).append("</h2>");
+            if (approvedBill.getCreater().getInstitution().getAddress() != null) {
+                html.append("<p>").append(esc(approvedBill.getCreater().getInstitution().getAddress())).append("</p>");
+            }
+            if (approvedBill.getCreater().getInstitution().getPhone() != null) {
+                html.append("<p>Phone: ").append(esc(approvedBill.getCreater().getInstitution().getPhone())).append("</p>");
+            }
+            html.append("</div>");
+        }
+
+        html.append("<h3 style='text-align: center; text-decoration: underline;'>Purchase Order</h3>");
+        html.append("<table style='width: 100%; margin-bottom: 20px;'>");
+        html.append("<tr><td><strong>Order No:</strong></td><td>").append(esc(approvedBill.getDeptId())).append("</td></tr>");
+        if (approvedBill.getDepartment() != null) {
+            html.append("<tr><td><strong>Order Department:</strong></td><td>").append(esc(approvedBill.getDepartment().getName())).append("</td></tr>");
+        }
+        if (approvedBill.getToInstitution() != null) {
+            html.append("<tr><td><strong>Supplier:</strong></td><td>").append(esc(approvedBill.getToInstitution().getName())).append("</td></tr>");
+            html.append("<tr><td><strong>Supplier Code:</strong></td><td>").append(esc(approvedBill.getToInstitution().getCode())).append("</td></tr>");
+            if (approvedBill.getToInstitution().getPhone() != null) {
+                html.append("<tr><td><strong>Supplier Phone:</strong></td><td>").append(esc(approvedBill.getToInstitution().getPhone())).append("</td></tr>");
+            }
+            if (approvedBill.getToInstitution().getAddress() != null) {
+                html.append("<tr><td><strong>Supplier Address:</strong></td><td>").append(esc(approvedBill.getToInstitution().getAddress())).append("</td></tr>");
+            }
+        }
+        html.append("<tr><td><strong>Payment Method:</strong></td><td>").append(approvedBill.getPaymentMethod() != null ? approvedBill.getPaymentMethod().toString() : "").append("</td></tr>");
+        html.append("<tr><td><strong>Consignment:</strong></td><td>").append(approvedBill.isConsignment() ? "Yes" : "No").append("</td></tr>");
+        html.append("</table>");
+
+        html.append("<table border='1' style='width: 100%; border-collapse: collapse; margin-bottom: 20px;'>");
+        html.append("<thead style='background-color: #f0f0f0;'>");
+        html.append("<tr><th style='padding: 8px;'>Item Code</th><th style='padding: 8px;'>Item Name</th>");
+        html.append("<th style='padding: 8px;'>Qty</th><th style='padding: 8px;'>Free Qty</th>");
+        html.append("<th style='padding: 8px;'>Purchase Rate</th><th style='padding: 8px;'>Purchase Value</th></tr></thead><tbody>");
+
+        if (billItems != null) {
+            for (BillItem bi : billItems) {
+                if (bi != null && !bi.isRetired() && bi.getItem() != null) {
+                    html.append("<tr>");
+                    html.append("<td style='padding: 8px;'>").append(esc(bi.getItem().getCode())).append("</td>");
+                    html.append("<td style='padding: 8px;'>").append(esc(bi.getItem().getName())).append("</td>");
+                    html.append("<td style='padding: 8px; text-align: right;'>");
+                    if (bi.getPharmaceuticalBillItem() != null) {
+                        html.append(String.format("%,.0f", bi.getPharmaceuticalBillItem().getQty()));
+                    }
+                    html.append("</td><td style='padding: 8px; text-align: right;'>");
+                    if (bi.getPharmaceuticalBillItem() != null) {
+                        html.append(String.format("%,.0f", bi.getPharmaceuticalBillItem().getFreeQty()));
+                    }
+                    html.append("</td><td style='padding: 8px; text-align: right;'>");
+                    if (bi.getPharmaceuticalBillItem() != null) {
+                        html.append(String.format("%,.2f", bi.getPharmaceuticalBillItem().getPurchaseRate()));
+                    }
+                    html.append("</td><td style='padding: 8px; text-align: right;'>").append(String.format("%,.2f", bi.getNetValue())).append("</td>");
+                    html.append("</tr>");
+                }
+            }
+        }
+
+        html.append("</tbody><tfoot style='font-weight: bold;'><tr>");
+        html.append("<td colspan='5' style='padding: 8px; text-align: right;'>Net Total:</td>");
+        html.append("<td style='padding: 8px; text-align: right;'>").append(String.format("%,.2f", approvedBill.getNetTotal())).append("</td>");
+        html.append("</tr></tfoot></table>");
+
+        html.append("<div style='margin-top: 20px;'>");
+        if (approvedBill.getCreater() != null && approvedBill.getCreater().getWebUserPerson() != null) {
+            html.append("<p><strong>Order Initiated By:</strong> ").append(esc(approvedBill.getCreater().getWebUserPerson().getName())).append("</p>");
+        }
+        if (approvedBill.getCheckedBy() != null) {
+            html.append("<p><strong>Order Finalized By:</strong> ").append(esc(approvedBill.getCheckedBy().getName())).append("</p>");
+        }
+        if (approvedBill.getCheckeAt() != null) {
+            html.append("<p><strong>Order Finalized At:</strong> ").append(CommonFunctions.formatDate(approvedBill.getCheckeAt(), "dd/MM/yyyy HH:mm:ss")).append("</p>");
+        }
+        html.append("<p><strong>Generated At:</strong> ").append(CommonFunctions.formatDate(new Date(), "dd/MM/yyyy HH:mm:ss")).append("</p>");
+        html.append("<p><strong>Total:</strong> ").append(String.format("%,.2f", approvedBill.getNetTotal())).append("</p>");
+        html.append("</div></div></body></html>");
+        return html.toString();
+    } catch (Exception e) {
+        LOGGER.log(Level.SEVERE, "Error generating purchase order HTML", e);
+        return null;
+    }
+}
+```
+
+- [ ] **Step 8: `displayItemDetails`, `onFocus`, getters/setters**
+
+```java
+public void displayItemDetails(BillItem bi) {
+    pharmacyController.fillItemDetails(bi.getItem());
+}
+
+public void onFocus(BillItem bi) {
+    pharmacyController.setPharmacyItem(bi.getItem());
+}
+
+public Bill getRequestedBill() {
+    return requestedBill;
+}
+
+public List<BillItem> getBillItems() {
+    if (billItems == null) {
+        billItems = new ArrayList<>();
+    }
+    return billItems;
+}
+
+public void setBillItems(List<BillItem> billItems) {
+    this.billItems = billItems;
+}
+
+public List<BillItem> getSelectedItems() {
+    return selectedItems;
+}
+
+public void setSelectedItems(List<BillItem> selectedItems) {
+    this.selectedItems = selectedItems;
+}
+
+public boolean isPrintPreview() {
+    return printPreview;
+}
+
+public void setPrintPreview(boolean printPreview) {
+    this.printPreview = printPreview;
+}
+
+public String getEmailRecipient() {
+    return emailRecipient;
+}
+
+public void setEmailRecipient(String emailRecipient) {
+    this.emailRecipient = emailRecipient;
+}
+```
+
+Note: `getPrintPreview()`/`printPreview` primitive boolean getter matches
+legacy's `getPrintPreview()` naming (not `isPrintPreview()` as Phase 1's
+Request controller uses) — the XHTML in Task 4 must call whichever name is
+actually declared here; use `isPrintPreview()` per this project's
+[[feedback_primitive_boolean_rendered_guards]] convention (`is` prefix for
+primitive boolean getters), and reference it as such in Task 4's page.
+
+- [ ] **Step 9: Compile**
+
+Run: `mvn -q -o compile`
+Expected: no errors.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/main/java/com/divudi/bean/pharmacy/PurchaseOrderApprovingNativeSqlController.java
+git commit -m "feat(pharmacy): native SQL controller for PO Approving page"
+```
+
+---
+
+### Task 4: `pharmacy_purhcase_order_approving_native.xhtml` — page
+
+**Files:**
+- Create: `src/main/webapp/pharmacy/pharmacy_purhcase_order_approving_native.xhtml`
+
+**Interfaces:**
+- Consumes: every public method/getter/setter from Task 3's controller.
+
+Copy `pharmacy_purhcase_order_approving.xhtml` (444 lines) as the starting
+point, then:
+
+- [ ] **Step 1: Copy the legacy file and do a global EL rebind**
+
+```bash
+cp src/main/webapp/pharmacy/pharmacy_purhcase_order_approving.xhtml src/main/webapp/pharmacy/pharmacy_purhcase_order_approving_native.xhtml
+```
+
+Then replace every `purchaseOrderController.` with
+`purchaseOrderApprovingNativeSqlController.` and every
+`purchaseOrderController.aprovedBill` with
+`purchaseOrderApprovingNativeSqlController.approvedBill` (note: this plan's
+controller field is spelled `approvedBill`, not legacy's `aprovedBill` typo —
+per CLAUDE.md's backward-compatibility rule, that rule protects **database**
+column/field names with existing data, not a page-local Java bean property
+name being introduced fresh in this new controller; there is no compatibility
+reason to carry the typo into new code).
+
+- [ ] **Step 2: Add the "Legacy View" fallback button**
+
+Insert immediately after the opening `<h:form id="form">`, matching Phase
+1's exact pattern:
+
+```xml
+<div class="d-flex justify-content-end">
+    <!-- Small non-prominent fallback to legacy entity-based page -->
+    <p:commandButton
+        ajax="false"
+        value="Legacy View"
+        title="Open original entity-based Purchase Order Approving page"
+        action="pharmacy_purhcase_order_approving?faces-redirect=true"
+        class="ui-button-secondary ms-3"
+        icon="fas fa-history"
+        style="font-size: 0.75rem; padding: 0.2rem 0.5rem;"/>
+</div>
+```
+
+- [ ] **Step 3: Fix the `p:ajax` listener wiring for qty/freeQty (the two-argument-mismatch bug)**
+
+Legacy's qty/freeQty columns bind `p:ajax`/`f:ajax` `listener="#{purchaseOrderController.onEdit(bi)}"`
+with `process="@this price"` — this pattern is copied as-is (Phase 1's review
+confirmed this same mixed `p:ajax`/`f:ajax` pattern is intentional legacy
+behavior, not a bug, when it appeared on the Request page). No functional
+change here beyond the EL rebind from Step 1.
+
+- [ ] **Step 4: Update the `rendered`/`disabled` checks on Approve and Remove buttons**
+
+Legacy's Approve button `disabled` check
+(`!webUserController.hasPrivilege('PurchaseOrdersApprovel')`) stays as-is —
+this is a UI-only convenience disable; the controller's own `isAuthorized()`
+check is the actual enforcement (Phase 1's review flagged the equivalent
+Remove buttons on the Request page as **missing** a `checked`-state disable;
+this page has no equivalent "already approved" UI disable on Remove buttons
+either — since navigating here at all is blocked once
+`requestedBill.getReferenceBill() != null` per Task 3 Step 2's guard, there
+is no reachable state where Remove is clickable on an approved order, so no
+new disable condition is needed here, unlike Phase 1's `checked` mid-workflow
+state).
+
+- [ ] **Step 5: Verify print/email dialog and print-config dialog blocks are unchanged**
+
+These reference `purchaseOrderController`/`purchaseOrderConfigController`
+for print-format config — the `purchaseOrderConfigController` (config
+storage for paper format checkboxes) is a **separate, unrelated** controller
+not part of this migration; only its `bill="#{purchaseOrderApprovingNativeSqlController.approvedBill}"`
+binding on the `ph:po_custom_*` composites needs the EL rebind from Step 1.
+Do not modify `purchaseOrderConfigController`-related markup beyond the
+mechanical rebind.
+
+- [ ] **Step 6: Manual review pass — diff against the legacy file**
+
+Run: `git diff --no-index src/main/webapp/pharmacy/pharmacy_purhcase_order_approving.xhtml src/main/webapp/pharmacy/pharmacy_purhcase_order_approving_native.xhtml`
+Expected: every hunk is either (a) an EL rebind (`purchaseOrderController` →
+`purchaseOrderApprovingNativeSqlController`, `aprovedBill` → `approvedBill`),
+or (b) the new Legacy View button block from Step 2. No line of legacy
+markup should be silently dropped — this file has no `- [ ]` sub-steps for
+"copy XYZ block" precisely because the whole file is one copy-then-rebind
+operation; use this diff as the actual verification.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/main/webapp/pharmacy/pharmacy_purhcase_order_approving_native.xhtml
+git commit -m "feat(pharmacy): native SQL Purchase Order Approving page"
+```
+
+---
+
+### Task 5: List-to-Approve button rewiring + navigation route registration
+
+**Files:**
+- Modify: `src/main/webapp/pharmacy/pharmacy_purhcase_order_list_to_approve_dto.xhtml`
+
+**Interfaces:**
+- Consumes: `PurchaseOrderApprovingNativeSqlController.navigateToPurchaseOrderApproval(Long)` (Task 3).
+
+- [ ] **Step 1: Rewire the Approve button**
+
+Per the design spec §6, change:
+
+```xml
+action="#{purchaseOrderController.navigateToPurchaseOrderApproval}">
+    <f:setPropertyActionListener target="#{purchaseOrderController.requestedBillId}" value="#{dto.billId}"/>
+```
+
+to:
+
+```xml
+action="#{purchaseOrderApprovingNativeSqlController.navigateToPurchaseOrderApproval(dto.billId)}">
+```
+
+Grep the file first to confirm the exact surrounding markup and attribute
+order before editing (line numbers may differ from the design spec's §6
+excerpt, which was based on this session's earlier read).
+
+- [ ] **Step 2: Compile-equivalent check (JSF-only change)**
+
+Per CLAUDE.md: "JSF-only changes (XHTML only, no Java) do not require
+compilation or testing." Skip straight to Task 6's Playwright walkthrough,
+which exercises this button directly.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main/webapp/pharmacy/pharmacy_purhcase_order_list_to_approve_dto.xhtml
+git commit -m "feat(pharmacy): route List-to-Approve button to native PO Approving page"
+```
+
+---
+
+### Task 6: Playwright walkthrough + whole-branch review
+
+Not a code task — this is the design spec's §7 review gate, required by the
+master issue (#22726) before this phase can be considered done.
+
+- [ ] **Step 1: Rebuild and redeploy locally**
+
+Follow `developer_docs/testing/playwright-e2e-workflow.md` §0a. This
+invalidates the current session — redeploy before logging in for the
+walkthrough.
+
+- [ ] **Step 2: End-to-end walkthrough**
+
+Using the `playwright-e2e` skill: finalize a PO Request (or use an existing
+finalized one), navigate to List-to-Approve, click Approve, verify:
+- The native Approving page loads with the request's lines pre-populated
+  and correct (qty, free qty, purchase rate, retail rate all match what was
+  finalized)
+- Edit a line's qty/rate, confirm the integer-only gate and total
+  recalculation both work
+- Remove a line via both the row button and multi-select "Remove All"
+- Attempt to approve with a missing payment method — confirm the error
+- Attempt to re-approve an already-approved order (e.g. by revisiting the
+  URL after a successful approve) — confirm the "already approved" guard
+  fires
+- Approve successfully — confirm: the approved bill is created, the
+  requested bill's `referenceBill` is set (verify via DB query, not just UI),
+  the print preview renders, "Send Email" works, "Legacy View" link works
+- Verify in the database (per the workflow doc §6): `bill` row for the new
+  approval exists with correct `BILLTYPEATOMIC`/`billType`/FKs; `billitem`/
+  `pharmaceuticalbillitem` rows exist per line with correct
+  `remainingQty`/`remainingFreeQty`; the requested bill's `referenceBill_ID`
+  points at the new approved bill's `ID`
+
+- [ ] **Step 2a: If DB lacks suitable test data, generate it through the app**
+
+Per the workflow doc §15 — never fall back to "code looks correct" as
+evidence. Use the native Request page (Phase 1) to create and finalize a
+fresh PO Request if no unapproved finalized request exists in the local DB.
+
+- [ ] **Step 3: Second-agent / whole-branch review**
+
+Dispatch a review of the full branch diff (all 5 prior tasks together),
+focused specifically on: any legacy button/function from
+`PurchaseOrderController.java` / `pharmacy_purhcase_order_approving.xhtml`
+with no native equivalent; the cross-link write's correctness; the
+synchronized/already-approved guard placement; HTML-escaping completeness in
+the email generator (per Phase 1's own review history, this is the finding
+category most likely to recur if skipped early).
+
+- [ ] **Step 4: Fix any findings, re-verify, then hand off per master issue process**
+
+Same PR/CodeRabbit/reply workflow as Phase 1 (#22733) — open the PR against
+`development`, address CodeRabbit findings inline with replies, push fix
+commits, re-review, merge.

--- a/docs/superpowers/specs/2026-08-08-po-approving-native-design.md
+++ b/docs/superpowers/specs/2026-08-08-po-approving-native-design.md
@@ -1,0 +1,327 @@
+# Native Purchase Order Approving — Design
+
+**Issue:** [#22738](https://github.com/hmislk/hmis/issues/22738)
+**Master issue:** [#22726](https://github.com/hmislk/hmis/issues/22726) — Phase 2 of the
+Purchase Order native migration.
+**Date:** 2026-08-08
+**Branch:** `22738-native-po-approving`
+
+---
+
+## 1. Goal
+
+Replace the write path of the Purchase Order Approving page
+(`pharmacy_purhcase_order_approving.xhtml` / `PurchaseOrderController`) with a
+native-SQL implementation, following the pattern established by Phase 1
+(`PurchaseOrderRequestNativeSqlController` / `PurchaseOrderRequestNativeSqlService`,
+issue #22727, PR #22733).
+
+**Requirement: 100% functional replication.** Every button, validation message,
+and guard on the legacy page carries over. Nothing is deferred to a follow-up.
+Any legacy behavior this spec does not explicitly mention is still in scope —
+the Playwright + second-agent review in §7 exists specifically to catch
+omissions.
+
+This phase does **not** touch:
+- `PurchaseOrderRequestController` / the Request page (Phase 1, done)
+- The List-to-Finalize or List-to-Approve list/search pages' own query logic —
+  both already query via JPQL DTO constructors (`PharmacyPurchaseOrderDTO`).
+  Only the List-to-Approve page's "Approve" button wiring changes (§6).
+
+---
+
+## 2. What the Approving page actually does
+
+Established by reading `PurchaseOrderController.java` and
+`pharmacy_purhcase_order_approving.xhtml` in full.
+
+**Bill lifecycle** — two bills, cross-linked:
+- `requestedBill` — the finalized PO Request bill (`BillTypeAtomic.PHARMACY_ORDER`),
+  loaded read-only; never mutated except for the cross-link write at approve time
+- `approvedBill` — a new `BilledBill` created on `navigateToPurchaseOrderApproval()`,
+  seeded from the request bill's lines, editable in memory. Unlike the Request
+  page, there is no repeated "Save Draft" — the page goes straight from
+  item-editing to a single `approve()` call that both saves and finalizes in
+  one step. (`saveBill()` + `saveBillComponent()` are internal helpers called
+  only from `approve()`, not separate page actions.)
+- Cross-link: on successful approve, `requestedBill.referenceBill = approvedBill`,
+  persisted via `billFacade.edit(requestedBill)` — **JPA merge, never native
+  SQL**, per the master issue's L2-cache-coherence rule (#22726 decisions).
+
+**Guards enforced before any write** (must all be replicated):
+- `navigateToPurchaseOrderApproval()`: reject if `requestedBill.getReferenceBill() != null`
+  (already approved) — checked again in `approve()` since the two calls can
+  race (see concurrency note below)
+- `approve()`: requires `APPROVE`/`PurchaseOrdersApprovel` privilege; payment
+  method set; at least one bill item; **every line** must have a non-null PBI,
+  `qty + freeQty > 0`, and `purchaseRate > 0` (all-or-nothing — one bad line
+  blocks the whole approve, unlike Request's finalize which auto-retires
+  zero-qty lines)
+- `onEdit()`: integer-only qty/free-qty gated on config
+  `Pharmacy Purchase - Quantity Must Be Integer` (default true) — identical
+  gate to Phase 1's Request page
+
+**Concurrency guards already in the legacy code** (must carry over verbatim —
+these fixed a real production incident, not defensive boilerplate):
+- Both `navigateToPurchaseOrderApproval()` and `approve()` are `synchronized`.
+  Per the legacy code comment: the Approve button posts directly with no
+  confirm-then-review gap large enough to matter, but a double-click on
+  **either** button race two calls through the same session-scoped
+  `billItems`/`generateBillComponent()` state, duplicating every line. This
+  reproduced the GRN item duplication reported by Ruhunu
+  (PO/RH/GSK/26/01093), the same bug class as the Request page's #21417 guard.
+  The native controller's equivalent entry points need the same
+  `synchronized` + already-approved re-check.
+
+**Line items:**
+- `removeItem()` / `removeSelected()` — in-memory only; no `saveRequestWithoutMessage()`-
+  style intermediate persistence step exists here (there is no draft-save
+  concept on this page) — removal just mutates the session's `billItems` list;
+  the removed lines are simply never included when `approve()` eventually
+  calls `saveBillComponent()`
+- `onEdit()` / `calculateLineValues()` / `updateCalculatedValues()` — recomputes
+  line gross/net from user-entered qty/free-qty/rate; `updateCalculatedValues()`
+  is a lighter path used when BIFD is already populated (skips resetting audit
+  fields) — this optimization is legacy-only bookkeeping and does not need a
+  native equivalent (see §3 rationale)
+- `generateBillComponent()` — seeds `billItems` from the request bill's
+  non-retired `PharmaceuticalBillItem`s on page entry; copies ~25 individual
+  `BillItemFinanceDetails` fields verbatim per line (see §3 for the native
+  approach, which recomputes instead of copying)
+- On `approve()`, `saveBillComponent()` retires any line with
+  `qty + freeQty <= 0` (comment: "Retired at Approving PO") and sets
+  `remainingQty`/`remainingFreeQty` to the approved qty/freeQty on survivors —
+  this is a **narrower guard than it looks**: the earlier all-or-nothing
+  validation loop in `approve()` already rejects zero-qty lines outright, so
+  this retire branch is effectively dead in the current legacy flow. Must
+  still be replicated (defense-in-depth, matches Request page's equivalent
+  sweep) but is not reachable via the UI's own validation.
+
+**Bill-number generation** (`approve()`, inline) — 3 independently config-gated
+strategies for `deptId`, 1 for `insId`, with a legacy default fallback for
+each — same shape as Phase 1's `createAndAssignBillNumber()`, different
+`BillTypeAtomic`/config-key strings (`PHARMACY_ORDER_APPROVAL`, "POA" default
+suffix). Must be replicated verbatim.
+
+**Email** (`prepareEmailDialog()` / `sendPurchaseOrderEmail()` /
+`generatePurchaseOrderHtml()`) — sends the **approved** bill to the supplier.
+Same structure as Phase 1's Request-page email, including the same HTML-escaping
+requirement (Phase 1's PR review caught unescaped free-text fields in the
+email body — apply `esc()` here from the start, not as a follow-up fix).
+
+**Totals** (`calculateBillTotals()`) — bill-level aggregate from line items,
+also renumbers `searialNo` for surviving lines (same in-memory-only gap Phase 1
+had before its review fix — see §3, this phase persists it from the start).
+
+**Print** (`printPreview` flag, 4 config-gated paper formats via
+`ph:po_custom_*` composite components) — read-only rendering, reuses the
+existing composites unchanged; not part of the write-path migration.
+
+---
+
+## 3. Approach
+
+**New `PurchaseOrderApprovingNativeSqlService` (`@Stateless`,
+`com.divudi.service.pharmacy`) + `PurchaseOrderApprovingNativeSqlController`
+(`@Named @SessionScoped`, `com.divudi.bean.pharmacy`)**, following Phase 1's
+package/naming/DTO conventions.
+
+### Naming
+
+Per your convention: `Service` suffix for `@Stateless` EJBs, `Controller`
+suffix for `@Named` CDI beans. `PurchaseOrderNativeSqlController`/`Service`
+(#20923) are already taken by the read-only print path — this phase's classes
+are named `PurchaseOrderApprovingNativeSqlController`/`Service` to avoid
+collision and match the page's own name.
+
+### Service responsibilities
+
+- `createApprovedBill(...)` — native INSERT for the approved bill row
+  (mirrors Phase 1's `createDraftBill`, different `BillTypeAtomic`/fields:
+  `referenceBill_ID`/`backwardReferenceBill_ID` point at the request bill,
+  set at insert time since — unlike Phase 1 — there is no repeated-save
+  lifecycle to worry about re-reading stale FKs across)
+- `saveApprovedLine(...)` — native INSERT/UPDATE for `billitem` +
+  `pharmaceuticalbillitem`, mirroring Phase 1's `saveLine()` exactly,
+  including the upsert-by-existence fix from Phase 1's review (never branch
+  on a DTO id the caller can't reliably supply back)
+- `retireZeroQtyApprovedLines(...)` — mirrors Phase 1's
+  `retireZeroQtyLines()`, reusing its package-private `isZeroQtyLine()`
+  predicate the same way `computeLineValues()` is reused; kept even though
+  current UI validation makes it unreachable, per §2
+- `loadRequestedLines(requestedBillId)` — **new for this phase**: a JPQL
+  `SELECT NEW` projection reading the request bill's non-retired
+  `PharmaceuticalBillItem`s, returning only: `itemId`, `ampp` (boolean),
+  `quantity`, `freeQuantity`, `purchaseRate` (line gross rate), `retailRate`,
+  `unitsPerPack`, `serialNo`. This is Phase 1's `PurchaseOrderRequestLineData`
+  shape, reused as the read-side projection too (see decision below).
+- `computeLineValues(...)` — **reused from Phase 1**. It is currently
+  package-private on `PurchaseOrderRequestNativeSqlService` (visible to
+  `PurchaseOrderApprovingNativeSqlService` since both live in
+  `com.divudi.service.pharmacy`) — default to injecting
+  `PurchaseOrderRequestNativeSqlService` and calling its existing method
+  directly rather than duplicating the logic. Only extract a shared helper
+  class if that cross-service dependency turns out to be awkward in practice.
+  Derives gross/net/purchase/retail values and PBI qty/rate conversions from
+  the 5 raw inputs, identically for both phases.
+- `BillItemFinanceDetails` stays JPA persist/merge, same split as Phase 1.
+- Evict `Bill`, `BillItem`, `PharmaceuticalBillItem`, `BillItemFinanceDetails`
+  from L2 cache after any native write (Phase 1 review finding, applied here
+  from the start).
+
+**Decision: recompute line values instead of copying ~25 BIFD fields.**
+Legacy's `generateBillComponent()` copies every `BillItemFinanceDetails`
+field verbatim from the request line (including discount/tax/expense/
+wholesale/cost fields that are always zero for POs — Purchase Orders don't
+use any of them). The native version instead carries only the 5 raw inputs
+(qty, freeQty, purchaseRate, retailRate, unitsPerPack) through
+`PurchaseOrderRequestLineData` and recomputes everything else via
+`computeLineValues()` — the same function Phase 1 already uses and already
+unit-tests. This is safe because:
+- The approving page's own `onEdit()`/`calculateLineValues()` already
+  recompute every derived field from user edits on the very first interaction
+  — the copied values are working data, not an audit trail of the original
+  request's numbers.
+- It eliminates a 25-field copy that's pure duplication risk (a typo'd
+  field name silently drops data) for zero behavioral gain.
+- It keeps the two phases' line math provably identical — Phase 1's existing
+  unit tests already cover this function's edge cases (zero qty, AMPP
+  pack conversion, null fields).
+
+**Decision: cross-link write stays JPA, `requestedBill` entity stays on JPA
+throughout.** Confirmed with you — only the new `approvedBill`'s own rows go
+through native SQL. `requestedBill` is loaded via `billFacade.find()` (as
+today), read for guard checks and header seeding (payment method, supplier,
+credit duration, department type, comments — all copied to `approvedBill` on
+`navigateToPurchaseOrderApproval()`, matching legacy), and the final
+`requestedBill.setReferenceBill(approvedBill); billFacade.edit(requestedBill)`
+happens exactly as legacy does it, in JPA. Never touched by native SQL.
+
+**Decision: `updateCalculatedValues()`'s "lighter recompute" optimization is
+dropped.** Legacy has two code paths in `onEdit()` — a full
+`calculateLineValues()` when BIFD looks incomplete, and a cheaper
+`updateCalculatedValues()` when it doesn't, to skip resetting audit fields
+(`createdAt`/`creater`) on an already-persisted line. Since audit fields are
+now set once at native-insert time (not re-derived from BIFD state), this
+distinction has no equivalent in the native flow — `onEdit()` here always
+calls the single recompute helper (mirrors Phase 1's `recalculateLineValues`
++ `calculateBillTotals` pairing exactly).
+
+### Controller responsibilities
+
+- `requestedBill` / `approvedBill` state, `navigateToPurchaseOrderApproval(Long requestedBillId)`
+  — takes the bill id as a parameter (see §6, matches Phase 1's
+  `navigateToUpdatePurchaseOrder(Long billId)` fix), loads `requestedBill` via
+  `billFacade.find()`, applies the same scope guard Phase 1's review added:
+  reject if not `BillTypeAtomic.PHARMACY_ORDER`, retired, cancelled, or not
+  owned by the logged-in user's department
+- Already-approved check (`requestedBill.getReferenceBill() != null`) in both
+  `navigateToPurchaseOrderApproval()` and `approve()`, `synchronized` on both
+- `removeItem()` / `removeSelected()` — in-memory list mutation + serial
+  renumbering (persisted only once `approve()` actually writes the lines —
+  there's no intermediate persisted state to keep in sync here, unlike
+  Phase 1's Request page)
+- `onEdit()` — integer-qty gate + recompute, calls into the service's
+  `computeLineValues()`-backed helper
+- `approve()` — full validation loop (payment method, non-empty items,
+  per-line PBI/qty/rate checks), then: native-create approved bill, native
+  per-line save, bill-number assignment, native zero-qty retirement sweep,
+  then the JPA cross-link write
+- `prepareEmailDialog()` / `sendPurchaseOrderEmail()` /
+  `generatePurchaseOrderHtml()` — same structure as Phase 1's, with `esc()`
+  HTML-escaping applied to every free-text field from the start
+- New page `pharmacy_purhcase_order_approving_native.xhtml` — copies the
+  legacy layout 1:1 (item table, header panel, print-preview panel, email
+  dialog, print-config dialog), with a "Legacy View" fallback button matching
+  Phase 1's pattern
+
+### Rejected alternatives
+
+- **Copy all ~25 BIFD fields verbatim, matching legacy exactly.** Rejected —
+  see decision above; recompute-from-raw-inputs is safer and reuses tested
+  code.
+- **Reuse `pharmaceuticalBillItemFacade.getPharmaceuticalBillItems()` (full
+  entity graph) for the request-line read.** Rejected — this is exactly the
+  entity-inflation cost the master issue exists to remove; a JPQL projection
+  is a direct, low-risk substitution here since the read only needs the 8
+  scalar fields listed in §3's `loadRequestedLines` description.
+- **Make the approved bill's cross-link write native too, with explicit cache
+  eviction to manage the risk.** Rejected — confirmed with you; goes against
+  the master issue's explicit decision and the retail-sale precedent, no
+  clear benefit.
+
+---
+
+## 4. Data written (native SQL + JPA)
+
+Same split as Phase 1's spec:
+- `bill` (the new approved bill), `billitem`, `pharmaceuticalbillitem` — native
+  SQL, this service only
+- `BillItemFinanceDetails` — JPA persist/merge, linked via
+  `BILLITEMFINANCEDETAILS_ID`
+- `requestedBill.referenceBill` (the cross-link FK) — JPA merge on the
+  **existing** `PurchaseOrderRequestNativeSqlController`'s/legacy's bill
+  entity, via `billFacade.edit()`, exactly as legacy does it. This is the one
+  write in this phase that is explicitly *not* native, by design.
+
+After any native INSERT/UPDATE, evict from L2 cache: `Bill`, `BillItem`,
+`PharmaceuticalBillItem`, `BillItemFinanceDetails`.
+
+---
+
+## 5. Error handling
+
+All validation stays as user-facing `JsfUtil` error messages, matching
+legacy's wording where the message is user-visible copy (not silently
+changed). Guards are checked in memory, before any native mutation reaches
+the DB — same ordering-safety lesson Phase 1's review caught (validate
+fully, then persist, never interleave).
+
+---
+
+## 6. List-to-Approve page rewiring
+
+`pharmacy_purhcase_order_list_to_approve_dto.xhtml`'s "Approve" button
+currently does:
+
+```xml
+action="#{purchaseOrderController.navigateToPurchaseOrderApproval}">
+    <f:setPropertyActionListener target="#{purchaseOrderController.requestedBillId}" value="#{dto.billId}"/>
+```
+
+Changes to:
+
+```xml
+action="#{purchaseOrderApprovingNativeSqlController.navigateToPurchaseOrderApproval(dto.billId)}">
+```
+
+Identical fix to Phase 1's list-to-finalize page rewiring (PR #22733).
+
+---
+
+## 7. Review requirements (per master issue #22726)
+
+Before this phase's PR merges:
+1. Automated code review (CodeRabbit) — fix or explicitly resolve every
+   finding, same process as Phase 1.
+2. Playwright-driven manual walkthrough of the native Approving page: finalize
+   a PO Request, navigate to Approve, edit/remove lines, approve, verify the
+   approved bill + cross-link + print + email all work, confirm the legacy
+   page's every button/function has a native equivalent.
+3. Ideally a second-agent review of the diff, focused specifically on
+   omissions relative to legacy (per master issue's stated purpose for this
+   gate).
+
+---
+
+## 8. Reference Files
+
+- `src/main/java/com/divudi/bean/pharmacy/PurchaseOrderController.java` — legacy reference
+- `src/main/webapp/pharmacy/pharmacy_purhcase_order_approving.xhtml` — legacy page
+- `src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestNativeSqlController.java` +
+  `src/main/java/com/divudi/service/pharmacy/PurchaseOrderRequestNativeSqlService.java` —
+  Phase 1, direct structural precedent (including its post-review fixes —
+  upsert-by-existence, scope guards, evict Bill.class, HTML-escaping)
+- `developer_docs/pharmacy/native-sql-bill-migration-guide.md` — native
+  rewrite architecture guide
+- Master issue #22726 — phase sequencing and cross-phase decisions

--- a/docs/superpowers/specs/2026-08-08-po-approving-native-design.md
+++ b/docs/superpowers/specs/2026-08-08-po-approving-native-design.md
@@ -44,9 +44,20 @@ Established by reading `PurchaseOrderController.java` and
   item-editing to a single `approve()` call that both saves and finalizes in
   one step. (`saveBill()` + `saveBillComponent()` are internal helpers called
   only from `approve()`, not separate page actions.)
-- Cross-link: on successful approve, `requestedBill.referenceBill = approvedBill`,
-  persisted via `billFacade.edit(requestedBill)` — **JPA merge, never native
-  SQL**, per the master issue's L2-cache-coherence rule (#22726 decisions).
+- Cross-link: on successful approve, both directions are written —
+  `approvedBill.referenceBill = requestedBill` and
+  `requestedBill.referenceBill = approvedBill`. **Superseded decision:** the
+  original design (below, §7) mandated JPA merge for the requested-bill side
+  only, per the master issue's L2-cache-coherence rule. Live testing during
+  PR review found the JPA merge on `approvedBill` for `approveAt`/
+  `approveUser` risked EclipseLink orphan-removal deleting the native-written
+  billitems on that detached entity (see the controller's `approve()`
+  comments); the same risk analysis was then applied uniformly and **both
+  cross-link writes were moved to native SQL** (`linkApprovedBillToRequest`/
+  `linkRequestedBillToApproval` in the service), confirmed working live via
+  Playwright + direct DB query. `requestedBill.setReferenceBill(approvedBill)`
+  is still set in-memory for this session's own double-approval guard, but
+  the persisted write is native, not `billFacade.edit()`.
 
 **Guards enforced before any write** (must all be replicated):
 - `navigateToPurchaseOrderApproval()`: reject if `requestedBill.getReferenceBill() != null`
@@ -188,14 +199,21 @@ unit-tests. This is safe because:
   unit tests already cover this function's edge cases (zero qty, AMPP
   pack conversion, null fields).
 
-**Decision: cross-link write stays JPA, `requestedBill` entity stays on JPA
-throughout.** Confirmed with you — only the new `approvedBill`'s own rows go
-through native SQL. `requestedBill` is loaded via `billFacade.find()` (as
-today), read for guard checks and header seeding (payment method, supplier,
-credit duration, department type, comments — all copied to `approvedBill` on
-`navigateToPurchaseOrderApproval()`, matching legacy), and the final
+**Superseded: cross-link write stays JPA, `requestedBill` entity stays on JPA
+throughout.** Originally confirmed with you — only the new `approvedBill`'s
+own rows go through native SQL, and the final
 `requestedBill.setReferenceBill(approvedBill); billFacade.edit(requestedBill)`
-happens exactly as legacy does it, in JPA. Never touched by native SQL.
+happens exactly as legacy does it, in JPA. **This decision was revisited
+during PR review** (see §2 above): the same orphan-removal risk that ruled
+out `billFacade.edit(approvedBill)` for `approveAt`/`approveUser` applies
+equally to any `billFacade.edit()` call on a bill whose lines were written by
+native SQL through a sibling EJB. Both cross-link directions are now written
+by native `UPDATE ... SET referenceBill_ID=?` (see `PurchaseOrderApprovingNativeSqlService
+.linkApprovedBillToRequest()`/`.linkRequestedBillToApproval()`), each scoped
+to touch only the FK column, not the bill's managed collections.
+`requestedBill` is still loaded via `billFacade.find()` (as today) and read
+for guard checks and header seeding, unchanged; it is simply no longer
+merged back via `billFacade.edit()`.
 
 **Decision: `updateCalculatedValues()`'s "lighter recompute" optimization is
 dropped.** Legacy has two code paths in `onEdit()` — a full
@@ -246,9 +264,12 @@ calls the single recompute helper (mirrors Phase 1's `recalculateLineValues`
   is a direct, low-risk substitution here since the read only needs the 8
   scalar fields listed in §3's `loadRequestedLines` description.
 - **Make the approved bill's cross-link write native too, with explicit cache
-  eviction to manage the risk.** Rejected — confirmed with you; goes against
-  the master issue's explicit decision and the retail-sale precedent, no
-  clear benefit.
+  eviction to manage the risk.** Originally rejected as going against the
+  master issue's explicit decision, no clear benefit. **Later adopted** (see
+  §2 and §7 above) once the orphan-removal risk on `billFacade.edit()` for a
+  natively-line-written bill was confirmed via a live runtime exception during
+  PR review — the benefit (avoiding that risk) turned out to be real, not
+  hypothetical.
 
 ---
 

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderApprovingNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderApprovingNativeSqlController.java
@@ -563,16 +563,24 @@ public class PurchaseOrderApprovingNativeSqlController implements Serializable {
                         html.append("<td style='padding: 8px;'>").append(esc(bi.getItem().getCode())).append("</td>");
                         html.append("<td style='padding: 8px;'>").append(esc(bi.getItem().getName())).append("</td>");
                         html.append("<td style='padding: 8px; text-align: right;'>");
-                        if (bi.getPharmaceuticalBillItem() != null) {
-                            html.append(String.format("%,.0f", bi.getPharmaceuticalBillItem().getQty()));
-                        }
-                        html.append("</td><td style='padding: 8px; text-align: right;'>");
-                        if (bi.getPharmaceuticalBillItem() != null) {
-                            html.append(String.format("%,.0f", bi.getPharmaceuticalBillItem().getFreeQty()));
-                        }
-                        html.append("</td><td style='padding: 8px; text-align: right;'>");
-                        if (bi.getPharmaceuticalBillItem() != null) {
-                            html.append(String.format("%,.2f", bi.getPharmaceuticalBillItem().getPurchaseRate()));
+                        // Read from BillItemFinanceDetails, not PharmaceuticalBillItem: the
+                        // PBI's primitive qty/freeQty/purchaseRate are only populated by
+                        // saveApprovedLine()'s native write at persist time and stay 0 on
+                        // this in-memory billItems list even after a successful approve()
+                        // (same reasoning as the validation loop above) -- reading them here
+                        // rendered every emailed line as 0.
+                        if (bi.getBillItemFinanceDetails() != null) {
+                            BigDecimal qty = bi.getBillItemFinanceDetails().getQuantity();
+                            BigDecimal freeQty = bi.getBillItemFinanceDetails().getFreeQuantity();
+                            BigDecimal rate = bi.getBillItemFinanceDetails().getLineGrossRate();
+                            html.append(String.format("%,.0f", qty != null ? qty.doubleValue() : 0.0));
+                            html.append("</td><td style='padding: 8px; text-align: right;'>");
+                            html.append(String.format("%,.0f", freeQty != null ? freeQty.doubleValue() : 0.0));
+                            html.append("</td><td style='padding: 8px; text-align: right;'>");
+                            html.append(String.format("%,.2f", rate != null ? rate.doubleValue() : 0.0));
+                        } else {
+                            html.append("</td><td style='padding: 8px; text-align: right;'>");
+                            html.append("</td><td style='padding: 8px; text-align: right;'>");
                         }
                         html.append("</td><td style='padding: 8px; text-align: right;'>").append(String.format("%,.2f", bi.getNetValue())).append("</td>");
                         html.append("</tr>");

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderApprovingNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderApprovingNativeSqlController.java
@@ -1,0 +1,613 @@
+package com.divudi.bean.pharmacy;
+
+import com.divudi.bean.common.SessionController;
+import com.divudi.bean.common.WebUserController;
+import com.divudi.bean.common.ConfigOptionApplicationController;
+import com.divudi.bean.common.ConfigOptionController;
+import com.divudi.core.data.BillType;
+import com.divudi.core.data.BillTypeAtomic;
+import com.divudi.core.data.DepartmentType;
+import com.divudi.core.data.PaymentMethod;
+import com.divudi.core.data.dto.pharmacy.PurchaseOrderRequestLineData;
+import com.divudi.core.entity.AppEmail;
+import com.divudi.core.data.MessageType;
+import com.divudi.core.entity.Bill;
+import com.divudi.core.entity.BilledBill;
+import com.divudi.core.entity.BillItem;
+import com.divudi.core.entity.Item;
+import com.divudi.core.entity.pharmacy.Ampp;
+import com.divudi.core.entity.pharmacy.PharmaceuticalBillItem;
+import com.divudi.core.facade.BillFacade;
+import com.divudi.core.facade.EmailFacade;
+import com.divudi.core.util.CommonFunctions;
+import com.divudi.core.util.JsfUtil;
+import com.divudi.ejb.BillNumberGenerator;
+import com.divudi.ejb.EmailManagerEjb;
+import com.divudi.service.pharmacy.PurchaseOrderApprovingNativeSqlService;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.ejb.EJB;
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+/**
+ * SessionScoped controller for the native-SQL Purchase Order Approving page.
+ * Native SQL: the APPROVED bill's own create/update, billitem+PBI writes
+ * (via the service). JPA (unchanged): the requested bill (read-only except
+ * for the referenceBill cross-link write), rate/email infra.
+ * Related issue: #22738
+ */
+@Named
+@SessionScoped
+public class PurchaseOrderApprovingNativeSqlController implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final Logger LOGGER = Logger.getLogger(PurchaseOrderApprovingNativeSqlController.class.getName());
+
+    @Inject
+    private SessionController sessionController;
+    @Inject
+    private WebUserController webUserController;
+    @Inject
+    private ConfigOptionApplicationController configOptionApplicationController;
+    @Inject
+    private ConfigOptionController configOptionController;
+    @Inject
+    private PharmacyController pharmacyController;
+
+    @EJB
+    private PurchaseOrderApprovingNativeSqlService purchaseOrderApprovingNativeSqlService;
+    @EJB
+    private BillNumberGenerator billNumberBean;
+    @EJB
+    private BillFacade billFacade;
+    @EJB
+    private EmailFacade emailFacade;
+    @EJB
+    private EmailManagerEjb emailManagerEjb;
+    @EJB
+    private com.divudi.core.facade.ItemFacade itemFacade;
+
+    private Bill requestedBill;
+    private Bill approvedBill;
+    private List<BillItem> billItems;
+    private List<BillItem> selectedItems;
+    private boolean printPreview;
+    private String emailRecipient;
+
+    private boolean isAuthorized(String action, String requiredPrivilege) {
+        if (webUserController == null || sessionController == null) {
+            LOGGER.log(Level.SEVERE, "Authorization failed - missing controllers: action={0}, userId=null, billId={1}",
+                    new Object[]{action, requestedBill != null ? requestedBill.getId() : "null"});
+            return false;
+        }
+        if (!webUserController.hasPrivilege(requiredPrivilege)) {
+            Long userId = sessionController.getLoggedUser() != null ? sessionController.getLoggedUser().getId() : null;
+            Long billId = requestedBill != null ? requestedBill.getId() : null;
+            LOGGER.log(Level.WARNING, "SECURITY: Unauthorized Purchase Order Approving access attempt - action={0}, userId={1}, billId={2}, requiredPrivilege={3}",
+                    new Object[]{action, userId, billId, requiredPrivilege});
+            JsfUtil.addErrorMessage("You don't have permission to " + action.toLowerCase() + " purchase orders.");
+            return false;
+        }
+        return true;
+    }
+
+    public void resetBillValues() {
+        requestedBill = null;
+        approvedBill = null;
+        billItems = new ArrayList<>();
+        selectedItems = null;
+        printPreview = false;
+    }
+
+    public Bill getApprovedBill() {
+        if (approvedBill == null) {
+            approvedBill = new BilledBill();
+            approvedBill.setBillType(BillType.PharmacyOrderApprove);
+            approvedBill.setBillTypeAtomic(BillTypeAtomic.PHARMACY_ORDER_APPROVAL);
+            if (requestedBill != null) {
+                approvedBill.setConsignment(requestedBill.isConsignment());
+                approvedBill.setDepartmentType(requestedBill.getDepartmentType());
+            }
+        }
+        return approvedBill;
+    }
+
+    // synchronized: see Task 3 doc comment on approve() for the production
+    // incident (GRN item duplication, PO/RH/GSK/26/01093) this guards against.
+    public synchronized String navigateToPurchaseOrderApproval(Long requestedBillId) {
+        if (requestedBillId == null) {
+            JsfUtil.addErrorMessage("No Bill");
+            return "";
+        }
+        Bill bill = billFacade.find(requestedBillId);
+        if (bill == null) {
+            JsfUtil.addErrorMessage("Bill not found");
+            return "";
+        }
+        if (bill.getBillTypeAtomic() != BillTypeAtomic.PHARMACY_ORDER) {
+            JsfUtil.addErrorMessage("Bill is not a finalized purchase order request");
+            return "";
+        }
+        if (bill.isRetired() || bill.isCancelled()) {
+            JsfUtil.addErrorMessage("Bill is retired or cancelled");
+            return "";
+        }
+        if (bill.getDepartment() == null || sessionController.getLoggedUser() == null
+                || !bill.getDepartment().equals(sessionController.getDepartment())) {
+            JsfUtil.addErrorMessage("You are not authorized to view this purchase order");
+            return "";
+        }
+        if (bill.getReferenceBill() != null) {
+            JsfUtil.addErrorMessage("This purchase order is already approved");
+            return "";
+        }
+
+        resetBillValues();
+        requestedBill = bill;
+        getApprovedBill().setPaymentMethod(requestedBill.getPaymentMethod());
+        getApprovedBill().setToInstitution(requestedBill.getToInstitution());
+        getApprovedBill().setCreditDuration(requestedBill.getCreditDuration());
+        generateBillComponent();
+        printPreview = false;
+        return "/pharmacy/pharmacy_purhcase_order_approving_native?faces-redirect=true";
+    }
+
+    public void generateBillComponent() {
+        billItems = new ArrayList<>();
+        if (requestedBill == null) {
+            return;
+        }
+        List<PurchaseOrderRequestLineData> lines = purchaseOrderApprovingNativeSqlService.loadRequestedLines(requestedBill.getId());
+        for (PurchaseOrderRequestLineData line : lines) {
+            Item item = itemFacade.find(line.getItemId());
+            if (item == null) {
+                continue;
+            }
+            BillItem bi = new BillItem();
+            bi.setItem(item);
+            bi.setSearialNo(line.getSerialNo());
+
+            PharmaceuticalBillItem pbi = new PharmaceuticalBillItem();
+            pbi.setBillItem(bi);
+            pbi.setCreatedAt(new Date());
+            pbi.setCreater(sessionController.getLoggedUser());
+            bi.setPharmaceuticalBillItem(pbi);
+
+            bi.getBillItemFinanceDetails().setQuantity(line.getQuantity());
+            bi.getBillItemFinanceDetails().setFreeQuantity(line.getFreeQuantity());
+            bi.getBillItemFinanceDetails().setLineGrossRate(line.getPurchaseRate());
+            bi.getBillItemFinanceDetails().setRetailSaleRate(line.getRetailRate());
+            bi.getBillItemFinanceDetails().setUnitsPerPack(line.getUnitsPerPack());
+
+            recalculateLineValues(bi);
+            billItems.add(bi);
+        }
+        calculateBillTotals();
+    }
+
+    public void onEdit(BillItem bi) {
+        if (bi.getBillItemFinanceDetails() != null
+                && configOptionController.getBooleanValueByKey("Pharmacy Purchase - Quantity Must Be Integer", true)) {
+            BigDecimal qty = bi.getBillItemFinanceDetails().getQuantity();
+            BigDecimal freeQty = bi.getBillItemFinanceDetails().getFreeQuantity();
+            if (qty != null && qty.remainder(BigDecimal.ONE).compareTo(BigDecimal.ZERO) != 0) {
+                bi.getBillItemFinanceDetails().setQuantity(BigDecimal.ZERO);
+                recalculateLineValues(bi);
+                JsfUtil.addErrorMessage("Please enter only whole numbers (integers) for quantity. Decimal values are not allowed.");
+                calculateBillTotals();
+                return;
+            }
+            if (freeQty != null && freeQty.remainder(BigDecimal.ONE).compareTo(BigDecimal.ZERO) != 0) {
+                bi.getBillItemFinanceDetails().setFreeQuantity(BigDecimal.ZERO);
+                recalculateLineValues(bi);
+                JsfUtil.addErrorMessage("Please enter only whole numbers (integers) for free quantity. Decimal values are not allowed.");
+                calculateBillTotals();
+                return;
+            }
+        }
+        recalculateLineValues(bi);
+        calculateBillTotals();
+    }
+
+    private void recalculateLineValues(BillItem bi) {
+        if (bi == null || bi.getBillItemFinanceDetails() == null) {
+            return;
+        }
+        BigDecimal qty = bi.getBillItemFinanceDetails().getQuantity();
+        BigDecimal purchaseRate = bi.getBillItemFinanceDetails().getLineGrossRate();
+        if (qty == null) qty = BigDecimal.ZERO;
+        if (purchaseRate == null) purchaseRate = BigDecimal.ZERO;
+
+        BigDecimal grossValue = purchaseRate.multiply(qty);
+        bi.setRate(purchaseRate.doubleValue());
+        bi.setNetRate(purchaseRate.doubleValue());
+        bi.setGrossValue(grossValue.doubleValue());
+        bi.setNetValue(grossValue.doubleValue());
+        bi.getBillItemFinanceDetails().setLineGrossTotal(grossValue);
+        bi.getBillItemFinanceDetails().setLineNetTotal(grossValue);
+    }
+
+    private void calculateBillTotals() {
+        double total = 0.0;
+        int serialNo = 0;
+        for (BillItem bi : billItems) {
+            if (bi == null || bi.isRetired()) {
+                continue;
+            }
+            bi.setSearialNo(serialNo++);
+            total += bi.getNetValue();
+        }
+        getApprovedBill().setNetTotal(total);
+        getApprovedBill().setTotal(total);
+    }
+
+    public void removeItem(BillItem billItem) {
+        if (billItem == null || !billItems.contains(billItem)) {
+            JsfUtil.addErrorMessage("Item not found or already removed");
+            return;
+        }
+        billItems.remove(billItem);
+        calculateBillTotals();
+    }
+
+    public void removeSelected() {
+        if (selectedItems == null || selectedItems.isEmpty()) {
+            JsfUtil.addErrorMessage("No items selected to remove");
+            return;
+        }
+        billItems.removeAll(selectedItems);
+        calculateBillTotals();
+        selectedItems = null;
+    }
+
+    // synchronized: a double-submit on the Approve button (no confirm-then-review
+    // gap, or a resubmitted ajax="false" postback) let two requests race through
+    // the same in-memory billItems list before either had persisted -- both saw
+    // BillItem.id == null and created every line twice, duplicating every GRN
+    // item (Ruhunu PO/RH/GSK/26/01093, same bug class as Phase 1's #21417 guard).
+    public synchronized void approve() {
+        if (!isAuthorized("APPROVE", "PurchaseOrdersApprovel")) {
+            return;
+        }
+        if (requestedBill == null) {
+            JsfUtil.addErrorMessage("No Bill");
+            return;
+        }
+        if (requestedBill.getReferenceBill() != null) {
+            JsfUtil.addErrorMessage("This purchase order is already approved");
+            return;
+        }
+        if (getApprovedBill().getPaymentMethod() == null) {
+            JsfUtil.addErrorMessage("Select Paymentmethod");
+            return;
+        }
+        if (billItems == null || billItems.isEmpty()) {
+            JsfUtil.addErrorMessage("Please add bill items");
+            return;
+        }
+        for (BillItem bi : billItems) {
+            PharmaceuticalBillItem pbi = bi.getPharmaceuticalBillItem();
+            if (pbi == null) {
+                JsfUtil.addErrorMessage("Missing pharmaceutical details for item: " + bi.getItem().getName());
+                return;
+            }
+            double totalQty = bi.getBillItemFinanceDetails().getQuantity().doubleValue()
+                    + bi.getBillItemFinanceDetails().getFreeQuantity().doubleValue();
+            if (totalQty <= 0) {
+                JsfUtil.addErrorMessage("Item '" + bi.getItem().getName() + "' has zero quantity and free quantity");
+                return;
+            }
+            if (bi.getBillItemFinanceDetails().getLineGrossRate() == null
+                    || bi.getBillItemFinanceDetails().getLineGrossRate().doubleValue() <= 0) {
+                JsfUtil.addErrorMessage("Item '" + bi.getItem().getName() + "' has invalid purchase price");
+                return;
+            }
+        }
+
+        calculateBillTotals();
+
+        String[] billNumbers = createAndAssignBillNumber();
+        long approvedBillId = purchaseOrderApprovingNativeSqlService.createApprovedBill(
+                requestedBill.getId(),
+                sessionController.getLoggedUser().getDepartment().getId(),
+                sessionController.getLoggedUser().getDepartment().getInstitution().getId(),
+                requestedBill.getDepartment().getId(),
+                requestedBill.getInstitution().getId(),
+                sessionController.getLoggedUser().getId(),
+                billNumbers[0],
+                billNumbers[1]);
+        approvedBill = billFacade.find(approvedBillId);
+        approvedBill.setPaymentMethod(getApprovedBill().getPaymentMethod());
+        approvedBill.setToInstitution(getApprovedBill().getToInstitution());
+        approvedBill.setCreditDuration(getApprovedBill().getCreditDuration());
+        approvedBill.setConsignment(getApprovedBill().isConsignment());
+        approvedBill.setDepartmentType(getApprovedBill().getDepartmentType());
+
+        purchaseOrderApprovingNativeSqlService.updateApprovedBillHeader(
+                approvedBillId,
+                approvedBill.getToInstitution() != null ? approvedBill.getToInstitution().getId() : null,
+                approvedBill.getPaymentMethod(),
+                approvedBill.getCreditDuration(),
+                approvedBill.isConsignment(),
+                approvedBill.getDepartmentType(),
+                approvedBill.getComments(),
+                sessionController.getLoggedUser().getId());
+
+        for (BillItem bi : billItems) {
+            PurchaseOrderRequestLineData line = new PurchaseOrderRequestLineData();
+            line.setItemId(bi.getItem().getId());
+            line.setAmpp(bi.getItem() instanceof Ampp);
+            line.setQuantity(bi.getBillItemFinanceDetails().getQuantity());
+            line.setFreeQuantity(bi.getBillItemFinanceDetails().getFreeQuantity());
+            line.setPurchaseRate(bi.getBillItemFinanceDetails().getLineGrossRate());
+            line.setRetailRate(bi.getBillItemFinanceDetails().getRetailSaleRate());
+            line.setUnitsPerPack(bi.getBillItemFinanceDetails().getUnitsPerPack());
+            line.setSerialNo(bi.getSearialNo());
+            line.setCreaterId(sessionController.getLoggedUser().getId());
+            purchaseOrderApprovingNativeSqlService.saveApprovedLine(approvedBillId, line);
+        }
+
+        purchaseOrderApprovingNativeSqlService.retireZeroQtyApprovedLines(approvedBillId, sessionController.getLoggedUser().getId());
+
+        approvedBill = billFacade.find(approvedBillId);
+        approvedBill.setApproveAt(new Date());
+        approvedBill.setApproveUser(sessionController.getLoggedUser());
+        billFacade.edit(approvedBill);
+
+        // The one JPA write in this phase that touches a bill this controller
+        // does not own the writes for -- required to stay JPA merge, never
+        // native SQL, per the master issue's L2-cache-coherence rule.
+        requestedBill.setReferenceBill(approvedBill);
+        billFacade.edit(requestedBill);
+
+        printPreview = true;
+        JsfUtil.addSuccessMessage("Purchase order approved successfully.");
+    }
+
+    private String[] createAndAssignBillNumber() {
+        String billSuffix = configOptionApplicationController.getLongTextValueByKey("Bill Number Suffix for " + BillTypeAtomic.PHARMACY_ORDER_APPROVAL, "");
+        if (billSuffix == null || billSuffix.trim().isEmpty()) {
+            configOptionApplicationController.setLongTextValueByKey("Bill Number Suffix for " + BillTypeAtomic.PHARMACY_ORDER_APPROVAL, "POA");
+        }
+
+        boolean stratInsDeptYear = configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Purchase Order Approvals - Prefix + Institution Code + Department Code + Year + Yearly Number and Yearly Number", false);
+        boolean stratInsYear = configOptionApplicationController.getBooleanValueByKey("Bill Number Generation Strategy for Purchase Order Approvals - Prefix + Institution Code + Year + Yearly Number and Yearly Number", false);
+        boolean stratInsIdInsYear = configOptionApplicationController.getBooleanValueByKey("Institution Number Generation Strategy for Purchase Order Approvals - Prefix + Institution Code + Year + Yearly Number and Yearly Number", false);
+
+        String deptId;
+        if (stratInsDeptYear) {
+            deptId = billNumberBean.departmentBillNumberGeneratorYearlyWithPrefixInsDeptYearCount(sessionController.getDepartment(), BillTypeAtomic.PHARMACY_ORDER_APPROVAL);
+        } else if (stratInsYear) {
+            deptId = billNumberBean.departmentBillNumberGeneratorYearlyWithPrefixInsYearCountInstitutionWide(sessionController.getDepartment(), BillTypeAtomic.PHARMACY_ORDER_APPROVAL);
+        } else {
+            deptId = billNumberBean.departmentBillNumberGeneratorYearly(sessionController.getDepartment(), BillTypeAtomic.PHARMACY_ORDER_APPROVAL);
+        }
+
+        String insId;
+        if (stratInsIdInsYear) {
+            insId = billNumberBean.institutionBillNumberGeneratorYearlyWithPrefixInsYearCountInstitutionWide(sessionController.getDepartment(), BillTypeAtomic.PHARMACY_ORDER_APPROVAL);
+        } else {
+            insId = deptId;
+        }
+
+        return new String[]{deptId, insId};
+    }
+
+    private static String esc(String value) {
+        return value != null ? org.apache.commons.text.StringEscapeUtils.escapeHtml4(value) : "";
+    }
+
+    public void prepareEmailDialog() {
+        if (approvedBill == null) {
+            JsfUtil.addErrorMessage("No Bill");
+            return;
+        }
+        if (approvedBill.getToInstitution() != null && approvedBill.getToInstitution().getEmail() != null) {
+            emailRecipient = approvedBill.getToInstitution().getEmail();
+        } else {
+            emailRecipient = "";
+        }
+    }
+
+    public void sendPurchaseOrderEmail() {
+        if (approvedBill == null) {
+            JsfUtil.addErrorMessage("No Bill");
+            return;
+        }
+        if (emailRecipient == null || emailRecipient.trim().isEmpty()) {
+            JsfUtil.addErrorMessage("Please enter recipient email");
+            return;
+        }
+        String recipient = emailRecipient.trim();
+        if (!CommonFunctions.isValidEmail(recipient)) {
+            JsfUtil.addErrorMessage("Please enter a valid email address");
+            return;
+        }
+        String body = generatePurchaseOrderHtml();
+        if (body == null) {
+            JsfUtil.addErrorMessage("Could not generate email body");
+            return;
+        }
+
+        AppEmail email = new AppEmail();
+        email.setCreatedAt(new Date());
+        email.setCreater(sessionController.getLoggedUser());
+        email.setReceipientEmail(recipient);
+        email.setMessageSubject("Purchase Order");
+        email.setMessageBody(body);
+        email.setDepartment(sessionController.getLoggedUser().getDepartment());
+        email.setInstitution(sessionController.getLoggedUser().getInstitution());
+        email.setBill(approvedBill);
+        email.setMessageType(MessageType.Marketing);
+        email.setSentSuccessfully(false);
+        email.setPending(true);
+        emailFacade.create(email);
+
+        try {
+            boolean success = emailManagerEjb.sendEmail(
+                    java.util.Collections.singletonList(recipient), body, "Purchase Order", true);
+            email.setSentSuccessfully(success);
+            email.setPending(!success);
+            if (success) {
+                email.setSentAt(new Date());
+                JsfUtil.addSuccessMessage("Email Sent Successfully");
+            } else {
+                JsfUtil.addErrorMessage("Sending Email Failed");
+            }
+            emailFacade.edit(email);
+        } catch (Exception ex) {
+            JsfUtil.addErrorMessage("Sending Email Failed");
+        }
+    }
+
+    private String generatePurchaseOrderHtml() {
+        try {
+            if (approvedBill == null) {
+                return null;
+            }
+            StringBuilder html = new StringBuilder();
+            html.append("<html><head><title>Purchase Order</title></head><body>");
+            html.append("<div style='font-family: Arial, sans-serif; padding: 20px;'>");
+
+            if (approvedBill.getCreater() != null && approvedBill.getCreater().getInstitution() != null) {
+                html.append("<div style='text-align: center; margin-bottom: 20px;'>");
+                html.append("<h2>").append(esc(approvedBill.getCreater().getInstitution().getName())).append("</h2>");
+                if (approvedBill.getCreater().getInstitution().getAddress() != null) {
+                    html.append("<p>").append(esc(approvedBill.getCreater().getInstitution().getAddress())).append("</p>");
+                }
+                if (approvedBill.getCreater().getInstitution().getPhone() != null) {
+                    html.append("<p>Phone: ").append(esc(approvedBill.getCreater().getInstitution().getPhone())).append("</p>");
+                }
+                html.append("</div>");
+            }
+
+            html.append("<h3 style='text-align: center; text-decoration: underline;'>Purchase Order</h3>");
+            html.append("<table style='width: 100%; margin-bottom: 20px;'>");
+            html.append("<tr><td><strong>Order No:</strong></td><td>").append(esc(approvedBill.getDeptId())).append("</td></tr>");
+            if (approvedBill.getDepartment() != null) {
+                html.append("<tr><td><strong>Order Department:</strong></td><td>").append(esc(approvedBill.getDepartment().getName())).append("</td></tr>");
+            }
+            if (approvedBill.getToInstitution() != null) {
+                html.append("<tr><td><strong>Supplier:</strong></td><td>").append(esc(approvedBill.getToInstitution().getName())).append("</td></tr>");
+                html.append("<tr><td><strong>Supplier Code:</strong></td><td>").append(esc(approvedBill.getToInstitution().getCode())).append("</td></tr>");
+                if (approvedBill.getToInstitution().getPhone() != null) {
+                    html.append("<tr><td><strong>Supplier Phone:</strong></td><td>").append(esc(approvedBill.getToInstitution().getPhone())).append("</td></tr>");
+                }
+                if (approvedBill.getToInstitution().getAddress() != null) {
+                    html.append("<tr><td><strong>Supplier Address:</strong></td><td>").append(esc(approvedBill.getToInstitution().getAddress())).append("</td></tr>");
+                }
+            }
+            html.append("<tr><td><strong>Payment Method:</strong></td><td>").append(approvedBill.getPaymentMethod() != null ? approvedBill.getPaymentMethod().toString() : "").append("</td></tr>");
+            html.append("<tr><td><strong>Consignment:</strong></td><td>").append(approvedBill.isConsignment() ? "Yes" : "No").append("</td></tr>");
+            html.append("</table>");
+
+            html.append("<table border='1' style='width: 100%; border-collapse: collapse; margin-bottom: 20px;'>");
+            html.append("<thead style='background-color: #f0f0f0;'>");
+            html.append("<tr><th style='padding: 8px;'>Item Code</th><th style='padding: 8px;'>Item Name</th>");
+            html.append("<th style='padding: 8px;'>Qty</th><th style='padding: 8px;'>Free Qty</th>");
+            html.append("<th style='padding: 8px;'>Purchase Rate</th><th style='padding: 8px;'>Purchase Value</th></tr></thead><tbody>");
+
+            if (billItems != null) {
+                for (BillItem bi : billItems) {
+                    if (bi != null && !bi.isRetired() && bi.getItem() != null) {
+                        html.append("<tr>");
+                        html.append("<td style='padding: 8px;'>").append(esc(bi.getItem().getCode())).append("</td>");
+                        html.append("<td style='padding: 8px;'>").append(esc(bi.getItem().getName())).append("</td>");
+                        html.append("<td style='padding: 8px; text-align: right;'>");
+                        if (bi.getPharmaceuticalBillItem() != null) {
+                            html.append(String.format("%,.0f", bi.getPharmaceuticalBillItem().getQty()));
+                        }
+                        html.append("</td><td style='padding: 8px; text-align: right;'>");
+                        if (bi.getPharmaceuticalBillItem() != null) {
+                            html.append(String.format("%,.0f", bi.getPharmaceuticalBillItem().getFreeQty()));
+                        }
+                        html.append("</td><td style='padding: 8px; text-align: right;'>");
+                        if (bi.getPharmaceuticalBillItem() != null) {
+                            html.append(String.format("%,.2f", bi.getPharmaceuticalBillItem().getPurchaseRate()));
+                        }
+                        html.append("</td><td style='padding: 8px; text-align: right;'>").append(String.format("%,.2f", bi.getNetValue())).append("</td>");
+                        html.append("</tr>");
+                    }
+                }
+            }
+
+            html.append("</tbody><tfoot style='font-weight: bold;'><tr>");
+            html.append("<td colspan='5' style='padding: 8px; text-align: right;'>Net Total:</td>");
+            html.append("<td style='padding: 8px; text-align: right;'>").append(String.format("%,.2f", approvedBill.getNetTotal())).append("</td>");
+            html.append("</tr></tfoot></table>");
+
+            html.append("<div style='margin-top: 20px;'>");
+            if (approvedBill.getCreater() != null && approvedBill.getCreater().getWebUserPerson() != null) {
+                html.append("<p><strong>Order Initiated By:</strong> ").append(esc(approvedBill.getCreater().getWebUserPerson().getName())).append("</p>");
+            }
+            if (approvedBill.getCheckedBy() != null) {
+                html.append("<p><strong>Order Finalized By:</strong> ").append(esc(approvedBill.getCheckedBy().getName())).append("</p>");
+            }
+            if (approvedBill.getCheckeAt() != null) {
+                html.append("<p><strong>Order Finalized At:</strong> ").append(CommonFunctions.formatDate(approvedBill.getCheckeAt(), "dd/MM/yyyy HH:mm:ss")).append("</p>");
+            }
+            html.append("<p><strong>Generated At:</strong> ").append(CommonFunctions.formatDate(new Date(), "dd/MM/yyyy HH:mm:ss")).append("</p>");
+            html.append("<p><strong>Total:</strong> ").append(String.format("%,.2f", approvedBill.getNetTotal())).append("</p>");
+            html.append("</div></div></body></html>");
+            return html.toString();
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, "Error generating purchase order HTML", e);
+            return null;
+        }
+    }
+
+    public void displayItemDetails(BillItem bi) {
+        pharmacyController.fillItemDetails(bi.getItem());
+    }
+
+    public void onFocus(BillItem bi) {
+        pharmacyController.setPharmacyItem(bi.getItem());
+    }
+
+    public Bill getRequestedBill() {
+        return requestedBill;
+    }
+
+    public List<BillItem> getBillItems() {
+        if (billItems == null) {
+            billItems = new ArrayList<>();
+        }
+        return billItems;
+    }
+
+    public void setBillItems(List<BillItem> billItems) {
+        this.billItems = billItems;
+    }
+
+    public List<BillItem> getSelectedItems() {
+        return selectedItems;
+    }
+
+    public void setSelectedItems(List<BillItem> selectedItems) {
+        this.selectedItems = selectedItems;
+    }
+
+    public boolean isPrintPreview() {
+        return printPreview;
+    }
+
+    public void setPrintPreview(boolean printPreview) {
+        this.printPreview = printPreview;
+    }
+
+    public String getEmailRecipient() {
+        return emailRecipient;
+    }
+
+    public void setEmailRecipient(String emailRecipient) {
+        this.emailRecipient = emailRecipient;
+    }
+}

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderApprovingNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderApprovingNativeSqlController.java
@@ -40,9 +40,11 @@ import javax.inject.Named;
 
 /**
  * SessionScoped controller for the native-SQL Purchase Order Approving page.
- * Native SQL: the APPROVED bill's own create/update, billitem+PBI writes
- * (via the service). JPA (unchanged): the requested bill (read-only except
- * for the referenceBill cross-link write), rate/email infra.
+ * Native SQL: the APPROVED bill's own create/update, billitem+PBI writes,
+ * approveAt/approveUser, and both directions of the referenceBill cross-link
+ * (via the service). JPA (unchanged): the requested bill stays read-only
+ * here -- its in-memory referenceBill field is set for this session's own
+ * double-approval guard, but the persisted cross-link write is native SQL.
  * Related issue: #22738
  */
 @Named

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderApprovingNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderApprovingNativeSqlController.java
@@ -4,6 +4,7 @@ import com.divudi.bean.common.SessionController;
 import com.divudi.bean.common.WebUserController;
 import com.divudi.bean.common.ConfigOptionApplicationController;
 import com.divudi.bean.common.ConfigOptionController;
+import com.divudi.bean.common.NotificationController;
 import com.divudi.core.data.BillType;
 import com.divudi.core.data.BillTypeAtomic;
 import com.divudi.core.data.DepartmentType;
@@ -62,6 +63,8 @@ public class PurchaseOrderApprovingNativeSqlController implements Serializable {
     private ConfigOptionController configOptionController;
     @Inject
     private PharmacyController pharmacyController;
+    @Inject
+    private NotificationController notificationController;
 
     @EJB
     private PurchaseOrderApprovingNativeSqlService purchaseOrderApprovingNativeSqlService;
@@ -384,16 +387,25 @@ public class PurchaseOrderApprovingNativeSqlController implements Serializable {
         purchaseOrderApprovingNativeSqlService.updateBillTotals(approvedBillId, netTotal, total);
         purchaseOrderApprovingNativeSqlService.retireZeroQtyApprovedLines(approvedBillId, sessionController.getLoggedUser().getId());
 
-        approvedBill = billFacade.find(approvedBillId);
-        approvedBill.setApproveAt(new Date());
-        approvedBill.setApproveUser(sessionController.getLoggedUser());
-        billFacade.edit(approvedBill);
+        // Native UPDATE, not billFacade.edit() -- approvedBill's lines were
+        // written by saveApprovedLine() through native SQL, not through this
+        // detached entity's managed billItems collection (cascade=ALL,
+        // orphanRemoval=true). Merging the detached bill here would risk
+        // EclipseLink treating those native-written lines as absent and
+        // deleting them via orphan removal.
+        purchaseOrderApprovingNativeSqlService.approveBill(approvedBillId, sessionController.getLoggedUser().getId());
+        // Mirrors legacy's getAprovedBill().setReferenceBill(getRequestedBill()):
+        // the approved bill's own referenceBill points at the requested bill --
+        // the po.xhtml/po_custom_*.xhtml print composites read
+        // cc.attrs.bill.referenceBill.* (institution letterhead, "Prepared By",
+        // "Authorized By") off the APPROVED bill passed in as cc.attrs.bill.
+        purchaseOrderApprovingNativeSqlService.linkApprovedBillToRequest(approvedBillId, requestedBill.getId());
+        purchaseOrderApprovingNativeSqlService.linkRequestedBillToApproval(requestedBill.getId(), approvedBillId);
 
-        // The one JPA write in this phase that touches a bill this controller
-        // does not own the writes for -- required to stay JPA merge, never
-        // native SQL, per the master issue's L2-cache-coherence rule.
+        approvedBill = billFacade.find(approvedBillId);
         requestedBill.setReferenceBill(approvedBill);
-        billFacade.edit(requestedBill);
+
+        notificationController.createNotification(approvedBill);
 
         printPreview = true;
         JsfUtil.addSuccessMessage("Purchase order approved successfully.");

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderApprovingNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderApprovingNativeSqlController.java
@@ -14,6 +14,7 @@ import com.divudi.core.data.MessageType;
 import com.divudi.core.entity.Bill;
 import com.divudi.core.entity.BilledBill;
 import com.divudi.core.entity.BillItem;
+import com.divudi.core.entity.Institution;
 import com.divudi.core.entity.Item;
 import com.divudi.core.entity.pharmacy.Ampp;
 import com.divudi.core.entity.pharmacy.PharmaceuticalBillItem;
@@ -295,12 +296,21 @@ public class PurchaseOrderApprovingNativeSqlController implements Serializable {
         }
         for (BillItem bi : billItems) {
             PharmaceuticalBillItem pbi = bi.getPharmaceuticalBillItem();
-            if (pbi == null) {
+            if (pbi == null || bi.getBillItemFinanceDetails() == null) {
                 JsfUtil.addErrorMessage("Missing pharmaceutical details for item: " + bi.getItem().getName());
                 return;
             }
-            double totalQty = bi.getBillItemFinanceDetails().getQuantity().doubleValue()
-                    + bi.getBillItemFinanceDetails().getFreeQuantity().doubleValue();
+            // Read from BillItemFinanceDetails, not PharmaceuticalBillItem: the PBI's
+            // primitive qty/freeQty are only populated by saveApprovedLine() at persist
+            // time (see computeLineValues()) and stay 0.0 for every in-memory/unsaved
+            // line -- reading them here would always fail this check. Quantity/free
+            // quantity are BigDecimal on BillItemFinanceDetails and can be null (e.g. a
+            // requested line whose free quantity was left blank), so default like
+            // recalculateLineValues() does.
+            BigDecimal qty = bi.getBillItemFinanceDetails().getQuantity();
+            BigDecimal freeQty = bi.getBillItemFinanceDetails().getFreeQuantity();
+            double totalQty = (qty != null ? qty.doubleValue() : 0.0)
+                    + (freeQty != null ? freeQty.doubleValue() : 0.0);
             if (totalQty <= 0) {
                 JsfUtil.addErrorMessage("Item '" + bi.getItem().getName() + "' has zero quantity and free quantity");
                 return;
@@ -314,6 +324,22 @@ public class PurchaseOrderApprovingNativeSqlController implements Serializable {
 
         calculateBillTotals();
 
+        // Capture the header values the user actually entered BEFORE reloading
+        // approvedBill below -- billFacade.find() returns a fresh entity with no
+        // header fields set, and getApprovedBill() only lazily re-inits when the
+        // field is null, so reading "getApprovedBill().getX()" AFTER the
+        // reassignment would just read the reloaded (empty) object back into
+        // itself, silently discarding what the user entered. Same class of bug
+        // as Phase 1's saveRequestWithoutMessage() header-loss fix.
+        Institution toInstitution = getApprovedBill().getToInstitution();
+        PaymentMethod paymentMethod = getApprovedBill().getPaymentMethod();
+        int creditDuration = getApprovedBill().getCreditDuration();
+        boolean consignment = getApprovedBill().isConsignment();
+        DepartmentType departmentType = getApprovedBill().getDepartmentType();
+        String comments = getApprovedBill().getComments();
+        double netTotal = getApprovedBill().getNetTotal();
+        double total = getApprovedBill().getTotal();
+
         String[] billNumbers = createAndAssignBillNumber();
         long approvedBillId = purchaseOrderApprovingNativeSqlService.createApprovedBill(
                 requestedBill.getId(),
@@ -325,20 +351,20 @@ public class PurchaseOrderApprovingNativeSqlController implements Serializable {
                 billNumbers[0],
                 billNumbers[1]);
         approvedBill = billFacade.find(approvedBillId);
-        approvedBill.setPaymentMethod(getApprovedBill().getPaymentMethod());
-        approvedBill.setToInstitution(getApprovedBill().getToInstitution());
-        approvedBill.setCreditDuration(getApprovedBill().getCreditDuration());
-        approvedBill.setConsignment(getApprovedBill().isConsignment());
-        approvedBill.setDepartmentType(getApprovedBill().getDepartmentType());
+        approvedBill.setPaymentMethod(paymentMethod);
+        approvedBill.setToInstitution(toInstitution);
+        approvedBill.setCreditDuration(creditDuration);
+        approvedBill.setConsignment(consignment);
+        approvedBill.setDepartmentType(departmentType);
 
         purchaseOrderApprovingNativeSqlService.updateApprovedBillHeader(
                 approvedBillId,
-                approvedBill.getToInstitution() != null ? approvedBill.getToInstitution().getId() : null,
-                approvedBill.getPaymentMethod(),
-                approvedBill.getCreditDuration(),
-                approvedBill.isConsignment(),
-                approvedBill.getDepartmentType(),
-                approvedBill.getComments(),
+                toInstitution != null ? toInstitution.getId() : null,
+                paymentMethod,
+                creditDuration,
+                consignment,
+                departmentType,
+                comments,
                 sessionController.getLoggedUser().getId());
 
         for (BillItem bi : billItems) {
@@ -355,6 +381,7 @@ public class PurchaseOrderApprovingNativeSqlController implements Serializable {
             purchaseOrderApprovingNativeSqlService.saveApprovedLine(approvedBillId, line);
         }
 
+        purchaseOrderApprovingNativeSqlService.updateBillTotals(approvedBillId, netTotal, total);
         purchaseOrderApprovingNativeSqlService.retireZeroQtyApprovedLines(approvedBillId, sessionController.getLoggedUser().getId());
 
         approvedBill = billFacade.find(approvedBillId);

--- a/src/main/java/com/divudi/core/data/dto/pharmacy/PurchaseOrderRequestLineData.java
+++ b/src/main/java/com/divudi/core/data/dto/pharmacy/PurchaseOrderRequestLineData.java
@@ -19,6 +19,27 @@ public class PurchaseOrderRequestLineData implements Serializable {
     private int serialNo;
     private Long createrId;
 
+    public PurchaseOrderRequestLineData() {
+    }
+
+    /**
+     * Constructor for the JPQL SELECT NEW projection used by
+     * PurchaseOrderApprovingNativeSqlService.loadRequestedLines(). Added
+     * alongside (not replacing) the existing no-arg constructor + setters,
+     * per this project's "never modify existing constructors" rule.
+     */
+    public PurchaseOrderRequestLineData(Long itemId, boolean ampp, BigDecimal quantity, BigDecimal freeQuantity,
+            BigDecimal purchaseRate, BigDecimal retailRate, BigDecimal unitsPerPack, int serialNo) {
+        this.itemId = itemId;
+        this.ampp = ampp;
+        this.quantity = quantity;
+        this.freeQuantity = freeQuantity;
+        this.purchaseRate = purchaseRate;
+        this.retailRate = retailRate;
+        this.unitsPerPack = unitsPerPack;
+        this.serialNo = serialNo;
+    }
+
     public Long getBillItemId() { return billItemId; }
     public void setBillItemId(Long billItemId) { this.billItemId = billItemId; }
 

--- a/src/main/java/com/divudi/core/data/dto/pharmacy/PurchaseOrderRequestLineData.java
+++ b/src/main/java/com/divudi/core/data/dto/pharmacy/PurchaseOrderRequestLineData.java
@@ -40,6 +40,24 @@ public class PurchaseOrderRequestLineData implements Serializable {
         this.serialNo = serialNo;
     }
 
+    /**
+     * Constructor for the JPQL SELECT NEW projection used by
+     * PurchaseOrderApprovingNativeSqlService.loadRequestedLines(), which
+     * cannot project ampp (EclipseLink rejects CASE WHEN TYPE(...) = X as a
+     * SELECT NEW constructor argument). ampp defaults to false here; callers
+     * that need it derive it separately from the resolved Item entity.
+     */
+    public PurchaseOrderRequestLineData(Long itemId, BigDecimal quantity, BigDecimal freeQuantity,
+            BigDecimal purchaseRate, BigDecimal retailRate, BigDecimal unitsPerPack, int serialNo) {
+        this.itemId = itemId;
+        this.quantity = quantity;
+        this.freeQuantity = freeQuantity;
+        this.purchaseRate = purchaseRate;
+        this.retailRate = retailRate;
+        this.unitsPerPack = unitsPerPack;
+        this.serialNo = serialNo;
+    }
+
     public Long getBillItemId() { return billItemId; }
     public void setBillItemId(Long billItemId) { this.billItemId = billItemId; }
 

--- a/src/main/java/com/divudi/service/pharmacy/PurchaseOrderApprovingNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PurchaseOrderApprovingNativeSqlService.java
@@ -75,40 +75,43 @@ public class PurchaseOrderApprovingNativeSqlService {
     }
 
     /**
-     * Native INSERT for the approved bill row. This row's own
-     * backwardReferenceBill_ID points at the requested bill, matching
-     * legacy's setBackwardReferenceBill(getRequestedBill()); the requested
-     * bill's own referenceBill_ID (pointing here) is written later in JPA by
-     * the controller. billClassType is BilledBill per legacy's
-     * "new BilledBill()" -- billClassType is a plain (non-discriminator)
-     * column on Bill (see Bill#billClassType), so it is written here as a
-     * literal .toString(), same as BillTypeAtomic/BillType.
+     * JPA persist for the approved bill row -- NOT native SQL. BilledBill is
+     * a single-table-inheritance subclass of Bill (discriminated by the
+     * DTYPE column), and DTYPE has no explicit @DiscriminatorColumn/
+     * @DiscriminatorValue mapping in this codebase -- EclipseLink derives and
+     * writes it automatically only through em.persist(), never through a raw
+     * native INSERT. A native INSERT here previously left DTYPE null,
+     * producing "Missing class indicator field from database row" on the
+     * very next JPA read of this bill. This is the same reason
+     * TransferIssueNativeSqlService.settle() persists its BilledBill header
+     * via JPA rather than native SQL (see its class-level Javadoc, step 1:
+     * "Persist bill header via JPA (correct DTYPE + IDENTITY PK)") --
+     * follow that established precedent here instead of reinventing it.
+     * This row's own backwardReferenceBill points at the requested bill,
+     * matching legacy's setBackwardReferenceBill(getRequestedBill()); the
+     * requested bill's own referenceBill (pointing here) is written later in
+     * JPA by the controller.
      */
     public long createApprovedBill(long requestedBillId, long departmentId, long institutionId,
             long fromDepartmentId, long fromInstitutionId, long createrId, String deptId, String insId) {
-        Date now = new Date();
-        em.createNativeQuery(
-            "INSERT INTO " + billTable()
-            + " (BILLTYPEATOMIC, billType, billClassType, department_ID, institution_ID,"
-            + " fromDepartment_ID, fromInstitution_ID, backwardReferenceBill_ID,"
-            + " creater_ID, createdAt, checked, retired, cancelled, deptId, insId, netTotal, total)"
-            + " VALUES (?,?,?,?,?,?,?,?,?,?,0,0,0,?,?,0,0)")
-            .setParameter(1, BillTypeAtomic.PHARMACY_ORDER_APPROVAL.toString())
-            .setParameter(2, BillType.PharmacyOrderApprove.toString())
-            .setParameter(3, com.divudi.core.data.BillClassType.BilledBill.toString())
-            .setParameter(4, departmentId)
-            .setParameter(5, institutionId)
-            .setParameter(6, fromDepartmentId)
-            .setParameter(7, fromInstitutionId)
-            .setParameter(8, requestedBillId)
-            .setParameter(9, createrId)
-            .setParameter(10, new Timestamp(now.getTime()))
-            .setParameter(11, deptId)
-            .setParameter(12, insId)
-            .executeUpdate();
-        long billId = ((Number) em.createNativeQuery("SELECT LAST_INSERT_ID()").getSingleResult()).longValue();
+        com.divudi.core.entity.BilledBill bill = new com.divudi.core.entity.BilledBill();
+        bill.setBillTypeAtomic(BillTypeAtomic.PHARMACY_ORDER_APPROVAL);
+        bill.setBillType(BillType.PharmacyOrderApprove);
+        bill.setDepartment(em.getReference(com.divudi.core.entity.Department.class, departmentId));
+        bill.setInstitution(em.getReference(com.divudi.core.entity.Institution.class, institutionId));
+        bill.setFromDepartment(em.getReference(com.divudi.core.entity.Department.class, fromDepartmentId));
+        bill.setFromInstitution(em.getReference(com.divudi.core.entity.Institution.class, fromInstitutionId));
+        bill.setBackwardReferenceBill(em.getReference(com.divudi.core.entity.Bill.class, requestedBillId));
+        bill.setCreater(em.getReference(com.divudi.core.entity.WebUser.class, createrId));
+        bill.setCreatedAt(new Date());
+        bill.setDeptId(deptId);
+        bill.setInsId(insId);
+        bill.setNetTotal(0.0);
+        bill.setTotal(0.0);
+        em.persist(bill);
+        em.flush();
         evictCache();
-        return billId;
+        return bill.getId();
     }
 
     /**
@@ -134,6 +137,17 @@ public class PurchaseOrderApprovingNativeSqlService {
             .setParameter(9, approvedBillId)
             .executeUpdate();
         evictCache();
+    }
+
+    /**
+     * Persists the approved bill's netTotal/total columns. Delegates to
+     * PurchaseOrderRequestNativeSqlService.updateBillTotals() (already public,
+     * same UPDATE shape) rather than duplicating it -- this service's own
+     * createApprovedBill()/updateApprovedBillHeader() never write these two
+     * columns, the same gap Phase 1 had before its own updateBillTotals() fix.
+     */
+    public void updateBillTotals(long billId, double netTotal, double total) {
+        purchaseOrderRequestNativeSqlService.updateBillTotals(billId, netTotal, total);
     }
 
     /**
@@ -355,10 +369,21 @@ public class PurchaseOrderApprovingNativeSqlService {
      * a live database -- flagged for confirmation during Task 6's Playwright
      * pass, per the task brief.
      */
+    /**
+     * ampp is deliberately not projected here: EclipseLink cannot resolve
+     * {@code CASE WHEN TYPE(bi.item) = <EntityClass> THEN ... END} as a
+     * SELECT NEW constructor argument (confirmed at runtime -- "state field
+     * path ... cannot be resolved to a valid type"), even though the same
+     * TYPE()-in-CASE pattern works fine as a plain SELECT/SUM operand
+     * elsewhere in this codebase. The caller (PurchaseOrderApprovingNativeSqlController
+     * .generateBillComponent()) already resolves the real Item entity via
+     * itemFacade.find(itemId) and derives ampp from that entity's own type
+     * where it's actually needed (approve()), so the projection doesn't need
+     * to carry it.
+     */
     public List<PurchaseOrderRequestLineData> loadRequestedLines(long requestedBillId) {
         String jpql = "SELECT NEW com.divudi.core.data.dto.pharmacy.PurchaseOrderRequestLineData("
                 + "bi.item.id, "
-                + "CASE WHEN TYPE(bi.item) = com.divudi.core.entity.pharmacy.Ampp THEN true ELSE false END, "
                 + "bi.billItemFinanceDetails.quantity, "
                 + "bi.billItemFinanceDetails.freeQuantity, "
                 + "bi.billItemFinanceDetails.lineGrossRate, "

--- a/src/main/java/com/divudi/service/pharmacy/PurchaseOrderApprovingNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PurchaseOrderApprovingNativeSqlService.java
@@ -151,6 +151,61 @@ public class PurchaseOrderApprovingNativeSqlService {
     }
 
     /**
+     * Native UPDATE for approveAt/approveUser_ID on the approved bill.
+     * Deliberately NOT a JPA billFacade.edit() merge: approvedBill is
+     * detached (BillFacade is @Stateless) and Bill.billItems carries
+     * cascade=ALL, orphanRemoval=true, but this bill's lines were written by
+     * saveApprovedLine() through native SQL, not through this entity's
+     * managed collection -- merging the detached bill would risk EclipseLink
+     * treating the native-written lines as absent from the in-memory
+     * collection and deleting them via orphan removal. Same reasoning as
+     * updateApprovedBillHeader() and updateBillTotals() above; see also
+     * PurchaseOrderRequestNativeSqlService's own Javadoc for the same trap.
+     */
+    public void approveBill(long approvedBillId, long approveUserId) {
+        em.createNativeQuery(
+            "UPDATE " + billTable() + " SET approveAt=?, approveUser_ID=? WHERE ID=?")
+            .setParameter(1, new Timestamp(new Date().getTime()))
+            .setParameter(2, approveUserId)
+            .setParameter(3, approvedBillId)
+            .executeUpdate();
+        evictCache();
+    }
+
+    /**
+     * Native UPDATE for the approved bill's own referenceBill_ID, pointing
+     * back at the requested bill. Mirrors legacy PurchaseOrderController
+     * .saveBill(): getAprovedBill().setReferenceBill(getRequestedBill()).
+     * The po.xhtml/po_custom_*.xhtml print composites read
+     * cc.attrs.bill.referenceBill.* (institution letterhead, "Prepared By",
+     * "Authorized By") off this same approved bill, so without this write
+     * those fields render blank (EL null-safe navigation swallows the NPE).
+     */
+    public void linkApprovedBillToRequest(long approvedBillId, long requestedBillId) {
+        em.createNativeQuery(
+            "UPDATE " + billTable() + " SET referenceBill_ID=? WHERE ID=?")
+            .setParameter(1, requestedBillId)
+            .setParameter(2, approvedBillId)
+            .executeUpdate();
+        evictCache();
+    }
+
+    /**
+     * Native UPDATE for the requested bill's forward-pointing referenceBill_ID
+     * cross-link (the approved bill's own backwardReferenceBill_ID is already
+     * set at creation in createApprovedBill()). Matches the referenceBill_ID
+     * write pattern in TransferReceiveNativeSqlService.settle().
+     */
+    public void linkRequestedBillToApproval(long requestedBillId, long approvedBillId) {
+        em.createNativeQuery(
+            "UPDATE " + billTable() + " SET referenceBill_ID=? WHERE ID=?")
+            .setParameter(1, approvedBillId)
+            .setParameter(2, requestedBillId)
+            .executeUpdate();
+        evictCache();
+    }
+
+    /**
      * Native INSERT/UPDATE for billitem + pharmaceuticalbillitem on the
      * approved bill. Delegates the line math to
      * PurchaseOrderRequestNativeSqlService.computeLineValues() (injected

--- a/src/main/java/com/divudi/service/pharmacy/PurchaseOrderApprovingNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PurchaseOrderApprovingNativeSqlService.java
@@ -1,0 +1,375 @@
+package com.divudi.service.pharmacy;
+
+import com.divudi.core.data.BillTypeAtomic;
+import com.divudi.core.data.BillType;
+import com.divudi.core.data.DepartmentType;
+import com.divudi.core.data.PaymentMethod;
+import com.divudi.core.data.dto.pharmacy.PurchaseOrderRequestLineData;
+import com.divudi.core.entity.BillItemFinanceDetails;
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * Native SQL write path for the Purchase Order Approving bill.
+ * Only the APPROVED bill's own bill / billitem / pharmaceuticalbillitem rows
+ * are touched here -- the requested bill stays JPA (see
+ * PurchaseOrderApprovingNativeSqlController). BillItemFinanceDetails stays
+ * JPA (IDENTITY PK, calculation-heavy), matching
+ * PurchaseOrderRequestNativeSqlService's split.
+ * Related issue: #22738
+ */
+@Stateless
+public class PurchaseOrderApprovingNativeSqlService {
+
+    @PersistenceContext(unitName = "hmisPU")
+    private EntityManager em;
+
+    @EJB
+    private PurchaseOrderRequestNativeSqlService purchaseOrderRequestNativeSqlService;
+
+    private String tBill;
+    private String tBillItem;
+    private String tPharmBillItem;
+
+    private String resolveTable(String upperName) {
+        Object name = em.createNativeQuery(
+            "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES "
+            + "WHERE TABLE_SCHEMA = DATABASE() AND UPPER(TABLE_NAME) = ? LIMIT 1")
+            .setParameter(1, upperName)
+            .getSingleResult();
+        return name.toString();
+    }
+
+    private String billTable() {
+        if (tBill == null) tBill = resolveTable("BILL");
+        return tBill;
+    }
+
+    private String billItemTable() {
+        if (tBillItem == null) tBillItem = resolveTable("BILLITEM");
+        return tBillItem;
+    }
+
+    private String pharmBillItemTable() {
+        if (tPharmBillItem == null) tPharmBillItem = resolveTable("PHARMACEUTICALBILLITEM");
+        return tPharmBillItem;
+    }
+
+    private void evictCache() {
+        javax.persistence.Cache cache = em.getEntityManagerFactory().getCache();
+        cache.evict(com.divudi.core.entity.Bill.class);
+    }
+
+    private void evictLineCache() {
+        javax.persistence.Cache cache = em.getEntityManagerFactory().getCache();
+        cache.evict(com.divudi.core.entity.Bill.class);
+        cache.evict(com.divudi.core.entity.BillItem.class);
+        cache.evict(com.divudi.core.entity.pharmacy.PharmaceuticalBillItem.class);
+        cache.evict(BillItemFinanceDetails.class);
+    }
+
+    /**
+     * Native INSERT for the approved bill row. This row's own
+     * backwardReferenceBill_ID points at the requested bill, matching
+     * legacy's setBackwardReferenceBill(getRequestedBill()); the requested
+     * bill's own referenceBill_ID (pointing here) is written later in JPA by
+     * the controller. billClassType is BilledBill per legacy's
+     * "new BilledBill()" -- billClassType is a plain (non-discriminator)
+     * column on Bill (see Bill#billClassType), so it is written here as a
+     * literal .toString(), same as BillTypeAtomic/BillType.
+     */
+    public long createApprovedBill(long requestedBillId, long departmentId, long institutionId,
+            long fromDepartmentId, long fromInstitutionId, long createrId, String deptId, String insId) {
+        Date now = new Date();
+        em.createNativeQuery(
+            "INSERT INTO " + billTable()
+            + " (BILLTYPEATOMIC, billType, billClassType, department_ID, institution_ID,"
+            + " fromDepartment_ID, fromInstitution_ID, backwardReferenceBill_ID,"
+            + " creater_ID, createdAt, checked, retired, cancelled, deptId, insId, netTotal, total)"
+            + " VALUES (?,?,?,?,?,?,?,?,?,?,0,0,0,?,?,0,0)")
+            .setParameter(1, BillTypeAtomic.PHARMACY_ORDER_APPROVAL.toString())
+            .setParameter(2, BillType.PharmacyOrderApprove.toString())
+            .setParameter(3, com.divudi.core.data.BillClassType.BilledBill.toString())
+            .setParameter(4, departmentId)
+            .setParameter(5, institutionId)
+            .setParameter(6, fromDepartmentId)
+            .setParameter(7, fromInstitutionId)
+            .setParameter(8, requestedBillId)
+            .setParameter(9, createrId)
+            .setParameter(10, new Timestamp(now.getTime()))
+            .setParameter(11, deptId)
+            .setParameter(12, insId)
+            .executeUpdate();
+        long billId = ((Number) em.createNativeQuery("SELECT LAST_INSERT_ID()").getSingleResult()).longValue();
+        evictCache();
+        return billId;
+    }
+
+    /**
+     * Native UPDATE for payment method / supplier / etc. Mirrors
+     * PurchaseOrderRequestNativeSqlService.updateDraftBillHeader exactly,
+     * including the comments column.
+     */
+    public void updateApprovedBillHeader(long approvedBillId, Long toInstitutionId, PaymentMethod paymentMethod,
+            int creditDuration, boolean consignment, DepartmentType departmentType, String comments, Long editorId) {
+        em.createNativeQuery(
+            "UPDATE " + billTable()
+            + " SET toInstitution_ID=?, paymentMethod=?, creditDuration=?, consignment=?,"
+            + " departmentType=?, comments=?, editor_ID=?, editedAt=?"
+            + " WHERE ID=?")
+            .setParameter(1, toInstitutionId)
+            .setParameter(2, paymentMethod != null ? paymentMethod.toString() : null)
+            .setParameter(3, creditDuration)
+            .setParameter(4, consignment ? 1 : 0)
+            .setParameter(5, departmentType != null ? departmentType.toString() : null)
+            .setParameter(6, comments)
+            .setParameter(7, editorId)
+            .setParameter(8, new Timestamp(new Date().getTime()))
+            .setParameter(9, approvedBillId)
+            .executeUpdate();
+        evictCache();
+    }
+
+    /**
+     * Native INSERT/UPDATE for billitem + pharmaceuticalbillitem on the
+     * approved bill. Delegates the line math to
+     * PurchaseOrderRequestNativeSqlService.computeLineValues() (injected
+     * @EJB) rather than duplicating it. Uses the same upsert-by-existence
+     * fix for the PBI row as Phase 1's saveLine (UPDATE first, INSERT only
+     * if 0 rows affected -- never branch on line.getPharmaceuticalBillItemId(),
+     * since the controller never learns the generated PBI id back from an
+     * insert).
+     *
+     * Unlike Phase 1's Request-side saveLine, the PBI UPDATE/INSERT here
+     * also sets remainingQty=pbiQty, remainingFreeQty=pbiFreeQty inline --
+     * legacy's saveBillComponent() sets these explicitly on approve, whereas
+     * a request line has no "remaining" concept until it is approved.
+     */
+    public long saveApprovedLine(long approvedBillId, PurchaseOrderRequestLineData line) {
+        PurchaseOrderRequestNativeSqlService.LineValues v = purchaseOrderRequestNativeSqlService.computeLineValues(line);
+        BigDecimal qty = v.qty, freeQty = v.freeQty, purchaseRate = v.purchaseRate, retailRate = v.retailRate;
+        BigDecimal grossValue = v.grossValue, netValue = v.netValue, netRate = v.netRate;
+        BigDecimal purchaseValue = v.purchaseValue, retailValue = v.retailValue, unitsPerPack = v.unitsPerPack;
+
+        long billItemId;
+        if (line.getBillItemId() == null) {
+            em.createNativeQuery(
+                "INSERT INTO " + billItemTable()
+                + " (bill_ID, item_ID, qty, netValue, grossValue, Rate, netRate,"
+                + " createdAt, creater_ID, retired, refunded, billItemRefunded,"
+                + " consideredForCosting, inwardChargeType, searialNo)"
+                + " VALUES (?,?,?,?,?,?,?,?,?,0,0,0,1,'Medicine',?)")
+                .setParameter(1, approvedBillId)
+                .setParameter(2, line.getItemId())
+                .setParameter(3, qty.doubleValue())
+                .setParameter(4, netValue.doubleValue())
+                .setParameter(5, grossValue.doubleValue())
+                .setParameter(6, purchaseRate.doubleValue())
+                .setParameter(7, netRate.doubleValue())
+                .setParameter(8, new Timestamp(new Date().getTime()))
+                .setParameter(9, line.getCreaterId())
+                .setParameter(10, line.getSerialNo())
+                .executeUpdate();
+            billItemId = ((Number) em.createNativeQuery("SELECT LAST_INSERT_ID()").getSingleResult()).longValue();
+        } else {
+            billItemId = line.getBillItemId();
+            em.createNativeQuery(
+                "UPDATE " + billItemTable()
+                + " SET qty=?, netValue=?, grossValue=?, Rate=?, netRate=? WHERE ID=?")
+                .setParameter(1, qty.doubleValue())
+                .setParameter(2, netValue.doubleValue())
+                .setParameter(3, grossValue.doubleValue())
+                .setParameter(4, purchaseRate.doubleValue())
+                .setParameter(5, netRate.doubleValue())
+                .setParameter(6, billItemId)
+                .executeUpdate();
+        }
+
+        double pbiQty = v.pbiQty, pbiFreeQty = v.pbiFreeQty, pbiPurchaseRate = v.pbiPurchaseRate, pbiRetailRate = v.pbiRetailRate;
+
+        int updated = em.createNativeQuery(
+                "UPDATE " + pharmBillItemTable()
+                + " SET qty=?, freeQty=?, purchaseRate=?, purchaseRatePack=?, purchaseValue=?,"
+                + " retailRate=?, retailRatePack=?, retailRateInUnit=?, retailValue=?,"
+                + " remainingQty=?, remainingFreeQty=? WHERE billItem_ID=?")
+                .setParameter(1, pbiQty)
+                .setParameter(2, pbiFreeQty)
+                .setParameter(3, pbiPurchaseRate)
+                .setParameter(4, purchaseRate.doubleValue())
+                .setParameter(5, purchaseValue.doubleValue())
+                .setParameter(6, pbiRetailRate)
+                .setParameter(7, retailRate.doubleValue())
+                .setParameter(8, pbiRetailRate)
+                .setParameter(9, retailValue.doubleValue())
+                .setParameter(10, pbiQty)
+                .setParameter(11, pbiFreeQty)
+                .setParameter(12, billItemId)
+                .executeUpdate();
+
+        if (updated == 0) {
+            em.createNativeQuery(
+                "INSERT INTO " + pharmBillItemTable()
+                + " (billItem_ID, qty, freeQty, purchaseRate, purchaseRatePack, purchaseValue,"
+                + " retailRate, retailRatePack, retailRateInUnit, retailValue, remainingQty, remainingFreeQty,"
+                + " costRate, costRatePack, costValue, createdAt, creater_ID)"
+                + " VALUES (?,?,?,?,?,?,?,?,?,?,?,?,0,0,0,?,?)")
+                .setParameter(1, billItemId)
+                .setParameter(2, pbiQty)
+                .setParameter(3, pbiFreeQty)
+                .setParameter(4, pbiPurchaseRate)
+                .setParameter(5, purchaseRate.doubleValue())
+                .setParameter(6, purchaseValue.doubleValue())
+                .setParameter(7, pbiRetailRate)
+                .setParameter(8, retailRate.doubleValue())
+                .setParameter(9, pbiRetailRate)
+                .setParameter(10, retailValue.doubleValue())
+                .setParameter(11, pbiQty)
+                .setParameter(12, pbiFreeQty)
+                .setParameter(13, new Timestamp(new Date().getTime()))
+                .setParameter(14, line.getCreaterId())
+                .executeUpdate();
+        }
+
+        saveBillItemFinanceDetails(billItemId, line, qty, freeQty, purchaseRate, retailRate, netValue, grossValue,
+                netRate, unitsPerPack, pbiQty, pbiFreeQty);
+
+        evictLineCache();
+        return billItemId;
+    }
+
+    private void saveBillItemFinanceDetails(long billItemId, PurchaseOrderRequestLineData line,
+            BigDecimal qty, BigDecimal freeQty, BigDecimal purchaseRate, BigDecimal retailRate,
+            BigDecimal netValue, BigDecimal grossValue, BigDecimal netRate, BigDecimal unitsPerPack,
+            double quantityByUnits, double freeQuantityByUnits) {
+        BillItemFinanceDetails bifd;
+        if (line.getBillItemId() != null) {
+            String jpql = "SELECT bi.billItemFinanceDetails FROM BillItem bi WHERE bi.id = :id";
+            List<BillItemFinanceDetails> existing = em.createQuery(jpql, BillItemFinanceDetails.class)
+                    .setParameter("id", billItemId)
+                    .getResultList();
+            bifd = (existing != null && !existing.isEmpty() && existing.get(0) != null) ? existing.get(0) : new BillItemFinanceDetails();
+        } else {
+            bifd = new BillItemFinanceDetails();
+        }
+
+        bifd.setLineNetRate(purchaseRate);
+        bifd.setLineGrossRate(purchaseRate);
+        bifd.setGrossRate(purchaseRate);
+        bifd.setLineNetTotal(netValue);
+        bifd.setLineGrossTotal(grossValue);
+        bifd.setGrossTotal(grossValue);
+        bifd.setQuantity(qty);
+        bifd.setFreeQuantity(freeQty);
+        bifd.setQuantityByUnits(BigDecimal.valueOf(quantityByUnits));
+        bifd.setFreeQuantityByUnits(BigDecimal.valueOf(freeQuantityByUnits));
+        bifd.setRetailSaleRate(retailRate);
+        bifd.setUnitsPerPack(unitsPerPack);
+        bifd.setValueAtPurchaseRate(purchaseRate.multiply(qty.add(freeQty)));
+        bifd.setValueAtRetailRate(retailRate.multiply(qty.add(freeQty)));
+        bifd.setLineCost(BigDecimal.ZERO);
+        bifd.setLineCostRate(BigDecimal.ZERO);
+        bifd.setValueAtCostRate(BigDecimal.ZERO);
+
+        if (bifd.getId() == null) {
+            bifd.setCreatedAt(new Date());
+            em.persist(bifd);
+            em.flush();
+            em.createNativeQuery("UPDATE " + billItemTable() + " SET BILLITEMFINANCEDETAILS_ID=? WHERE ID=?")
+                    .setParameter(1, bifd.getId())
+                    .setParameter(2, billItemId)
+                    .executeUpdate();
+        } else {
+            em.merge(bifd);
+        }
+    }
+
+    /**
+     * Native zero-qty retirement sweep for the approved bill's lines.
+     * Delegates the zero-qty predicate to
+     * PurchaseOrderRequestNativeSqlService.isZeroQtyLine() rather than
+     * duplicating it. Retire comment is "Retired at Approving PO" (matching
+     * legacy's saveBillComponent()), distinct from the Request page's
+     * "Retired at Finalising PO".
+     *
+     * Unlike Phase 1's retireZeroQtyLines, the surviving branch here does
+     * NOT re-set remainingQty/remainingFreeQty -- saveApprovedLine already
+     * writes those at save time, so there is nothing left to do for
+     * survivors here.
+     */
+    @SuppressWarnings("unchecked")
+    public int retireZeroQtyApprovedLines(long approvedBillId, long retirerId) {
+        List<Object[]> rows = em.createNativeQuery(
+            "SELECT bi.ID, pbi.qty, pbi.freeQty FROM " + billItemTable() + " bi "
+            + "JOIN " + pharmBillItemTable() + " pbi ON pbi.billItem_ID = bi.ID "
+            + "WHERE bi.bill_ID = ? AND bi.retired = 0")
+            .setParameter(1, approvedBillId)
+            .getResultList();
+
+        int survivingCount = 0;
+        Timestamp now = new Timestamp(new Date().getTime());
+        for (Object[] row : rows) {
+            long billItemId = ((Number) row[0]).longValue();
+            double qty = row[1] != null ? ((Number) row[1]).doubleValue() : 0.0;
+            double freeQty = row[2] != null ? ((Number) row[2]).doubleValue() : 0.0;
+
+            if (purchaseOrderRequestNativeSqlService.isZeroQtyLine(qty, freeQty)) {
+                em.createNativeQuery(
+                    "UPDATE " + billItemTable() + " SET retired=1, retirer_ID=?, retiredAt=?, retireComments=? WHERE ID=?")
+                    .setParameter(1, retirerId)
+                    .setParameter(2, now)
+                    .setParameter(3, "Retired at Approving PO")
+                    .setParameter(4, billItemId)
+                    .executeUpdate();
+                em.createNativeQuery(
+                    "UPDATE " + pharmBillItemTable() + " SET retired=1, retirer_ID=?, retiredAt=? WHERE billItem_ID=?")
+                    .setParameter(1, retirerId)
+                    .setParameter(2, now)
+                    .setParameter(3, billItemId)
+                    .executeUpdate();
+            } else {
+                survivingCount++;
+            }
+        }
+        evictLineCache();
+        return survivingCount;
+    }
+
+    /**
+     * JPQL projection reading the requested bill's non-retired
+     * PharmaceuticalBillItem lines. The ampp flag uses TYPE(bi.item) inside
+     * a CASE WHEN expression within the SELECT NEW constructor argument list.
+     * Precedent for TYPE(x) = EntityName inside CASE WHEN (in a plain SELECT,
+     * not SELECT NEW) exists elsewhere in this codebase --
+     * MdInwardReportController (SUM(CASE WHEN TYPE(bi.bill) = BilledBill ...))
+     * and ChannelService (SUM(CASE WHEN TYPE(b) = CancelledBill ...)) -- and
+     * this project pins EclipseLink 2.7.12, which per its release notes
+     * supports TYPE() in CASE expressions. Using it as a SELECT NEW
+     * constructor argument specifically (rather than as a SUM operand) is
+     * NOT directly precedented in this codebase and has not been run against
+     * a live database -- flagged for confirmation during Task 6's Playwright
+     * pass, per the task brief.
+     */
+    public List<PurchaseOrderRequestLineData> loadRequestedLines(long requestedBillId) {
+        String jpql = "SELECT NEW com.divudi.core.data.dto.pharmacy.PurchaseOrderRequestLineData("
+                + "bi.item.id, "
+                + "CASE WHEN TYPE(bi.item) = com.divudi.core.entity.pharmacy.Ampp THEN true ELSE false END, "
+                + "bi.billItemFinanceDetails.quantity, "
+                + "bi.billItemFinanceDetails.freeQuantity, "
+                + "bi.billItemFinanceDetails.lineGrossRate, "
+                + "bi.billItemFinanceDetails.retailSaleRate, "
+                + "bi.billItemFinanceDetails.unitsPerPack, "
+                + "bi.searialNo) "
+                + "FROM PharmaceuticalBillItem p JOIN p.billItem bi "
+                + "WHERE bi.bill.id = :billId AND bi.retired = false "
+                + "ORDER BY bi.searialNo";
+        return em.createQuery(jpql, PurchaseOrderRequestLineData.class)
+                .setParameter("billId", requestedBillId)
+                .getResultList();
+    }
+}

--- a/src/main/java/com/divudi/service/pharmacy/PurchaseOrderRequestNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PurchaseOrderRequestNativeSqlService.java
@@ -156,7 +156,7 @@ public class PurchaseOrderRequestNativeSqlService {
      * unit tested directly. AMPP items store rates per-pack on BillItemFinanceDetails
      * but per-unit on PharmaceuticalBillItem; non-AMPP items use the same rate for both.
      */
-    static final class LineValues {
+    public static final class LineValues {
         final BigDecimal qty, freeQty, purchaseRate, retailRate, unitsPerPack;
         final BigDecimal grossValue, netValue, purchaseValue, retailValue, netRate;
         final double pbiQty, pbiFreeQty, pbiPurchaseRate, pbiRetailRate;
@@ -173,7 +173,16 @@ public class PurchaseOrderRequestNativeSqlService {
         }
     }
 
-    LineValues computeLineValues(PurchaseOrderRequestLineData line) {
+    /**
+     * Public (not package-private): called cross-EJB from
+     * PurchaseOrderApprovingNativeSqlService via the injected @EJB reference.
+     * A stateless EJB's no-interface local view only exposes public methods
+     * through the container-generated proxy -- package-private access works
+     * for plain same-package Java calls but throws "Illegal non-business
+     * method access on no-interface view" when invoked through the proxy.
+     * Confirmed by a live redeploy failure; do not revert to package-private.
+     */
+    public LineValues computeLineValues(PurchaseOrderRequestLineData line) {
         BigDecimal qty = line.getQuantity() != null ? line.getQuantity() : BigDecimal.ZERO;
         BigDecimal freeQty = line.getFreeQuantity() != null ? line.getFreeQuantity() : BigDecimal.ZERO;
         BigDecimal purchaseRate = line.getPurchaseRate() != null ? line.getPurchaseRate() : BigDecimal.ZERO;
@@ -348,7 +357,13 @@ public class PurchaseOrderRequestNativeSqlService {
      * totalUnits.compareTo(BigDecimal.ZERO) <= 0 check.
      * No em access, unit tested.
      */
-    boolean isZeroQtyLine(double qty, double freeQty) {
+    /**
+     * Public (not package-private): called cross-EJB from
+     * PurchaseOrderApprovingNativeSqlService.retireZeroQtyApprovedLines() via
+     * the injected @EJB reference -- see computeLineValues()'s Javadoc above
+     * for why package-private fails through the EJB proxy.
+     */
+    public boolean isZeroQtyLine(double qty, double freeQty) {
         return (qty + freeQty) <= 0;
     }
 

--- a/src/main/webapp/pharmacy/pharmacy_purhcase_order_approving_native.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purhcase_order_approving_native.xhtml
@@ -1,0 +1,456 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/resources/template/template.xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:p="http://primefaces.org/ui"
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns:ph="http://xmlns.jcp.org/jsf/composite/pharmacy"
+                xmlns:pa="http://xmlns.jcp.org/jsf/composite/paymentMethod">
+
+    <ui:define name="content">
+        <h:form id="form">
+
+            <div class="d-flex justify-content-end">
+                <!-- Small non-prominent fallback to legacy entity-based page -->
+                <p:commandButton
+                    ajax="false"
+                    value="Legacy View"
+                    title="Open original entity-based Purchase Order Approving page"
+                    action="pharmacy_purhcase_order_approving?faces-redirect=true"
+                    class="ui-button-secondary ms-3"
+                    icon="fas fa-history"
+                    style="font-size: 0.75rem; padding: 0.2rem 0.5rem;"/>
+            </div>
+
+            <h:panelGroup rendered="#{!webUserController.hasPrivilege('PurchaseOrdersApprovel')}" >
+                You are NOT authorized
+            </h:panelGroup>
+            <h:panelGroup rendered="#{webUserController.hasPrivilege('PurchaseOrdersApprovel')}" >
+
+            <h:panelGroup rendered="#{!purchaseOrderApprovingNativeSqlController.printPreview}">
+                <p:panel >
+                    <f:facet name="header">
+                        <p:outputLabel value="Purchase order Request Order"/>
+                        <div style="float:right;" >
+                            <p:commandButton ajax="false"  
+                                             value="Approve" 
+                                             class="ui-button-success m-1" 
+                                             icon="fas fa-check" 
+                                             disabled="#{!webUserController.hasPrivilege('PurchaseOrdersApprovel')}"
+                                             onclick="return confirm('Are you sure you want to approve this purchase order? This action cannot be undone.');"
+                                             action="#{purchaseOrderApprovingNativeSqlController.approve}">
+                            </p:commandButton>
+                            <p:commandButton ajax="false"  
+                                             value="Back To PO List to Approve" 
+                                             class="ui-button-warning" 
+                                             icon="fas fa-arrow-left" 
+                                             action="#{searchController.navigateToPurchaseOrderApprove}">
+                            </p:commandButton>
+                        </div>
+                    </f:facet>
+
+                    <p:panel class="mb-2" id="po">
+                        <div class="row">
+                            <div class="col-12" >
+                                <p:messages id="pageMessages" ></p:messages>
+                            </div>
+                        </div>
+                        <div class="row">
+
+                            <div class="col-10" >
+                                <p:panel>
+                                    <f:facet name="header">  
+                                        <div class="d-flex justify-content-between">
+                                            <h:outputLabel  value="Pharmacy Bill Item"/>
+                                            <p:commandButton id="btnRemoveAll" process="itemList @this" update=":#{p:resolveFirstComponentWithId('itemList',view).clientId} :#{p:resolveFirstComponentWithId('po',view).clientId}" value="Remove All" class="ui-button-danger" style="float: right" onclick="return confirm('Remove all selected items? This action cannot be undone.');" action="#{purchaseOrderApprovingNativeSqlController.removeSelected()}"/>                            
+                                        </div>
+                                    </f:facet>
+                                    <p:dataTable scrollable="true" styleClass="noBorder" scrollHeight="250"
+                                                 var="bi" value="#{purchaseOrderApprovingNativeSqlController.billItems}"
+                                                 id="itemList" sortBy="#{bi.searialNo}"  rowKey="#{bi.searialNo}"
+                                                 paginator="true" 
+                                                 rows="10" 
+                                                 selectionMode="multiple"
+                                                 paginatorPosition="bottom"
+                                                 paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                                 rowsPerPageTemplate="5,10,15"
+                                                 selection="#{purchaseOrderApprovingNativeSqlController.selectedItems}">  
+
+                                        <p:column selectionBox="true" style="width: 30px;"></p:column>
+
+                                        <p:column headerText="No" style="width: 50px;" >
+                                            <p:outputLabel value="#{bi.searialNo + 1}" ></p:outputLabel>
+                                        </p:column>
+
+                                        <p:column headerText="Item Name" >  
+                                            <h:outputText value="#{bi.item.name}" ></h:outputText>
+                                            <p:commandButton
+                                                icon="pi pi-search"
+                                                id="btnViewSelectedItemDetails"
+                                                title="View Item Details"
+                                                action="#{purchaseOrderApprovingNativeSqlController.displayItemDetails(bi)}"
+                                                update=":#{p:resolveFirstComponentWithId('tab',view).clientId}"
+                                                process="@this"
+                                                class="ui-button-icon-only mx-3"/>
+                                        </p:column>  
+
+                                        <p:column headerText="Code" styleClass="shortNumericColumn"  >  
+                                            <h:outputText value="#{bi.item.code}" ></h:outputText>
+                                        </p:column>  
+
+                                        <p:column
+                                            headerText="Qty"
+                                            class="text-end px-1"
+                                            width="6em">
+                                            <p:inputText
+                                                autocomplete="off"
+                                                id="qty"
+                                                value="#{bi.billItemFinanceDetails.quantity}"
+                                                class="w-100 text-end"
+                                                label="Qty" onfocus="this.select()">
+                                                <f:convertNumber pattern="#,#00"/>
+                                                <p:ajax event="blur" update="total :#{p:resolveFirstComponentWithId('tot',view).clientId} @this :#{p:resolveFirstComponentWithId('pageMessages',view).clientId}"  process="@this price" listener="#{purchaseOrderApprovingNativeSqlController.onEdit(bi)}" ></p:ajax>
+                                                <f:ajax event="focus" render=":#{p:resolveFirstComponentWithId('tab',view).clientId}" listener="#{purchaseOrderApprovingNativeSqlController.onFocus(bi)}" />
+                                            </p:inputText>
+                                        </p:column>  
+                                        <p:column
+                                            width="6em"
+                                            headerText="Free Qty"
+                                            class="text-end px-1"  >
+                                            <p:inputText
+                                                autocomplete="off"
+                                                id="freeQty"
+                                                value="#{bi.billItemFinanceDetails.freeQuantity}"
+                                                class="w-100 text-end"
+                                                onfocus="this.select()">
+                                                <f:convertNumber pattern="#,#00"/>
+                                                <p:ajax event="blur" update="total :#{p:resolveFirstComponentWithId('tot',view).clientId} @this :#{p:resolveFirstComponentWithId('pageMessages',view).clientId}"  process="@this price" listener="#{purchaseOrderApprovingNativeSqlController.onEdit(bi)}" ></p:ajax>
+                                                <f:ajax event="focus" render=":#{p:resolveFirstComponentWithId('tab',view).clientId}" listener="#{purchaseOrderApprovingNativeSqlController.onFocus(bi)}" />
+                                            </p:inputText>
+                                        </p:column> 
+                                        <p:column 
+                                            width="6em"
+                                            headerText="Purchase Price"   
+                                            class="text-end px-1"  >  
+                                            <p:inputText
+                                                id="price"
+                                                class="w-100 text-end"
+                                                style="margin: 0px;"
+                                                autocomplete="off"
+                                                value="#{bi.billItemFinanceDetails.lineGrossRate}" onfocus="this.select()">   
+                                                <f:convertNumber pattern="#00.00"/>
+                                                <f:ajax event="blur" render="total :#{p:resolveFirstComponentWithId('tot',view).clientId}"  execute="@this" listener="#{purchaseOrderApprovingNativeSqlController.onEdit(bi)}" ></f:ajax>
+                                                <f:ajax event="focus" render=":#{p:resolveFirstComponentWithId('tab',view).clientId}" listener="#{purchaseOrderApprovingNativeSqlController.onFocus(bi)}" />
+                                            </p:inputText>
+                                        </p:column>  
+
+                                        <p:column 
+                                            headerText="Last Purchase Price" 
+                                            width="6em"
+                                            class="text-end px-1"  
+                                            >  
+                                            <h:panelGroup >
+                                                <h:outputText value="#{pharmacyController.getLastPurchaseRate(bi.item)}">
+                                                    <f:convertNumber pattern="#00.00"/>
+                                                </h:outputText>
+                                            </h:panelGroup>
+                                        </p:column>  
+
+
+                                        <p:column headerText="Total" width="6em"  class="text-end px-1"  >  
+                                            <h:outputText id="total" value="#{bi.billItemFinanceDetails.lineGrossTotal}" >
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputText>
+                                        </p:column>  
+                                        <p:column  class="text-end px-1"  width="4em" >
+                                            <p:commandButton id="btnRemoveItem" process="itemList" update="itemList :#{p:resolveFirstComponentWithId('po',view).clientId}" icon="fas fa-trash" class="ui-button-danger" onclick="return confirm('Remove this item? This action cannot be undone.');" action="#{purchaseOrderApprovingNativeSqlController.removeItem(bi)}"/>
+                                        </p:column>
+                                    </p:dataTable> 
+
+                                    <div >
+                                        <ph:history/>
+                                    </div>
+                                </p:panel>
+                            </div>
+
+                            <div class="col-2" >
+
+                                <p:panel header="Approved Purchase Order" id="panelPo">
+
+                                    <p:outputLabel value="Supplier"
+                                                   class="form-label"
+                                                   for="lblSupplier" />
+                                    <p:outputLabel id="lblSupplier"
+                                                   value="#{purchaseOrderApprovingNativeSqlController.approvedBill.toInstitution.name}"
+                                                   class="form-control w-100 mb-2" 
+                                                   style="font-weight: bold;" />
+
+                                    <p:outputLabel value="Payment Method"
+                                                   class="form-label"
+                                                   for="cmbPs" />
+                                    <p:selectOneMenu id="cmbPs"
+                                                     value="#{purchaseOrderApprovingNativeSqlController.approvedBill.paymentMethod}"
+                                                     class="w-100 mb-2">
+                                        <f:selectItem itemLabel="Select Payment method" />
+                                        <f:selectItems value="#{enumController.paymentMethodsForPo}" />
+                                        <p:ajax process="@this" update="po" event="change" />
+                                        <p:ajax process="@this" update="duration" event="itemSelect" />
+                                    </p:selectOneMenu>
+                                    
+                                    <p:outputLabel value="Department Type"
+                                                   class="form-label"></p:outputLabel>
+                                    <p:outputLabel
+                                        id="selDepartmentType"
+                                        value="#{purchaseOrderApprovingNativeSqlController.approvedBill.departmentType}"
+                                        class="w-100" >
+                                    </p:outputLabel>
+
+                                    <h:panelGroup rendered="#{purchaseOrderApprovingNativeSqlController.approvedBill.paymentMethod eq 'Credit'}" id="duration">
+                                        <div class="d-flex mb-3">
+                                            <div class="ui-inputgroup mx-1 my-1">
+                                                <p:inputText value="#{purchaseOrderApprovingNativeSqlController.approvedBill.creditDuration}"
+                                                             onfocus="this.select();"
+                                                             style="width: 10em;" />
+                                                <div class="ui-inputgroup-addon">Days</div>
+                                            </div>
+                                        </div>
+                                    </h:panelGroup>
+
+                                    <p:spacer class="my-1"
+                                              rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable Consignment in Pharmacy Purchasing', true)}" />
+
+                                    <p:outputLabel 
+                                        class="my-1 w-100"
+                                        value="Consignment"
+                                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable Consignment in Pharmacy Purchasing', true)}" />
+
+                                    <h:panelGroup 
+                                        class="my-1 w-100"
+                                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Enable Consignment in Pharmacy Purchasing', true)}">
+                                        <p:selectBooleanButton 
+                                            onLabel="Yes" 
+                                            offLabel="No"
+                                            class="w-100"
+                                            value="#{purchaseOrderApprovingNativeSqlController.approvedBill.consignment}"
+                                            />
+                                    </h:panelGroup>
+
+                                    <p:outputLabel 
+                                        value="Request Comments"
+                                        class="form-label mt-1"/>
+                                    <p:outputLabel 
+                                        class="form-control"
+                                        value="#{purchaseOrderApprovingNativeSqlController.requestedBill.comments}"/>
+
+                                    <p:outputLabel 
+                                        value="Approve Comments"
+                                        class="form-label mt-1"/>
+                                    <p:inputTextarea 
+                                        class="form-control"
+                                        value="#{purchaseOrderApprovingNativeSqlController.approvedBill.comments}"/>
+
+
+                                    <p:outputLabel value="Total Value"
+                                                   class="form-label w-100"
+                                                   for="tot" />
+                                    <p:outputLabel id="tot"
+                                                   value="#{purchaseOrderApprovingNativeSqlController.approvedBill.netTotal}"
+                                                   class="m-1 w-100"
+                                                   style="font-weight: bold;">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </p:outputLabel>
+
+                                </p:panel>
+
+
+                            </div>
+
+
+
+
+
+                        </div>
+                    </p:panel>
+
+
+                    <p:spacer height="50"/>
+                </p:panel>
+            </h:panelGroup>
+            <h:panelGroup rendered="#{purchaseOrderApprovingNativeSqlController.printPreview}">
+                <p:panel >
+                    <p:commandButton ajax="false" value="Back To Po List" action="pharmacy_purhcase_order_list_to_approve_dto?faces-redirect=true" class="ui-button-warning" icon="fas fa-arrow-left"/>
+                    <p:commandButton
+                        rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
+                        value="Settings"
+                        icon="fas fa-cog"
+                        class="ui-button-secondary m-1"
+                        type="button"
+                        onclick="PF('purchaseOrderConfigDialog').show();" />
+                    <p:commandButton value="Print" ajax="false" action="#" class="ui-button-info m-1" icon="fas fa-print">
+                        <p:printer target=":form:gpBillPreview" ></p:printer>
+                    </p:commandButton>
+                    <p:commandButton
+                        value="Send Email"
+                        icon="fas fa-envelope"
+                        action="#{purchaseOrderApprovingNativeSqlController.prepareEmailDialog}"
+                        styleClass="ui-button-secondary m-1"
+                        oncomplete="PF('emailDialog').show();"
+                        update="emailDialogForm"/>
+
+                    <h:panelGroup  id="gpBillPreview" class="my-2">
+
+                        <ph:po_custom_1
+                            rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Purchase Order Approval Print - A4 Custom 1 Paper Format', true)}"
+                            bill="#{purchaseOrderApprovingNativeSqlController.approvedBill}" controller="#{purchaseOrderApprovingNativeSqlController}"/>
+
+                        <ph:po_custom_2
+                            rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Purchase Order Approval Print - A4 Custom 2 Paper Format', true)}"
+                            bill="#{purchaseOrderApprovingNativeSqlController.approvedBill}" controller="#{purchaseOrderApprovingNativeSqlController}"/>
+
+                        <ph:po_custom_3_letter
+                            rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Purchase Order Approval Print - Letter Paper Format', true)}"
+                            bill="#{purchaseOrderApprovingNativeSqlController.approvedBill}" controller="#{purchaseOrderApprovingNativeSqlController}"/>
+                        
+                        <ph:po_custom_4_letter
+                            rendered="#{configOptionController.getBooleanValueByKey('Pharmacy Purchase Order Approval Print - Custom 4 Paper Format', true)}"
+                            bill="#{purchaseOrderApprovingNativeSqlController.approvedBill}" controller="#{purchaseOrderApprovingNativeSqlController}"/>
+
+
+                    </h:panelGroup>
+
+                </p:panel>
+            </h:panelGroup>
+
+            </h:panelGroup>
+
+        </h:form>
+
+        <p:dialog widgetVar="emailDialog" modal="true" header="Send Purchase Order Email" width="400px" height="auto" resizable="false">
+            <h:form id="emailDialogForm">
+                <div class="p-3">
+                    <div class="mb-3">
+                        <p:outputLabel value="Supplier: " style="font-weight: bold;"/>
+                        <p:outputLabel value="#{purchaseOrderApprovingNativeSqlController.approvedBill.toInstitution.name}"/>
+                    </div>
+
+                    <div class="mb-3">
+                        <p:outputLabel for="emailRecipient" value="Email Address:" class="form-label"/>
+                        <p:inputText 
+                            id="emailRecipient" 
+                            value="#{purchaseOrderApprovingNativeSqlController.emailRecipient}" 
+                            class="w-100"
+                            placeholder="Enter email address"
+                            required="true"
+                            requiredMessage="Email address is required"/>
+                    </div>
+
+                    <div class="d-flex justify-content-end gap-2">
+                        <p:commandButton 
+                            value="Cancel" 
+                            onclick="PF('emailDialog').hide();"
+                            class="ui-button-secondary"
+                            type="button"/>
+                        <p:commandButton 
+                            value="Send Email" 
+                            action="#{purchaseOrderApprovingNativeSqlController.sendPurchaseOrderEmail}"
+                            class="ui-button-success"
+                            icon="fas fa-envelope"
+                            ajax="false"
+                            oncomplete="PF('emailDialog').hide();"/>
+                    </div>
+                </div>
+            </h:form>
+        </p:dialog>
+
+        <!-- Purchase Order Configuration Dialog -->
+        <p:dialog id="purchaseOrderConfigDialog"
+                  header="Purchase Order Approving Printer Configuration"
+                  widgetVar="purchaseOrderConfigDialog"
+                  modal="true"
+                  width="800"
+                  height="500"
+                  resizable="true"
+                  maximizable="true"
+                  closeOnEscape="true">
+
+            <p:ajax event="open" listener="#{purchaseOrderConfigController.loadCurrentConfig}" update="purchaseOrderConfigForm" />
+
+            <h:form id="purchaseOrderConfigForm">
+
+                <div class="row">
+                    <div class="col-md-12">
+                        <div class="card config-section">
+                            <div class="card-header">
+                                <h6><i class="fas fa-file-alt"></i> Purchase Order Paper Settings</h6>
+                            </div>
+                            <div class="card-body">
+                                <div class="mb-3">
+                                    <p:selectBooleanCheckbox
+                                        id="a4custom1paper"
+                                        value="#{purchaseOrderConfigController.a4custom1paper}" />
+                                    <p:outputLabel for="a4custom1paper" value="A4 Paper Custom Format 1" class="ms-2" />
+                                    <small class="form-text text-muted d-block">A4 purchase order format - Custom 1</small>
+                                </div>
+
+                                <div class="mb-3">
+                                    <p:selectBooleanCheckbox
+                                        id="a4custom2paper"
+                                        value="#{purchaseOrderConfigController.a4custom2paper}" />
+                                    <p:outputLabel for="a4custom2paper" value="A4 Paper Custom Format 2" class="ms-2" />
+                                    <small class="form-text text-muted d-block">A4 purchase order format - Custom 2</small>
+                                </div>
+
+                                <div class="mb-3">
+                                    <p:selectBooleanCheckbox
+                                        id="letterPaper"
+                                        value="#{purchaseOrderConfigController.letterPaper}" />
+                                    <p:outputLabel for="letterPaper" value="Letter Paper Format" class="ms-2" />
+                                    <small class="form-text text-muted d-block">Purchase order format - Letter Paper</small>
+                                </div>
+                                
+                                <div class="mb-3">
+                                    <p:selectBooleanCheckbox
+                                        id="custom4paper"
+                                        value="#{purchaseOrderConfigController.custom4paper}" />
+                                    <p:outputLabel for="custom4paper" value="Custom 4 Paper Format" class="ms-2" />
+                                    <small class="form-text text-muted d-block">Purchase order format - Custom 4 Paper</small>
+                                </div>
+
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="row mt-4">
+                    <div class="col-12">
+                        <div class="card">
+                            <div class="card-body">
+                                <p:messages id="purchaseOrderConfigMessages" showDetail="true" closable="true" />
+                                <div class="d-flex justify-content-between align-items-center">
+                                    <div class="d-flex gap-2">
+                                        <p:commandButton
+                                            value="Apply &amp; Close"
+                                            icon="fas fa-save"
+                                            class="ui-button-success"
+                                            ajax="false"
+                                            action="#{purchaseOrderConfigController.saveConfig}" />
+                                        <p:commandButton
+                                            value="Cancel"
+                                            icon="fas fa-times"
+                                            class="ui-button-secondary"
+                                            onclick="PF('purchaseOrderConfigDialog').hide(); return false;"
+                                            type="button" />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+            </h:form>
+        </p:dialog>
+
+    </ui:define>
+
+</ui:composition>

--- a/src/main/webapp/pharmacy/pharmacy_purhcase_order_list_to_approve_dto.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purhcase_order_list_to_approve_dto.xhtml
@@ -274,9 +274,8 @@
                                             icon="pi pi-check"
                                             class="ui-button-success ui-button-sm"
                                             title="Approve Purchase Order"
-                                            action="#{purchaseOrderController.navigateToPurchaseOrderApproval}"
+                                            action="#{purchaseOrderApprovingNativeSqlController.navigateToPurchaseOrderApproval(dto.billId)}"
                                             disabled="#{dto.checkedById eq null or dto.approved or dto.cancelled eq true or !webUserController.hasPrivilege('PurchaseOrdersApprovel')}">
-                                            <f:setPropertyActionListener target="#{purchaseOrderController.requestedBillId}" value="#{dto.billId}"/>
                                         </p:commandButton>
                                         <p:commandButton
                                             id="btnViewApproved"

--- a/src/test/java/com/divudi/core/data/dto/pharmacy/PurchaseOrderRequestLineDataTest.java
+++ b/src/test/java/com/divudi/core/data/dto/pharmacy/PurchaseOrderRequestLineDataTest.java
@@ -3,6 +3,8 @@ package com.divudi.core.data.dto.pharmacy;
 import org.junit.jupiter.api.Test;
 import java.math.BigDecimal;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class PurchaseOrderRequestLineDataTest {
     @Test
@@ -31,5 +33,23 @@ class PurchaseOrderRequestLineDataTest {
         assertEquals(BigDecimal.valueOf(10), d.getUnitsPerPack());
         assertEquals(2, d.getSerialNo());
         assertEquals(Long.valueOf(1L), d.getCreaterId());
+    }
+
+    @Test
+    void projectionConstructorSetsOnlyProjectedFields() {
+        var d = new PurchaseOrderRequestLineData(100L, true, BigDecimal.TEN, BigDecimal.ONE,
+                BigDecimal.valueOf(12.5), BigDecimal.valueOf(15.0), BigDecimal.valueOf(10), 3);
+
+        assertEquals(Long.valueOf(100L), d.getItemId());
+        assertTrue(d.isAmpp());
+        assertEquals(BigDecimal.TEN, d.getQuantity());
+        assertEquals(BigDecimal.ONE, d.getFreeQuantity());
+        assertEquals(BigDecimal.valueOf(12.5), d.getPurchaseRate());
+        assertEquals(BigDecimal.valueOf(15.0), d.getRetailRate());
+        assertEquals(BigDecimal.valueOf(10), d.getUnitsPerPack());
+        assertEquals(3, d.getSerialNo());
+        assertNull(d.getBillItemId());
+        assertNull(d.getPharmaceuticalBillItemId());
+        assertNull(d.getCreaterId());
     }
 }

--- a/src/test/java/com/divudi/service/pharmacy/PurchaseOrderApprovingNativeSqlServiceTest.java
+++ b/src/test/java/com/divudi/service/pharmacy/PurchaseOrderApprovingNativeSqlServiceTest.java
@@ -4,17 +4,27 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
+/**
+ * PurchaseOrderApprovingNativeSqlService itself has no pure-logic public
+ * method -- every one of its methods requires a live EntityManager (native
+ * SQL bill/billitem writes), same as every sibling *NativeSqlService class in
+ * this codebase. What IS unit-testable is the cross-EJB delegation contract:
+ * retireZeroQtyApprovedLines() decides which lines to retire by calling
+ * PurchaseOrderRequestNativeSqlService.isZeroQtyLine(), so this locks in that
+ * shared logic's behavior. It intentionally does not instantiate
+ * PurchaseOrderApprovingNativeSqlService.
+ */
 class PurchaseOrderApprovingNativeSqlServiceTest {
 
     private final PurchaseOrderRequestNativeSqlService requestService = new PurchaseOrderRequestNativeSqlService();
 
     @Test
-    void isZeroQtyLine_deferredToRequestService_trueWhenBothZero() {
+    void isZeroQtyLine_sharedWithRequestService_trueWhenBothZero() {
         assertTrue(requestService.isZeroQtyLine(0.0, 0.0));
     }
 
     @Test
-    void isZeroQtyLine_deferredToRequestService_falseWhenQtyPositive() {
+    void isZeroQtyLine_sharedWithRequestService_falseWhenQtyPositive() {
         assertFalse(requestService.isZeroQtyLine(5.0, 0.0));
     }
 }

--- a/src/test/java/com/divudi/service/pharmacy/PurchaseOrderApprovingNativeSqlServiceTest.java
+++ b/src/test/java/com/divudi/service/pharmacy/PurchaseOrderApprovingNativeSqlServiceTest.java
@@ -1,0 +1,20 @@
+package com.divudi.service.pharmacy;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class PurchaseOrderApprovingNativeSqlServiceTest {
+
+    private final PurchaseOrderRequestNativeSqlService requestService = new PurchaseOrderRequestNativeSqlService();
+
+    @Test
+    void isZeroQtyLine_deferredToRequestService_trueWhenBothZero() {
+        assertTrue(requestService.isZeroQtyLine(0.0, 0.0));
+    }
+
+    @Test
+    void isZeroQtyLine_deferredToRequestService_falseWhenQtyPositive() {
+        assertFalse(requestService.isZeroQtyLine(5.0, 0.0));
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 of the Purchase Order native-SQL migration (master issue #22726), following the same pattern established in Phase 1 (Request page, PR #22733). Adds a native-SQL-backed "Approving" page and controller alongside the legacy JPA-entity-graph implementation, routed to from the List-to-Approve page's Approve button.

- New `PurchaseOrderApprovingNativeSqlService`: native SQL create/update for the approved bill header, billitem+pharmaceuticalbillitem writes, totals, approveAt/approveUser, and both directions of the requested↔approved referenceBill cross-link.
- New `PurchaseOrderApprovingNativeSqlController` + `pharmacy_purhcase_order_approving_native.xhtml`: mirrors every legacy button/field (consignment, credit duration, comments, payment method, integer-only qty gate, row/bulk remove, print in 4 paper formats, Send Email, already-approved guard).
- `PurchaseOrderRequestNativeSqlService`: three previously package-private helper methods widened to `public` (required for cross-EJB no-interface-view calls from the new Approving service).
- `PurchaseOrderRequestLineData`: additive-only 7-arg constructor for a projection that can't carry `ampp` (EclipseLink limitation, documented in code).

## Bugs found and fixed during Playwright + DB testing (not caught by code review alone)

1. EclipseLink can't resolve `CASE WHEN TYPE(x) = Entity THEN...` inside a `SELECT NEW` constructor call — removed `ampp` from the projection, resolved separately in the controller instead.
2. Native INSERT for the approved bill never wrote `DTYPE` (single-table-inheritance discriminator) — switched bill creation to JPA `em.persist()`, following `TransferIssueNativeSqlService`'s established precedent.
3. EJB no-interface-view proxies only expose `public` methods — three package-private helpers on the sibling service were unreachable from this controller's cross-EJB calls.
4. Header fields and totals were silently discarded by a reload-then-read-self bug (reassigning `approvedBill` to a freshly-loaded empty entity, then reading the "user's input" back off that same reassigned field) — same bug class Phase 1 already hit once.

## Bugs found by final whole-branch review (also fixed, also re-verified live)

5. `approvedBill.referenceBill` was never set (only `backwardReferenceBill`) — broke the print composites' institution letterhead and "Prepared By/At" fields, which read `cc.attrs.bill.referenceBill.*`.
6. `billFacade.edit(approvedBill)` for `approveAt`/`approveUser` risked EclipseLink orphan-removal deleting the native-written billitems (cascade=ALL, orphanRemoval=true, collection not populated on the detached entity) — replaced with a native UPDATE.
7. `notificationController.createNotification()` was never called, dropping configured approval notifications.

All 7 fixes verified live via Playwright + direct MySQL queries against the local dev DB, not just code-reviewed.

## Test plan

- [x] Unit tests pass (`PurchaseOrderApprovingNativeSqlServiceTest`, `PurchaseOrderRequestLineDataTest`)
- [x] Full approve flow: DTYPE, header fields, totals, both cross-link directions, line items (incl. free qty) all correctly persisted
- [x] Print preview renders full letterhead, Prepared/Approved By/At
- [x] Notification rows created on approval
- [x] Already-approved guard: approved POs excluded from "To Approve" search, shown in "Approved" search with Approve button disabled
- [x] Integer-only quantity gate fires and resets correctly
- [x] Qty/Price edit recalculates line total and page total
- [x] Row-level remove (trash icon + confirm dialog)
- [x] Empty-cart validation ("Please add bill items") — no crash, no partial DB write
- [x] Missing-payment-method validation verified by code inspection (guard order confirmed to run before the empty-cart check)
- [x] `mvn compile` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a streamlined purchase-order approval workflow with editing, quantity and price validation, item removal, totals, payment settings, comments, and approval confirmation.
  * Added print preview and email options, including recipient validation and printer configuration for multiple paper formats.
  * Approval now creates the approved purchase order, links it to the request, updates status, and prevents duplicate submissions.

* **Documentation**
  * Added implementation and design documentation for the updated approval workflow.

* **Tests**
  * Added coverage for purchase-order line projections and zero-quantity handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->