### PR TITLE
Fix ComponentNotFoundException on Float Transfer Report

### DIFF
--- a/src/main/webapp/reports/cashier_reports/float_transfer_report.xhtml
+++ b/src/main/webapp/reports/cashier_reports/float_transfer_report.xhtml
@@ -61,12 +61,12 @@
                                     value="Search"
                                     icon="pi pi-search"
                                     class="ui-button-primary me-2"
-                                    update="tblTransfers tblRequests"
+                                    update="tabFloatTransfer"
                                     action="#{financialTransactionController.fillFundTransferReport()}"/>
                             </div>
                         </div>
 
-                        <p:tabView>
+                        <p:tabView id="tabFloatTransfer">
 
                             <p:tab title="Float Transfers">
                                 <p:dataTable


### PR DESCRIPTION
## Summary
- Fixes the error page shown when opening/searching the Float Transfer Report (`reports/cashier_reports/float_transfer_report.xhtml`)
- Root cause: the Search button used `update="tblTransfers tblRequests"`, referencing bare `p:dataTable` IDs that live inside `p:tabView`, which is a JSF `NamingContainer`. Bare IDs can't be resolved across a naming-container boundary, causing `javax.faces.component.search.ComponentNotFoundException` on every search.
- Fix: gave the `p:tabView` an explicit `id="tabFloatTransfer"` and changed the button's `update` target to that id, so both the Float Transfers and Float Requests tables refresh correctly regardless of which tab is active.

## Test plan
- [x] JSF-only change (XHTML only, no Java) — no compilation/build required per project convention
- [ ] Manually verify in a running environment: open Float Transfer Report, set a date range, click Search, confirm no error page and both tabs' tables populate correctly

Closes #20104

---
_Generated by [Claude Code](https://claude.ai/code/session_018FVbFV8dS9JfG9kraKfJY4)_