### PR TITLE
Fix final bill version credit-company allocation drop and add email review step

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -2541,7 +2541,11 @@ public class BhtSummeryController implements Serializable {
         Map<Institution, Double> allocatedByCompany = new LinkedHashMap<>();
         if (ccBills != null) {
             for (Bill ccBill : ccBills) {
-                allocatedByCompany.put(ccBill.getCreditCompany(), ccBill.getNetTotal());
+                // Sum rather than overwrite: normally one CC bill per institution, but
+                // duplicate EncounterCreditCompany registrations for the same institution
+                // are possible via older data paths (e.g. AdmissionController), which
+                // would otherwise silently drop all but the last bill's amount here.
+                allocatedByCompany.merge(ccBill.getCreditCompany(), ccBill.getNetTotal(), Double::sum);
             }
         }
 

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -2519,6 +2519,16 @@ public class BhtSummeryController implements Serializable {
      * commitment bills recorded against {@code sourceBill}, so a new version
      * starts from the same split rather than forcing the cashier to re-allocate
      * from scratch.
+     * <p>
+     * {@code settle()} only persists a CC bill for allocations {@code > 0}, so a
+     * company that was allocated 0.00 in the source bill has no CC bill to read
+     * back here. Every company still on the encounter (from
+     * {@link #fillCreditCompaniesByPatient}) is therefore always given a row —
+     * defaulting to 0.00 when no CC bill is found — the same way
+     * {@link #populateCreditCompanyAllocations()} always shows every company on
+     * the normal settle flow. Without this, a zero-allocated company would
+     * silently disappear from every subsequent version and could never be
+     * re-allocated to.
      */
     private List<CreditCompanyAllocation> rebuildAllocationsFromSourceBill(Bill sourceBill) {
         List<CreditCompanyAllocation> allocations = new ArrayList<>();
@@ -2528,12 +2538,32 @@ public class BhtSummeryController implements Serializable {
         params.put("atomic", BillTypeAtomic.INWARD_FINAL_BILL_PAYMENT_BY_CREDIT_COMPANY);
         List<Bill> ccBills = getBillFacade().findByJpql(jpql, params);
 
-        double allocatedSoFar = 0.0;
+        Map<Institution, Double> allocatedByCompany = new LinkedHashMap<>();
         if (ccBills != null) {
             for (Bill ccBill : ccBills) {
-                allocations.add(new CreditCompanyAllocation(ccBill.getCreditCompany(), ccBill.getNetTotal()));
-                allocatedSoFar += ccBill.getNetTotal();
+                allocatedByCompany.put(ccBill.getCreditCompany(), ccBill.getNetTotal());
             }
+        }
+
+        double allocatedSoFar = 0.0;
+        List<EncounterCreditCompany> eccs = fillCreditCompaniesByPatient(sourceBill.getPatientEncounter());
+        if (eccs != null && !eccs.isEmpty()) {
+            eccs.sort(Comparator.comparing(
+                    ecc -> ecc.getInstitution() != null ? ecc.getInstitution().getName() : "",
+                    Comparator.nullsLast(Comparator.naturalOrder())));
+            for (EncounterCreditCompany ecc : eccs) {
+                Double amount = allocatedByCompany.remove(ecc.getInstitution());
+                double allocated = amount != null ? amount : 0.0;
+                allocations.add(new CreditCompanyAllocation(ecc, allocated));
+                allocatedSoFar += allocated;
+            }
+        }
+        // Any CC bill for a company no longer in the encounter's active list (e.g.
+        // retired since the source bill was settled) still keeps its allocated
+        // amount visible instead of silently dropping it.
+        for (Map.Entry<Institution, Double> leftover : allocatedByCompany.entrySet()) {
+            allocations.add(new CreditCompanyAllocation(leftover.getKey(), leftover.getValue()));
+            allocatedSoFar += leftover.getValue();
         }
 
         double newLiveNetDue = Math.max(0.0, (grantTotal - discount) - paidByPatient - paidByCompany);

--- a/src/main/java/com/divudi/bean/inward/InwardSearch.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSearch.java
@@ -822,6 +822,13 @@ public class InwardSearch implements Serializable {
         return "/inward/inward_final_bill_email?faces-redirect=true";
     }
 
+    // Attachments are held Base64-encoded in this SessionScoped bean until sent —
+    // capped here (in addition to the fileUpload's client-side sizeLimit) so a
+    // careless or malicious upload can't grow session memory unbounded.
+    private static final int MAX_EMAIL_ATTACHMENTS = 5;
+    private static final long MAX_EMAIL_ATTACHMENT_FILE_BYTES = 10_000_000L;
+    private static final long MAX_EMAIL_ATTACHMENT_TOTAL_BYTES = 20_000_000L;
+
     /**
      * Adds a cashier-chosen file (e.g. a supporting document requested by the
      * credit company) to the attachment list for the email being composed.
@@ -832,8 +839,24 @@ public class InwardSearch implements Serializable {
         if (pendingEmailAttachments == null) {
             pendingEmailAttachments = new ArrayList<>();
         }
+        UploadedFile file = event.getFile();
+        if (pendingEmailAttachments.size() >= MAX_EMAIL_ATTACHMENTS) {
+            JsfUtil.addErrorMessage("Cannot attach more than " + MAX_EMAIL_ATTACHMENTS + " documents");
+            return;
+        }
+        if (file.getSize() > MAX_EMAIL_ATTACHMENT_FILE_BYTES) {
+            JsfUtil.addErrorMessage(file.getFileName() + " exceeds the 10MB attachment size limit");
+            return;
+        }
+        long attachedSoFar = 0;
+        for (EmailAttachment existing : pendingEmailAttachments) {
+            attachedSoFar += existing.getBase64Content() != null ? existing.getBase64Content().length() * 3L / 4 : 0;
+        }
+        if (attachedSoFar + file.getSize() > MAX_EMAIL_ATTACHMENT_TOTAL_BYTES) {
+            JsfUtil.addErrorMessage("Total attachments cannot exceed 20MB");
+            return;
+        }
         try {
-            UploadedFile file = event.getFile();
             EmailAttachment attachment = new EmailAttachment(
                     file.getFileName(),
                     file.getContentType(),
@@ -877,6 +900,14 @@ public class InwardSearch implements Serializable {
     private boolean emailFinalBillVersionInternal(Bill b) {
         if (b == null) {
             JsfUtil.addErrorMessage("No bill selected");
+            return false;
+        }
+        // InwardSearch.bill is shared session state set by many unrelated flows
+        // (interim estimates, staff payment cancel, etc.), and this page is reachable
+        // by direct URL — without this check, a stale/unrelated bill left over from
+        // another flow could be sent out mislabeled as a Final Bill.
+        if (b.getBillType() != BillType.InwardFinalBill) {
+            JsfUtil.addErrorMessage("Selected bill is not a Final Bill");
             return false;
         }
         if (emailRecipient == null || emailRecipient.trim().isEmpty()) {

--- a/src/main/java/com/divudi/bean/inward/InwardSearch.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSearch.java
@@ -65,6 +65,8 @@ import javax.inject.Named;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 import org.primefaces.PrimeFaces;
+import org.primefaces.event.FileUploadEvent;
+import org.primefaces.model.file.UploadedFile;
 
 /**
  *
@@ -765,6 +767,9 @@ public class InwardSearch implements Serializable {
     }
 
     private String emailRecipient;
+    private String emailSubject;
+    private String emailBody;
+    private List<EmailAttachment> pendingEmailAttachments;
     private List<AppEmail> sentEmailsForBill;
 
     public String getEmailRecipient() {
@@ -775,11 +780,85 @@ public class InwardSearch implements Serializable {
         this.emailRecipient = emailRecipient;
     }
 
+    public String getEmailSubject() {
+        return emailSubject;
+    }
+
+    public void setEmailSubject(String emailSubject) {
+        this.emailSubject = emailSubject;
+    }
+
+    public String getEmailBody() {
+        return emailBody;
+    }
+
+    public void setEmailBody(String emailBody) {
+        this.emailBody = emailBody;
+    }
+
+    public List<EmailAttachment> getPendingEmailAttachments() {
+        return pendingEmailAttachments;
+    }
+
+    /**
+     * Navigates from the Final Bill Versions list to the email review page
+     * for {@code b}, prefilling recipient/subject/body so the cashier can
+     * check and edit them — and attach extra documents — before anything is
+     * actually sent. Replaces the old pattern of sending straight from a
+     * "Recipient + Send" dialog with no review step.
+     */
+    public String prepareEmailFinalBillVersion(Bill b) {
+        if (b == null) {
+            JsfUtil.addErrorMessage("No bill selected");
+            return "";
+        }
+        bill = b;
+        PatientEncounter pe = b.getPatientEncounter();
+        emailRecipient = pe != null && pe.getPatient() != null && pe.getPatient().getPerson() != null
+                ? pe.getPatient().getPerson().getEmail() : null;
+        emailSubject = "Final Bill " + b.getDeptId();
+        emailBody = "Please find attached the final bill " + b.getDeptId() + ".";
+        pendingEmailAttachments = new ArrayList<>();
+        return "/inward/inward_final_bill_email?faces-redirect=true";
+    }
+
+    /**
+     * Adds a cashier-chosen file (e.g. a supporting document requested by the
+     * credit company) to the attachment list for the email being composed.
+     * Kept separate from the auto-generated final bill PDF, which is always
+     * attached in addition to whatever is added here.
+     */
+    public void uploadEmailAttachment(FileUploadEvent event) {
+        if (pendingEmailAttachments == null) {
+            pendingEmailAttachments = new ArrayList<>();
+        }
+        try {
+            UploadedFile file = event.getFile();
+            EmailAttachment attachment = new EmailAttachment(
+                    file.getFileName(),
+                    file.getContentType(),
+                    Base64.getEncoder().encodeToString(file.getContent()));
+            pendingEmailAttachments.add(attachment);
+            JsfUtil.addSuccessMessage("Attached " + file.getFileName());
+        } catch (Exception ex) {
+            JsfUtil.addErrorMessage("Failed to attach file");
+            java.util.logging.Logger.getLogger(InwardSearch.class.getName())
+                    .log(java.util.logging.Level.SEVERE, "Final bill email attachment failed", ex);
+        }
+    }
+
+    public void removeEmailAttachment(EmailAttachment attachment) {
+        if (pendingEmailAttachments != null) {
+            pendingEmailAttachments.remove(attachment);
+        }
+    }
+
     /**
      * Emails a one-page summary of the given final bill version (patient,
      * admission, and totals — not a full itemized reprint) as a PDF
-     * attachment, and logs the send via {@link AppEmail} so it shows up in
-     * the "Sent Emails" history on the view/print screen.
+     * attachment, plus any cashier-attached documents, and logs the send via
+     * {@link AppEmail} so it shows up in the "Sent Emails" history on the
+     * view/print screen.
      */
     public void emailFinalBillVersion(Bill b) {
         boolean sent = false;
@@ -809,12 +888,17 @@ public class InwardSearch implements Serializable {
             return false;
         }
 
+        String subject = (emailSubject != null && !emailSubject.trim().isEmpty())
+                ? emailSubject : "Final Bill " + b.getDeptId();
+        String body = (emailBody != null && !emailBody.trim().isEmpty())
+                ? emailBody : "Please find attached the final bill " + b.getDeptId() + ".";
+
         AppEmail email = new AppEmail();
         email.setCreatedAt(new Date());
         email.setCreater(sessionController.getLoggedUser());
         email.setReceipientEmail(emailRecipient);
-        email.setMessageSubject("Final Bill " + b.getDeptId());
-        email.setMessageBody("Please find attached the final bill " + b.getDeptId() + ".");
+        email.setMessageSubject(subject);
+        email.setMessageBody(body);
         email.setDepartment(b.getDepartment());
         email.setInstitution(b.getInstitution());
         email.setBill(b);
@@ -832,12 +916,18 @@ public class InwardSearch implements Serializable {
                     "application/pdf",
                     Base64.getEncoder().encodeToString(pdfBytes));
 
+            List<EmailAttachment> attachments = new ArrayList<>();
+            attachments.add(attachment);
+            if (pendingEmailAttachments != null) {
+                attachments.addAll(pendingEmailAttachments);
+            }
+
             success = emailManagerEjb.sendEmail(
                     Collections.singletonList(email.getReceipientEmail()),
                     email.getMessageBody(),
                     email.getMessageSubject(),
                     false,
-                    Collections.singletonList(attachment));
+                    attachments);
 
             if (success) {
                 email.setSentAt(new Date());
@@ -845,6 +935,7 @@ public class InwardSearch implements Serializable {
                 email.setPending(false);
                 emailFacade.edit(email);
                 JsfUtil.addSuccessMessage("Email Sent Successfully");
+                pendingEmailAttachments = new ArrayList<>();
             } else {
                 email.setPending(false);
                 emailFacade.edit(email);

--- a/src/main/java/com/divudi/bean/inward/InwardSearch.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSearch.java
@@ -906,7 +906,12 @@ public class InwardSearch implements Serializable {
         // (interim estimates, staff payment cancel, etc.), and this page is reachable
         // by direct URL — without this check, a stale/unrelated bill left over from
         // another flow could be sent out mislabeled as a Final Bill.
-        if (b.getBillType() != BillType.InwardFinalBill) {
+        // billTypeAtomic is required in addition to billType: createCancelBill()
+        // copies billType=InwardFinalBill onto the cancellation record it creates
+        // (see fetchFinalBillVersions()), so billType alone would let a cancellation
+        // record through as if it were a real final bill.
+        if (b.getBillType() != BillType.InwardFinalBill
+                || b.getBillTypeAtomic() != BillTypeAtomic.INWARD_FINAL_BILL) {
             JsfUtil.addErrorMessage("Selected bill is not a Final Bill");
             return false;
         }

--- a/src/main/webapp/inward/inward_final_bill_email.xhtml
+++ b/src/main/webapp/inward/inward_final_bill_email.xhtml
@@ -13,7 +13,7 @@
             <ui:define name="content">
                 <h:form id="formEmailFinalBill" enctype="multipart/form-data">
 
-                    <p:panel rendered="#{webUserController.hasPrivilege('InwardFinalBillEmail') and inwardSearch.bill ne null and inwardSearch.bill.billType eq 'InwardFinalBill'}">
+                    <p:panel rendered="#{webUserController.hasPrivilege('InwardFinalBillEmail') and inwardSearch.bill ne null and inwardSearch.bill.billType eq 'InwardFinalBill' and inwardSearch.bill.billTypeAtomic eq 'INWARD_FINAL_BILL'}">
 
                         <f:facet name="header">
                             <div class="d-flex justify-content-between">

--- a/src/main/webapp/inward/inward_final_bill_email.xhtml
+++ b/src/main/webapp/inward/inward_final_bill_email.xhtml
@@ -1,0 +1,126 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <h:body>
+
+        <ui:composition template="/resources/template/template.xhtml">
+
+            <ui:define name="content">
+                <h:form id="formEmailFinalBill" enctype="multipart/form-data">
+
+                    <p:panel rendered="#{webUserController.hasPrivilege('InwardFinalBillEmail') and inwardSearch.bill ne null}">
+
+                        <f:facet name="header">
+                            <div class="d-flex justify-content-between">
+                                <div class="d-flex">
+                                    <h:outputText styleClass="fas fa-envelope"></h:outputText>
+                                    <h:outputLabel value="Email Final Bill" class="mx-4"></h:outputLabel>
+                                </div>
+                                <div class="d-flex gap-2">
+                                    <p:commandButton
+                                        ajax="false"
+                                        icon="fas fa-list"
+                                        class="ui-button-secondary"
+                                        value="Back to Final Bill Versions"
+                                        action="#{inwardSearch.navigateToManageFinalBills()}"
+                                        title="Back to Final Bill Versions">
+                                    </p:commandButton>
+                                </div>
+                            </div>
+                        </f:facet>
+
+                        <p:messages id="emailFormMessages" showDetail="true" closable="true" />
+
+                        <h:panelGrid columns="2" cellpadding="6" style="width:100%;max-width:800px;">
+
+                            <p:outputLabel value="Bill Number" />
+                            <h:outputText id="txtBillNumber" value="#{inwardSearch.bill.deptId}" />
+
+                            <p:outputLabel value="Patient" />
+                            <h:outputText id="txtPatientName" value="#{inwardSearch.bill.patientEncounter.patient.person.nameWithTitle}" />
+
+                            <p:outputLabel for="txtEmailRecipient" value="Recipient Email" />
+                            <p:inputText id="txtEmailRecipient" value="#{inwardSearch.emailRecipient}" style="width:100%;" title="Recipient Email" />
+
+                            <p:outputLabel for="txtEmailSubject" value="Subject" />
+                            <p:inputText id="txtEmailSubject" value="#{inwardSearch.emailSubject}" style="width:100%;" title="Email Subject" />
+
+                            <p:outputLabel for="txtEmailBody" value="Message" />
+                            <p:inputTextarea id="txtEmailBody" value="#{inwardSearch.emailBody}" style="width:100%;" rows="6" title="Email Message Body" />
+
+                        </h:panelGrid>
+
+                        <p:panel class="mt-3">
+                            <f:facet name="header">
+                                <h:outputLabel value="Attachments"></h:outputLabel>
+                            </f:facet>
+
+                            <p:outputLabel value="The final bill (PDF) is always attached automatically. Add any additional supporting documents below." styleClass="text-muted" />
+
+                            <div class="mt-2">
+                                <p:fileUpload
+                                    id="fileUploadEmailAttachment"
+                                    mode="advanced"
+                                    dragDropSupport="true"
+                                    multiple="true"
+                                    auto="true"
+                                    update="tblEmailAttachments emailFormMessages"
+                                    listener="#{inwardSearch.uploadEmailAttachment}"
+                                    label="Choose File"
+                                    title="Attach Document" />
+                            </div>
+
+                            <p:dataTable
+                                id="tblEmailAttachments"
+                                widgetVar="wTblEmailAttachments"
+                                rowKey="#{attachment.fileName}"
+                                value="#{inwardSearch.pendingEmailAttachments}"
+                                var="attachment"
+                                emptyMessage="No additional documents attached."
+                                class="w-100 mt-2">
+
+                                <p:column headerText="File Name">
+                                    <h:outputText value="#{attachment.fileName}" />
+                                </p:column>
+
+                                <p:column headerText="Type">
+                                    <h:outputText value="#{attachment.contentType}" />
+                                </p:column>
+
+                                <p:column headerText="Actions" width="100">
+                                    <p:commandButton
+                                        ajax="true"
+                                        icon="fa fa-trash"
+                                        class="ui-button-danger"
+                                        title="Remove #{attachment.fileName}"
+                                        update="tblEmailAttachments"
+                                        actionListener="#{inwardSearch.removeEmailAttachment(attachment)}" />
+                                </p:column>
+
+                            </p:dataTable>
+
+                        </p:panel>
+
+                        <div class="mt-3">
+                            <p:commandButton
+                                ajax="true"
+                                icon="fa fa-envelope"
+                                class="ui-button-help"
+                                value="Send Email"
+                                title="Send Email"
+                                update=":growl emailFormMessages"
+                                actionListener="#{inwardSearch.emailFinalBillVersion(inwardSearch.bill)}" />
+                        </div>
+
+                    </p:panel>
+
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/inward/inward_final_bill_email.xhtml
+++ b/src/main/webapp/inward/inward_final_bill_email.xhtml
@@ -13,7 +13,7 @@
             <ui:define name="content">
                 <h:form id="formEmailFinalBill" enctype="multipart/form-data">
 
-                    <p:panel rendered="#{webUserController.hasPrivilege('InwardFinalBillEmail') and inwardSearch.bill ne null}">
+                    <p:panel rendered="#{webUserController.hasPrivilege('InwardFinalBillEmail') and inwardSearch.bill ne null and inwardSearch.bill.billType eq 'InwardFinalBill'}">
 
                         <f:facet name="header">
                             <div class="d-flex justify-content-between">
@@ -69,6 +69,7 @@
                                     dragDropSupport="true"
                                     multiple="true"
                                     auto="true"
+                                    sizeLimit="10000000"
                                     update="tblEmailAttachments emailFormMessages"
                                     listener="#{inwardSearch.uploadEmailAttachment}"
                                     label="Choose File"
@@ -113,7 +114,7 @@
                                 class="ui-button-help"
                                 value="Send Email"
                                 title="Send Email"
-                                update=":growl emailFormMessages"
+                                update=":growl emailFormMessages tblEmailAttachments"
                                 actionListener="#{inwardSearch.emailFinalBillVersion(inwardSearch.bill)}" />
                         </div>
 

--- a/src/main/webapp/inward/inward_final_bill_list.xhtml
+++ b/src/main/webapp/inward/inward_final_bill_list.xhtml
@@ -144,16 +144,13 @@
                                     </p:commandButton>
 
                                     <p:commandButton
-                                        ajax="true"
+                                        ajax="false"
                                         icon="fa fa-envelope"
                                         class="ui-button-help"
                                         value="Email"
                                         title="Email #{b.deptId}"
-                                        update=":formFinalBillVersions:emailDialog"
-                                        oncomplete="PF('wEmailDialog').show()"
+                                        action="#{inwardSearch.prepareEmailFinalBillVersion(b)}"
                                         rendered="#{webUserController.hasPrivilege('InwardFinalBillEmail')}">
-                                        <f:setPropertyActionListener value="#{b}" target="#{inwardSearch.bill}"/>
-                                        <f:setPropertyActionListener value="#{b.patientEncounter.patient.person.email}" target="#{inwardSearch.emailRecipient}"/>
                                     </p:commandButton>
 
                                 </p:column>
@@ -163,22 +160,6 @@
                         </p:panel>
 
                     </p:panel>
-
-                    <p:dialog id="emailDialog" widgetVar="wEmailDialog" header="Email Final Bill" modal="true" width="420">
-                        <h:panelGrid columns="1" style="width:100%;">
-                            <p:outputLabel value="Bill Number: #{inwardSearch.bill.deptId}" rendered="#{inwardSearch.bill ne null}" />
-                            <p:outputLabel for="txtEmailRecipient" value="Recipient Email" />
-                            <p:inputText id="txtEmailRecipient" value="#{inwardSearch.emailRecipient}" style="width:100%;" />
-                            <p:commandButton
-                                ajax="true"
-                                icon="fa fa-envelope"
-                                class="ui-button-help"
-                                value="Send"
-                                update=":growl"
-                                oncomplete="if (args &amp;&amp; args.emailSent) { PF('wEmailDialog').hide(); }"
-                                actionListener="#{inwardSearch.emailFinalBillVersion(inwardSearch.bill)}" />
-                        </h:panelGrid>
-                    </p:dialog>
 
                     <p:confirmDialog global="true" showEffect="fade" hideEffect="fade">
                         <p:commandButton value="Yes" type="button" styleClass="ui-confirmdialog-yes ui-button-success" icon="pi pi-check" />


### PR DESCRIPTION
## Summary
- Fixes #22786 — creating a new final bill version dropped any credit company that was allocated 0.00 on the previous version, so it could never be selected/re-allocated to (e.g. when the original insurer refuses to pay part of the claim and the balance needs to move to a second company on file).
- Fixes #22787 — the Email button on Manage Final Bills sent instantly from a recipient-only dialog with a hardcoded subject/body. Replaced it with a dedicated review page where subject/body are editable and extra documents can be attached before sending.

## Changes
- `BhtSummeryController.rebuildAllocationsFromSourceBill()`: seed the new version's allocation list from every `EncounterCreditCompany` still on the encounter (defaulting to 0.00 when no CC bill was persisted for it), not just the companies that had a non-zero CC bill on the source version.
- `InwardSearch`: added `prepareEmailFinalBillVersion`, `uploadEmailAttachment`, `removeEmailAttachment`, editable `emailSubject`/`emailBody`, and combined the auto-generated PDF with any cashier-attached documents when sending.
- New page `inward_final_bill_email.xhtml`: recipient/subject/body review fields, file upload for extra attachments, Send button.
- `inward_final_bill_list.xhtml`: Email button now navigates to the review page instead of opening the old inline dialog.

## Test plan
- [x] Rebuilt and redeployed locally; created a first final bill (Credit, two companies on file) allocating the full net due to Company A (AIA Insurance Lanka PLC) and 0.00 to Company B (Sri Lanka Insurance)
- [x] Clicked Create New Version — confirmed Company B now appears in the allocation table as an editable 0.00 row (previously missing entirely)
- [x] Reallocated (AIA partial, Sri Lanka Insurance covers the rest) and saved the new version — confirmed via DB (`BILL` table) that both CC commitment bills were persisted with the correct split
- [x] Clicked Email on Manage Final Bills — confirmed it navigates to the new review page with prefilled, editable recipient/subject/body
- [x] Uploaded a test attachment — confirmed it appears in the attachment table with a Remove action
- [x] Clicked Send Email with an empty recipient — confirmed validation blocks the send with an error message (no email actually dispatched)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated screen for reviewing and sending inward final-bill emails.
  * Edit recipients, subject, and message before sending.
  * Automatically include the final-bill PDF and add or remove multiple attachments.
  * Added navigation between final-bill versions and the email screen.

* **Bug Fixes**
  * Added validation for attachment type, count, and total size.
  * Improved success and error feedback during attachment handling and email delivery.
  * Prevented sending emails for bills that are not final versions.
  * Improved credit-company allocation rebuilding while preserving existing and inactive-company allocations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->