### PR TITLE
Fix Department Type filter excluding legacy items in Stock Ledger reports

### DIFF
--- a/src/main/java/com/divudi/bean/report/PharmacyReportController.java
+++ b/src/main/java/com/divudi/bean/report/PharmacyReportController.java
@@ -10732,7 +10732,15 @@ public class PharmacyReportController implements Serializable {
                 m.put("itm", item);
             }
             if (selectedDepartmentTypes != null && !selectedDepartmentTypes.isEmpty()) {
-                jpql += " and s.item.departmentType in :departmentTypes ";
+                if (selectedDepartmentTypes.contains(DepartmentType.Pharmacy)) {
+                    // Item.getDepartmentType() defaults a null departmentType to Pharmacy for
+                    // PharmaceuticalItem, but that fallback only lives in the Java getter -
+                    // legacy items with a null departmentType column would otherwise be
+                    // silently dropped by "IN :departmentTypes" whenever Pharmacy is selected.
+                    jpql += " and (s.item.departmentType in :departmentTypes or s.item.departmentType is null) ";
+                } else {
+                    jpql += " and s.item.departmentType in :departmentTypes ";
+                }
                 m.put("departmentTypes", selectedDepartmentTypes);
             }
 //            if ("transferReceiveDoc".equals(documentType) || "transferIssueDoc".equals(documentType) || documentType == null) {
@@ -10949,7 +10957,15 @@ public class PharmacyReportController implements Serializable {
                 m.put("df", dosageForm);
             }
             if (selectedDepartmentTypes != null && !selectedDepartmentTypes.isEmpty()) {
-                jpql.append(" AND s.item.departmentType IN :departmentTypes");
+                if (selectedDepartmentTypes.contains(DepartmentType.Pharmacy)) {
+                    // Item.getDepartmentType() defaults a null departmentType to Pharmacy for
+                    // PharmaceuticalItem, but that fallback only lives in the Java getter -
+                    // legacy items with a null departmentType column would otherwise be
+                    // silently dropped by "IN :departmentTypes" whenever Pharmacy is selected.
+                    jpql.append(" AND (s.item.departmentType IN :departmentTypes OR s.item.departmentType IS NULL)");
+                } else {
+                    jpql.append(" AND s.item.departmentType IN :departmentTypes");
+                }
                 m.put("departmentTypes", selectedDepartmentTypes);
             }
 


### PR DESCRIPTION
## Summary
- Fixes the "Department Type" filter on `/reports/inventoryReports/stock_ledger_dto.xhtml` not returning rows for **Transfer Receive** (and potentially other document types) when a Department Type is selected.
- Root cause: `PharmacyReportController.processStockLedgerReport()` and `processStockLedgerDtoReport()` filter with `s.item.departmentType IN :departmentTypes`. `Item.getDepartmentType()` falls back to `DepartmentType.Pharmacy` in Java when the `departmentType` column is `null` for a `PharmaceuticalItem`, but that fallback only exists in the getter — the raw JPQL comparison ignores it. Any item whose `departmentType` column was never explicitly set (common for items predating this field) is silently excluded whenever `Pharmacy` is selected, since `NULL IN (...)` evaluates to unknown/false in SQL. Transfer Receive commonly moves such long-established stock items, which is why it was the most visible symptom.
- Fix: when `Pharmacy` is among the selected department types, also match rows where `s.item.departmentType IS NULL`, mirroring the existing Java-level fallback.

## Test plan
- [ ] Could not run a full Maven build in this sandbox — the `com.github.hmislk:lims-middleware-libraries` dependency is hosted on jitpack.io, which this environment's network proxy blocks (403), unrelated to this change.
- [ ] Manually verified the JPQL changes are syntactically consistent with existing patterns in the same file (mirrors the `if (selectedDepartmentTypes.contains(...))` style and the `DepartmentType.Pharmacy` reference already used elsewhere in `PharmacyReportController`).
- [ ] Please verify in a real environment: generate the Stock Ledger DTO report with Document Type = "Transfer Receive" and Department Type = "Pharmacy" and confirm rows are now returned.

Closes #19169


---
_Generated by [Claude Code](https://claude.ai/code/session_01CztnrwcFNqTpie5ter2AtP)_