### PR TITLE
Fix Department Type filter dropping Stock Adjustment/Rate Adjustment rows

### DIFF
--- a/src/main/java/com/divudi/bean/report/PharmacyReportController.java
+++ b/src/main/java/com/divudi/bean/report/PharmacyReportController.java
@@ -10732,7 +10732,7 @@ public class PharmacyReportController implements Serializable {
                 m.put("itm", item);
             }
             if (selectedDepartmentTypes != null && !selectedDepartmentTypes.isEmpty()) {
-                jpql += " and s.pbItem.billItem.bill.departmentType in :departmentTypes ";
+                jpql += " and s.item.departmentType in :departmentTypes ";
                 m.put("departmentTypes", selectedDepartmentTypes);
             }
 //            if ("transferReceiveDoc".equals(documentType) || "transferIssueDoc".equals(documentType) || documentType == null) {
@@ -10949,7 +10949,7 @@ public class PharmacyReportController implements Serializable {
                 m.put("df", dosageForm);
             }
             if (selectedDepartmentTypes != null && !selectedDepartmentTypes.isEmpty()) {
-                jpql.append(" AND b.departmentType IN :departmentTypes");
+                jpql.append(" AND s.item.departmentType IN :departmentTypes");
                 m.put("departmentTypes", selectedDepartmentTypes);
             }
 


### PR DESCRIPTION
## Summary

Fixes #19172 — the Department Type filter on the Stock Ledger reports (`reports/inventoryReports/stock_ledger_dto.xhtml` and the non-DTO `stock_ledger.xhtml`) silently dropped Stock Adjustment / Rate Adjustment rows whenever a Department Type was selected.

**Root cause**: `PharmacyReportController.processStockLedgerDtoReport()` and `processStockLedgerReport()` filtered department type via `b.departmentType` / `s.pbItem.billItem.bill.departmentType`, reached through a chain of `LEFT JOIN`s: `StockHistory s -> s.pbItem -> pbItem.billItem -> billItem.bill b`. Stock Adjustment and Rate Adjustment `StockHistory` rows have no `PharmaceuticalBillItem`/`BillItem`/`Bill` linkage through that path, so `b` resolves to `null` and `NULL IN (:departmentTypes)` is never true — those rows get excluded instead of matched whenever the filter is applied.

**Fix**: switch both queries to `s.item.departmentType`, matching the already-correct pattern used elsewhere in the same file (e.g. the Opening/Closing Stock queries, `sh.item.departmentType` / `sh2.item.departmentType`). `StockHistory` always has a direct `item` reference, and `Item.getDepartmentType()` defaults to `Pharmacy` for `PharmaceuticalItem`, so this is reliably populated regardless of which bill type produced the stock history row.

Both `processStockLedgerReport()` (backs `stock_ledger.xhtml`) and `processStockLedgerDtoReport()` (backs `stock_ledger_dto.xhtml`, the page named in the issue) had the identical bug, so both were fixed for consistency.

## Changes

- `src/main/java/com/divudi/bean/report/PharmacyReportController.java`
  - `processStockLedgerReport()`: `s.pbItem.billItem.bill.departmentType` → `s.item.departmentType`
  - `processStockLedgerDtoReport()`: `b.departmentType` → `s.item.departmentType`

## Test plan

This PR was developed in a network-restricted remote container without local Payara/Playwright access, so full UI/DB verification wasn't possible here. Verification performed:

- [x] Manually traced the JPQL scope — `s` (root `FROM StockHistory s`) and `s.item` (direct `@ManyToOne` field on `StockHistory`) are valid in both queries.
- [x] Confirmed `Item.departmentType` is the established, working pattern for this exact filter dropdown (Pharmacy/Store/Lab/Kitchen) elsewhere in the same controller (Opening/Closing Stock queries).
- [x] `mvn compile` could not run in this environment — the build depends on `com.github.hmislk:lims-middleware-libraries` from `jitpack.io`, which returns `403 Forbidden` through this container's network proxy (pre-existing environment limitation, unrelated to this change).
- [ ] **Needs reviewer verification against a local/staging deployment**: apply a Department Type filter on the Stock Adjustment / Rate Adjustment tabs of both Stock Ledger reports and confirm the expected rows now appear.

Co-Authored-By: Claude <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01PWEupRjBwdJZsdNCDfP2iT)_