### PR TITLE
Fix: load existing surgery service item requests from DB (#20893)

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BillBhtController.java
+++ b/src/main/java/com/divudi/bean/inward/BillBhtController.java
@@ -312,7 +312,61 @@ public class BillBhtController implements Serializable {
         resetBillData();
         batchBill = surgeryBill;
         patientEncounter = surgeryBill.getPatientEncounter();
+        loadExistingSurgeryServiceEntries(surgeryBill);
         return "/theater/inward_bill_surgery_service?faces-redirect=true";
+    }
+
+    /**
+     * Rebuilds {@link #lstBillEntries} (the "Item Requests" / Bill Items cart
+     * shown in inward_bill_surgery_service.xhtml) from the surgery service
+     * BillItems already saved to the DB against this surgery bill.
+     *
+     * Each time the surgery service cart is settled, settleBillSurgery() ->
+     * saveBill() creates one or more Service sub-bills whose
+     * forwardReferenceBill points back at the surgery bill (see
+     * BillBeanController.setSurgeryData). resetBillData() clears
+     * lstBillEntries on every navigation into this page, so without this,
+     * previously requested/billed items never reappear (issue #20893).
+     */
+    private void loadExistingSurgeryServiceEntries(Bill surgeryBill) {
+        lstBillEntries = new ArrayList<>();
+        if (surgeryBill == null) {
+            return;
+        }
+        Map<String, Object> params = new HashMap<>();
+        params.put("surgeryBill", surgeryBill);
+        params.put("surgeryBillType", SurgeryBillType.Service);
+        String jpql = "select bi from BillItem bi "
+                + "where bi.bill.forwardReferenceBill = :surgeryBill "
+                + "and bi.bill.surgeryBillType = :surgeryBillType "
+                + "and bi.retired = false "
+                + "and bi.bill.retired = false "
+                + "order by bi.id";
+        List<BillItem> existingBillItems = billItemFacade.findByJpql(jpql, params);
+        if (existingBillItems == null) {
+            return;
+        }
+        for (BillItem bItem : existingBillItems) {
+            BillEntry entry = new BillEntry();
+            entry.setBillItem(bItem);
+            entry.setLstBillComponents(getBillBean().billComponentsFromBillItem(bItem));
+            entry.setLstBillFees(existingBillFeesForBillItem(bItem));
+            entry.setLstBillSessions(getBillBean().billSessionsfromBillItem(bItem));
+            lstBillEntries.add(entry);
+        }
+    }
+
+    /**
+     * Fetches the BillFees already persisted for a previously-billed BillItem,
+     * so re-displaying the item shows the fees actually charged rather than
+     * recomputing them against the current price matrix.
+     */
+    private List<BillFee> existingBillFeesForBillItem(BillItem bItem) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("billItem", bItem);
+        String jpql = "select bf from BillFee bf where bf.billItem = :billItem and bf.retired = false order by bf.id";
+        List<BillFee> fees = billFeeFacade.findByJpql(jpql, params);
+        return fees != null ? fees : new ArrayList<>();
     }
 
     public String navigateToPrintLabelsForInvestigations() {
@@ -438,6 +492,7 @@ public class BillBhtController implements Serializable {
 
     public void selectSurgeryBillListener() {
         patientEncounter = getBatchBill().getPatientEncounter();
+        loadExistingSurgeryServiceEntries(getBatchBill());
     }
 
     public String navigateToAddServicesFromAdmissionProfile() {


### PR DESCRIPTION
## Summary

Fixes #20893 — requested items were not displayed in the Surgery Service (Theatre) Item Requests / Bill Items table (`theater/inward_bill_surgery_service.xhtml`, `tblRequests`, bound to `billBhtController.lstBillEntries`).

## Root cause

`BillBhtController.navigateToSurgeryServices()` calls `resetBillData()`, which sets `lstBillEntries = null`. Nothing ever re-populated `lstBillEntries` from the database, so `getLstBillEntries()` always lazily initialized it to an empty list. This meant that every time a user navigated into the surgery service page for a surgery bill that already had requested/billed items, the list appeared empty — even though the items exist in the DB as service sub-bills whose `forwardReferenceBill` points back at the surgery bill (set in `BillBeanController.setSurgeryData()` during `settleBillSurgery()`).

This was already confirmed in the issue thread by @buddhika75.

## Fix

Added `BillBhtController.loadExistingSurgeryServiceEntries(Bill surgeryBill)`, which:
- Queries `BillItem`s via JPQL where `bi.bill.forwardReferenceBill = :surgeryBill`, `bi.bill.surgeryBillType = Service` (excluding other sub-bill types like `ProfessionalFee`/`PharmacyItem` that also reference the surgery bill), and both the item and its bill are not retired.
- Rebuilds `BillEntry` wrappers around each `BillItem`, using the item's actual persisted `BillFee`s (via a small `existingBillFeesForBillItem` helper) rather than recomputing fees against the current price matrix, so the displayed values match what was actually charged.

Wired into both places that select a surgery bill and set `batchBill`:
- `navigateToSurgeryServices(Bill surgeryBill)` — entry point from the Surgery Dashboard's "Add Services & Investigations" button.
- `selectSurgeryBillListener()` — entry point when a surgery bill is picked directly on the page via the BHT autocomplete.

## Testing

- `mvn compile` succeeds with no errors.
- This is a Java change (not JSF-only), but there is no theatre/surgery test data available in this environment to run an end-to-end Playwright check against a real surgery bill with pre-existing items.


---
_Generated by [Claude Code](https://claude.ai/code/session_018CgSbnB7Qrtr7y7FAZghpr)_