### PR TITLE
Fix Professional Fees cache invalidation in Interim Bill

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -4493,6 +4493,19 @@ public class BhtSummeryController implements Serializable {
         this.profesionallFee = profesionallFee;
     }
 
+    /**
+     * Invalidates the cached Professional Fees tab list so the next call to
+     * {@link #getProfesionallFee()} re-queries the database. This bean is
+     * @SessionScoped and many pages navigate directly to inward_bill_intrim.xhtml
+     * without calling {@link #createTables()}, so professional fees added from
+     * elsewhere (e.g. the surgery professional fee bill) would otherwise never
+     * appear until some unrelated action happened to reset the cache. See
+     * issue #20146.
+     */
+    public void refreshProfesionallFee() {
+        profesionallFee = null;
+    }
+
     public List<Bill> getPaymentBill() {
         if (paymentBill == null) {
             paymentBill = getInwardBean().fetchPaymentBill(getPatientEncounter(), childPatientEncouters);

--- a/src/main/java/com/divudi/bean/inward/InwardProfessionalBillController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardProfessionalBillController.java
@@ -77,6 +77,8 @@ public class InwardProfessionalBillController implements Serializable {
     @Inject
     SurgeryBillController surgeryBillController;
     @Inject
+    BhtSummeryController bhtSummeryController;
+    @Inject
     ConfigOptionController configOptionController;
     ////////////////////
     @EJB
@@ -461,6 +463,13 @@ public class InwardProfessionalBillController implements Serializable {
         current = null;
         settlePreview = true;
         surgeryBillController.refreshProEncounterComponents();
+        // The Interim Bill (BhtSummeryController) is @SessionScoped and caches its
+        // Professional Fees tab list (profesionallFee) until explicitly invalidated.
+        // Many pages navigate straight to inward_bill_intrim.xhtml without going through
+        // a BhtSummeryController navigation method that would refresh it, so without this
+        // call a surgery professional fee saved here would not show up in the Interim Bill
+        // until some unrelated action happened to reset the cache. See issue #20146.
+        bhtSummeryController.refreshProfesionallFee();
         JsfUtil.addSuccessMessage("Professional fee bill saved.");
     }
 


### PR DESCRIPTION
## Summary
Fixes issue #20146 where professional fees added via the Surgery Professional Fee Bill would not appear in the Interim Bill (inward_bill_intrim.xhtml) until an unrelated action reset the cache.

## Root Cause
The `BhtSummeryController` is `@SessionScoped` and caches its Professional Fees tab list (`profesionallFee`) until the bean is recreated. Many pages navigate directly to `inward_bill_intrim.xhtml` without calling `createTables()`, so the cached list is never refreshed. When a professional fee bill is saved from the Surgery module, the Interim Bill's cache remains stale.

## Changes Made
- **BhtSummeryController**: Added `refreshProfesionallFee()` method to invalidate the cached professional fees list by setting it to `null`, forcing a re-query on the next access
- **InwardProfessionalBillController**: Injected `BhtSummeryController` and added a call to `refreshProfesionallFee()` after saving a professional fee bill, ensuring the Interim Bill's cache is cleared

## Implementation Details
- The refresh is called immediately after `surgeryBillController.refreshProEncounterComponents()` in the `saveProfessionalFeeBill()` method
- Both methods include detailed JavaDoc comments explaining the session scope caching issue and why the explicit invalidation is necessary
- This follows the existing pattern used by `SurgeryBillController.refreshProEncounterComponents()`

https://claude.ai/code/session_017hF9sitd3My6citw9swDLS