### PR TITLE
fix(inward): BHT Deposit and Credit Settlement Detail report ignores cancelled CC payments

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -1569,6 +1569,43 @@ While testing issue #22719 (appointment → admission → deposit conversion), t
     `SELECT OPTIONVALUE FROM configoption WHERE OPTIONKEY = '...'` — this is
     live config on a real hospital's local dev copy, not disposable test data.
 
+## 59. `CreditCompanyBillSearch.printPreview` is a single shared flag reused for two different meanings — viewing a bill before cancelling can make the cancel form permanently unreachable via normal navigation
+
+On `credit/credit_company_bill_search.xhtml` → **View** → `inpatient_credit_company_bill_reprint.xhtml` → **To Cancel** → `inpatient_credit_company_bill_cancel.xhtml`, the cancel page conditionally
+renders either the cancel **form** (`rendered="#{!creditCompanyBillSearch.printPreview}"`) or a
+read-only "cancellation receipt" preview (`rendered="#{creditCompanyBillSearch.printPreview}"`).
+`BillSearch.navigateToViewBillByAtomicBillType()` (used by the search page's **View** button) calls
+`creditCompanyBillSearch.setBill(bill)` (which resets `printPreview=false` via `recreateModel()`)
+**immediately followed by** `creditCompanyBillSearch.setPrintPreview(true)` — by design, so the
+Reprint page shows a print preview. But `printPreview` is `@SessionScoped` and shared with the
+Cancel page, and clicking **To Cancel** is a plain outcome-string navigation (no bean method call)
+that never resets it. Result: landing on the cancel page via the only in-UI path always shows the
+receipt view instead of the cancel form — **there is no button an end user can click to actually
+reach the cancel form**, even though nothing has been cancelled yet (verify via
+`SELECT CANCELLED FROM BILL WHERE ID=...` — it's still `0`). This is a real product bug, not a
+Playwright limitation; flag/file it rather than silently building around it. Found while verifying
+issue #19931.
+
+**Workaround used only for E2E verification** (not a fix an end user has access to): reach the same
+bill via `credit/credit_company_bill_search_billItems.xhtml` → **Search BHT** → **View Bill**
+instead. That page's button does a *raw* `f:setPropertyActionListener value="#{b.bill}"
+target="#{creditCompanyBillSearch.bill}"` with no follow-up `setPrintPreview(true)`, so
+`printPreview` stays `false`. It navigates to the *generic* `credit_company_bill_reprint.xhtml`
+(whose own **To Cancel** button targets `credit_company_bill_cancel.xhtml` and the *different*
+`creditCompanyBillSearch.cancelBill()` method — **do not click that button**, it may produce the
+wrong `BillTypeAtomic` for an inpatient bill). Instead, once `creditCompanyBillSearch.bill` +
+`printPreview=false` are set, `browser_navigate` directly to
+`inpatient_credit_company_bill_cancel.xhtml` — the session-scoped bean state carries over and the
+correct cancel form (bound to `cancelCreditCompanyPaymentBill()`) renders.
+
+Separately: the cancel form's "Enter a comment" `p:inputText` is required by
+`CreditCompanyBillSearch.errorCheck()` (`"Please enter a comment"`), but that page has no visible
+`<p:messages>`/`<h:messages>` for the resulting `JsfUtil.addErrorMessage(...)` — clicking **Cancel**
+with it empty just re-renders the identical form with **zero visible feedback and zero DB change**,
+easy to mistake for the click not registering at all. Always fill the comment field first; if a
+"Cancel" (or similarly `ajax="false"`) button appears to no-op, check for this pattern before
+assuming a click/ref problem.
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.

--- a/src/main/java/com/divudi/bean/inward/BhtPaymentDetailReportController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtPaymentDetailReportController.java
@@ -209,11 +209,19 @@ public class BhtPaymentDetailReportController implements Serializable {
         return paymentFacade.findByJpql(jpql.toString(), params);
     }
 
+    /**
+     * Fetch BillItems from INPATIENT_CREDIT_COMPANY_PAYMENT_RECEIVED and
+     * INPATIENT_CREDIT_COMPANY_PAYMENT_CANCELLATION bills that reference this encounter.
+     * Deliberately does NOT filter on bi.bill.cancelled: cancelling a CC payment sets
+     * cancelled=true on the original RECEIVED bill while its negative-value items live on
+     * a separate CANCELLATION bill, so filtering by cancelled would drop the original
+     * positive row and leave only the negative one. Including both rows with their signed
+     * netValue preserves the audit trail and nets out correctly.
+     */
     private List<BillItem> fetchCreditSettlementItems(PatientEncounter enc) {
         String jpql = "select bi from BillItem bi"
                 + " where bi.retired = false"
                 + " and bi.bill.retired = false"
-                + " and bi.bill.cancelled = false"
                 + " and bi.bill.billTypeAtomic in :btas"
                 + " and bi.patientEncounter = :enc"
                 + " order by bi.createdAt";


### PR DESCRIPTION
## What changed

`BhtPaymentDetailReportController.fetchCreditSettlementItems()` filtered on
`bi.bill.cancelled = false`. Cancelling a CC payment marks the **original**
`INPATIENT_CREDIT_COMPANY_PAYMENT_RECEIVED` bill's `cancelled` flag `true`
while the offsetting negative amount lives on a **separate**
`INPATIENT_CREDIT_COMPANY_PAYMENT_CANCELLATION` bill (never itself marked
cancelled). The filter therefore silently dropped the original positive row
while still showing the negative cancellation row — wrong per-row detail and
a swung total, instead of "positive row + negative row = net zero".

This is the exact same bug already fixed for the sibling **summary** report
in #19772 (commit `fd07f588`). Applied the identical, proven fix here:
removed the `bi.bill.cancelled = false` clause. The detail controller
already queried both `RECEIVED`/`CANCELLATION` bill types and already summed
signed `netValue` (not `Math.abs()`), so this one-line removal was
sufficient — no other files needed to change.

Closes #19931

## Verification (Playwright + DB, local Payara)

1. Created a real CC payment: BHT/55360, AIA Insurance Lanka PLC, ₨9,000 via
   **Credit Company Management → Inpatient Credit Management**.
2. Generated the **BHT Deposit and Credit Settlement Detail** report —
   confirmed the positive settlement row appears (CC Settlement / Grand
   Total = 9,000.00):

   ![Before cancellation](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/19931-bht-payment-detail-before-cancellation.png)

3. Cancelled the payment via **Credit Company Payment Bill Search → Cancel**.
4. Regenerated the report — confirmed **both** rows now appear (original
   +9,000.00, cancellation -9,000.00), netting correctly to CC Settlement /
   Grand Total = 0.00:

   ![After cancellation](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/19931-bht-payment-detail-after-cancellation.png)

5. **DB cross-check**: `SUM(BILLITEM.NETVALUE)` across the RECEIVED and
   CANCELLATION bill items tied to the admission = **0**, matching the
   report exactly.

Full before/after evidence and DB verification also posted as a comment on
#19931.

## Also found (filed separately, out of scope here)

While reaching the cancel flow for testing, found that the inpatient CC
payment cancel form is unreachable via normal in-app navigation (a shared
session-scoped `printPreview` flag gets stuck `true` after viewing a bill,
so the cancel page always shows a read-only receipt instead of the actual
cancel form). Filed as #22793 — not fixed here since it's unrelated to this
report bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Credit-company settlement reports now include both received and cancelled payment entries, with cancellation amounts reflected correctly.

- **Documentation**
  - Added end-to-end testing guidance for cancelling inpatient bills, including navigation workarounds and the required cancellation comment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->