### PR TITLE
fix(report): correct Inward Collections bill count/total in DTO report

### DIFF
--- a/src/main/java/com/divudi/bean/report/BookKeepingSummery.java
+++ b/src/main/java/com/divudi/bean/report/BookKeepingSummery.java
@@ -4570,7 +4570,8 @@ public class BookKeepingSummery implements Serializable {
                 + "SUM(bi.netValue), "
                 + "COUNT(DISTINCT b.id)) "
                 + "FROM BillItem bi JOIN bi.bill b "
-                + "LEFT JOIN bi.item.category c "
+                + "LEFT JOIN bi.item it "
+                + "LEFT JOIN it.category c "
                 + "WHERE b.billType IN :billTypes "
                 + "AND b.institution = :ins "
                 + "AND b.createdAt BETWEEN :fd AND :td "
@@ -4580,7 +4581,7 @@ public class BookKeepingSummery implements Serializable {
                 + "ORDER BY c.name";
 
         Map<String, Object> params = new HashMap<>();
-        params.put("billTypes", Arrays.asList(BillType.InwardBill, BillType.InwardPaymentBill));
+        params.put("billTypes", Arrays.asList(BillType.InwardPaymentBill));
         params.put("ins", institution);
         params.put("fd", fromDate);
         params.put("td", toDate);


### PR DESCRIPTION
## Summary
- `BookKeepingSummery.fetchInwardCollectionsDto()` (used by `reportInstitution/report_cash_category_with_pro_day_dto.xhtml`, "By Category Day End (DTO Optimized)") counted `BillType.InwardBill` (ward/service **charge** bills, `BillFinanceType.NO_FINANCE_TRANSACTIONS`) as an Inward Collection alongside `BillType.InwardPaymentBill` (the actual cash-in collection). Narrowed the filter to `InwardPaymentBill` only, matching the existing `BillBeanController.calInwardPaymentTotal()` logic used elsewhere in the same class.
- Also fixed a second bug surfaced during testing: `InwardPaymentBill` bill items always have a `null` `item` (deposit/payment items aren't tied to a catalog `Item`). The query's chained JPQL path `LEFT JOIN bi.item.category c` was silently dropped by EclipseLink as an inner join on the intermediate `bi.item` step, hiding real collections. Split into two explicit joins: `LEFT JOIN bi.item it LEFT JOIN it.category c`.

Closes #19142

## Test plan
- [x] Rebuilt and redeployed locally (Maven + Payara).
- [x] Bug repro: Galle Co Operative Hospital, 2026-07-01 to 2026-07-02 (119 `InwardBill` service-charge rows, 0 `InwardPaymentBill` rows) — Inward Collections now shows "No data available" / Total 0.0 instead of a spurious count.
- [x] Regression check: same institution, 2026-06-11 (6 real `InwardPaymentBill` records) — Inward Collections now correctly shows Bill Count 6, Total 106,755.39, matching a direct DB cross-check (`SELECT COUNT(DISTINCT b.id), SUM(bi.netvalue) ... WHERE billtype='InwardPaymentBill' ...`).
- [x] Spot-checked OPD Cash Collections totals for the same date against the DB — unaffected, no regression.
- [x] Checked `server.log` — no new errors during testing.

Screenshots (posted on the issue, hosted on the wiki):
- No collections case: https://raw.githubusercontent.com/wiki/hmislk/hmis/images/19142-inward-collections-empty-fixed.png
- Real collections case: https://raw.githubusercontent.com/wiki/hmislk/hmis/images/19142-inward-collections-real-data-fixed.png

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inward collection reporting by using the correct item category relationship.
  * Updated filtering to include only inward payment bills, improving report accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->