### PR TITLE
Appointment deposit conversion receipts, printPreview, and payment reports (#22783)

### DIFF
--- a/src/main/java/com/divudi/bean/common/BillSearch.java
+++ b/src/main/java/com/divudi/bean/common/BillSearch.java
@@ -58,6 +58,7 @@ import com.divudi.core.facade.PaymentFacade;
 import com.divudi.core.facade.PharmaceuticalBillItemFacade;
 import com.divudi.core.facade.WebUserFacade;
 import com.divudi.core.util.JsfUtil;
+import com.divudi.bean.inward.InwardSearch;
 import com.divudi.bean.opd.OpdBillController;
 import com.divudi.bean.pharmacy.BhtIssueReturnController;
 import com.divudi.bean.pharmacy.GrnReturnWithCostingController;
@@ -267,6 +268,8 @@ public class BillSearch implements Serializable, ControllerWithMultiplePayments 
     PharmacyBillSearch pharmacyBillSearch;
     @Inject
     PatientDepositController patientDepositController;
+    @Inject
+    InwardSearch inwardSearch;
     @Inject
     OpdBillController opdBillController;
     @Inject
@@ -5305,6 +5308,50 @@ public class BillSearch implements Serializable, ControllerWithMultiplePayments 
 
             case DRAWER_ADJUSTMENT:
                 return requestController.navigateToDrawerAdjustmentApproveByBill(bill);
+
+            case INWARD_DEPOSIT:
+                inwardSearch.setBill(bill);
+                return "/inward/inward_reprint_bill_payment?faces-redirect=true";
+
+            case INWARD_DEPOSIT_CANCELLATION: {
+                // `bill` here is the cancellation bill itself (a CancelledBill).
+                // InwardSearch.createCancelDepositBill() links it back to the
+                // original deposit bill via billedBill, and the original bill's
+                // cancelledBill points forward to this cancellation bill.
+                // The view page (inward_deposit_cancel_bill_payment.xhtml) needs
+                // the ORIGINAL bill loaded with printPreview=true so it can show
+                // inwardSearch.bill.cancelledBill.
+                Bill originalDepositBill = bill.getBilledBill();
+                if (originalDepositBill == null || originalDepositBill.getId() == null) {
+                    JsfUtil.addErrorMessage("Original bill not found for this cancellation");
+                    return "";
+                }
+                Bill reloadedOriginalDepositBill = billService.reloadBill(originalDepositBill.getId());
+                return inwardSearch.navigateToViewInwardDepositCancellationBill(reloadedOriginalDepositBill);
+            }
+
+            case INWARD_DEPOSIT_REFUND:
+            case INWARD_DEPOSIT_REFUND_CANCELLATION:
+                // No dedicated view/reprint page exists yet for these two atomics.
+                // Both are still InwardPaymentBill-family bills created via
+                // Bill.copy() of the original deposit bill, so patientEncounter
+                // (and therefore the patient/admission details on the receipt)
+                // is preserved. Falling back to the generic Inward payment
+                // reprint page is a reasonable, functioning view.
+                inwardSearch.setBill(bill);
+                return "/inward/inward_reprint_bill_payment?faces-redirect=true";
+
+            case INWARD_APPOINTMENT_BILL:
+            case INWARD_APPOINTMENT_CANCEL_BILL:
+                // Unlike deposit bills, InwardAppointmentBill never populates
+                // patientEncounter (it lives only on Appointment.patientEncounter,
+                // set later at admission time). inward_reprint_bill_payment.xhtml
+                // reads bill.patientEncounter.* directly, so it can't be reused
+                // here. Instead route to a thin DTO-backed view page whose query
+                // (BillFacade.findInwardBillReceiptDTO) resolves the patient via
+                // LEFT JOINs and tolerates the null patientEncounter.
+                inwardSearch.setAppointmentReceiptBillId(bill.getId());
+                return "/inward/inward_view_appointment_bill_receipt?faces-redirect=true";
 
         }
 

--- a/src/main/java/com/divudi/bean/common/UserPrivilageController.java
+++ b/src/main/java/com/divudi/bean/common/UserPrivilageController.java
@@ -1012,6 +1012,7 @@ public class UserPrivilageController implements Serializable {
         new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingWorkBenchPanelOperationTheatre, "Operation Theatre Panel"), nursingWorkBenchPanelsNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingWorkBenchPanelPharmaceuticals, "Pharmaceuticals Panel"), nursingWorkBenchPanelsNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingWorkBenchPanelReports, "Reports Panel"), nursingWorkBenchPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingWorkBenchPanelPayments, "Payments Panel"), nursingWorkBenchPanelsNode);
 
         // Admin Privileges
         TreeNode superAdminNode = new DefaultTreeNode(new PrivilegeHolder(Privileges.SuperAdmin, "Super Admin"), allNode);

--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -2344,6 +2344,12 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
     /** Id of the INWARD_DEPOSIT bill created by the last conversion. */
     private Long lastConversionDepositBillId;
 
+    /** Lazily-loaded, request-lifetime cache for {@link #getConversionCancelReceipt()}. */
+    private InwardBillReceiptDTO conversionCancelReceipt;
+
+    /** Lazily-loaded, request-lifetime cache for {@link #getConversionDepositReceipt()}. */
+    private InwardBillReceiptDTO conversionDepositReceipt;
+
     public Appointment getPendingAppointmentConversion() {
         return pendingAppointmentConversion;
     }
@@ -2466,7 +2472,10 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         if (lastConversionCancelBillId == null) {
             return null;
         }
-        return getBillFacade().findInwardBillReceiptDTO(lastConversionCancelBillId);
+        if (conversionCancelReceipt == null || !lastConversionCancelBillId.equals(conversionCancelReceipt.getBillId())) {
+            conversionCancelReceipt = getBillFacade().findInwardBillReceiptDTO(lastConversionCancelBillId);
+        }
+        return conversionCancelReceipt;
     }
 
     /**
@@ -2478,7 +2487,10 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         if (lastConversionDepositBillId == null) {
             return null;
         }
-        return getBillFacade().findInwardBillReceiptDTO(lastConversionDepositBillId);
+        if (conversionDepositReceipt == null || !lastConversionDepositBillId.equals(conversionDepositReceipt.getBillId())) {
+            conversionDepositReceipt = getBillFacade().findInwardBillReceiptDTO(lastConversionDepositBillId);
+        }
+        return conversionDepositReceipt;
     }
 
     /**

--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -65,6 +65,7 @@ import com.divudi.core.data.AppointmentStatus;
 import com.divudi.core.data.BillType;
 import com.divudi.core.data.BillTypeAtomic;
 import com.divudi.core.data.clinical.ClinicalFindingValueType;
+import com.divudi.core.data.dto.InwardBillReceiptDTO;
 import com.divudi.core.data.dto.PatientEncounterDto;
 import com.divudi.core.entity.Area;
 import com.divudi.core.entity.Department;
@@ -2337,6 +2338,12 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
      */
     private Appointment pendingAppointmentConversion;
 
+    /** Id of the INWARD_APPOINTMENT_CANCEL_BILL created by the last conversion. */
+    private Long lastConversionCancelBillId;
+
+    /** Id of the INWARD_DEPOSIT bill created by the last conversion. */
+    private Long lastConversionDepositBillId;
+
     public Appointment getPendingAppointmentConversion() {
         return pendingAppointmentConversion;
     }
