### PR TITLE
Fix Inward Charge Type Breakdown by BHT: outside charges & admission fee mismatch

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardAdditionalChargeController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardAdditionalChargeController.java
@@ -162,6 +162,14 @@ public class InwardAdditionalChargeController implements Serializable {
             return true;
         }
 
+        if (selectedItem.getInwardChargeType() == null) {
+            JsfUtil.addErrorMessage("This item has no Inward Category configured. "
+                    + "Please set an Inward Category for \"" + selectedItem.getName()
+                    + "\" under Admin > Items before billing it, otherwise this charge "
+                    + "will not appear in Inward Charge Type reports.");
+            return true;
+        }
+
         if (getCurrent().getTotal() < 1) {
             JsfUtil.addErrorMessage("Enter Added Charge Correctly");
             return true;

--- a/src/main/java/com/divudi/bean/inward/InwardChargeTypeBreakdownController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardChargeTypeBreakdownController.java
@@ -1,5 +1,6 @@
 package com.divudi.bean.inward;
 
+import com.divudi.bean.common.BillBeanController;
 import com.divudi.bean.common.ConfigOptionApplicationController;
 import com.divudi.core.data.BillType;
 import com.divudi.core.data.BillTypeAtomic;
@@ -61,6 +62,8 @@ public class InwardChargeTypeBreakdownController implements Serializable {
     private PatientEncounterFacade patientEncounterFacade;
     @Inject
     private ConfigOptionApplicationController configOptionApplicationController;
+    @Inject
+    private BillBeanController billBeanController;
 
     // -------------------------------------------------------------------------
     // Filter fields
@@ -711,8 +714,7 @@ public class InwardChargeTypeBreakdownController implements Serializable {
                 if (enc.getBhtNo() == null) {
                     continue;
                 }
-                double fee = (enc.getAdmissionType() != null)
-                        ? enc.getAdmissionType().getAdmissionFee() : 0.0;
+                double fee = resolveBilledAdmissionFee(enc);
                 if (fee == 0.0) {
                     continue;
                 }
@@ -738,6 +740,27 @@ public class InwardChargeTypeBreakdownController implements Serializable {
         }
         grandTotal = colSum;
         columnTotals = Arrays.asList(colSum);
+    }
+
+    /**
+     * Resolves the Admission Fee actually billed for an encounter, instead of
+     * recomputing it from the current (mutable) AdmissionType master fee.
+     * Prefers the persisted Final Bill admission-fee BillItem (post-discount,
+     * for discharged/finalised encounters), falling back to the persisted
+     * Interim Bill admission-fee BillItem (for admitted-but-not-discharged
+     * encounters with a saved interim bill). If neither has ever been billed
+     * for this encounter, falls back to the live AdmissionType fee as a
+     * projected value, matching prior behaviour for not-yet-billed cases.
+     */
+    private double resolveBilledAdmissionFee(PatientEncounter enc) {
+        BillItem billed = billBeanController.fetchBillItem(enc, BillType.InwardFinalBill, InwardChargeType.AdmissionFee);
+        if (billed == null) {
+            billed = billBeanController.fetchBillItem(enc, BillType.InwardIntrimBill, InwardChargeType.AdmissionFee);
+        }
+        if (billed != null) {
+            return billed.getAdjustedValue();
+        }
+        return (enc.getAdmissionType() != null) ? enc.getAdmissionType().getAdmissionFee() : 0.0;
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes both issues reported in #19930 for `inward/inward_report_inward_charge_type_breakdown.xhtml`:

- **Outside charges (e.g. Ambulance Charges) not reflected in the report.** The report matches a `BillItem` to a report column via `Item.inwardChargeType` — a master-data field set once on the Item in Admin → Items, and copied onto the `BillItem` at billing time (`InwardAdditionalChargeController.saveBillItem()`). That field is optional and nothing validated it before billing, so an outside-charge item with no Inward Category configured would bill successfully but silently never match any charge-type filter in this (or any other) InwardChargeType-based report. `InwardAdditionalChargeController.errorCheck()` now rejects adding an outside charge for an item with no Inward Category configured, with a message pointing staff to fix it in Admin → Items.
  - Note: this does not retroactively fix any *already-billed* charges whose Item still has no Inward Category set — that needs a one-time check/fix of the actual "Ambulance Charges" (and similar) Item master record(s) in the DB, which I could not inspect from this environment.
- **Admission Fee mismatch between Interim Bill and the report.** `InwardChargeTypeBreakdownController.buildFromAdmissionFee()` computed the fee from the *live* `AdmissionType.admissionFee` master value at report-generation time. The Interim/Final Bill, by contrast, persists the fee actually billed as a real `BillItem` (`InwardIntrimBill`/`InwardFinalBill`, `inwardChargeType = AdmissionFee`) at the time it's generated/saved. If the master `AdmissionType.admissionFee` is edited afterward, the report and the (already billed) Interim Bill diverge — exactly the Rs 4600 vs Rs 1500 example in the issue. The report now looks up the actual persisted admission-fee `BillItem` (Final Bill first, then Interim Bill) via the existing `BillBeanController.fetchBillItem()` helper — the same helper already used by `BhtSummeryController.toPrintItrim()` for this exact purpose — falling back to the live master fee only when nothing has been billed for that encounter yet.

## Files changed

- `src/main/java/com/divudi/bean/inward/InwardAdditionalChargeController.java`
- `src/main/java/com/divudi/bean/inward/InwardChargeTypeBreakdownController.java`

## Verification

This session runs in a remote container without local Payara/DB/Playwright access (the issue's own comment confirms the local dev DB also has no active inpatients to test against), so I was not able to exercise this end-to-end in a browser or reprint/regenerate real bills. Verification performed instead:

- Traced both bugs to their exact root cause by reading the full save/query code paths (`InwardAdditionalChargeController`, `BhtSummeryController.toPrintItrim()`/`setKnownChargeTot()`, `IntrimPrintController.saveIntrimBill()`, `BillBeanController.fetchBillItem()`) and confirmed method/field signatures (`BillItem.getAdjustedValue()`, `Item.getName()`, `BillType.InwardFinalBill`/`InwardIntrimBill`, `InwardChargeType.AdmissionFee`) against the actual entity/enum source.
- `mvn compile` could not run in this sandbox (blocked resolving an external `jitpack.io` dependency through the network proxy, unrelated to this change) — reviewed the diff manually against the existing injection pattern already used identically in `InwardAdditionalChargeController.java` (`@Inject private BillBeanController billBeanController;`).

Given the lack of runtime verification here, please re-check against a real admitted patient with outside charges and a saved Interim Bill before/after an admission-fee master-data change, to confirm both fixes behave as intended.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gmzto2j52eHGjDfcbUh5Au)_