### PR TITLE
Add Site and Department columns to outside inward bill report

### DIFF
--- a/src/main/webapp/inward/report_out_side_inward_bill.xhtml
+++ b/src/main/webapp/inward/report_out_side_inward_bill.xhtml
@@ -103,6 +103,18 @@
                             </f:facet>
                             <p:outputLabel value="#{bi.bill.fromInstitution.name}" />
                         </p:column>
+                        <p:column headerText="Site">
+                            <f:facet name="header">
+                                <p:outputLabel value="Site" />
+                            </f:facet>
+                            <p:outputLabel value="#{bi.bill.institution.name}" />
+                        </p:column>
+                        <p:column headerText="Department">
+                            <f:facet name="header">
+                                <p:outputLabel value="Department" />
+                            </f:facet>
+                            <p:outputLabel value="#{bi.bill.department.name}" />
+                        </p:column>
                         <p:column headerText="Discription">
                             <f:facet name="header">
                                 <p:outputLabel value="Discription" />


### PR DESCRIPTION
## Summary
Added two new columns to the outside inward bill report table to display Site and Department information for each bill.

## Changes
- Added "Site" column displaying `bill.institution.name`
- Added "Department" column displaying `bill.department.name`
- Both columns inserted after the "From Institution" column in the report table

## Implementation Details
The new columns follow the existing pattern in the report:
- Each column includes a header facet with `p:outputLabel`
- Data is bound to the corresponding bill entity properties
- Columns are positioned logically in the bill information flow (after source institution, before description)

This change enhances the report's visibility into bill organizational context without modifying any business logic or data model.

https://claude.ai/code/session_01K6LtJ6v2jfGLsnV4WNekWS