@@ -2374,6 +2381,7 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
     }
 
     public String navigateToAppointmentDepositConversion() {
+        printPreview = false;
         if (!webUserController.hasPrivilege("InwardEditPaymentDetails")) {
             JsfUtil.addErrorMessage("You are not authorized to convert appointment deposits.");
             return "";
@@ -2423,10 +2431,11 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         Bill originalBill = pendingAppointmentConversion.getBill();
         double amount = originalBill.getTotal();
 
-        appointmentController.cancelAppointmentBillForConversion(
+        Bill cancelBill = appointmentController.cancelAppointmentBillForConversion(
                 originalBill,
                 pendingAppointmentConversion,
                 "Converted to Inward Deposit on Admission — BHT " + getCurrent().getBhtNo());
+        lastConversionCancelBillId = cancelBill.getId();
 
         PaymentMethod appointmentPaymentMethod = originalBill.getPaymentMethod() != null
                 ? originalBill.getPaymentMethod()
@@ -2440,10 +2449,36 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         getInwardPaymentController().getCurrent().setPatientEncounter(current);
         getInwardPaymentController().getCurrent().setTotal(amount);
         getInwardPaymentController().pay();
+        lastConversionDepositBillId = getInwardPaymentController().getCurrent().getId();
         getInwardPaymentController().makeNull();
 
         pendingAppointmentConversion = null;
+        printPreview = true;
         JsfUtil.addSuccessMessage("Appointment deposit converted to Inward Deposit.");
+    }
+
+    /**
+     * Print DTO for the INWARD_APPOINTMENT_CANCEL_BILL receipt from the most
+     * recent {@link #convertAppointmentDepositToInwardDeposit()} call. Null
+     * until a conversion has succeeded (see {@link #isPrintPreview()}).
+     */
+    public InwardBillReceiptDTO getConversionCancelReceipt() {
+        if (lastConversionCancelBillId == null) {
+            return null;
+        }
+        return getBillFacade().findInwardBillReceiptDTO(lastConversionCancelBillId);
+    }
+
+    /**
+     * Print DTO for the INWARD_DEPOSIT receipt from the most recent
+     * {@link #convertAppointmentDepositToInwardDeposit()} call. Null until a
+     * conversion has succeeded (see {@link #isPrintPreview()}).
+     */
+    public InwardBillReceiptDTO getConversionDepositReceipt() {
+        if (lastConversionDepositBillId == null) {
+            return null;
+        }
+        return getBillFacade().findInwardBillReceiptDTO(lastConversionDepositBillId);
     }
 
     /**

--- a/src/main/java/com/divudi/bean/inward/InwardReportControllerBht.java
+++ b/src/main/java/com/divudi/bean/inward/InwardReportControllerBht.java
@@ -783,7 +783,14 @@ public class InwardReportControllerBht implements Serializable {
         params.put("toDate", toDate);
 
         if (bhtNoFilter != null && !bhtNoFilter.trim().isEmpty()) {
-            jpql += "AND pe.bhtNo LIKE :bhtNo ";
+            // pe.bhtNo alone misses INWARD_APPOINTMENT_BILL / INWARD_APPOINTMENT_CANCEL_BILL
+            // bills (their Bill.patientEncounter is always null) - fall back to the
+            // admission's BHT No via the Appointment that references this bill either
+            // as its original bill or its cancellation bill.
+            jpql += "AND (pe.bhtNo LIKE :bhtNo OR EXISTS ("
+                    + "SELECT a FROM Appointment a "
+                    + "WHERE (a.bill = b OR a.appointmentCancelBill = b) "
+                    + "AND a.patientEncounter.bhtNo LIKE :bhtNo)) ";
             params.put("bhtNo", "%" + bhtNoFilter.trim() + "%");
         }
 

--- a/src/main/java/com/divudi/bean/inward/InwardReportControllerBht.java
+++ b/src/main/java/com/divudi/bean/inward/InwardReportControllerBht.java
@@ -7,6 +7,7 @@ package com.divudi.bean.inward;
 
 import com.divudi.bean.common.ConfigOptionApplicationController;
 import com.divudi.bean.common.SessionController;
+import com.divudi.core.util.CommonFunctions;
 import com.divudi.core.util.JsfUtil;
 import com.divudi.core.data.BillType;
 import com.divudi.core.data.BillTypeAtomic;
@@ -17,6 +18,7 @@ import com.divudi.core.data.hr.ReportKeyWord;
 import com.divudi.core.data.inward.InwardChargeType;
 import com.divudi.core.data.table.String1Value2;
 import com.divudi.core.data.table.String2Value4;
+import com.divudi.core.entity.Appointment;
 import com.divudi.core.entity.Bill;
 import com.divudi.core.entity.BillFee;
 import com.divudi.core.entity.BillItem;
@@ -118,6 +120,19 @@ public class InwardReportControllerBht implements Serializable {
 
     private List<BillListReportDTO> serviceBillDtosToPatientEncounter;
     private double serviceBillDtosToPatientEncounterNetTotal;
+
+    // Issue #22783 (Part B) - encounter-scoped payment bills (deposits +
+    // appointment bills) and their cancellations.
+    private List<BillListReportDTO> paymentBillDtosToPatientEncounter;
+    private double paymentBillDtosToPatientEncounterNetTotal;
+
+    // Issue #22783 (Part C) - department-wide, date-filtered payment bills.
+    private List<BillListReportDTO> paymentBillDtosForDepartment;
+    private double paymentBillDtosForDepartmentNetTotal;
+    private Date fromDate;
+    private Date toDate;
+    private String bhtNoFilter;
+    private String patientNameFilter;
 
     private List<BillItem> labBillItemsToPatientEncounter;
     private double labBillItemsToPatientEncounterNetTotal;
@@ -580,6 +595,204 @@ public class InwardReportControllerBht implements Serializable {
         Map<String, Object> params = new HashMap<>();
         params.put("billTypeAtomics", billTypes);
         params.put("patientEncounter", patientEncounter);
+
+        List<BillListReportDTO> result = (List<BillListReportDTO>) billFacade.findLightsByJpqlWithoutCache(jpql, params, javax.persistence.TemporalType.TIMESTAMP);
+        return result != null ? result : new ArrayList<>();
+    }
+
+    // Issue #22783 (Part B) - unlike deposit bills, INWARD_APPOINTMENT_BILL /
+    // INWARD_APPOINTMENT_CANCEL_BILL never populate Bill.patientEncounter
+    // (only Appointment.patientEncounter is set, at admission time - see
+    // BillFacade.findInwardBillReceiptDTO's javadoc, discovered while
+    // building Part A). A plain "b.patientEncounter = :patientEncounter"
+    // filter - which fetchServiceBillDtos above uses - silently excludes
+    // both the appointment bill and its cancellation. This method unions
+    // the two patterns in one query: deposit-family bills matched via
+    // Bill.patientEncounter directly, appointment-family bills matched via
+    // Appointment.patientEncounter (through Appointment.bill, and through
+    // Bill.referenceBill for the cancel bill, which points back at the
+    // original appointment bill). All patientEncounter/patient/creater
+    // navigation uses explicit LEFT JOINs rather than dot-path expressions,
+    // for the same reason: an inner-join dot-path would drop the
+    // null-patientEncounter appointment rows from the SELECT list too.
+    private List<BillListReportDTO> fetchPaymentBillDtosForEncounter(List<BillTypeAtomic> depositTypes, List<BillTypeAtomic> appointmentTypes) {
+        String jpql = "SELECT new com.divudi.core.data.dto.BillListReportDTO("
+                + "b.id, "
+                + "COALESCE(b.deptId, ''), "
+                + "b.billTypeAtomic, "
+                + "b.paymentMethod, "
+                + "COALESCE(per.name, per2.name, ''), "
+                + "b.createdAt, "
+                + "COALESCE(cr.name, ''), "
+                + "b.retired, "
+                + "b.cancelled, "
+                + "b.refunded, "
+                + "b.total, "
+                + "b.discount, "
+                + "b.netTotal, "
+                + "COALESCE(pe.bhtNo, ''), "
+                + "COALESCE(b.deptId, ''), "
+                + "b.margin) "
+                + "FROM Bill b "
+                + "LEFT JOIN b.patientEncounter pe "
+                + "LEFT JOIN pe.patient pt "
+                + "LEFT JOIN pt.person per "
+                + "LEFT JOIN b.patient pt2 "
+                + "LEFT JOIN pt2.person per2 "
+                + "LEFT JOIN b.creater cr "
+                + "WHERE b.retired = FALSE "
+                + "AND ("
+                + "  (b.billTypeAtomic IN :depositTypes AND pe = :patientEncounter) "
+                + "  OR "
+                + "  (b.billTypeAtomic IN :appointmentTypes AND ("
+                + "     b IN (SELECT a.bill FROM Appointment a WHERE a.patientEncounter = :patientEncounter) "
+                + "     OR b.referenceBill IN (SELECT a.bill FROM Appointment a WHERE a.patientEncounter = :patientEncounter)"
+                + "  ))"
+                + ") "
+                + "ORDER BY b.createdAt, b.id";
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("depositTypes", depositTypes);
+        params.put("appointmentTypes", appointmentTypes);
+        params.put("patientEncounter", patientEncounter);
+
+        List<BillListReportDTO> result = (List<BillListReportDTO>) billFacade.findLightsByJpqlWithoutCache(jpql, params, javax.persistence.TemporalType.TIMESTAMP);
+        return result != null ? result : new ArrayList<>();
+    }
+
+    // Issue #22783 (Part B) - Encounter-scoped list of inward payment bills
+    // (deposits + appointment bills) together with their cancellations/refunds.
+    // Row-level View/Reprint action is done from the XHTML by calling the
+    // existing BillSearch#navigateToViewBillByAtomicBillTypeByBillId(billId)
+    // directly, same pattern as the service bill list (#21247).
+    public String navigateToInpatientPaymentBillListDto() {
+        if (patientEncounter == null) {
+            JsfUtil.addErrorMessage("No encounter");
+            return null;
+        }
+        paymentBillDtosToPatientEncounter = new ArrayList<>();
+        paymentBillDtosToPatientEncounterNetTotal = 0.0;
+        try {
+            List<BillTypeAtomic> depositTypes = new ArrayList<>();
+            depositTypes.add(BillTypeAtomic.INWARD_DEPOSIT);
+            depositTypes.add(BillTypeAtomic.INWARD_DEPOSIT_CANCELLATION);
+            depositTypes.add(BillTypeAtomic.INWARD_DEPOSIT_REFUND);
+            depositTypes.add(BillTypeAtomic.INWARD_DEPOSIT_REFUND_CANCELLATION);
+
+            List<BillTypeAtomic> appointmentTypes = new ArrayList<>();
+            appointmentTypes.add(BillTypeAtomic.INWARD_APPOINTMENT_BILL);
+            appointmentTypes.add(BillTypeAtomic.INWARD_APPOINTMENT_CANCEL_BILL);
+
+            paymentBillDtosToPatientEncounter = fetchPaymentBillDtosForEncounter(depositTypes, appointmentTypes);
+
+            for (BillListReportDTO dto : paymentBillDtosToPatientEncounter) {
+                double netValue = dto.getNetTotal() != null ? dto.getNetTotal().doubleValue() : 0.0;
+                paymentBillDtosToPatientEncounterNetTotal += netValue;
+            }
+        } catch (Exception e) {
+            Logger.getLogger(InwardReportControllerBht.class.getName()).log(Level.SEVERE, "Error loading payment bill DTOs", e);
+            JsfUtil.addErrorMessage("Error loading payment bill data");
+            return null;
+        }
+        return "/inward/reports/inpatient_payment_bill_list_dto?faces-redirect=true";
+    }
+
+    // Issue #22783 (Part C) - Department-wide, date-filtered list of inward
+    // payment bills (deposits + appointment bills) together with their
+    // cancellations/refunds, with optional BHT No / patient name filters.
+    public String navigateToInwardPaymentBillListForDepartment() {
+        if (department == null) {
+            department = sessionController.getDepartment();
+        }
+        if (department == null) {
+            JsfUtil.addErrorMessage("No department");
+            return null;
+        }
+        if (fromDate == null) {
+            fromDate = CommonFunctions.getStartOfDay(new Date());
+        }
+        if (toDate == null) {
+            toDate = new Date();
+        }
+        paymentBillDtosForDepartment = new ArrayList<>();
+        paymentBillDtosForDepartmentNetTotal = 0.0;
+        try {
+            List<BillTypeAtomic> paymentTypes = new ArrayList<>();
+            paymentTypes.add(BillTypeAtomic.INWARD_APPOINTMENT_BILL);
+            paymentTypes.add(BillTypeAtomic.INWARD_APPOINTMENT_CANCEL_BILL);
+            paymentTypes.add(BillTypeAtomic.INWARD_DEPOSIT);
+            paymentTypes.add(BillTypeAtomic.INWARD_DEPOSIT_CANCELLATION);
+            paymentTypes.add(BillTypeAtomic.INWARD_DEPOSIT_REFUND);
+            paymentTypes.add(BillTypeAtomic.INWARD_DEPOSIT_REFUND_CANCELLATION);
+
+            paymentBillDtosForDepartment = fetchPaymentBillDtosForDepartment(paymentTypes);
+
+            for (BillListReportDTO dto : paymentBillDtosForDepartment) {
+                double netValue = dto.getNetTotal() != null ? dto.getNetTotal().doubleValue() : 0.0;
+                paymentBillDtosForDepartmentNetTotal += netValue;
+            }
+        } catch (Exception e) {
+            Logger.getLogger(InwardReportControllerBht.class.getName()).log(Level.SEVERE, "Error loading department payment bill DTOs", e);
+            JsfUtil.addErrorMessage("Error loading payment bill data");
+            return null;
+        }
+        return "/inward/reports/inward_payment_bill_list_department_dto?faces-redirect=true";
+    }
+
+    private List<BillListReportDTO> fetchPaymentBillDtosForDepartment(List<BillTypeAtomic> billTypes) {
+        // Explicit LEFT JOINs throughout (not dot-path navigation) for the
+        // same reason as fetchPaymentBillDtosForEncounter above: implicit
+        // path navigation through a null Bill.patientEncounter (true for
+        // INWARD_APPOINTMENT_BILL / INWARD_APPOINTMENT_CANCEL_BILL) compiles
+        // to an INNER JOIN and silently drops those rows from the whole
+        // result set, not just the projected column. b.patient (set
+        // directly on appointment bills) is the fallback patient path.
+        String jpql = "SELECT new com.divudi.core.data.dto.BillListReportDTO("
+                + "b.id, "
+                + "COALESCE(b.deptId, ''), "
+                + "b.billTypeAtomic, "
+                + "b.paymentMethod, "
+                + "COALESCE(per.name, per2.name, ''), "
+                + "b.createdAt, "
+                + "COALESCE(cr.name, ''), "
+                + "b.retired, "
+                + "b.cancelled, "
+                + "b.refunded, "
+                + "b.total, "
+                + "b.discount, "
+                + "b.netTotal, "
+                + "COALESCE(pe.bhtNo, ''), "
+                + "COALESCE(b.deptId, ''), "
+                + "b.margin) "
+                + "FROM Bill b "
+                + "LEFT JOIN b.patientEncounter pe "
+                + "LEFT JOIN pe.patient pt "
+                + "LEFT JOIN pt.person per "
+                + "LEFT JOIN b.patient pt2 "
+                + "LEFT JOIN pt2.person per2 "
+                + "LEFT JOIN b.creater cr "
+                + "WHERE b.department = :department "
+                + "AND b.billTypeAtomic IN :billTypeAtomics "
+                + "AND b.retired = FALSE "
+                + "AND b.createdAt BETWEEN :fromDate AND :toDate ";
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("billTypeAtomics", billTypes);
+        params.put("department", department);
+        params.put("fromDate", fromDate);
+        params.put("toDate", toDate);
+
+        if (bhtNoFilter != null && !bhtNoFilter.trim().isEmpty()) {
+            jpql += "AND pe.bhtNo LIKE :bhtNo ";
+            params.put("bhtNo", "%" + bhtNoFilter.trim() + "%");
+        }
+
+        if (patientNameFilter != null && !patientNameFilter.trim().isEmpty()) {
+            jpql += "AND (per.name LIKE :patientName OR per2.name LIKE :patientName) ";
+            params.put("patientName", "%" + patientNameFilter.trim() + "%");
+        }
+
+        jpql += "ORDER BY b.createdAt, b.id";
 
         List<BillListReportDTO> result = (List<BillListReportDTO>) billFacade.findLightsByJpqlWithoutCache(jpql, params, javax.persistence.TemporalType.TIMESTAMP);
         return result != null ? result : new ArrayList<>();
@@ -2262,5 +2475,75 @@ public class InwardReportControllerBht implements Serializable {
 
     public void setServiceBillDtosToPatientEncounterNetTotal(double serviceBillDtosToPatientEncounterNetTotal) {
         this.serviceBillDtosToPatientEncounterNetTotal = serviceBillDtosToPatientEncounterNetTotal;
+    }
+
+    public List<BillListReportDTO> getPaymentBillDtosToPatientEncounter() {
+        return paymentBillDtosToPatientEncounter;
+    }
+
+    public void setPaymentBillDtosToPatientEncounter(List<BillListReportDTO> paymentBillDtosToPatientEncounter) {
+        this.paymentBillDtosToPatientEncounter = paymentBillDtosToPatientEncounter;
+    }
+
+    public double getPaymentBillDtosToPatientEncounterNetTotal() {
+        return paymentBillDtosToPatientEncounterNetTotal;
+    }
+
+    public void setPaymentBillDtosToPatientEncounterNetTotal(double paymentBillDtosToPatientEncounterNetTotal) {
+        this.paymentBillDtosToPatientEncounterNetTotal = paymentBillDtosToPatientEncounterNetTotal;
+    }
+
+    public List<BillListReportDTO> getPaymentBillDtosForDepartment() {
+        return paymentBillDtosForDepartment;
+    }
+
+    public void setPaymentBillDtosForDepartment(List<BillListReportDTO> paymentBillDtosForDepartment) {
+        this.paymentBillDtosForDepartment = paymentBillDtosForDepartment;
+    }
+
+    public double getPaymentBillDtosForDepartmentNetTotal() {
+        return paymentBillDtosForDepartmentNetTotal;
+    }
+
+    public void setPaymentBillDtosForDepartmentNetTotal(double paymentBillDtosForDepartmentNetTotal) {
+        this.paymentBillDtosForDepartmentNetTotal = paymentBillDtosForDepartmentNetTotal;
+    }
+
+    public Date getFromDate() {
+        if (fromDate == null) {
+            fromDate = CommonFunctions.getStartOfDay(new Date());
+        }
+        return fromDate;
+    }
+
+    public void setFromDate(Date fromDate) {
+        this.fromDate = fromDate;
+    }
+
+    public Date getToDate() {
+        if (toDate == null) {
+            toDate = new Date();
+        }
+        return toDate;
+    }
+
+    public void setToDate(Date toDate) {
+        this.toDate = toDate;
+    }
+
+    public String getBhtNoFilter() {
+        return bhtNoFilter;
+    }
+
+    public void setBhtNoFilter(String bhtNoFilter) {
+        this.bhtNoFilter = bhtNoFilter;
+    }
+
+    public String getPatientNameFilter() {
+        return patientNameFilter;
+    }
+
+    public void setPatientNameFilter(String patientNameFilter) {
+        this.patientNameFilter = patientNameFilter;
     }
 }

--- a/src/main/java/com/divudi/bean/inward/InwardSearch.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSearch.java
@@ -18,6 +18,7 @@ import com.divudi.core.data.Sex;
 import com.divudi.core.data.dataStructure.ComponentDetail;
 import com.divudi.core.data.dataStructure.PaymentMethodData;
 import com.divudi.core.data.dataStructure.YearMonthDay;
+import com.divudi.core.data.dto.InwardBillReceiptDTO;
 import com.divudi.core.data.EmailAttachment;
 import com.divudi.core.data.MessageType;
 import com.divudi.core.data.hr.ReportKeyWord;
@@ -139,6 +140,17 @@ public class InwardSearch implements Serializable {
      */
     private Bill bill;
     private boolean printPreview = false;
+
+    /**
+     * Bill id to render on {@code /inward/inward_view_appointment_bill_receipt}
+     * (Issue #22783 — appointment bill / appointment cancel bill view, routed
+     * from {@code BillSearch.navigateToViewBillByAtomicBillType}). Appointment
+     * bills never have {@code Bill.patientEncounter} populated, so they can't
+     * use the regular {@code inward_reprint_bill_payment} template; the DTO
+     * query behind {@link #getAppointmentBillReceipt()} handles that via
+     * LEFT JOINs instead.
+     */
+    private Long appointmentReceiptBillId;
     @Temporal(TemporalType.TIME)
     private Date fromDate;
     @Temporal(TemporalType.TIME)
@@ -2402,6 +2414,26 @@ public class InwardSearch implements Serializable {
             bill = new BilledBill();
         }
         return bill;
+    }
+
+    public Long getAppointmentReceiptBillId() {
+        return appointmentReceiptBillId;
+    }
+
+    public void setAppointmentReceiptBillId(Long appointmentReceiptBillId) {
+        this.appointmentReceiptBillId = appointmentReceiptBillId;
+    }
+
+    /**
+     * DTO for {@code /inward/inward_view_appointment_bill_receipt} — null
+     * until {@link #appointmentReceiptBillId} is set by the BillSearch
+     * routing case.
+     */
+    public InwardBillReceiptDTO getAppointmentBillReceipt() {
+        if (appointmentReceiptBillId == null) {
+            return null;
+        }
+        return billFacade.findInwardBillReceiptDTO(appointmentReceiptBillId);
     }
 
     public void markAsChecked() {

--- a/src/main/java/com/divudi/bean/inward/InwardSearch.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSearch.java
@@ -151,6 +151,7 @@ public class InwardSearch implements Serializable {
      * LEFT JOINs instead.
      */
     private Long appointmentReceiptBillId;
+    private InwardBillReceiptDTO appointmentBillReceipt;
     @Temporal(TemporalType.TIME)
     private Date fromDate;
     @Temporal(TemporalType.TIME)
@@ -2422,18 +2423,24 @@ public class InwardSearch implements Serializable {
 
     public void setAppointmentReceiptBillId(Long appointmentReceiptBillId) {
         this.appointmentReceiptBillId = appointmentReceiptBillId;
+        this.appointmentBillReceipt = null;
     }
 
     /**
      * DTO for {@code /inward/inward_view_appointment_bill_receipt} — null
      * until {@link #appointmentReceiptBillId} is set by the BillSearch
-     * routing case.
+     * routing case. Lazily loaded and cached for the lifetime of this bean
+     * (the composite receipt templates dereference it many times per
+     * render); the cache is cleared by {@link #setAppointmentReceiptBillId}.
      */
     public InwardBillReceiptDTO getAppointmentBillReceipt() {
         if (appointmentReceiptBillId == null) {
             return null;
         }
-        return billFacade.findInwardBillReceiptDTO(appointmentReceiptBillId);
+        if (appointmentBillReceipt == null) {
+            appointmentBillReceipt = billFacade.findInwardBillReceiptDTO(appointmentReceiptBillId);
+        }
+        return appointmentBillReceipt;
     }
 
     public void markAsChecked() {

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -201,6 +201,7 @@ public enum Privileges {
     NursingWorkBenchPanelOperationTheatre("Nursing Workbench - Operation Theatre Panel"),
     NursingWorkBenchPanelPharmaceuticals("Nursing Workbench - Pharmaceuticals Panel"),
     NursingWorkBenchPanelReports("Nursing Workbench - Reports Panel"),
+    NursingWorkBenchPanelPayments("Nursing Workbench - Payments Panel"),
     //</editor-fold>
 
     //<editor-fold defaultstate="collapsed" desc="Finance">
@@ -1226,6 +1227,7 @@ public enum Privileges {
             case NursingWorkBenchPanelOperationTheatre:
             case NursingWorkBenchPanelPharmaceuticals:
             case NursingWorkBenchPanelReports:
+            case NursingWorkBenchPanelPayments:
                 return "Nursing Work Bench";
 
             case WatingRoomAdmitPatient:

--- a/src/main/java/com/divudi/core/data/dto/InwardBillReceiptDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/InwardBillReceiptDTO.java
@@ -184,7 +184,7 @@ public class InwardBillReceiptDTO implements Serializable {
         } else {
             temT = "";
         }
-        return temT + " " + patientName;
+        return temT + " " + (patientName != null ? patientName : "");
     }
 
     /**
@@ -198,7 +198,7 @@ public class InwardBillReceiptDTO implements Serializable {
         } else {
             temT = "";
         }
-        return temT + " " + cashierName;
+        return temT + " " + (cashierName != null ? cashierName : "");
     }
 
     /**

--- a/src/main/java/com/divudi/core/data/dto/InwardBillReceiptDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/InwardBillReceiptDTO.java
@@ -1,0 +1,219 @@
+package com.divudi.core.data.dto;
+
+import com.divudi.core.data.PaymentMethod;
+import com.divudi.core.data.Sex;
+import com.divudi.core.data.Title;
+import com.divudi.core.util.CommonFunctions;
+import java.io.Serializable;
+import java.util.Date;
+
+/**
+ * Print DTO shared by the Appointment Deposit Conversion receipts (Issue
+ * #22783, Part A): the INWARD_APPOINTMENT_CANCEL_BILL receipt and the
+ * INWARD_DEPOSIT receipt created by
+ * {@code AdmissionController.convertAppointmentDepositToInwardDeposit()}.
+ *
+ * All fields are populated from persisted database columns only, via the
+ * JPQL constructor below (see {@code BillFacade.findInwardBillReceiptDTO}).
+ * Derived/computed values (name-with-title, age) are added as plain Java
+ * getters after construction since JPQL cannot call derived getters.
+ */
+public class InwardBillReceiptDTO implements Serializable {
+
+    private Long billId;
+    private String deptId;
+    private Date billDate;
+    private PaymentMethod paymentMethod;
+    private Double amount;
+    private String comments;
+    private String referenceBillDeptId;
+    private String departmentPrintingName;
+    private String departmentAddress;
+    private String departmentTelephone1;
+    private String departmentTelephone2;
+    private String departmentFax;
+    private String departmentEmail;
+    private Title patientTitle;
+    private String patientName;
+    private Date patientDob;
+    private Sex patientSex;
+    private String admissionTypeName;
+    private String bhtNo;
+    private Title cashierTitle;
+    private String cashierName;
+
+    public InwardBillReceiptDTO() {
+    }
+
+    public InwardBillReceiptDTO(Long billId,
+            String deptId,
+            Date billDate,
+            PaymentMethod paymentMethod,
+            Double amount,
+            String comments,
+            String referenceBillDeptId,
+            String departmentPrintingName,
+            String departmentAddress,
+            String departmentTelephone1,
+            String departmentTelephone2,
+            String departmentFax,
+            String departmentEmail,
+            Title patientTitle,
+            String patientName,
+            Date patientDob,
+            Sex patientSex,
+            String admissionTypeName,
+            String bhtNo,
+            Title cashierTitle,
+            String cashierName) {
+        this.billId = billId;
+        this.deptId = deptId;
+        this.billDate = billDate;
+        this.paymentMethod = paymentMethod;
+        this.amount = amount;
+        this.comments = comments;
+        this.referenceBillDeptId = referenceBillDeptId;
+        this.departmentPrintingName = departmentPrintingName;
+        this.departmentAddress = departmentAddress;
+        this.departmentTelephone1 = departmentTelephone1;
+        this.departmentTelephone2 = departmentTelephone2;
+        this.departmentFax = departmentFax;
+        this.departmentEmail = departmentEmail;
+        this.patientTitle = patientTitle;
+        this.patientName = patientName;
+        this.patientDob = patientDob;
+        this.patientSex = patientSex;
+        this.admissionTypeName = admissionTypeName;
+        this.bhtNo = bhtNo;
+        this.cashierTitle = cashierTitle;
+        this.cashierName = cashierName;
+    }
+
+    public Long getBillId() {
+        return billId;
+    }
+
+    public String getDeptId() {
+        return deptId;
+    }
+
+    public Date getBillDate() {
+        return billDate;
+    }
+
+    public PaymentMethod getPaymentMethod() {
+        return paymentMethod;
+    }
+
+    public Double getAmount() {
+        return amount;
+    }
+
+    public String getComments() {
+        return comments;
+    }
+
+    public String getReferenceBillDeptId() {
+        return referenceBillDeptId;
+    }
+
+    public String getDepartmentPrintingName() {
+        return departmentPrintingName;
+    }
+
+    public String getDepartmentAddress() {
+        return departmentAddress;
+    }
+
+    public String getDepartmentTelephone1() {
+        return departmentTelephone1;
+    }
+
+    public String getDepartmentTelephone2() {
+        return departmentTelephone2;
+    }
+
+    public String getDepartmentFax() {
+        return departmentFax;
+    }
+
+    public String getDepartmentEmail() {
+        return departmentEmail;
+    }
+
+    public Title getPatientTitle() {
+        return patientTitle;
+    }
+
+    public String getPatientName() {
+        return patientName;
+    }
+
+    public Date getPatientDob() {
+        return patientDob;
+    }
+
+    public Sex getPatientSex() {
+        return patientSex;
+    }
+
+    public String getAdmissionTypeName() {
+        return admissionTypeName;
+    }
+
+    public String getBhtNo() {
+        return bhtNo;
+    }
+
+    public Title getCashierTitle() {
+        return cashierTitle;
+    }
+
+    public String getCashierName() {
+        return cashierName;
+    }
+
+    /**
+     * Mirrors {@code Person.getNameWithTitle()}'s composition
+     * (title label + " " + name) since JPQL cannot call that derived getter.
+     */
+    public String getPatientNameWithTitle() {
+        String temT;
+        if (patientTitle != null) {
+            temT = patientTitle.getLabel();
+        } else {
+            temT = "";
+        }
+        return temT + " " + patientName;
+    }
+
+    /**
+     * Mirrors {@code Person.getNameWithTitle()}'s composition for the
+     * cashier (creater.webUserPerson) title + name.
+     */
+    public String getCashierNameWithTitle() {
+        String temT;
+        if (cashierTitle != null) {
+            temT = cashierTitle.getLabel();
+        } else {
+            temT = "";
+        }
+        return temT + " " + cashierName;
+    }
+
+    /**
+     * Mirrors {@code Person.getAgeAsString()}'s "Not Recorded" fallback,
+     * computed via {@link CommonFunctions#calculateAge(Date, Date)} against
+     * the bill date (JPQL cannot call the derived age getter directly).
+     */
+    public String getPatientAgeAsString() {
+        if (patientDob == null) {
+            return "Not Recorded";
+        }
+        String age = new CommonFunctions().calculateAge(patientDob, billDate);
+        if (age == null || age.trim().isEmpty()) {
+            return "Not Recorded";
+        }
+        return age;
+    }
+}

--- a/src/main/java/com/divudi/core/facade/BillFacade.java
+++ b/src/main/java/com/divudi/core/facade/BillFacade.java
@@ -4,9 +4,12 @@
  */
 package com.divudi.core.facade;
 
+import com.divudi.core.data.dto.InwardBillReceiptDTO;
 import com.divudi.core.entity.Bill;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import javax.ejb.Stateless;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
@@ -27,6 +30,76 @@ public class BillFacade extends AbstractFacade<Bill> {
 
     public BillFacade() {
         super(Bill.class);
+    }
+
+    /**
+     * Fetches the print DTO used by the Appointment Deposit Conversion
+     * receipts (Issue #22783, Part A) for a single bill — either the
+     * INWARD_APPOINTMENT_CANCEL_BILL or the INWARD_DEPOSIT bill created by
+     * {@code AdmissionController.convertAppointmentDepositToInwardDeposit()}.
+     *
+     * LEFT JOINs are used throughout because the appointment bill's
+     * {@code patientEncounter} is never populated on the {@code Bill} itself
+     * (only on {@code Appointment.patientEncounter}, set at admission time by
+     * {@code AdmissionController.updateAppointment()}) — so the cloned
+     * INWARD_APPOINTMENT_CANCEL_BILL also has a null {@code patientEncounter}.
+     * An inner (dot-path) navigation there would silently drop that bill from
+     * the result set. {@code referenceBill} is likewise only present on the
+     * cancel bill, not on the deposit bill.
+     *
+     * Patient name is resolved two ways and COALESCEd: via
+     * {@code Bill.patientEncounter.patient} (populated for INWARD_DEPOSIT
+     * bills) and via {@code Bill.patient} directly (the only path populated
+     * on appointment bills, per {@code AppointmentController.saveBill()} —
+     * without this fallback, appointment-bill receipts render "Name: null").
+     * Title/DOB/sex are read only from the encounter-based path (EclipseLink
+     * fails the DTO constructor's reflective binding with
+     * "argument type mismatch" when an enum- or Date-typed field is wrapped
+     * in COALESCE across two different join paths in the same SELECT NEW —
+     * confirmed by temporarily logging the swallowed exception from
+     * findLightsByJpql's catch block) — so on an appointment bill's receipt,
+     * name resolves correctly but Age/Sex render blank, same as fields the
+     * bill genuinely has no data for (Admission Type, BHT No).
+     *
+     * Bill.netTotal is a primitive double and is projected directly (not
+     * COALESCEd) to avoid EclipseLink DTO-constructor binding mismatches.
+     *
+     * @param billId the Bill id
+     * @return the populated DTO, or null if not found
+     */
+    public InwardBillReceiptDTO findInwardBillReceiptDTO(Long billId) {
+        if (billId == null) {
+            return null;
+        }
+        String jpql = "SELECT NEW com.divudi.core.data.dto.InwardBillReceiptDTO("
+                + "b.id, b.deptId, b.billDate, b.paymentMethod, b.netTotal, b.comments, "
+                + "rb.deptId, "
+                + "dept.printingName, dept.address, dept.telephone1, dept.telephone2, dept.fax, dept.email, "
+                + "per.title, COALESCE(per.name, per2.name), per.dob, per.sex, "
+                + "at.name, "
+                + "pe.bhtNo, "
+                + "cp.title, cp.name) "
+                + "FROM Bill b "
+                + "LEFT JOIN b.referenceBill rb "
+                + "LEFT JOIN b.department dept "
+                + "LEFT JOIN b.patientEncounter pe "
+                + "LEFT JOIN pe.patient pat "
+                + "LEFT JOIN pat.person per "
+                + "LEFT JOIN b.patient pat2 "
+                + "LEFT JOIN pat2.person per2 "
+                + "LEFT JOIN pe.admissionType at "
+                + "LEFT JOIN b.creater cr "
+                + "LEFT JOIN cr.webUserPerson cp "
+                + "WHERE b.id = :billId";
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("billId", billId);
+
+        List<?> results = findLightsByJpql(jpql, params);
+        if (results == null || results.isEmpty()) {
+            return null;
+        }
+        return (InwardBillReceiptDTO) results.get(0);
     }
 
     /**

--- a/src/main/webapp/inward/admission_profile.xhtml
+++ b/src/main/webapp/inward/admission_profile.xhtml
@@ -1289,6 +1289,24 @@
                                             target="#{inwardReportControllerBht.department}" />
                                     </p:commandButton>
                                 </div>
+                                <div class="col-6">
+                                    <p:commandButton
+                                        id="btnPaymentsAndCancellations"
+                                        value="Payments &amp; Cancellations"
+                                        rendered="#{webUserController.hasPrivilege('InwardReport')}"
+                                        action="#{inwardReportControllerBht.navigateToInpatientPaymentBillListDto()}"
+                                        icon="fa fa-money-bill-wave"
+                                        ajax="false"
+                                        class="w-100 ui-button-success"
+                                        title="Payment bills and their cancellations for this admission - view/reprint">
+                                        <f:setPropertyActionListener
+                                            value="#{admissionController.current}"
+                                            target="#{inwardReportControllerBht.patientEncounter}" />
+                                        <f:setPropertyActionListener
+                                            value="#{null}"
+                                            target="#{inwardReportControllerBht.department}" />
+                                    </p:commandButton>
+                                </div>
                                 <div class="col-12">
                                     <p:commandButton
                                         id="btnPharmacyAndServiceSummary"

--- a/src/main/webapp/inward/appointment_deposit_conversion.xhtml
+++ b/src/main/webapp/inward/appointment_deposit_conversion.xhtml
@@ -5,7 +5,8 @@
                  xmlns:h="http://xmlns.jcp.org/jsf/html"
                  xmlns:p="http://primefaces.org/ui"
                  xmlns:f="http://xmlns.jcp.org/jsf/core"
-                 xmlns="http://www.w3.org/1999/xhtml">
+                 xmlns="http://www.w3.org/1999/xhtml"
+                 xmlns:bill="http://xmlns.jcp.org/jsf/composite/inward/bill/payment">
 
     <!-- Issue #22719: explicit, user-triggered conversion of an appointment's
          deposit bill (INWARD_APPOINTMENT_BILL) into this admission's Inward
@@ -17,7 +18,8 @@
 
             <p:panel>
                 <f:facet name="header">
-                    <div class="d-flex justify-content-between align-items-center">
+                    <div class="d-flex justify-content-between align-items-center w-100">
+                        <!-- LEFT: title + patient badge -->
                         <div class="d-flex align-items-center">
                             <i class="fa-solid fa-money-bill-transfer fa-lg text-warning me-3"></i>
                             <div>
@@ -31,25 +33,38 @@
                                 </h:panelGroup>
                             </div>
                         </div>
+
+                        <!-- CENTER: entity-level navigation -->
                         <div class="d-flex gap-2">
                             <p:commandButton
-                                value="Back to Dashboard"
+                                value="Inpatient Dashboard"
                                 ajax="false"
                                 action="#{admissionController.navigateToAdmissionProfilePage()}"
                                 icon="fa fa-arrow-left"
-                                class="ui-button-secondary"/>
+                                styleClass="ui-button-info ui-button-outlined"/>
+                            <h:panelGroup rendered="#{webUserController.hasPrivilege('NursingWorkBench')}">
+                                <p:commandButton
+                                    value="Nursing WorkBench"
+                                    action="#{nursingWorkBenchController.navigateToBackNursingWorkBench()}"
+                                    ajax="false"
+                                    icon="fa fa-arrow-left"
+                                    styleClass="ui-button-info ui-button-outlined"/>
+                            </h:panelGroup>
                         </div>
+
+                        <!-- RIGHT: page actions (none beyond navigation on this page) -->
+                        <div class="d-flex gap-2 align-items-center"></div>
                     </div>
                 </f:facet>
 
-                <h:panelGroup rendered="#{admissionController.pendingAppointmentConversion eq null}" layout="block">
+                <h:panelGroup rendered="#{!admissionController.printPreview and admissionController.pendingAppointmentConversion eq null}" layout="block">
                     <div class="text-center py-5">
                         <i class="fa-solid fa-check-circle fa-3x text-success mb-3"></i>
                         <p class="text-muted">No pending appointment deposit conversion for this admission.</p>
                     </div>
                 </h:panelGroup>
 
-                <h:panelGroup rendered="#{admissionController.pendingAppointmentConversion ne null}" layout="block">
+                <h:panelGroup rendered="#{!admissionController.printPreview and admissionController.pendingAppointmentConversion ne null}" layout="block">
                     <div class="alert alert-info" role="alert">
                         <h:outputText styleClass="fas fa-circle-info me-2"/>
                         <h:outputText value="This patient paid a deposit at the time of the appointment. Converting it will cancel the original appointment bill (offsetting it correctly in reports) and create a new Inward Deposit for the admission, for the same amount."/>
@@ -98,7 +113,156 @@
                             class="ui-button-warning"/>
                     </div>
                 </h:panelGroup>
+
+                <!-- Issue #22783 Part A: print-preview receipts shown right after a
+                     successful conversion — the cancellation receipt for the original
+                     appointment deposit bill, and the deposit receipt for the new
+                     Inward Deposit bill. -->
+                <h:panelGroup layout="block" rendered="#{admissionController.printPreview}">
+                    <div class="row">
+                        <div class="col-6">
+                            <p:panel>
+                                <f:facet name="header">
+                                    <div class="d-flex justify-content-between align-items-center">
+                                        <h:outputText value="Appointment Deposit Cancellation Receipt"/>
+                                        <div class="d-flex gap-2">
+                                            <p:commandButton
+                                                id="btnCancelReceiptSettings"
+                                                rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
+                                                value="Settings"
+                                                icon="fas fa-cog"
+                                                styleClass="ui-button-secondary"
+                                                type="button"
+                                                title="Configure cancellation receipt paper"
+                                                onclick="PF('inwardPaymentConfigDialog').show();"/>
+                                            <p:commandButton
+                                                id="btnPrintCancelReceipt"
+                                                value="Print"
+                                                styleClass="ui-button-info"
+                                                icon="fas fa-print"
+                                                title="Print cancellation receipt">
+                                                <p:printer target="gpCancelReceiptPreview"/>
+                                            </p:commandButton>
+                                        </div>
+                                    </div>
+                                </f:facet>
+
+                                <div class="d-flex justify-content-center align-items-center">
+                                    <h:panelGroup id="gpCancelReceiptPreview">
+                                        <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Payment Bill Five Five Paper', false)}" >
+                                            <bill:FiveFiveCancellationReceipt receipt="#{admissionController.conversionCancelReceipt}" duplicate="false"/>
+                                        </h:panelGroup>
+
+                                        <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Payment Bill A4 Paper', false)}" >
+                                            <bill:A4PaperCancellationReceipt receipt="#{admissionController.conversionCancelReceipt}" duplicate="false"/>
+                                        </h:panelGroup>
+
+                                        <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Payment Bill POS Paper', true)}" style="align-items: center;">
+                                            <bill:PosPaperCancellationReceipt receipt="#{admissionController.conversionCancelReceipt}" duplicate="false"/>
+                                        </h:panelGroup>
+                                    </h:panelGroup>
+                                </div>
+                            </p:panel>
+                        </div>
+
+                        <div class="col-6">
+                            <p:panel>
+                                <f:facet name="header">
+                                    <div class="d-flex justify-content-between align-items-center">
+                                        <h:outputText value="New Inpatient Deposit Receipt"/>
+                                        <div class="d-flex gap-2">
+                                            <p:commandButton
+                                                id="btnDepositReceiptSettings"
+                                                rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
+                                                value="Settings"
+                                                icon="fas fa-cog"
+                                                styleClass="ui-button-secondary"
+                                                type="button"
+                                                title="Configure deposit receipt paper"
+                                                onclick="PF('inwardPaymentConfigDialog').show();"/>
+                                            <p:commandButton
+                                                id="btnPrintDepositReceipt"
+                                                value="Print"
+                                                styleClass="ui-button-info"
+                                                icon="fas fa-print"
+                                                title="Print deposit receipt">
+                                                <p:printer target="gpDepositReceiptPreview"/>
+                                            </p:commandButton>
+                                        </div>
+                                    </div>
+                                </f:facet>
+
+                                <div class="d-flex justify-content-center align-items-center">
+                                    <h:panelGroup id="gpDepositReceiptPreview">
+                                        <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Payment Bill Five Five Paper', false)}" >
+                                            <bill:FiveFiveDepositReceipt receipt="#{admissionController.conversionDepositReceipt}" duplicate="false"/>
+                                        </h:panelGroup>
+
+                                        <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Payment Bill A4 Paper', false)}" >
+                                            <bill:A4PaperDepositReceipt receipt="#{admissionController.conversionDepositReceipt}" duplicate="false"/>
+                                        </h:panelGroup>
+
+                                        <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Payment Bill POS Paper', true)}" style="align-items: center;">
+                                            <bill:PosPaperDepositReceipt receipt="#{admissionController.conversionDepositReceipt}" duplicate="false"/>
+                                        </h:panelGroup>
+                                    </h:panelGroup>
+                                </div>
+                            </p:panel>
+                        </div>
+                    </div>
+                </h:panelGroup>
             </p:panel>
         </h:form>
+
+        <!-- Shared printer paper-format dialog for both receipts above (same
+             widgetVar/config bean as the Inward Payment Bill and Inward
+             Deposit Cancellation Bill print flows) -->
+        <p:dialog id="inwardPaymentConfigDialog"
+                  header="Inward Payment Bill Printer Configuration"
+                  widgetVar="inwardPaymentConfigDialog"
+                  modal="true"
+                  width="560"
+                  resizable="false"
+                  closeOnEscape="true">
+            <p:ajax event="open" listener="#{pharmacyConfigController.loadCurrentConfig}" update="inwardPaymentConfigForm"/>
+            <h:form id="inwardPaymentConfigForm">
+                <div class="card config-section">
+                    <div class="card-header">
+                        <i class="fas fa-file-alt me-2"/>
+                        <h:outputText value="Paper Format Settings"/>
+                    </div>
+                    <div class="card-body">
+                        <div class="mb-3">
+                            <h:selectBooleanCheckbox id="inwardPaymentPOS" value="#{pharmacyConfigController.inwardPaymentPosPaper}"/>
+                            <h:outputLabel for="inwardPaymentPOS" value="POS Paper" class="ms-2"/>
+                        </div>
+                        <div class="mb-3">
+                            <h:selectBooleanCheckbox id="inwardPaymentFiveFive" value="#{pharmacyConfigController.inwardPaymentFiveFivePaper}"/>
+                            <h:outputLabel for="inwardPaymentFiveFive" value="5×5 Paper" class="ms-2"/>
+                        </div>
+                        <div class="mb-3">
+                            <h:selectBooleanCheckbox id="inwardPaymentFiveFiveCustom3" value="#{pharmacyConfigController.inwardPaymentFiveFiveCustom3Paper}"/>
+                            <h:outputLabel for="inwardPaymentFiveFiveCustom3" value="5×5 Custom 3 Paper" class="ms-2"/>
+                        </div>
+                        <div class="mb-3">
+                            <h:selectBooleanCheckbox id="inwardPaymentA4" value="#{pharmacyConfigController.inwardPaymentA4Paper}"/>
+                            <h:outputLabel for="inwardPaymentA4" value="A4 Paper" class="ms-2"/>
+                        </div>
+                    </div>
+                </div>
+                <div class="d-flex gap-2 mt-3">
+                    <p:commandButton value="Apply &amp; Close"
+                                     icon="fas fa-save"
+                                     class="ui-button-success"
+                                     ajax="false"
+                                     action="#{pharmacyConfigController.saveInwardPaymentConfig}"/>
+                    <p:commandButton value="Cancel"
+                                     icon="fas fa-times"
+                                     class="ui-button-secondary"
+                                     type="button"
+                                     onclick="PF('inwardPaymentConfigDialog').hide(); return false;"/>
+                </div>
+            </h:form>
+        </p:dialog>
     </ui:define>
 </ui:composition>

--- a/src/main/webapp/inward/inward_view_appointment_bill_receipt.xhtml
+++ b/src/main/webapp/inward/inward_view_appointment_bill_receipt.xhtml
@@ -1,0 +1,147 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:bill="http://xmlns.jcp.org/jsf/composite/inward/bill/payment">
+
+    <!-- Issue #22783: view/reprint page for INWARD_APPOINTMENT_BILL and
+         INWARD_APPOINTMENT_CANCEL_BILL, routed from
+         BillSearch.navigateToViewBillByAtomicBillTypeByBillId. Appointment
+         bills never populate Bill.patientEncounter, so this uses the same
+         DTO (InwardBillReceiptDTO, LEFT-JOIN based) and print composites
+         built for the Appointment Deposit Conversion page (Part A) rather
+         than the entity-bound inward_reprint_bill_payment.xhtml. Whether
+         the bill is itself a cancellation is inferred from
+         receipt.referenceBillDeptId being non-null (only cancel bills have
+         a reference bill). -->
+    <h:body>
+        <ui:composition template="/resources/template/template.xhtml">
+            <ui:define name="content">
+                <h:form id="form">
+                    <p:panel>
+                        <f:facet name="header">
+                            <div class="d-flex justify-content-between align-items-center">
+                                <h:outputText value="Appointment Bill Receipt" styleClass="fw-bold"/>
+                                <p:commandButton
+                                    id="btnBackToSearchPayment"
+                                    value="Back to Bill List"
+                                    action="/inward/inward_search_payment?faces-redirect=true"
+                                    ajax="false"
+                                    styleClass="ui-button-warning"
+                                    icon="fa fa-arrow-left"
+                                    title="Return to the payment bill list"/>
+                            </div>
+                        </f:facet>
+
+                        <h:panelGroup rendered="#{inwardSearch.appointmentBillReceipt eq null}" layout="block">
+                            <div class="text-center py-5">
+                                <i class="fa-solid fa-triangle-exclamation fa-2x text-warning mb-3"></i>
+                                <p class="text-muted">Bill not found.</p>
+                            </div>
+                        </h:panelGroup>
+
+                        <h:panelGroup rendered="#{inwardSearch.appointmentBillReceipt ne null}" layout="block">
+                            <div class="d-flex justify-content-end gap-2 mb-3">
+                                <p:commandButton
+                                    id="btnAppointmentReceiptSettings"
+                                    rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
+                                    value="Settings"
+                                    icon="fas fa-cog"
+                                    styleClass="ui-button-secondary"
+                                    type="button"
+                                    title="Configure receipt paper"
+                                    onclick="PF('inwardPaymentConfigDialog').show();"/>
+                                <p:commandButton
+                                    id="btnPrintAppointmentReceipt"
+                                    value="Print"
+                                    styleClass="ui-button-info"
+                                    icon="fas fa-print"
+                                    title="Print receipt">
+                                    <p:printer target="gpAppointmentReceiptPreview"/>
+                                </p:commandButton>
+                            </div>
+
+                            <div class="d-flex justify-content-center align-items-center">
+                                <h:panelGroup id="gpAppointmentReceiptPreview">
+                                    <h:panelGroup rendered="#{inwardSearch.appointmentBillReceipt.referenceBillDeptId ne null}">
+                                        <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Payment Bill Five Five Paper', false)}">
+                                            <bill:FiveFiveCancellationReceipt receipt="#{inwardSearch.appointmentBillReceipt}" duplicate="true"/>
+                                        </h:panelGroup>
+                                        <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Payment Bill A4 Paper', false)}">
+                                            <bill:A4PaperCancellationReceipt receipt="#{inwardSearch.appointmentBillReceipt}" duplicate="true"/>
+                                        </h:panelGroup>
+                                        <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Payment Bill POS Paper', true)}" style="align-items: center;">
+                                            <bill:PosPaperCancellationReceipt receipt="#{inwardSearch.appointmentBillReceipt}" duplicate="true"/>
+                                        </h:panelGroup>
+                                    </h:panelGroup>
+                                    <h:panelGroup rendered="#{inwardSearch.appointmentBillReceipt.referenceBillDeptId eq null}">
+                                        <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Payment Bill Five Five Paper', false)}">
+                                            <bill:FiveFiveDepositReceipt receipt="#{inwardSearch.appointmentBillReceipt}" duplicate="true"/>
+                                        </h:panelGroup>
+                                        <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Payment Bill A4 Paper', false)}">
+                                            <bill:A4PaperDepositReceipt receipt="#{inwardSearch.appointmentBillReceipt}" duplicate="true"/>
+                                        </h:panelGroup>
+                                        <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Payment Bill POS Paper', true)}" style="align-items: center;">
+                                            <bill:PosPaperDepositReceipt receipt="#{inwardSearch.appointmentBillReceipt}" duplicate="true"/>
+                                        </h:panelGroup>
+                                    </h:panelGroup>
+                                </h:panelGroup>
+                            </div>
+                        </h:panelGroup>
+                    </p:panel>
+                </h:form>
+
+                <p:dialog id="inwardPaymentConfigDialog"
+                          header="Inward Payment Bill Printer Configuration"
+                          widgetVar="inwardPaymentConfigDialog"
+                          modal="true"
+                          width="560"
+                          resizable="false"
+                          closeOnEscape="true">
+                    <p:ajax event="open" listener="#{pharmacyConfigController.loadCurrentConfig}" update="inwardPaymentConfigForm"/>
+                    <h:form id="inwardPaymentConfigForm">
+                        <div class="card config-section">
+                            <div class="card-header">
+                                <i class="fas fa-file-alt me-2"/>
+                                <h:outputText value="Paper Format Settings"/>
+                            </div>
+                            <div class="card-body">
+                                <div class="mb-3">
+                                    <h:selectBooleanCheckbox id="inwardPaymentPOS" value="#{pharmacyConfigController.inwardPaymentPosPaper}"/>
+                                    <h:outputLabel for="inwardPaymentPOS" value="POS Paper" class="ms-2"/>
+                                </div>
+                                <div class="mb-3">
+                                    <h:selectBooleanCheckbox id="inwardPaymentFiveFive" value="#{pharmacyConfigController.inwardPaymentFiveFivePaper}"/>
+                                    <h:outputLabel for="inwardPaymentFiveFive" value="5×5 Paper" class="ms-2"/>
+                                </div>
+                                <div class="mb-3">
+                                    <h:selectBooleanCheckbox id="inwardPaymentFiveFiveCustom3" value="#{pharmacyConfigController.inwardPaymentFiveFiveCustom3Paper}"/>
+                                    <h:outputLabel for="inwardPaymentFiveFiveCustom3" value="5×5 Custom 3 Paper" class="ms-2"/>
+                                </div>
+                                <div class="mb-3">
+                                    <h:selectBooleanCheckbox id="inwardPaymentA4" value="#{pharmacyConfigController.inwardPaymentA4Paper}"/>
+                                    <h:outputLabel for="inwardPaymentA4" value="A4 Paper" class="ms-2"/>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="d-flex gap-2 mt-3">
+                            <p:commandButton value="Apply &amp; Close"
+                                             icon="fas fa-save"
+                                             class="ui-button-success"
+                                             ajax="false"
+                                             action="#{pharmacyConfigController.saveInwardPaymentConfig}"/>
+                            <p:commandButton value="Cancel"
+                                             icon="fas fa-times"
+                                             class="ui-button-secondary"
+                                             type="button"
+                                             onclick="PF('inwardPaymentConfigDialog').hide(); return false;"/>
+                        </div>
+                    </h:form>
+                </p:dialog>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/inward/reports/inpatient_payment_bill_list_dto.xhtml
+++ b/src/main/webapp/inward/reports/inpatient_payment_bill_list_dto.xhtml
@@ -1,0 +1,235 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/resources/template/template.xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:p="http://primefaces.org/ui"
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:common="http://xmlns.jcp.org/jsf/composite/ezcomp/common">
+
+    <ui:define name="content">
+        <h:form id="form">
+            <p:growl id="inpatientPaymentBillReportGrowl"></p:growl>
+            <p:panel>
+                <f:facet name="header">
+                    <h:outputText styleClass="fa fa-money-bill-wave"></h:outputText>
+                    <p:outputLabel value="&nbsp;&nbsp;&nbsp;Inward Payments &amp; Cancellations" class="m-2"></p:outputLabel>
+
+                    <p:commandButton
+                        value="Download"
+                        ajax="false"
+                        class="ui-button-primary m-1"
+                        icon="fa fa-download">
+                        <p:dataExporter fileName="Inward Payments" target="tbl1" type="xlsx"></p:dataExporter>
+                    </p:commandButton>
+
+                    <p:commandButton
+                        value="Print"
+                        ajax="false"
+                        class="ui-button-primary m-1"
+                        icon="fa fa-print">
+                        <p:printer target="tbl1"></p:printer>
+                    </p:commandButton>
+
+                    <p:commandButton
+                        id="btnBackToProfile"
+                        value="Inpatient Profile"
+                        action="#{inwardReportControllerBht.navigateToAdmissionProfile()}"
+                        style="float: right;"
+                        ajax="false"
+                        class="ui-button-secondary m-1"
+                        icon="fa fa-arrow-circle-left">
+                    </p:commandButton>
+
+                </f:facet>
+
+                <style>
+                    @media print {
+                        body {
+                            margin: 0px 5px;
+                        }
+                    }
+                </style>
+
+                <div class="row">
+                    <div class="col-3">
+                        <div class="m-1">
+                            <p:panel class="w-100 m-1">
+                                <f:facet name="header">
+                                    <h:outputText styleClass="fas fa-user"></h:outputText>
+                                    <h:outputLabel value="Patient Details" class="mx-4"></h:outputLabel>
+                                </f:facet>
+                                <div class="row">
+                                    <div class="col-md-5"><p:outputLabel value="Name" /></div>
+                                    <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                                    <div class="col-md-6"><h:outputText value="#{admissionController.current.patient.person.nameWithTitle}" /></div>
+
+                                    <div class="col-md-5"><p:outputLabel value="Gender" /></div>
+                                    <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                                    <div class="col-md-6"><h:outputText value="#{admissionController.current.patient.person.sex}" /></div>
+
+                                    <div class="col-md-5"><p:outputLabel value="Age" /></div>
+                                    <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                                    <div class="col-md-6"><h:outputText value="#{admissionController.current.patient.person.ageAsString}" /></div>
+
+                                    <div class="col-md-5"><p:outputLabel value="Mobile No." /></div>
+                                    <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                                    <div class="col-md-6"><h:outputText value="#{admissionController.current.patient.person.mobile}" /></div>
+
+                                    <div class="col-md-5"><p:outputLabel value="NIC" /></div>
+                                    <div class="col-md-1 justify-content-end d-flex"><p:outputLabel value=":" class="mx-2"/></div>
+                                    <div class="col-md-6"><h:outputText value="#{empty admissionController.current.patient.person.nic ? 'N/A' : admissionController.current.patient.person.nic}" /></div>
+                                </div>
+                            </p:panel>
+                        </div>
+                        <div class="m-1">
+                            <common:admission_details admission="#{admissionController.current}" class="w-100 m-1"></common:admission_details>
+                        </div>
+                    </div>
+                    <div class="col-9">
+                        <p:panel>
+                            <f:facet name="header">
+                                <p:outputLabel value="Inward Payments &amp; Cancellations" style="font-weight: bold"></p:outputLabel>
+                            </f:facet>
+
+                            <p:dataTable
+                                id="tbl1"
+                                rowIndexVar="rowIndex"
+                                value="#{inwardReportControllerBht.paymentBillDtosToPatientEncounter}"
+                                var="dto">
+
+                                <f:facet name="header">
+                                    <h:panelGrid columns="5" style="width: 100%; text-align: left;">
+                                        <h:outputLabel value="Name:" />
+                                        <h:outputLabel value="#{inwardReportControllerBht.patientEncounter.patient.person.nameWithTitle}" />
+                                        <h:outputLabel value="" />
+                                        <h:outputLabel value="BHT:" />
+                                        <h:outputLabel value="#{inwardReportControllerBht.patientEncounter.bhtNo}" />
+
+                                        <h:outputLabel value="Date of Admission:" />
+                                        <h:outputLabel>
+                                            <h:outputText value="#{inwardReportControllerBht.patientEncounter.dateOfAdmission}">
+                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                            </h:outputText>
+                                        </h:outputLabel>
+                                        <h:outputLabel value="" />
+                                        <h:outputLabel value="Date of Discharge:" />
+                                        <h:outputLabel>
+                                            <h:outputText value="#{inwardReportControllerBht.patientEncounter.dateOfDischarge}">
+                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                            </h:outputText>
+                                        </h:outputLabel>
+                                    </h:panelGrid>
+                                </f:facet>
+
+                                <p:column width="2em" style="padding: 2px" styleClass="#{dto.cancelled ? 'ui-messages-fatal' : ''}">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="No" />
+                                    </f:facet>
+                                    <h:outputLabel value="#{rowIndex+1}" />
+                                </p:column>
+
+                                <p:column width="8em" style="padding: 2px" styleClass="#{dto.cancelled ? 'ui-messages-fatal' : ''}">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Bill No" />
+                                    </f:facet>
+                                    <h:outputLabel value="#{dto.deptId}" />
+                                </p:column>
+
+                                <p:column width="8em" style="padding: 2px" styleClass="#{dto.cancelled ? 'ui-messages-fatal' : ''}">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="BHT" />
+                                    </f:facet>
+                                    <h:outputLabel value="#{dto.bhtNo}" />
+                                </p:column>
+
+                                <p:column width="12em" style="padding: 2px" styleClass="#{dto.cancelled ? 'ui-messages-fatal' : ''}">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Date" />
+                                    </f:facet>
+                                    <h:outputText value="#{dto.createdAt}">
+                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                    </h:outputText>
+                                </p:column>
+
+                                <p:column width="10em" style="padding: 2px" styleClass="#{dto.cancelled ? 'ui-messages-fatal' : ''}">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Payment Method" />
+                                    </f:facet>
+                                    <h:outputLabel value="#{dto.paymentMethod}" />
+                                </p:column>
+
+                                <p:column width="8em" style="text-align: right; padding: 2px" styleClass="#{dto.cancelled ? 'ui-messages-fatal' : ''}">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Total" />
+                                    </f:facet>
+                                    <h:outputLabel value="#{dto.total}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </p:column>
+
+                                <p:column width="8em" style="text-align: right; padding: 2px" styleClass="#{dto.cancelled ? 'ui-messages-fatal' : ''}">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Discount" />
+                                    </f:facet>
+                                    <h:outputLabel value="#{dto.discount}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </p:column>
+
+                                <p:column width="8em" style="text-align: right; padding: 2px" styleClass="#{dto.cancelled ? 'ui-messages-fatal' : ''}">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Net Total" />
+                                    </f:facet>
+                                    <h:outputLabel value="#{dto.netTotal}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{inwardReportControllerBht.paymentBillDtosToPatientEncounterNetTotal}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </f:facet>
+                                </p:column>
+
+                                <p:column width="10em" style="padding: 2px" styleClass="#{dto.cancelled ? 'ui-messages-fatal' : ''}">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Type" />
+                                    </f:facet>
+                                    <h:outputLabel value="Cancellation" style="color: red;" rendered="#{not empty dto.billTypeAtomic and dto.billTypeAtomic.contains('CANCEL')}" />
+                                    <h:outputLabel value="Refund / Return" style="color: red;" rendered="#{not empty dto.billTypeAtomic and dto.billTypeAtomic.contains('REFUND') and not dto.billTypeAtomic.contains('CANCEL')}" />
+                                    <h:outputLabel value="Payment" rendered="#{empty dto.billTypeAtomic or (not dto.billTypeAtomic.contains('CANCEL') and not dto.billTypeAtomic.contains('REFUND'))}" />
+                                </p:column>
+
+                                <p:column width="8em" style="padding: 2px">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Status" />
+                                    </f:facet>
+                                    <h:outputLabel value="Cancelled" style="color: red;" rendered="#{dto.cancelled}" />
+                                    <h:outputLabel value="Returned" style="color: red;" rendered="#{dto.refunded and not dto.cancelled}" />
+                                </p:column>
+
+                                <p:column width="6em" style="padding: 2px" exportable="false">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Action" />
+                                    </f:facet>
+                                    <p:commandButton
+                                        value="View"
+                                        icon="fa fa-eye"
+                                        ajax="false"
+                                        class="ui-button-info"
+                                        title="View / Reprint Bill ##{dto.deptId}"
+                                        action="#{billSearch.navigateToViewBillByAtomicBillTypeByBillId(dto.billId)}" />
+                                </p:column>
+
+                            </p:dataTable>
+
+                        </p:panel>
+
+                    </div>
+                </div>
+            </p:panel>
+
+        </h:form>
+    </ui:define>
+</ui:composition>

--- a/src/main/webapp/inward/reports/inward_payment_bill_list_department_dto.xhtml
+++ b/src/main/webapp/inward/reports/inward_payment_bill_list_department_dto.xhtml
@@ -1,0 +1,215 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+
+    <h:body>
+        <ui:composition template="/resources/template/template.xhtml">
+            <ui:define name="content">
+                <h:form id="form">
+                    <p:growl id="departmentPaymentBillReportGrowl"></p:growl>
+                    <p:panel>
+                        <f:facet name="header">
+                            <h:outputText styleClass="fa fa-money-bill-wave"></h:outputText>
+                            <p:outputLabel value="&nbsp;&nbsp;&nbsp;Department Payments &amp; Cancellations" class="m-2"></p:outputLabel>
+
+                            <p:commandButton
+                                value="Download"
+                                ajax="false"
+                                class="ui-button-primary m-1"
+                                icon="fa fa-download">
+                                <p:dataExporter fileName="Department Payments" target="tbl1" type="xlsx"></p:dataExporter>
+                            </p:commandButton>
+
+                            <p:commandButton
+                                value="Print"
+                                ajax="false"
+                                class="ui-button-primary m-1"
+                                icon="fa fa-print">
+                                <p:printer target="tbl1"></p:printer>
+                            </p:commandButton>
+                        </f:facet>
+
+                        <style>
+                            @media print {
+                                body {
+                                    margin: 0px 5px;
+                                }
+                            }
+                        </style>
+
+                        <div class="row">
+                            <div class="col-2">
+                                <h:outputLabel value="From Date" for="fromDate" />
+                                <p:calendar
+                                    styleClass="dateTimePicker"
+                                    id="fromDate"
+                                    value="#{inwardReportControllerBht.fromDate}"
+                                    navigator="false"
+                                    pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
+                                    class="w-100"
+                                    inputStyleClass="w-100">
+                                </p:calendar>
+
+                                <h:outputLabel value="To Date" for="toDate" />
+                                <p:calendar
+                                    id="toDate"
+                                    value="#{inwardReportControllerBht.toDate}"
+                                    navigator="false"
+                                    pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
+                                    class="w-100"
+                                    inputStyleClass="w-100">
+                                </p:calendar>
+
+                                <h:outputLabel value="BHT No" for="bhtNo" />
+                                <p:inputText id="bhtNo" autocomplete="off" value="#{inwardReportControllerBht.bhtNoFilter}" class="w-100"/>
+
+                                <h:outputLabel value="Patient Name" for="patientName" />
+                                <p:inputText id="patientName" autocomplete="off" value="#{inwardReportControllerBht.patientNameFilter}" class="w-100"/>
+
+                                <p:commandButton
+                                    ajax="false"
+                                    action="#{inwardReportControllerBht.navigateToInwardPaymentBillListForDepartment()}"
+                                    value="Search"
+                                    class="ui-button-warning w-100 my-1"
+                                    icon="fas fa-search">
+                                </p:commandButton>
+                            </div>
+
+                            <div class="col-10">
+                                <p:dataTable
+                                    id="tbl1"
+                                    rowIndexVar="rowIndex"
+                                    paginator="true"
+                                    paginatorPosition="bottom"
+                                    rows="20"
+                                    paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                    rowsPerPageTemplate="20,50,100"
+                                    value="#{inwardReportControllerBht.paymentBillDtosForDepartment}"
+                                    var="dto">
+
+                                    <p:column width="2em" style="padding: 2px" styleClass="#{dto.cancelled ? 'ui-messages-fatal' : ''}">
+                                        <f:facet name="header">
+                                            <h:outputLabel value="No" />
+                                        </f:facet>
+                                        <h:outputLabel value="#{rowIndex+1}" />
+                                    </p:column>
+
+                                    <p:column width="8em" style="padding: 2px" styleClass="#{dto.cancelled ? 'ui-messages-fatal' : ''}">
+                                        <f:facet name="header">
+                                            <h:outputLabel value="Bill No" />
+                                        </f:facet>
+                                        <h:outputLabel value="#{dto.deptId}" />
+                                    </p:column>
+
+                                    <p:column width="8em" style="padding: 2px" styleClass="#{dto.cancelled ? 'ui-messages-fatal' : ''}">
+                                        <f:facet name="header">
+                                            <h:outputLabel value="BHT" />
+                                        </f:facet>
+                                        <h:outputLabel value="#{dto.bhtNo}" />
+                                    </p:column>
+
+                                    <p:column style="padding: 2px" styleClass="#{dto.cancelled ? 'ui-messages-fatal' : ''}">
+                                        <f:facet name="header">
+                                            <h:outputLabel value="Patient" />
+                                        </f:facet>
+                                        <h:outputLabel value="#{dto.patientName}" />
+                                    </p:column>
+
+                                    <p:column width="12em" style="padding: 2px" styleClass="#{dto.cancelled ? 'ui-messages-fatal' : ''}">
+                                        <f:facet name="header">
+                                            <h:outputLabel value="Date" />
+                                        </f:facet>
+                                        <h:outputText value="#{dto.createdAt}">
+                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                        </h:outputText>
+                                    </p:column>
+
+                                    <p:column width="10em" style="padding: 2px" styleClass="#{dto.cancelled ? 'ui-messages-fatal' : ''}">
+                                        <f:facet name="header">
+                                            <h:outputLabel value="Payment Method" />
+                                        </f:facet>
+                                        <h:outputLabel value="#{dto.paymentMethod}" />
+                                    </p:column>
+
+                                    <p:column width="10em" style="padding: 2px" styleClass="#{dto.cancelled ? 'ui-messages-fatal' : ''}">
+                                        <f:facet name="header">
+                                            <h:outputLabel value="Billed By" />
+                                        </f:facet>
+                                        <h:outputLabel value="#{dto.createdUserName}" />
+                                    </p:column>
+
+                                    <p:column width="8em" style="text-align: right; padding: 2px" styleClass="#{dto.cancelled ? 'ui-messages-fatal' : ''}">
+                                        <f:facet name="header">
+                                            <h:outputLabel value="Total" />
+                                        </f:facet>
+                                        <h:outputLabel value="#{dto.total}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </p:column>
+
+                                    <p:column width="8em" style="text-align: right; padding: 2px" styleClass="#{dto.cancelled ? 'ui-messages-fatal' : ''}">
+                                        <f:facet name="header">
+                                            <h:outputLabel value="Discount" />
+                                        </f:facet>
+                                        <h:outputLabel value="#{dto.discount}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </p:column>
+
+                                    <p:column width="8em" style="text-align: right; padding: 2px" styleClass="#{dto.cancelled ? 'ui-messages-fatal' : ''}">
+                                        <f:facet name="header">
+                                            <h:outputLabel value="Net Total" />
+                                        </f:facet>
+                                        <h:outputLabel value="#{dto.netTotal}">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                        <f:facet name="footer">
+                                            <h:outputLabel value="#{inwardReportControllerBht.paymentBillDtosForDepartmentNetTotal}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                        </f:facet>
+                                    </p:column>
+
+                                    <p:column width="10em" style="padding: 2px" styleClass="#{dto.cancelled ? 'ui-messages-fatal' : ''}">
+                                        <f:facet name="header">
+                                            <h:outputLabel value="Type" />
+                                        </f:facet>
+                                        <h:outputLabel value="Cancellation" style="color: red;" rendered="#{not empty dto.billTypeAtomic and dto.billTypeAtomic.contains('CANCEL')}" />
+                                        <h:outputLabel value="Refund / Return" style="color: red;" rendered="#{not empty dto.billTypeAtomic and dto.billTypeAtomic.contains('REFUND') and not dto.billTypeAtomic.contains('CANCEL')}" />
+                                        <h:outputLabel value="Payment" rendered="#{empty dto.billTypeAtomic or (not dto.billTypeAtomic.contains('CANCEL') and not dto.billTypeAtomic.contains('REFUND'))}" />
+                                    </p:column>
+
+                                    <p:column width="8em" style="padding: 2px">
+                                        <f:facet name="header">
+                                            <h:outputLabel value="Status" />
+                                        </f:facet>
+                                        <h:outputLabel value="Cancelled" style="color: red;" rendered="#{dto.cancelled}" />
+                                        <h:outputLabel value="Returned" style="color: red;" rendered="#{dto.refunded and not dto.cancelled}" />
+                                    </p:column>
+
+                                    <p:column width="6em" style="padding: 2px" exportable="false">
+                                        <f:facet name="header">
+                                            <h:outputLabel value="Action" />
+                                        </f:facet>
+                                        <p:commandButton
+                                            value="View"
+                                            icon="fa fa-eye"
+                                            ajax="false"
+                                            class="ui-button-info"
+                                            title="View / Reprint Bill ##{dto.deptId}"
+                                            action="#{billSearch.navigateToViewBillByAtomicBillTypeByBillId(dto.billId)}" />
+                                    </p:column>
+
+                                </p:dataTable>
+                            </div>
+                        </div>
+                    </p:panel>
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/nurse/index.xhtml
+++ b/src/main/webapp/nurse/index.xhtml
@@ -763,7 +763,7 @@
                                                                         ajax="false"
                                                                         action="#{admissionController.navigateToAppointmentDepositConversion()}"
                                                                         icon="fa fa-right-left"
-                                                                        rendered="#{admissionController.current ne null and admissionController.hasPendingAppointmentDepositConversion}"
+                                                                        rendered="#{webUserController.hasPrivilege('InwardEditPaymentDetails') and admissionController.current ne null and admissionController.hasPendingAppointmentDepositConversion}"
                                                                         class="w-100">
                                                                     </p:commandButton>
                                                                 </div>
@@ -783,6 +783,7 @@
                                                                     ajax="false"
                                                                     action="#{inwardReportControllerBht.navigateToInwardPaymentBillListForDepartment()}"
                                                                     icon="fa fa-money-bill-wave"
+                                                                    rendered="#{webUserController.hasPrivilege('InwardReport')}"
                                                                     class="w-100 ui-button-success">
                                                                 </p:commandButton>
                                                             </div>
@@ -793,7 +794,7 @@
                                                                     ajax="false"
                                                                     action="#{inwardReportControllerBht.navigateToInpatientPaymentBillListDto()}"
                                                                     icon="fa fa-file-invoice-dollar"
-                                                                    rendered="#{admissionController.current ne null}"
+                                                                    rendered="#{webUserController.hasPrivilege('InwardReport') and admissionController.current ne null}"
                                                                     class="w-100 ui-button-success">
                                                                     <f:setPropertyActionListener
                                                                         value="#{admissionController.current}"

--- a/src/main/webapp/nurse/index.xhtml
+++ b/src/main/webapp/nurse/index.xhtml
@@ -749,6 +749,65 @@
                                                 </p:panel>
                                             </div>
                                         </h:panelGroup>
+                                        <h:panelGroup rendered="#{webUserController.hasPrivilege('NursingWorkBenchPanelPayments')}">
+                                            <div class="col-6">
+                                                <p:panel header="Payments">
+                                                    <h:panelGroup layout="block" rendered="#{admissionController.current ne null and admissionController.hasPendingAppointmentDepositConversion}">
+                                                        <div class="p-2 rounded mb-2" style="background-color:#e8f5ee;">
+                                                            <div class="text-uppercase small fw-bold text-muted mb-2">Payment Actions</div>
+                                                            <div class="row g-2">
+                                                                <div class="col-6">
+                                                                    <p:commandButton
+                                                                        id="btnConvertAppointmentDepositNurse"
+                                                                        value="Convert Appointment Deposit"
+                                                                        ajax="false"
+                                                                        action="#{admissionController.navigateToAppointmentDepositConversion()}"
+                                                                        icon="fa fa-right-left"
+                                                                        rendered="#{admissionController.current ne null and admissionController.hasPendingAppointmentDepositConversion}"
+                                                                        class="w-100">
+                                                                    </p:commandButton>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                    </h:panelGroup>
+
+                                                    <hr class="my-2"/>
+
+                                                    <div class="p-2 rounded" style="background-color:#eef1f4;">
+                                                        <div class="text-uppercase small fw-bold text-muted mb-2">Payment Reports</div>
+                                                        <div class="row g-2">
+                                                            <div class="col-6">
+                                                                <p:commandButton
+                                                                    id="btnDepartmentPaymentsReportNurse"
+                                                                    value="Department Payments Report"
+                                                                    ajax="false"
+                                                                    action="#{inwardReportControllerBht.navigateToInwardPaymentBillListForDepartment()}"
+                                                                    icon="fa fa-money-bill-wave"
+                                                                    class="w-100 ui-button-success">
+                                                                </p:commandButton>
+                                                            </div>
+                                                            <div class="col-6">
+                                                                <p:commandButton
+                                                                    id="btnAdmissionPaymentsReportNurse"
+                                                                    value="This Admission's Payments"
+                                                                    ajax="false"
+                                                                    action="#{inwardReportControllerBht.navigateToInpatientPaymentBillListDto()}"
+                                                                    icon="fa fa-file-invoice-dollar"
+                                                                    rendered="#{admissionController.current ne null}"
+                                                                    class="w-100 ui-button-success">
+                                                                    <f:setPropertyActionListener
+                                                                        value="#{admissionController.current}"
+                                                                        target="#{inwardReportControllerBht.patientEncounter}" />
+                                                                    <f:setPropertyActionListener
+                                                                        value="#{null}"
+                                                                        target="#{inwardReportControllerBht.department}" />
+                                                                </p:commandButton>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </p:panel>
+                                            </div>
+                                        </h:panelGroup>
                                     </div>
                                     </h:panelGroup>
                                 </p:splitterPanel>

--- a/src/main/webapp/resources/inward/bill/payment/A4PaperCancellationReceipt.xhtml
+++ b/src/main/webapp/resources/inward/bill/payment/A4PaperCancellationReceipt.xhtml
@@ -1,0 +1,169 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui">
+
+    <!-- INTERFACE -->
+    <cc:interface>
+        <cc:attribute name="receipt" type="com.divudi.core.data.dto.InwardBillReceiptDTO" />
+        <cc:attribute name="duplicate" type="java.lang.Boolean"/>
+    </cc:interface>
+
+    <!-- IMPLEMENTATION -->
+    <cc:implementation>
+        <h:outputStylesheet library="css" name="inwardpayments.css" ></h:outputStylesheet>
+        <div class="a4bill1" style="align-items: center; margin: 0; padding: 0; max-width: 210mm" >
+            <div class="institutionName">
+                <h:outputLabel value="#{cc.attrs.receipt.departmentPrintingName}" />
+            </div>
+            <div class="institutionContact" >
+                <div>
+                    <h:outputLabel value="#{cc.attrs.receipt.departmentAddress}"/>
+                </div>
+                <div >
+                    <h:outputLabel value="Phone : #{cc.attrs.receipt.departmentTelephone1} "/>
+                    <h:outputLabel value=" /" style="width: 20px; text-align: center;"/>
+                    <h:outputLabel value="#{cc.attrs.receipt.departmentTelephone2}"/>
+                </div>
+                <div >
+                    <h:outputLabel value="Fax : #{cc.attrs.receipt.departmentFax}"/>
+                </div>
+                <div >
+                    <h:outputLabel value="Email : #{cc.attrs.receipt.departmentEmail}"/>
+                </div>
+            </div>
+
+            <div class="billline">
+                <hr/>
+            </div>
+
+            <div class="headingBill" style="text-align: center;">
+                <h:outputLabel value="Deposit Cancellation Receipt" style="font-size: 20px;" /><br/>
+                <h:outputLabel value="**Duplicate**"  rendered="#{cc.attrs.duplicate eq true}" />
+            </div>
+
+            <div class="billline">
+                <hr/>
+            </div>
+
+            <div class="billDetailsFiveFive" >
+                <table style="width: 95%!important;" align="center" >
+                    <tr>
+                        <td><h:outputLabel value="Name" class="billDetailsFiveFive" ></h:outputLabel></td>
+                        <td style="text-align: center;" >:</td>
+                        <td>
+                            <h:outputLabel value="#{cc.attrs.receipt.patientNameWithTitle}" class="billDetailsFiveFive" />
+                        </td>
+                        <td width="2%" />
+                        <td><h:outputLabel value="Age / Sex" class="billDetailsFiveFive" ></h:outputLabel></td>
+                        <td style="text-align: center;" >:</td>
+                        <td>
+                            <h:outputLabel value="#{cc.attrs.receipt.patientAgeAsString} / #{cc.attrs.receipt.patientSex}" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td><h:outputLabel value="Admission Type" class="billDetailsFiveFive" ></h:outputLabel></td>
+                        <td style="text-align: center;" >:</td>
+                        <td>
+                            <h:outputLabel value="#{cc.attrs.receipt.admissionTypeName}" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+                        <td width="2%" />
+                        <td><h:outputLabel value="BHT No" class="billDetailsFiveFive" ></h:outputLabel></td>
+                        <td style="text-align: center;" >:</td>
+                        <td>
+                            <h:outputLabel value="#{cc.attrs.receipt.bhtNo}" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+
+            <div class="billline">
+                <hr/>
+            </div>
+
+            <div class="billDetailsFiveFive" >
+                <table style="width: 95%!important;" align="center" >
+                    <tr>
+                        <td><h:outputLabel value="Cancellation Bill No" class="billDetailsFiveFive" ></h:outputLabel></td>
+                        <td style="text-align: center;" >:</td>
+                        <td>
+                            <h:outputLabel value="#{cc.attrs.receipt.deptId}" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+                        <td width="2%" />
+                        <td><h:outputLabel value="Cancelled At" class="billDetailsFiveFive" ></h:outputLabel></td>
+                        <td style="text-align: center;" >:</td>
+                        <td>
+                            <h:outputLabel value="#{cc.attrs.receipt.billDate}" class="billDetailsFiveFive" >
+                                <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td><h:outputLabel value="Payment Method" class="billDetailsFiveFive" ></h:outputLabel></td>
+                        <td style="text-align: center;" >:</td>
+                        <td>
+                            <h:outputLabel value="#{cc.attrs.receipt.paymentMethod.label}" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+                        <td width="2%" />
+                        <td><h:outputLabel value="Original Bill No" class="billDetailsFiveFive" rendered="#{cc.attrs.receipt.referenceBillDeptId ne null}"></h:outputLabel></td>
+                        <td style="text-align: center;" >
+                            <h:outputLabel value=":" rendered="#{cc.attrs.receipt.referenceBillDeptId ne null}"/>
+                        </td>
+                        <td>
+                            <h:outputLabel value="#{cc.attrs.receipt.referenceBillDeptId}" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+                    </tr>
+                    <h:panelGroup rendered="#{cc.attrs.receipt.comments ne null and cc.attrs.receipt.comments ne ''}">
+                        <tr>
+                            <td><h:outputLabel value="Cancellation Reason" class="billDetailsFiveFive" ></h:outputLabel></td>
+                            <td style="text-align: center;" >:</td>
+                            <td colspan="5">
+                                <h:outputLabel value="#{cc.attrs.receipt.comments}" class="billDetailsFiveFive" ></h:outputLabel>
+                            </td>
+                        </tr>
+                    </h:panelGroup>
+                </table>
+            </div>
+
+            <div class="billline">
+                <hr/>
+            </div>
+
+            <div  >
+                <table style="width: 100%;">
+                    <tr>
+                        <td  style="text-align: left; width: 60%; font-size: 16px!important;
+                             font-family:Verdana, Helvetica, sans-serif!important;
+                             font-weight: bold;">
+                            &nbsp;&nbsp;
+                            <h:outputLabel value="Amount" />
+                        </td>
+                        <td  style="text-align: right!important; width: 40%; padding-right: 32px; font-size: 16px!important;
+                             font-family:Verdana, Helvetica, sans-serif!important;
+                             font-weight: bold;">
+                            <h:outputLabel value="#{cc.attrs.receipt.amount}" >
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+
+            <div class="billline">
+                <hr/>
+            </div>
+
+            <div class="footer" >
+                <div class="row" >
+                    <div class="col-12" >
+                        <h:outputLabel value="Cashier :  #{cc.attrs.receipt.cashierNameWithTitle}"/>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </cc:implementation>
+</html>

--- a/src/main/webapp/resources/inward/bill/payment/A4PaperDepositReceipt.xhtml
+++ b/src/main/webapp/resources/inward/bill/payment/A4PaperDepositReceipt.xhtml
@@ -1,0 +1,165 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui">
+
+    <!-- INTERFACE -->
+    <cc:interface>
+        <cc:attribute name="receipt" type="com.divudi.core.data.dto.InwardBillReceiptDTO" />
+        <cc:attribute name="duplicate" type="java.lang.Boolean"/>
+    </cc:interface>
+
+    <!-- IMPLEMENTATION -->
+    <cc:implementation>
+        <h:outputStylesheet library="css" name="inwardpayments.css" ></h:outputStylesheet>
+        <div class="a4bill1" style="align-items: center; margin: 0; padding: 0; max-width: 210mm" >
+            <div class="institutionName">
+                <h:outputLabel value="#{cc.attrs.receipt.departmentPrintingName}" />
+            </div>
+            <div class="institutionContact" >
+                <div>
+                    <h:outputLabel value="#{cc.attrs.receipt.departmentAddress}"/>
+                </div>
+                <div >
+                    <h:outputLabel value="Phone : #{cc.attrs.receipt.departmentTelephone1} "/>
+                    <h:outputLabel value=" /" style="width: 20px; text-align: center;"/>
+                    <h:outputLabel value="#{cc.attrs.receipt.departmentTelephone2}"/>
+                </div>
+                <div >
+                    <h:outputLabel value="Fax : #{cc.attrs.receipt.departmentFax}"/>
+                </div>
+                <div >
+                    <h:outputLabel value="Email : #{cc.attrs.receipt.departmentEmail}"/>
+                </div>
+            </div>
+
+            <div class="billline">
+                <hr/>
+            </div>
+
+            <div class="headingBill" style="text-align: center;">
+                <h:outputLabel value="Deposit Receipt" style="font-size: 20px;" /><br/>
+                <h:outputLabel value="**Duplicate**"  rendered="#{cc.attrs.duplicate eq true}" />
+            </div>
+
+            <div class="billline">
+                <hr/>
+            </div>
+
+            <div class="billDetailsFiveFive" >
+                <table style="width: 95%!important;" align="center" >
+                    <tr>
+                        <td><h:outputLabel value="Name" class="billDetailsFiveFive" ></h:outputLabel></td>
+                        <td style="text-align: center;" >:</td>
+                        <td>
+                            <h:outputLabel value="#{cc.attrs.receipt.patientNameWithTitle}" class="billDetailsFiveFive" />
+                        </td>
+                        <td width="2%" />
+                        <td><h:outputLabel value="Age / Sex" class="billDetailsFiveFive" ></h:outputLabel></td>
+                        <td style="text-align: center;" >:</td>
+                        <td>
+                            <h:outputLabel value="#{cc.attrs.receipt.patientAgeAsString} / #{cc.attrs.receipt.patientSex}" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td><h:outputLabel value="Admission Type" class="billDetailsFiveFive" ></h:outputLabel></td>
+                        <td style="text-align: center;" >:</td>
+                        <td>
+                            <h:outputLabel value="#{cc.attrs.receipt.admissionTypeName}" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+                        <td width="2%" />
+                        <td><h:outputLabel value="BHT No" class="billDetailsFiveFive" ></h:outputLabel></td>
+                        <td style="text-align: center;" >:</td>
+                        <td>
+                            <h:outputLabel value="#{cc.attrs.receipt.bhtNo}" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+
+            <div class="billline">
+                <hr/>
+            </div>
+
+            <div class="billDetailsFiveFive" >
+                <table style="width: 95%!important;" align="center" >
+                    <tr>
+                        <td><h:outputLabel value="Bill No" class="billDetailsFiveFive" ></h:outputLabel></td>
+                        <td style="text-align: center;" >:</td>
+                        <td>
+                            <h:outputLabel value="#{cc.attrs.receipt.deptId}" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+                        <td width="2%" />
+                        <td><h:outputLabel value="Date At" class="billDetailsFiveFive" ></h:outputLabel></td>
+                        <td style="text-align: center;" >:</td>
+                        <td>
+                            <h:outputLabel value="#{cc.attrs.receipt.billDate}" class="billDetailsFiveFive" >
+                                <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td><h:outputLabel value="Payment Method" class="billDetailsFiveFive" ></h:outputLabel></td>
+                        <td style="text-align: center;" >:</td>
+                        <td>
+                            <h:outputLabel value="#{cc.attrs.receipt.paymentMethod.label}" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+                        <td width="2%" />
+                        <td/>
+                        <td/>
+                        <td/>
+                    </tr>
+                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Show Comment on Inward Deposit Bill',false) and cc.attrs.receipt.comments ne null and cc.attrs.receipt.comments ne ''}">
+                        <tr>
+                            <td><h:outputLabel value="Comment" class="billDetailsFiveFive" ></h:outputLabel></td>
+                            <td style="text-align: center;" >:</td>
+                            <td colspan="5">
+                                <h:outputLabel value="#{cc.attrs.receipt.comments}" class="billDetailsFiveFive" ></h:outputLabel>
+                            </td>
+                        </tr>
+                    </h:panelGroup>
+                </table>
+            </div>
+
+            <div class="billline">
+                <hr/>
+            </div>
+
+            <div  >
+                <table style="width: 100%;">
+                    <tr>
+                        <td  style="text-align: left; width: 60%; font-size: 16px!important;
+                             font-family:Verdana, Helvetica, sans-serif!important;
+                             font-weight: bold;">
+                            &nbsp;&nbsp;
+                            <h:outputLabel value="Paying Amount" />
+                        </td>
+                        <td  style="text-align: right!important; width: 40%; padding-right: 32px; font-size: 16px!important;
+                             font-family:Verdana, Helvetica, sans-serif!important;
+                             font-weight: bold;">
+                            <h:outputLabel value="#{cc.attrs.receipt.amount}" >
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+
+            <div class="billline">
+                <hr/>
+            </div>
+
+            <div class="footer" >
+                <div class="row" >
+                    <div class="col-12" >
+                        <h:outputLabel value="Cashier :  #{cc.attrs.receipt.cashierNameWithTitle}"/>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </cc:implementation>
+</html>

--- a/src/main/webapp/resources/inward/bill/payment/FiveFiveCancellationReceipt.xhtml
+++ b/src/main/webapp/resources/inward/bill/payment/FiveFiveCancellationReceipt.xhtml
@@ -1,0 +1,246 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui">
+
+
+    <!-- INTERFACE -->
+    <cc:interface>
+        <cc:attribute name="receipt" type="com.divudi.core.data.dto.InwardBillReceiptDTO" />
+        <cc:attribute name="duplicate" type="java.lang.Boolean"/>
+    </cc:interface>
+
+    <!-- IMPLEMENTATION -->
+    <cc:implementation>
+
+        <h:outputStylesheet library="css" name="opd_five_five.css" ></h:outputStylesheet>
+        <div class="fiveinchbill" style="page-break-after: always" >
+
+            <div class="institutionName">
+                <h:outputLabel value="#{cc.attrs.receipt.departmentPrintingName}" />
+            </div>
+            <div class="institutionContact" >
+                <div>
+                    <h:outputLabel value="#{cc.attrs.receipt.departmentAddress}"/>
+                </div>
+                <div >
+                    <h:outputLabel value="#{cc.attrs.receipt.departmentTelephone1} "/>
+                    <h:outputLabel value=" /" style="width: 20px; text-align: center;"/>
+                    <h:outputLabel value="#{cc.attrs.receipt.departmentTelephone2}"/>
+                </div>
+                <div >
+                    <h:outputLabel value="#{cc.attrs.receipt.departmentFax}"/>
+                </div>
+            </div>
+
+            <div class="headingBillFiveFive" style="text-align: center;font-weight: bold;">
+                <h:outputLabel value="Deposit Cancellation Receipt"   />
+                <h:outputLabel value="**Duplicate**"  rendered="#{cc.attrs.duplicate eq true}" />
+            </div>
+
+            <div class="billline">
+                <hr/>
+            </div>
+
+            <div class="billDetailsFiveFive" >
+                <table style="width: 99%!important;" >
+                    <tr>
+                        <td style="text-align: left;" >
+                            <h:outputLabel value="Admission Type" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+                        <td style="width: 10px;"></td>
+                        <td >:</td>
+                        <td style="width: 5px;"></td>
+                        <td>
+                            <h:outputLabel value="#{cc.attrs.receipt.admissionTypeName}" class="billDetailsFiveFive" >
+                            </h:outputLabel>
+
+                        </td>
+                        <td style="width: 50px;"></td>
+                        <td>
+                            <h:outputLabel value="BHT No" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+                        <td>
+                            <h:outputLabel value=":" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+
+                        <td>
+                            <h:outputLabel value="#{cc.attrs.receipt.bhtNo}" class="billDetailsFiveFive">
+                            </h:outputLabel>
+                        </td>
+
+                    </tr>
+
+                    <tr>
+                        <td style="text-align: left;" >
+                            <h:outputLabel value="Name" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+                        <td style="width: 10px;"></td>
+                        <td >:</td>
+                        <td style="width: 5px;"></td>
+                        <td>
+                            <h:outputLabel value="#{cc.attrs.receipt.patientNameWithTitle}" class="billDetailsFiveFive" >
+                            </h:outputLabel>
+
+                        </td>
+                        <td style="width: 50px;"></td>
+                        <td>
+                            <h:outputLabel value="Age" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+                        <td>
+                            <h:outputLabel value=":" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+
+                        <td>
+                            <h:outputLabel value="#{cc.attrs.receipt.patientAgeAsString}" class="billDetailsFiveFive">
+                            </h:outputLabel>
+                        </td>
+
+                    </tr>
+
+
+                    <tr>
+                        <td style="text-align: left;" >
+                            <h:outputLabel value="Gender" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+                        <td style="width: 10px;"></td>
+                        <td >:</td>
+                        <td style="width: 5px;"></td>
+                        <td>
+                            <h:outputLabel value="#{cc.attrs.receipt.patientSex}" class="billDetailsFiveFive" >
+                            </h:outputLabel>
+
+                        </td>
+                        <td style="width: 50px;"></td>
+                        <td>
+                            <h:outputLabel value="Payment" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+                        <td>
+                            <h:outputLabel value=":" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+
+                        <td>
+                            <h:outputLabel value="#{cc.attrs.receipt.paymentMethod.label}" class="billDetailsFiveFive">
+                            </h:outputLabel>
+                        </td>
+
+                    </tr>
+
+                    <tr>
+                        <td style="text-align: left;" >
+                            <h:outputLabel value="Cancellation Bill No" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+                        <td style="width: 10px;"></td>
+                        <td >:</td>
+                        <td style="width: 5px;"></td>
+                        <td>
+                            <h:outputLabel value="#{cc.attrs.receipt.deptId}" class="billDetailsFiveFive" >
+                            </h:outputLabel>
+
+                        </td>
+                        <td style="width: 50px;"></td>
+                        <td>
+                            <h:outputLabel value="Original Bill No" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+                        <td>
+                            <h:outputLabel value=":" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+
+                        <td>
+                            <h:outputLabel value="#{cc.attrs.receipt.referenceBillDeptId}" class="billDetailsFiveFive">
+                            </h:outputLabel>
+                        </td>
+
+                    </tr>
+                    <tr>
+                        <td style="text-align: left;" >
+                            <h:outputLabel value="Cancelled At" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+                        <td style="width: 10px;"></td>
+                        <td >:</td>
+                        <td style="width: 5px;"></td>
+                        <td>
+                            <h:outputLabel value="#{cc.attrs.receipt.billDate}" class="billDetailsFiveFive" >
+                                <f:convertDateTime pattern="dd/MMM/yyyy" ></f:convertDateTime>
+                            </h:outputLabel>
+
+                        </td>
+                        <td style="width: 50px;"></td>
+                        <td>
+                            <h:outputLabel value="Time" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+                        <td>
+                            <h:outputLabel value=":" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+
+                        <td>
+                            <h:outputLabel value="#{cc.attrs.receipt.billDate}" class="billDetailsFiveFive">
+                                <f:convertDateTime  timeZone="Asia/Colombo" pattern="hh:mm a"  ></f:convertDateTime>
+                            </h:outputLabel>
+                        </td>
+
+                    </tr>
+
+                    <h:panelGroup rendered="#{cc.attrs.receipt.comments ne null and cc.attrs.receipt.comments ne ''}">
+                        <tr>
+                            <td style="text-align: left;" colspan="2">
+                                <h:outputLabel value="Cancellation Reason" class="billDetailsFiveFive" ></h:outputLabel>
+                            </td>
+                            <td >:</td>
+                            <td colspan="6">
+                                <h:outputLabel value="#{cc.attrs.receipt.comments}" class="billDetailsFiveFive" >
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                    </h:panelGroup>
+
+                </table>
+            </div>
+
+            <div class="itemHeadingsFiveFive" >
+
+                <table width="100%" style="width: 100%;" >
+                    <tr>
+                        <td colspan="2" style="text-align: center;" class="billline">
+                            <hr/>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="width:55%!important;">
+                            <h:outputLabel value="Amount" styleClass="itemHeadingsFiveFive" ></h:outputLabel>
+                        </td>
+                        <td  style="width:10%!important;text-align: right; padding-right: 30px!important">
+                            <h:outputLabel value="#{cc.attrs.receipt.amount}"  styleClass="itemHeadingsFiveFive" >
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td colspan="2" style="text-align: center;" class="billline">
+                            <hr />
+                        </td>
+                    </tr>
+                </table>
+
+
+            </div>
+
+            <div style="text-decoration: overline; margin-top: 20px;">
+                <h:outputLabel value="Cashier : #{cc.attrs.receipt.cashierNameWithTitle}"/>
+            </div>
+
+            <div class="footer" style="text-align: center;">
+                <br/>
+                <h:outputLabel value="#{sessionController.userPreference.pharmacyBillFooter}"/>
+                <br/>
+            </div>
+
+
+
+        </div>
+    </cc:implementation>
+</html>

--- a/src/main/webapp/resources/inward/bill/payment/FiveFiveDepositReceipt.xhtml
+++ b/src/main/webapp/resources/inward/bill/payment/FiveFiveDepositReceipt.xhtml
@@ -1,0 +1,238 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui">
+
+
+    <!-- INTERFACE -->
+    <cc:interface>
+        <cc:attribute name="receipt" type="com.divudi.core.data.dto.InwardBillReceiptDTO" />
+        <cc:attribute name="duplicate" type="java.lang.Boolean"/>
+    </cc:interface>
+
+    <!-- IMPLEMENTATION -->
+    <cc:implementation>
+
+        <h:outputStylesheet library="css" name="opd_five_five.css" ></h:outputStylesheet>
+        <div class="fiveinchbill" style="page-break-after: always" >
+
+            <div class="institutionName">
+                <h:outputLabel value="#{cc.attrs.receipt.departmentPrintingName}" />
+            </div>
+            <div class="institutionContact" >
+                <div>
+                    <h:outputLabel value="#{cc.attrs.receipt.departmentAddress}"/>
+                </div>
+                <div >
+                    <h:outputLabel value="#{cc.attrs.receipt.departmentTelephone1} "/>
+                    <h:outputLabel value=" /" style="width: 20px; text-align: center;"/>
+                    <h:outputLabel value="#{cc.attrs.receipt.departmentTelephone2}"/>
+                </div>
+                <div >
+                    <h:outputLabel value="#{cc.attrs.receipt.departmentFax}"/>
+                </div>
+            </div>
+
+            <div class="headingBillFiveFive" style="text-align: center;font-weight: bold;">
+                <h:outputLabel value="Deposit Receipt"   />
+                <h:outputLabel value="**Duplicate**"  rendered="#{cc.attrs.duplicate eq true}" />
+            </div>
+
+            <div class="billline">
+                <hr/>
+            </div>
+
+            <div class="billDetailsFiveFive" >
+                <table style="width: 99%!important;" >
+                    <tr>
+                        <td style="text-align: left;" >
+                            <h:outputLabel value="Admission Type" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+                        <td style="width: 10px;"></td>
+                        <td >:</td>
+                        <td style="width: 5px;"></td>
+                        <td>
+                            <h:outputLabel value="#{cc.attrs.receipt.admissionTypeName}" class="billDetailsFiveFive" >
+                            </h:outputLabel>
+
+                        </td>
+                        <td style="width: 50px;"></td>
+                        <td>
+                            <h:outputLabel value="BHT No" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+                        <td>
+                            <h:outputLabel value=":" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+
+                        <td>
+                            <h:outputLabel value="#{cc.attrs.receipt.bhtNo}" class="billDetailsFiveFive">
+                            </h:outputLabel>
+                        </td>
+
+                    </tr>
+
+                    <tr>
+                        <td style="text-align: left;" >
+                            <h:outputLabel value="Name" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+                        <td style="width: 10px;"></td>
+                        <td >:</td>
+                        <td style="width: 5px;"></td>
+                        <td>
+                            <h:outputLabel value="#{cc.attrs.receipt.patientNameWithTitle}" class="billDetailsFiveFive" >
+                            </h:outputLabel>
+
+                        </td>
+                        <td style="width: 50px;"></td>
+                        <td>
+                            <h:outputLabel value="Age" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+                        <td>
+                            <h:outputLabel value=":" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+
+                        <td>
+                            <h:outputLabel value="#{cc.attrs.receipt.patientAgeAsString}" class="billDetailsFiveFive">
+                            </h:outputLabel>
+                        </td>
+
+                    </tr>
+
+
+                    <tr>
+                        <td style="text-align: left;" >
+                            <h:outputLabel value="Gender" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+                        <td style="width: 10px;"></td>
+                        <td >:</td>
+                        <td style="width: 5px;"></td>
+                        <td>
+                            <h:outputLabel value="#{cc.attrs.receipt.patientSex}" class="billDetailsFiveFive" >
+                            </h:outputLabel>
+
+                        </td>
+                        <td style="width: 50px;"></td>
+                        <td>
+                            <h:outputLabel value="Payment" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+                        <td>
+                            <h:outputLabel value=":" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+
+                        <td>
+                            <h:outputLabel value="#{cc.attrs.receipt.paymentMethod.label}" class="billDetailsFiveFive">
+                            </h:outputLabel>
+                        </td>
+
+                    </tr>
+
+                    <tr>
+                        <td style="text-align: left;" >
+                            <h:outputLabel value="Bill No" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+                        <td style="width: 10px;"></td>
+                        <td >:</td>
+                        <td style="width: 5px;"></td>
+                        <td>
+                            <h:outputLabel value="#{cc.attrs.receipt.deptId}" class="billDetailsFiveFive" >
+                            </h:outputLabel>
+
+                        </td>
+                        <td style="width: 50px;"></td>
+                        <td>
+                            <h:outputLabel value="Bill Date" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+                        <td>
+                            <h:outputLabel value=":" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+
+                        <td>
+                            <h:outputLabel value="#{cc.attrs.receipt.billDate}" class="billDetailsFiveFive">
+                                <f:convertDateTime pattern="dd/MMM/yyyy" ></f:convertDateTime>
+                            </h:outputLabel>
+                        </td>
+
+                    </tr>
+                    <tr>
+                        <td style="text-align: left;" >
+                            <h:outputLabel value="Bill Time" class="billDetailsFiveFive" ></h:outputLabel>
+                        </td>
+                        <td style="width: 10px;"></td>
+                        <td >:</td>
+                        <td style="width: 5px;"></td>
+                        <td>
+                            <h:outputLabel value="#{cc.attrs.receipt.billDate}" class="billDetailsFiveFive" >
+                                <f:convertDateTime  timeZone="Asia/Colombo" pattern="hh:mm a"  ></f:convertDateTime>
+                            </h:outputLabel>
+
+                        </td>
+                        <td style="width: 50px;"></td>
+                        <td/>
+                        <td/>
+                        <td/>
+
+                    </tr>
+
+                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Show Comment on Inward Deposit Bill',false) and cc.attrs.receipt.comments ne null and cc.attrs.receipt.comments ne ''}">
+                        <tr>
+                            <td style="text-align: left;" colspan="2">
+                                <h:outputLabel value="Comment" class="billDetailsFiveFive" ></h:outputLabel>
+                            </td>
+                            <td >:</td>
+                            <td colspan="6">
+                                <h:outputLabel value="#{cc.attrs.receipt.comments}" class="billDetailsFiveFive" >
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                    </h:panelGroup>
+
+                </table>
+            </div>
+
+            <div class="itemHeadingsFiveFive" >
+
+                <table width="100%" style="width: 100%;" >
+                    <tr>
+                        <td colspan="2" style="text-align: center;" class="billline">
+                            <hr/>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="width:55%!important;">
+                            <h:outputLabel value="Paying Amount" styleClass="itemHeadingsFiveFive" ></h:outputLabel>
+                        </td>
+                        <td  style="width:10%!important;text-align: right; padding-right: 30px!important">
+                            <h:outputLabel value="#{cc.attrs.receipt.amount}"  styleClass="itemHeadingsFiveFive" >
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td colspan="2" style="text-align: center;" class="billline">
+                            <hr />
+                        </td>
+                    </tr>
+                </table>
+
+
+            </div>
+
+            <div style="text-decoration: overline; margin-top: 20px;">
+                <h:outputLabel value="Cashier : #{cc.attrs.receipt.cashierNameWithTitle}"/>
+            </div>
+
+            <div class="footer" style="text-align: center;">
+                <br/>
+                <h:outputLabel value="#{sessionController.userPreference.pharmacyBillFooter}"/>
+                <br/>
+            </div>
+
+
+
+        </div>
+    </cc:implementation>
+</html>

--- a/src/main/webapp/resources/inward/bill/payment/PosPaperCancellationReceipt.xhtml
+++ b/src/main/webapp/resources/inward/bill/payment/PosPaperCancellationReceipt.xhtml
@@ -1,0 +1,286 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:h="http://xmlns.jcp.org/jsf/html">
+
+    <!-- INTERFACE -->
+    <cc:interface>
+        <cc:attribute name="receipt" class="com.divudi.core.data.dto.InwardBillReceiptDTO"  />
+        <cc:attribute name="duplicate" />
+    </cc:interface>
+
+    <!-- IMPLEMENTATION -->
+    <cc:implementation>
+
+        <h:outputStylesheet library="css" name="pharmacypos.css" ></h:outputStylesheet>
+        <div class="posbillBreak" style="page-break-after: always">
+
+
+            <div class="institutionName" style="text-align: center!important;
+                 font-weight: bold!important;
+                 font-size: 18px!important;
+                 font-weight: bold;">
+                <h:outputLabel value="#{cc.attrs.receipt.departmentPrintingName}" />
+            </div>
+            <div class="institutionContact" >
+                <div>
+                    <h:outputLabel value="#{cc.attrs.receipt.departmentAddress}"/>
+                </div>
+                <div >
+                    <h:outputLabel value="Phone : #{cc.attrs.receipt.departmentTelephone1} "/>
+                    <h:outputLabel value=" /" style="width: 20px; text-align: center;"/>
+                    <h:outputLabel value="#{cc.attrs.receipt.departmentTelephone2}"/>
+                </div>
+                <div >
+                    <h:outputLabel value="Fax : #{cc.attrs.receipt.departmentFax}"/>
+                </div>
+                <div >
+                    <h:outputLabel value=" Email : #{cc.attrs.receipt.departmentEmail}"/>
+                </div>
+            </div>
+
+            <div>
+                <hr style="border: 1px solid black; margin-left: 5%; margin-right: 5%;" />
+            </div>
+
+            <div class="headingBill">
+                <h:outputLabel value="Deposit Cancellation Receipt" style="font-size: 20px;" /><br/>
+                <h:outputLabel value="**Duplicate**"  rendered="#{cc.attrs.duplicate eq true}" />
+            </div>
+
+
+            <div>
+                <hr style="border: 1px solid black; margin-left: 5%; margin-right: 5%;" />
+            </div>
+
+            <div >
+                <table style="width: 100%; margin-left:0.5cm;" >
+                    <tr>
+                        <td style="width: 30% ;text-align: left;" >
+                            <h:outputLabel
+                                value="Name"
+                                style="text-align: center!important;
+                                font-size: 12px!important;
+                                font-family:Arial, Helvetica, sans-serif!important;">
+                            </h:outputLabel>
+                        </td>
+                        <td>:</td>
+                        <td style="width: 70%;" >
+                            <h:outputLabel
+                                value="#{cc.attrs.receipt.patientNameWithTitle}"
+                                style="text-align: center!important;
+                                font-size: 12px!important;
+                                font-family:Arial, Helvetica, sans-serif!important;">
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td style="width: 15% ;text-align: left;" >
+                            <h:outputLabel
+                                value="Age / Sex"
+                                style="text-align: center!important;
+                                font-size: 12px!important;
+                                font-family:Arial, Helvetica, sans-serif!important;">
+                            </h:outputLabel>
+                        </td>
+                        <td>:</td>
+                        <td style="width: 30%;" >
+                            <div class="d-flex gap-2">
+                                <h:outputLabel
+                                    value="#{cc.attrs.receipt.patientAgeAsString}"
+                                    style="text-align: center!important;
+                                    font-size: 12px!important;
+                                    font-family:Arial, Helvetica, sans-serif!important;">
+                                </h:outputLabel>
+                                <h:outputLabel
+                                    value="/"
+                                    style="text-align: center!important;
+                                    font-size: 12px!important;
+                                    font-family:Arial, Helvetica, sans-serif!important;">
+                                </h:outputLabel>
+                                <h:outputLabel
+                                    value="#{cc.attrs.receipt.patientSex}"
+                                    style="text-align: center!important;
+                                    font-size: 12px!important;
+                                    font-family:Arial, Helvetica, sans-serif!important;">
+                                </h:outputLabel>
+                            </div>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td style="width: 15% ;text-align: left;" >
+                            <h:outputLabel
+                                value="Admission Type"
+                                style="text-align: center!important;
+                                font-size: 12px!important;
+                                font-family:Arial, Helvetica, sans-serif!important;">
+                            </h:outputLabel>
+                        </td>
+                        <td>:</td>
+                        <td style="width: 30%;" >
+                            <h:outputLabel
+                                value="#{cc.attrs.receipt.admissionTypeName}"
+                                style="text-align: center!important;
+                                font-size: 12px!important;
+                                font-family:Arial, Helvetica, sans-serif!important;">
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td style="width: 15% ;text-align: left;" >
+                            <h:outputLabel
+                                value="BHT No"
+                                style="text-align: center!important;
+                                font-size: 12px!important;
+                                font-family:Arial, Helvetica, sans-serif!important;">
+                            </h:outputLabel>
+                        </td>
+                        <td>:</td>
+                        <td style="width: 30%;" >
+                            <h:outputLabel
+                                value="#{cc.attrs.receipt.bhtNo}"
+                                style="text-align: center!important;
+                                font-size: 12px!important;
+                                font-family:Arial, Helvetica, sans-serif!important;">
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td style="width: 15% ;text-align: left;" >
+                            <h:outputLabel
+                                value="Cancelled At"
+                                style="text-align: center!important;
+                                font-size: 12px!important;
+                                font-family:Arial, Helvetica, sans-serif!important;">
+                            </h:outputLabel>
+                        </td>
+                        <td>:</td>
+                        <td style="width: 30%;" >
+                            <h:outputLabel
+                                value="#{cc.attrs.receipt.billDate}"
+                                style="text-align: center!important;
+                                font-size: 12px!important;
+                                font-family:Arial, Helvetica, sans-serif!important;">
+                                <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" ></f:convertDateTime>
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td style="width: 15% ;text-align: left;" >
+                            <h:outputLabel
+                                value="Cancellation Bill No"
+                                style="text-align: center!important;
+                                font-size: 12px!important;
+                                font-family:Arial, Helvetica, sans-serif!important;">
+                            </h:outputLabel>
+                        </td>
+                        <td>:</td>
+                        <td style="width: 30%;" >
+                            <h:outputLabel
+                                value="#{cc.attrs.receipt.deptId}"
+                                style="text-align: center!important;
+                                font-size: 12px!important;
+                                font-family:Arial, Helvetica, sans-serif!important;">
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td style="width: 15% ;text-align: left;" >
+                            <h:outputLabel
+                                value="Payment Method"
+                                style="text-align: center!important;
+                                font-size: 12px!important;
+                                font-family:Arial, Helvetica, sans-serif!important;">
+                            </h:outputLabel>
+                        </td>
+                        <td>:</td>
+                        <td style="width: 30%;" >
+                            <h:outputLabel
+                                value="#{cc.attrs.receipt.paymentMethod.label}"
+                                style="text-align: center!important;
+                                font-size: 12px!important;
+                                font-family:Arial, Helvetica, sans-serif!important;">
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+
+                    <h:panelGroup rendered="#{cc.attrs.receipt.comments ne null and cc.attrs.receipt.comments ne ''}">
+                        <tr>
+                            <td style="width: 15% ;text-align: left;" >
+                                <h:outputLabel
+                                    value="Cancellation Reason"
+                                    style="text-align: center!important;
+                                    font-size: 12px!important;
+                                    font-family:Arial, Helvetica, sans-serif!important;">
+                                </h:outputLabel>
+                            </td>
+                            <td>:</td>
+                            <td style="width: 30%;" >
+                                <h:outputLabel
+                                    value="#{cc.attrs.receipt.comments}"
+                                    style="text-align: center!important;
+                                    font-size: 12px!important;
+                                    font-family:Arial, Helvetica, sans-serif!important;">
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                    </h:panelGroup>
+                </table>
+            </div>
+
+            <div class="billline">
+                <hr style="border: 1px solid black; margin-left: 5%; margin-right: 5%;" />
+            </div>
+
+            <div  >
+                <table style="width: 100%; margin-left:0.5cm; ">
+                    <tr>
+                        <td  class="totalsBlock" style="text-align: left;">
+                            <h:outputLabel value="Amount" style="font-weight: bolder!important;"/>
+                        </td>
+                        <td  class="totalsBlock" style="text-align: right!important; padding-right: 30px;">
+                            <h:outputLabel value="#{cc.attrs.receipt.amount}" style="font-size: 13px!important; font-weight: bolder!important;" >
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+
+            <br/>
+
+            <div class="d-flex justify-content-start mb-3" style="font-size: 12px; margin-left: 0.5cm;">
+                <h:outputLabel value="Original Bill No : #{cc.attrs.receipt.referenceBillDeptId}"
+                               rendered="#{cc.attrs.receipt.referenceBillDeptId ne null}">
+                </h:outputLabel>
+            </div>
+
+            <div class=" d-flex justify-content-center">
+                <h:outputLabel
+                    value="Cashier : #{cc.attrs.receipt.cashierNameWithTitle}">
+                </h:outputLabel>
+            </div>
+
+            <div class="footer">
+                <br/>
+                The Greatest Wealth is Health!
+                <h:panelGroup  rendered="#{sessionController.loggedPreference.pharmacyBillFooter ne null}">
+                    <br/>
+                </h:panelGroup>
+                <h:outputLabel value="#{sessionController.loggedPreference.pharmacyBillFooter}" ></h:outputLabel>
+                <br/>
+                <h:outputLabel value="Powered by CareCode (Pvt) Ltd" style="font-size: 10px;"></h:outputLabel>
+            </div>
+
+        </div>
+    </cc:implementation>
+</html>

--- a/src/main/webapp/resources/inward/bill/payment/PosPaperCancellationReceipt.xhtml
+++ b/src/main/webapp/resources/inward/bill/payment/PosPaperCancellationReceipt.xhtml
@@ -8,8 +8,8 @@
 
     <!-- INTERFACE -->
     <cc:interface>
-        <cc:attribute name="receipt" class="com.divudi.core.data.dto.InwardBillReceiptDTO"  />
-        <cc:attribute name="duplicate" />
+        <cc:attribute name="receipt" type="com.divudi.core.data.dto.InwardBillReceiptDTO" />
+        <cc:attribute name="duplicate" type="java.lang.Boolean"/>
     </cc:interface>
 
     <!-- IMPLEMENTATION -->

--- a/src/main/webapp/resources/inward/bill/payment/PosPaperDepositReceipt.xhtml
+++ b/src/main/webapp/resources/inward/bill/payment/PosPaperDepositReceipt.xhtml
@@ -8,8 +8,8 @@
 
     <!-- INTERFACE -->
     <cc:interface>
-        <cc:attribute name="receipt" class="com.divudi.core.data.dto.InwardBillReceiptDTO"  />
-        <cc:attribute name="duplicate" />
+        <cc:attribute name="receipt" type="com.divudi.core.data.dto.InwardBillReceiptDTO" />
+        <cc:attribute name="duplicate" type="java.lang.Boolean"/>
     </cc:interface>
 
     <!-- IMPLEMENTATION -->

--- a/src/main/webapp/resources/inward/bill/payment/PosPaperDepositReceipt.xhtml
+++ b/src/main/webapp/resources/inward/bill/payment/PosPaperDepositReceipt.xhtml
@@ -1,0 +1,279 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:h="http://xmlns.jcp.org/jsf/html">
+
+    <!-- INTERFACE -->
+    <cc:interface>
+        <cc:attribute name="receipt" class="com.divudi.core.data.dto.InwardBillReceiptDTO"  />
+        <cc:attribute name="duplicate" />
+    </cc:interface>
+
+    <!-- IMPLEMENTATION -->
+    <cc:implementation>
+
+        <h:outputStylesheet library="css" name="pharmacypos.css" ></h:outputStylesheet>
+        <div class="posbillBreak" style="page-break-after: always">
+
+
+            <div class="institutionName" style="text-align: center!important;
+                 font-weight: bold!important;
+                 font-size: 18px!important;
+                 font-weight: bold;">
+                <h:outputLabel value="#{cc.attrs.receipt.departmentPrintingName}" />
+            </div>
+            <div class="institutionContact" >
+                <div>
+                    <h:outputLabel value="#{cc.attrs.receipt.departmentAddress}"/>
+                </div>
+                <div >
+                    <h:outputLabel value="Phone : #{cc.attrs.receipt.departmentTelephone1} "/>
+                    <h:outputLabel value=" /" style="width: 20px; text-align: center;"/>
+                    <h:outputLabel value="#{cc.attrs.receipt.departmentTelephone2}"/>
+                </div>
+                <div >
+                    <h:outputLabel value="Fax : #{cc.attrs.receipt.departmentFax}"/>
+                </div>
+                <div >
+                    <h:outputLabel value=" Email : #{cc.attrs.receipt.departmentEmail}"/>
+                </div>
+            </div>
+
+            <div>
+                <hr style="border: 1px solid black; margin-left: 5%; margin-right: 5%;" />
+            </div>
+
+            <div class="headingBill">
+                <h:outputLabel value="Deposit Receipt" style="font-size: 20px;" /><br/>
+                <h:outputLabel value="**Duplicate**"  rendered="#{cc.attrs.duplicate eq true}" />
+            </div>
+
+
+            <div>
+                <hr style="border: 1px solid black; margin-left: 5%; margin-right: 5%;" />
+            </div>
+
+            <div >
+                <table style="width: 100%; margin-left:0.5cm;" >
+                    <tr>
+                        <td style="width: 30% ;text-align: left;" >
+                            <h:outputLabel
+                                value="Name"
+                                style="text-align: center!important;
+                                font-size: 12px!important;
+                                font-family:Arial, Helvetica, sans-serif!important;">
+                            </h:outputLabel>
+                        </td>
+                        <td>:</td>
+                        <td style="width: 70%;" >
+                            <h:outputLabel
+                                value="#{cc.attrs.receipt.patientNameWithTitle}"
+                                style="text-align: center!important;
+                                font-size: 12px!important;
+                                font-family:Arial, Helvetica, sans-serif!important;">
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td style="width: 15% ;text-align: left;" >
+                            <h:outputLabel
+                                value="Age / Sex"
+                                style="text-align: center!important;
+                                font-size: 12px!important;
+                                font-family:Arial, Helvetica, sans-serif!important;">
+                            </h:outputLabel>
+                        </td>
+                        <td>:</td>
+                        <td style="width: 30%;" >
+                            <div class="d-flex gap-2">
+                                <h:outputLabel
+                                    value="#{cc.attrs.receipt.patientAgeAsString}"
+                                    style="text-align: center!important;
+                                    font-size: 12px!important;
+                                    font-family:Arial, Helvetica, sans-serif!important;">
+                                </h:outputLabel>
+                                <h:outputLabel
+                                    value="/"
+                                    style="text-align: center!important;
+                                    font-size: 12px!important;
+                                    font-family:Arial, Helvetica, sans-serif!important;">
+                                </h:outputLabel>
+                                <h:outputLabel
+                                    value="#{cc.attrs.receipt.patientSex}"
+                                    style="text-align: center!important;
+                                    font-size: 12px!important;
+                                    font-family:Arial, Helvetica, sans-serif!important;">
+                                </h:outputLabel>
+                            </div>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td style="width: 15% ;text-align: left;" >
+                            <h:outputLabel
+                                value="Admission Type"
+                                style="text-align: center!important;
+                                font-size: 12px!important;
+                                font-family:Arial, Helvetica, sans-serif!important;">
+                            </h:outputLabel>
+                        </td>
+                        <td>:</td>
+                        <td style="width: 30%;" >
+                            <h:outputLabel
+                                value="#{cc.attrs.receipt.admissionTypeName}"
+                                style="text-align: center!important;
+                                font-size: 12px!important;
+                                font-family:Arial, Helvetica, sans-serif!important;">
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td style="width: 15% ;text-align: left;" >
+                            <h:outputLabel
+                                value="BHT No"
+                                style="text-align: center!important;
+                                font-size: 12px!important;
+                                font-family:Arial, Helvetica, sans-serif!important;">
+                            </h:outputLabel>
+                        </td>
+                        <td>:</td>
+                        <td style="width: 30%;" >
+                            <h:outputLabel
+                                value="#{cc.attrs.receipt.bhtNo}"
+                                style="text-align: center!important;
+                                font-size: 12px!important;
+                                font-family:Arial, Helvetica, sans-serif!important;">
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td style="width: 15% ;text-align: left;" >
+                            <h:outputLabel
+                                value="Date At"
+                                style="text-align: center!important;
+                                font-size: 12px!important;
+                                font-family:Arial, Helvetica, sans-serif!important;">
+                            </h:outputLabel>
+                        </td>
+                        <td>:</td>
+                        <td style="width: 30%;" >
+                            <h:outputLabel
+                                value="#{cc.attrs.receipt.billDate}"
+                                style="text-align: center!important;
+                                font-size: 12px!important;
+                                font-family:Arial, Helvetica, sans-serif!important;">
+                                <f:convertDateTime timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" ></f:convertDateTime>
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td style="width: 15% ;text-align: left;" >
+                            <h:outputLabel
+                                value="Bill No"
+                                style="text-align: center!important;
+                                font-size: 12px!important;
+                                font-family:Arial, Helvetica, sans-serif!important;">
+                            </h:outputLabel>
+                        </td>
+                        <td>:</td>
+                        <td style="width: 30%;" >
+                            <h:outputLabel
+                                value="#{cc.attrs.receipt.deptId}"
+                                style="text-align: center!important;
+                                font-size: 12px!important;
+                                font-family:Arial, Helvetica, sans-serif!important;">
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td style="width: 15% ;text-align: left;" >
+                            <h:outputLabel
+                                value="Payment Method"
+                                style="text-align: center!important;
+                                font-size: 12px!important;
+                                font-family:Arial, Helvetica, sans-serif!important;">
+                            </h:outputLabel>
+                        </td>
+                        <td>:</td>
+                        <td style="width: 30%;" >
+                            <h:outputLabel
+                                value="#{cc.attrs.receipt.paymentMethod.label}"
+                                style="text-align: center!important;
+                                font-size: 12px!important;
+                                font-family:Arial, Helvetica, sans-serif!important;">
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+
+                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Show Comment on Inward Deposit Bill',false) and cc.attrs.receipt.comments ne null and cc.attrs.receipt.comments ne ''}">
+                        <tr>
+                            <td style="width: 15% ;text-align: left;" >
+                                <h:outputLabel
+                                    value="Comment"
+                                    style="text-align: center!important;
+                                    font-size: 12px!important;
+                                    font-family:Arial, Helvetica, sans-serif!important;">
+                                </h:outputLabel>
+                            </td>
+                            <td>:</td>
+                            <td style="width: 30%;" >
+                                <h:outputLabel
+                                    value="#{cc.attrs.receipt.comments}"
+                                    style="text-align: center!important;
+                                    font-size: 12px!important;
+                                    font-family:Arial, Helvetica, sans-serif!important;">
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                    </h:panelGroup>
+                </table>
+            </div>
+
+            <div class="billline">
+                <hr style="border: 1px solid black; margin-left: 5%; margin-right: 5%;" />
+            </div>
+
+            <div  >
+                <table style="width: 100%; margin-left:0.5cm; ">
+                    <tr>
+                        <td  class="totalsBlock" style="text-align: left;">
+                            <h:outputLabel value="Paying Amount" style="font-weight: bolder!important;"/>
+                        </td>
+                        <td  class="totalsBlock" style="text-align: right!important; ; padding-right: 30px;">
+                            <h:outputLabel value="#{cc.attrs.receipt.amount}" style="font-size: 13px!important; font-weight: bolder!important;" >
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputLabel>
+
+                        </td>
+                    </tr>
+                </table>
+            </div>
+
+            <br/>
+
+            <div class=" d-flex justify-content-center">
+                <h:outputLabel
+                    value="Cashier : #{cc.attrs.receipt.cashierNameWithTitle}">
+                </h:outputLabel>
+            </div>
+
+            <div class="footer">
+                <br/>
+                The Greatest Wealth is Health!
+                <h:panelGroup  rendered="#{sessionController.loggedPreference.pharmacyBillFooter ne null}">
+                    <br/>
+                </h:panelGroup>
+                <h:outputLabel value="#{sessionController.loggedPreference.pharmacyBillFooter}" ></h:outputLabel>
+            </div>
+
+        </div>
+    </cc:implementation>
+</html>


### PR DESCRIPTION
## Summary

- **Separate, independently-printable receipts** on the appointment→inward-deposit conversion page: the original appointment payment's cancellation receipt and the new inpatient deposit receipt each get their own paper-format Settings button and Print button, so the cashier can print just the cancellation while the deposit receipt (the one that goes to the insurance company) prints separately. Both support A4, POS, and Five Five paper formats via a shared `InwardBillReceiptDTO` and 6 new DTO-bound print composites (existing entity-bound composites are untouched).
- **`printPreview` flag** on `AdmissionController`: `false` when navigating to the conversion page, flips to `true` only after a successful conversion — this is what reveals the two receipt panels.
- **Three-zone page header** on the conversion page (title/patient badge — Inpatient Dashboard / Nursing WorkBench nav — actions), per the project's UI guidelines.
- **Per-admission "Payments & Cancellations" report**, linked from the Inpatient Dashboard's Reports panel — lists all of an admission's deposit and appointment-bill payments plus their cancellations, with a View/reprint action per row.
- **Department-wide, filterable Payments report** (From/To Date, BHT No, Patient Name), linked from a new "Payments" panel on the Nursing Dashboard (mirrors the existing Pharmaceuticals panel's Actions/separator/Reports layout), gated by a new `NursingWorkBenchPanelPayments` privilege.
- Fixed a routing gap in `BillSearch.navigateToViewBillByAtomicBillTypeByBillId` — `INWARD_DEPOSIT*` and `INWARD_APPOINTMENT*` bill types previously had no view/reprint destination; appointment bill types now route to a new `inward_view_appointment_bill_receipt.xhtml` page reusing the same DTO/composites.

## Test plan

- [x] Rebuilt and redeployed locally; verified via Playwright against the local `coop` DB (BHT/56754, department: Inward)
- [x] Confirmed the per-admission report shows all 4 related bills (appointment bill "Cancelled", deposit, cancellation, second deposit) with correct highlighting and a correct footer net total (2,222.00)
- [x] Confirmed the department-wide report's date/BHT/patient-name filters work and correctly aggregate both deposit and appointment-type bills/cancellations across patients, with a correct footer total
- [x] Confirmed the new appointment-bill view/reprint page renders the correct receipt (cancellation vs deposit, inferred from `referenceBillDeptId`) and that the patient name resolves correctly for appointment bills (which have no `patientEncounter`)
- [x] Confirmed the new `NursingWorkBenchPanelPayments` privilege is assignable through the existing admin "Manage Privileges" tree UI, and that the "Payments" panel appears on the Nursing Dashboard once granted
- [x] DB-verified local department print config (`CONFIGOPTION` `Inward - Inward Payment Bill * Paper`) before/after test toggles, restored to original state

### Screenshots

**Appointment bill receipt (patient name correctly resolved for appointment-only bills):**
![Appointment bill receipt](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/22783-01-appointment-bill-receipt-name-fixed.png)

**Department-wide filterable Payments report:**
![Department Payments report](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/22783-02-department-payments-report.png)

**Per-admission Payments & Cancellations report (BHT/56754):**
![Inpatient Payments report](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/22783-03-inpatient-payments-report.png)

**New "Payments" panel on the Nursing Dashboard:**
![Nursing Dashboard Payments panel](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/22783-04-nursing-dashboard-payments-panel.png)

### Known limitation (flagged, not fixed in this PR)

The local "Inward" department's active print config uses "Five Five Custom 3 Paper", a 4th format not covered by the 3 formats (A4/POS/Five Five) this PR builds composites for — receipts render blank under that specific config until either a 4th composite pair is added or the department switches to one of the 3 supported formats via Settings. Scope was confirmed as 3 formats during planning.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a privilege-controlled Nursing Workbench Payments panel for appointment deposit conversion and inpatient payment reporting.
  - Added admission- and department-based payment reports with filters, totals, status indicators, printing, and XLSX export.
  - Added navigation and receipt views for inward deposits, cancellations, refunds, and appointment bills.
  - Added printable POS, 5×5, custom 5×5, and A4 receipts with configurable paper settings and duplicate receipt support.
- **Bug Fixes**
  - Improved missing-bill handling and error reporting during deposit cancellations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->