### PR TITLE
Resolve role-based trigger subscriptions to users (#22791)

### DIFF
--- a/src/main/java/com/divudi/bean/common/TriggerSubscriptionController.java
+++ b/src/main/java/com/divudi/bean/common/TriggerSubscriptionController.java
@@ -64,16 +64,46 @@ public class TriggerSubscriptionController implements Serializable {
         // DISTINCT avoids duplicate UserNotifications when a user holds both a
         // department-specific and an application-wide subscription for the trigger.
         Map m = new HashMap();
-        String jpql = "SELECT DISTINCT i.webUser "
-                + " FROM TriggerSubscription i "
-                + " where i.triggerType=:tt "
-                + " and i.retired=:ret "
-                + " and (i.department=:dep or i.department is null)";
-
         m.put("tt", tt);
         m.put("ret", false);
         m.put("dep", dept);
-        us = webUserFacade.findByJpql(jpql, m);
+
+        String directUserJpql = "SELECT DISTINCT i.webUser "
+                + " FROM TriggerSubscription i "
+                + " where i.triggerType=:tt "
+                + " and i.retired=:ret "
+                + " and i.webUser is not null "
+                + " and (i.department=:dep or i.department is null)";
+        List<WebUser> directUsers = webUserFacade.findByJpql(directUserJpql, m);
+        if (directUsers != null) {
+            us.addAll(directUsers);
+        }
+
+        // TriggerSubscription.webUser is nullable because a subscription can
+        // instead target a WebUserRole (UserRoleTriggerSubscriptionController).
+        // Resolve those role-based subscriptions to their member users via
+        // WebUserRoleUser and merge (de-duplicated) with the direct subscribers,
+        // instead of letting the role rows surface as null entries (issue #22791).
+        String roleUserJpql = "SELECT DISTINCT ru.webUser "
+                + " FROM WebUserRoleUser ru "
+                + " where ru.retired=:ret "
+                + " and ru.webUser is not null "
+                + " and ru.webUserRole in ("
+                + "   SELECT i.webUserRole FROM TriggerSubscription i "
+                + "   where i.triggerType=:tt "
+                + "   and i.retired=:ret "
+                + "   and i.webUserRole is not null "
+                + "   and (i.department=:dep or i.department is null)"
+                + " )";
+        List<WebUser> roleUsers = webUserFacade.findByJpql(roleUserJpql, m);
+        if (roleUsers != null) {
+            for (WebUser u : roleUsers) {
+                if (u != null && !us.contains(u)) {
+                    us.add(u);
+                }
+            }
+        }
+
         return us;
     }
 

--- a/src/main/java/com/divudi/bean/common/UserNotificationController.java
+++ b/src/main/java/com/divudi/bean/common/UserNotificationController.java
@@ -543,18 +543,31 @@ public class UserNotificationController implements Serializable {
         switch (n.getTriggerType().getMedium()) {
             case EMAIL:
                 for (WebUser u : notificationUsers) {
+                    if (u == null) {
+                        continue;
+                    }
                     String number = u.getWebUserPerson().getMobile();
                     //TODo
                 }
                 break;
             case SMS:
                 for (WebUser u : notificationUsers) {
+                    if (u == null) {
+                        continue;
+                    }
                     String number = u.getWebUserPerson().getMobile();
                     sendSmsForUserSubscriptions(number);
                 }
                 break;
             case SYSTEM_NOTIFICATION:
+                // Defensive null-check kept as a second line of defense: even though
+                // fillSubscribedUsersByDepartment now resolves role-based subscriptions
+                // to real users, a future gap of this kind should degrade to "one user
+                // doesn't get notified" instead of crashing the whole action (issue #22791).
                 for (WebUser u : notificationUsers) {
+                    if (u == null) {
+                        continue;
+                    }
                     UserNotification nun = new UserNotification();
                     nun.setNotification(n);
                     nun.setWebUser(u);


### PR DESCRIPTION
## Summary
Fixes issue #22791 by properly resolving role-based trigger subscriptions to their member users, preventing null entries from surfacing in user notification lists.

## Key Changes
- **TriggerSubscriptionController.fillSubscribedUsersByDepartment()**: Split the single JPQL query into two separate queries:
  - Direct user subscriptions: queries `TriggerSubscription` where `webUser` is not null
  - Role-based subscriptions: queries `WebUserRoleUser` to resolve users belonging to subscribed roles, then merges results with deduplication
  - Added explanatory comments documenting why role-based subscriptions must be resolved separately

- **UserNotificationController.createUserNotificationsForMedium()**: Added defensive null-checks in all three notification medium branches (EMAIL, SMS, SYSTEM_NOTIFICATION) to skip null users gracefully instead of crashing
  - Includes a comment explaining this is a second line of defense against future similar issues

## Implementation Details
- The role-based subscription resolution uses a subquery to find all `WebUserRole` entries in `TriggerSubscription` matching the trigger type and department, then resolves those roles to their member users via `WebUserRoleUser`
- Manual deduplication is performed when adding role-based users to avoid duplicates (a user could be both a direct subscriber and a role member)
- Null-checks in notification processing are defensive; they degrade gracefully to "one user doesn't get notified" rather than crashing the entire notification action

https://claude.ai/code/session_013szqExiqiJUsRTiUS2VdZ9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved department-based subscription handling to include both direct and role-based subscriptions.
  * Included application-wide subscriptions while removing duplicate and inactive entries.
  * Prevented notification processing from failing when subscribed user records are unavailable.
  * Skipped invalid users safely across email, SMS, and system notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->