### PR TITLE
feat(inward): Summary/Detailed report types, BHT-range search, rowspan layout for Professional Payment Report

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardReportControllerBht.java
+++ b/src/main/java/com/divudi/bean/inward/InwardReportControllerBht.java
@@ -46,10 +46,14 @@ import com.divudi.core.data.dto.InpatientServiceIssueDTO;
 import com.divudi.core.data.dto.BillListReportDTO;
 import com.divudi.core.data.dto.InwardProfessionalPaymentAdmissionDTO;
 import com.divudi.core.data.dto.InwardProfessionalPaymentAdmissionGroupDTO;
+import com.divudi.core.data.dto.InwardProfessionalPaymentDetailRowDTO;
 import com.divudi.core.data.dto.InwardProfessionalPaymentFeeRowDTO;
 import com.divudi.core.data.dto.InwardProfessionalPaymentReportRowDTO;
 import com.divudi.core.entity.Service;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
 import java.io.Serializable;
+import java.text.DecimalFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -66,7 +70,23 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.faces.context.ExternalContext;
+import javax.faces.context.FacesContext;
 import javax.persistence.TemporalType;
+import javax.servlet.http.HttpServletResponse;
+import com.lowagie.text.Element;
+import com.lowagie.text.FontFactory;
+import com.lowagie.text.Phrase;
+import com.lowagie.text.pdf.PdfPCell;
+import com.lowagie.text.pdf.PdfPTable;
+// NOTE: com.lowagie.text.Document/Font are used fully-qualified in the PDF
+// export methods below (not imported) - org.apache.poi.ss.usermodel.Font
+// (pulled in by the wildcard import) would otherwise collide with the
+// same-named PDF class.
+import org.apache.poi.ss.usermodel.*;
+import org.apache.poi.ss.util.CellRangeAddress;
+import org.apache.poi.xssf.usermodel.XSSFSheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 
 /**
  *
@@ -143,6 +163,15 @@ public class InwardReportControllerBht implements Serializable {
 
     // Issue #22800 - admission-grouped inpatient professional payment report.
     private List<InwardProfessionalPaymentAdmissionGroupDTO> professionalPaymentReportGroups;
+
+    // Issue #22803 - Summary vs Detailed report type, BHT-range search mode
+    // (admission-to-admission instead of a date range), and a filter to show
+    // only admissions that never got any professional fee added.
+    private String professionalPaymentReportType = "summary"; // "summary" | "detailed"
+    private String professionalPaymentSearchMode = "dateRange"; // "dateRange" | "bhtRange"
+    private PatientEncounter admissionFromForProfessionalPaymentReport;
+    private PatientEncounter admissionToForProfessionalPaymentReport;
+    private boolean onlyAdmissionsWithoutProfessionalFees;
 
     private List<BillItem> labBillItemsToPatientEncounter;
     private double labBillItemsToPatientEncounterNetTotal;
@@ -842,6 +871,549 @@ public class InwardReportControllerBht implements Serializable {
         return "/inward/reports/inward_professional_payment_report_dto?faces-redirect=true";
     }
 
+    // Issue #22803 - row-span helpers shared by the Excel and PDF exporters,
+    // delegating to the same DTO getters the xhtml view binds `rowspan` to
+    // (InwardProfessionalPaymentAdmissionGroupDTO.getSummaryAdmissionRowSpan/
+    // getDetailedAdmissionRowSpan, InwardProfessionalPaymentDetailRowDTO.
+    // getBlockRowSpan) so the export layout can never drift from the on-screen one.
+    private int summaryAdmissionRowSpan(InwardProfessionalPaymentAdmissionGroupDTO group) {
+        return group.getSummaryAdmissionRowSpan();
+    }
+
+    private int detailedConsultantBlockRowSpan(InwardProfessionalPaymentDetailRowDTO detail) {
+        return detail.getBlockRowSpan();
+    }
+
+    private int detailedAdmissionRowSpan(InwardProfessionalPaymentAdmissionGroupDTO group) {
+        return group.getDetailedAdmissionRowSpan();
+    }
+
+    // Issue #22803 - Excel export for the Summary report.
+    public void downloadProfessionalPaymentSummaryExcel() {
+        if (professionalPaymentReportGroups == null || professionalPaymentReportGroups.isEmpty()) {
+            JsfUtil.addErrorMessage("No data to export. Please process the report first.");
+            return;
+        }
+
+        FacesContext facesContext = FacesContext.getCurrentInstance();
+        HttpServletResponse response = (HttpServletResponse) facesContext.getExternalContext().getResponse();
+        SimpleDateFormat dateFormat = new SimpleDateFormat("dd/MM/yyyy");
+
+        try (XSSFWorkbook workbook = new XSSFWorkbook()) {
+            XSSFSheet sheet = workbook.createSheet("Professional Payment Summary");
+
+            CellStyle headerStyle = workbook.createCellStyle();
+            Font headerFont = workbook.createFont();
+            headerFont.setBold(true);
+            headerFont.setColor(IndexedColors.WHITE.getIndex());
+            headerStyle.setFont(headerFont);
+            headerStyle.setFillForegroundColor(IndexedColors.GREY_50_PERCENT.getIndex());
+            headerStyle.setFillPattern(FillPatternType.SOLID_FOREGROUND);
+
+            DataFormat dataFormat = workbook.createDataFormat();
+            CellStyle moneyStyle = workbook.createCellStyle();
+            moneyStyle.setDataFormat(dataFormat.getFormat("#,##0.00"));
+
+            String[] headers = {"BHT Number", "Admitted", "Discharged", "Final Bill Number",
+                "Consultant", "Speciality", "Sum Added Fee", "Sum Paid Fee", "Balance to Pay"};
+            Row headerRow = sheet.createRow(0);
+            for (int c = 0; c < headers.length; c++) {
+                Cell cell = headerRow.createCell(c);
+                cell.setCellValue(headers[c]);
+                cell.setCellStyle(headerStyle);
+            }
+
+            int rowIdx = 1;
+            for (InwardProfessionalPaymentAdmissionGroupDTO group : professionalPaymentReportGroups) {
+                int span = summaryAdmissionRowSpan(group);
+                int admissionStartRow = rowIdx;
+                List<InwardProfessionalPaymentReportRowDTO> detailRows = group.getDetailRows();
+
+                for (int i = 0; i < span; i++) {
+                    Row row = sheet.createRow(rowIdx++);
+                    if (i == 0) {
+                        row.createCell(0).setCellValue(group.getBhtNo() != null ? group.getBhtNo() : "");
+                        row.createCell(1).setCellValue(group.getDateOfAdmission() != null ? dateFormat.format(group.getDateOfAdmission()) : "");
+                        row.createCell(2).setCellValue(group.getDateOfDischarge() != null ? dateFormat.format(group.getDateOfDischarge()) : "");
+                        row.createCell(3).setCellValue(group.getFirstFinalBillNo() != null ? group.getFirstFinalBillNo() : "");
+                    }
+                    if (detailRows != null && i < detailRows.size()) {
+                        InwardProfessionalPaymentReportRowDTO detail = detailRows.get(i);
+                        row.createCell(4).setCellValue(detail.getConsultantName() != null ? detail.getConsultantName() : "");
+                        row.createCell(5).setCellValue(detail.getSpecialityName() != null ? detail.getSpecialityName() : "");
+                        Cell addedCell = row.createCell(6);
+                        addedCell.setCellValue(detail.getSumAddedFee());
+                        addedCell.setCellStyle(moneyStyle);
+                        Cell paidCell = row.createCell(7);
+                        paidCell.setCellValue(detail.getSumPaidFee());
+                        paidCell.setCellStyle(moneyStyle);
+                        Cell balanceCell = row.createCell(8);
+                        balanceCell.setCellValue(detail.getSumAddedFee() - detail.getSumPaidFee());
+                        balanceCell.setCellStyle(moneyStyle);
+                    }
+                }
+
+                if (span > 1) {
+                    for (int c = 0; c <= 3; c++) {
+                        sheet.addMergedRegion(new CellRangeAddress(admissionStartRow, rowIdx - 1, c, c));
+                    }
+                }
+            }
+
+            for (int c = 0; c < headers.length; c++) {
+                sheet.autoSizeColumn(c);
+            }
+
+            String filename = "Inpatient_Professional_Payment_Summary_"
+                    + new SimpleDateFormat("yyyyMMdd_HHmm").format(new Date()) + ".xlsx";
+            response.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+            response.setHeader("Content-Disposition", "attachment; filename=" + filename);
+            try (OutputStream out = response.getOutputStream()) {
+                workbook.write(out);
+            }
+            facesContext.responseComplete();
+        } catch (Exception e) {
+            Logger.getLogger(InwardReportControllerBht.class.getName()).log(Level.SEVERE, "Error exporting professional payment summary to Excel", e);
+            JsfUtil.addErrorMessage("Failed to generate Excel: " + e.getMessage());
+        }
+    }
+
+    // Issue #22803 - Excel export for the Detailed report.
+    public void downloadProfessionalPaymentDetailedExcel() {
+        if (professionalPaymentReportGroups == null || professionalPaymentReportGroups.isEmpty()) {
+            JsfUtil.addErrorMessage("No data to export. Please process the report first.");
+            return;
+        }
+
+        FacesContext facesContext = FacesContext.getCurrentInstance();
+        HttpServletResponse response = (HttpServletResponse) facesContext.getExternalContext().getResponse();
+        SimpleDateFormat dateFormat = new SimpleDateFormat("dd/MM/yyyy");
+
+        try (XSSFWorkbook workbook = new XSSFWorkbook()) {
+            XSSFSheet sheet = workbook.createSheet("Professional Payment Detailed");
+
+            CellStyle headerStyle = workbook.createCellStyle();
+            Font headerFont = workbook.createFont();
+            headerFont.setBold(true);
+            headerFont.setColor(IndexedColors.WHITE.getIndex());
+            headerStyle.setFont(headerFont);
+            headerStyle.setFillForegroundColor(IndexedColors.GREY_50_PERCENT.getIndex());
+            headerStyle.setFillPattern(FillPatternType.SOLID_FOREGROUND);
+
+            DataFormat poiDataFormat = workbook.createDataFormat();
+            CellStyle moneyStyle = workbook.createCellStyle();
+            moneyStyle.setDataFormat(poiDataFormat.getFormat("#,##0.00"));
+
+            Font boldFont = workbook.createFont();
+            boldFont.setBold(true);
+            CellStyle boldStyle = workbook.createCellStyle();
+            boldStyle.setFont(boldFont);
+            CellStyle boldMoneyStyle = workbook.createCellStyle();
+            boldMoneyStyle.setFont(boldFont);
+            boldMoneyStyle.setDataFormat(poiDataFormat.getFormat("#,##0.00"));
+
+            String[] headers = {"BHT Number", "Admitted", "Discharged", "Final Bill Number",
+                "Consultant", "Speciality", "Added Fee Date", "Added Fee Value", "Paid Date",
+                "Paid Bill Number", "Paid Fee Value"};
+            Row headerRow = sheet.createRow(0);
+            for (int c = 0; c < headers.length; c++) {
+                Cell cell = headerRow.createCell(c);
+                cell.setCellValue(headers[c]);
+                cell.setCellStyle(headerStyle);
+            }
+
+            int rowIdx = 1;
+            for (InwardProfessionalPaymentAdmissionGroupDTO group : professionalPaymentReportGroups) {
+                int admissionStartRow = rowIdx;
+                List<InwardProfessionalPaymentDetailRowDTO> detailedRows = group.getDetailedRows();
+                boolean admissionInfoWritten = false;
+
+                if (detailedRows == null || detailedRows.isEmpty()) {
+                    Row row = sheet.createRow(rowIdx++);
+                    writeDetailedAdmissionCells(row, group, dateFormat);
+                    admissionInfoWritten = true;
+                } else {
+                    for (InwardProfessionalPaymentDetailRowDTO detail : detailedRows) {
+                        int consultantStartRow = rowIdx;
+                        int dataRows = Math.max(detail.rowCount(), 1);
+
+                        for (int i = 0; i < dataRows; i++) {
+                            Row row = sheet.createRow(rowIdx++);
+                            if (!admissionInfoWritten) {
+                                writeDetailedAdmissionCells(row, group, dateFormat);
+                                admissionInfoWritten = true;
+                            }
+                            if (i == 0) {
+                                row.createCell(4).setCellValue(detail.getConsultantName() != null ? detail.getConsultantName() : "");
+                                row.createCell(5).setCellValue(detail.getSpecialityName() != null ? detail.getSpecialityName() : "");
+                            }
+                            if (i < detail.getAddedFeeValues().size()) {
+                                Date addedDate = detail.getAddedFeeDates().get(i);
+                                row.createCell(6).setCellValue(addedDate != null ? dateFormat.format(addedDate) : "");
+                                Double addedValue = detail.getAddedFeeValues().get(i);
+                                Cell addedCell = row.createCell(7);
+                                addedCell.setCellValue(addedValue != null ? addedValue : 0.0);
+                                addedCell.setCellStyle(moneyStyle);
+                            }
+                            if (i < detail.getPaidFeeValues().size()) {
+                                Date paidDate = detail.getPaidFeeDates().get(i);
+                                row.createCell(8).setCellValue(paidDate != null ? dateFormat.format(paidDate) : "");
+                                String paidBillNo = detail.getPaidBillNumbers().get(i);
+                                row.createCell(9).setCellValue(paidBillNo != null ? paidBillNo : "");
+                                Double paidValue = detail.getPaidFeeValues().get(i);
+                                Cell paidCell = row.createCell(10);
+                                paidCell.setCellValue(paidValue != null ? paidValue : 0.0);
+                                paidCell.setCellStyle(moneyStyle);
+                            }
+                        }
+
+                        Row totalRow = sheet.createRow(rowIdx++);
+                        Cell totalLabelCell = totalRow.createCell(6);
+                        totalLabelCell.setCellValue("Total");
+                        totalLabelCell.setCellStyle(boldStyle);
+                        Cell totalAddedCell = totalRow.createCell(7);
+                        totalAddedCell.setCellValue(detail.getSumAddedFee());
+                        totalAddedCell.setCellStyle(boldMoneyStyle);
+                        Cell totalPaidCell = totalRow.createCell(10);
+                        totalPaidCell.setCellValue(detail.getSumPaidFee());
+                        totalPaidCell.setCellStyle(boldMoneyStyle);
+
+                        Row balanceRow = sheet.createRow(rowIdx++);
+                        Cell balanceLabelCell = balanceRow.createCell(6);
+                        balanceLabelCell.setCellValue("Balance to Pay");
+                        balanceLabelCell.setCellStyle(boldStyle);
+                        Cell balanceValueCell = balanceRow.createCell(7);
+                        balanceValueCell.setCellValue(detail.getSumAddedFee() - detail.getSumPaidFee());
+                        balanceValueCell.setCellStyle(boldMoneyStyle);
+
+                        if (rowIdx - 1 > consultantStartRow) {
+                            sheet.addMergedRegion(new CellRangeAddress(consultantStartRow, rowIdx - 1, 4, 4));
+                            sheet.addMergedRegion(new CellRangeAddress(consultantStartRow, rowIdx - 1, 5, 5));
+                        }
+                    }
+                }
+
+                if (rowIdx - 1 > admissionStartRow) {
+                    for (int c = 0; c <= 3; c++) {
+                        sheet.addMergedRegion(new CellRangeAddress(admissionStartRow, rowIdx - 1, c, c));
+                    }
+                }
+            }
+
+            for (int c = 0; c < headers.length; c++) {
+                sheet.autoSizeColumn(c);
+            }
+
+            String filename = "Inpatient_Professional_Payment_Detailed_"
+                    + new SimpleDateFormat("yyyyMMdd_HHmm").format(new Date()) + ".xlsx";
+            response.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+            response.setHeader("Content-Disposition", "attachment; filename=" + filename);
+            try (OutputStream out = response.getOutputStream()) {
+                workbook.write(out);
+            }
+            facesContext.responseComplete();
+        } catch (Exception e) {
+            Logger.getLogger(InwardReportControllerBht.class.getName()).log(Level.SEVERE, "Error exporting professional payment detailed report to Excel", e);
+            JsfUtil.addErrorMessage("Failed to generate Excel: " + e.getMessage());
+        }
+    }
+
+    private void writeDetailedAdmissionCells(Row row, InwardProfessionalPaymentAdmissionGroupDTO group, SimpleDateFormat dateFormat) {
+        row.createCell(0).setCellValue(group.getBhtNo() != null ? group.getBhtNo() : "");
+        row.createCell(1).setCellValue(group.getDateOfAdmission() != null ? dateFormat.format(group.getDateOfAdmission()) : "");
+        row.createCell(2).setCellValue(group.getDateOfDischarge() != null ? dateFormat.format(group.getDateOfDischarge()) : "");
+        row.createCell(3).setCellValue(group.getFirstFinalBillNo() != null ? group.getFirstFinalBillNo() : "");
+    }
+
+    // Issue #22803 - PDF export for the Summary report. Mirrors
+    // InwardReportController.downloadSurgeryCostEstimationPdf()'s structure
+    // (OpenPDF PdfPTable/PdfPCell, direct HttpServletResponse write via
+    // ExternalContext).
+    public void downloadProfessionalPaymentSummaryPdf() {
+        if (professionalPaymentReportGroups == null || professionalPaymentReportGroups.isEmpty()) {
+            JsfUtil.addErrorMessage("No data to export. Please process the report first.");
+            return;
+        }
+
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            FacesContext facesContext = FacesContext.getCurrentInstance();
+            ExternalContext externalContext = facesContext.getExternalContext();
+
+            String fileName = "Inpatient_Professional_Payment_Summary_"
+                    + new SimpleDateFormat("yyyyMMdd_HHmm").format(new Date()) + ".pdf";
+
+            com.lowagie.text.Document document = new com.lowagie.text.Document(
+                    com.lowagie.text.PageSize.A4.rotate(), 15, 15, 30, 20);
+            com.lowagie.text.pdf.PdfWriter.getInstance(document, baos);
+            document.open();
+
+            com.lowagie.text.Font titleFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 14);
+            com.lowagie.text.Font headerFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 8);
+            com.lowagie.text.Font normalFont = FontFactory.getFont(FontFactory.HELVETICA, 8);
+            com.lowagie.text.Font boldFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 8);
+
+            SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yyyy");
+            DecimalFormat df = new DecimalFormat("#,##0.00");
+
+            com.lowagie.text.Paragraph titlePara = new com.lowagie.text.Paragraph("Inpatient Professional Payment Report - Summary", titleFont);
+            titlePara.setAlignment(Element.ALIGN_CENTER);
+            titlePara.setSpacingAfter(10);
+            document.add(titlePara);
+
+            String[] headers = {"BHT Number", "Admitted", "Discharged", "Final Bill Number",
+                "Consultant", "Speciality", "Sum Added Fee", "Sum Paid Fee", "Balance to Pay"};
+            PdfPTable table = new PdfPTable(headers.length);
+            table.setWidthPercentage(100);
+            float[] widths = {3f, 3f, 3f, 3f, 4f, 4f, 3f, 3f, 3f};
+            table.setWidths(widths);
+
+            for (String h : headers) {
+                PdfPCell cell = new PdfPCell(new Phrase(h, headerFont));
+                cell.setHorizontalAlignment(Element.ALIGN_CENTER);
+                table.addCell(cell);
+            }
+
+            double grandAdded = 0;
+            double grandPaid = 0;
+
+            for (InwardProfessionalPaymentAdmissionGroupDTO group : professionalPaymentReportGroups) {
+                int span = summaryAdmissionRowSpan(group);
+                List<InwardProfessionalPaymentReportRowDTO> detailRows = group.getDetailRows();
+
+                PdfPCell bhtCell = new PdfPCell(new Phrase(group.getBhtNo() != null ? group.getBhtNo() : "", normalFont));
+                bhtCell.setRowspan(span);
+                table.addCell(bhtCell);
+
+                PdfPCell admittedCell = new PdfPCell(new Phrase(group.getDateOfAdmission() != null ? sdf.format(group.getDateOfAdmission()) : "", normalFont));
+                admittedCell.setRowspan(span);
+                table.addCell(admittedCell);
+
+                PdfPCell dischargedCell = new PdfPCell(new Phrase(group.getDateOfDischarge() != null ? sdf.format(group.getDateOfDischarge()) : "", normalFont));
+                dischargedCell.setRowspan(span);
+                table.addCell(dischargedCell);
+
+                PdfPCell finalBillCell = new PdfPCell(new Phrase(group.getFirstFinalBillNo() != null ? group.getFirstFinalBillNo() : "", normalFont));
+                finalBillCell.setRowspan(span);
+                table.addCell(finalBillCell);
+
+                if (detailRows == null || detailRows.isEmpty()) {
+                    table.addCell(new Phrase("", normalFont));
+                    table.addCell(new Phrase("", normalFont));
+                    table.addCell(new Phrase("", normalFont));
+                    table.addCell(new Phrase("", normalFont));
+                    table.addCell(new Phrase("", normalFont));
+                } else {
+                    for (InwardProfessionalPaymentReportRowDTO detail : detailRows) {
+                        table.addCell(new Phrase(detail.getConsultantName() != null ? detail.getConsultantName() : "", normalFont));
+                        table.addCell(new Phrase(detail.getSpecialityName() != null ? detail.getSpecialityName() : "", normalFont));
+
+                        PdfPCell addedCell = new PdfPCell(new Phrase(df.format(detail.getSumAddedFee()), normalFont));
+                        addedCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
+                        table.addCell(addedCell);
+
+                        PdfPCell paidCell = new PdfPCell(new Phrase(df.format(detail.getSumPaidFee()), normalFont));
+                        paidCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
+                        table.addCell(paidCell);
+
+                        PdfPCell balanceCell = new PdfPCell(new Phrase(df.format(detail.getSumAddedFee() - detail.getSumPaidFee()), normalFont));
+                        balanceCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
+                        table.addCell(balanceCell);
+
+                        grandAdded += detail.getSumAddedFee();
+                        grandPaid += detail.getSumPaidFee();
+                    }
+                }
+            }
+
+            PdfPCell totalLblCell = new PdfPCell(new Phrase("Grand Total", boldFont));
+            totalLblCell.setColspan(6);
+            totalLblCell.setHorizontalAlignment(Element.ALIGN_LEFT);
+            table.addCell(totalLblCell);
+
+            PdfPCell tgAdded = new PdfPCell(new Phrase(df.format(grandAdded), boldFont));
+            tgAdded.setHorizontalAlignment(Element.ALIGN_RIGHT);
+            table.addCell(tgAdded);
+
+            PdfPCell tgPaid = new PdfPCell(new Phrase(df.format(grandPaid), boldFont));
+            tgPaid.setHorizontalAlignment(Element.ALIGN_RIGHT);
+            table.addCell(tgPaid);
+
+            PdfPCell tgBalance = new PdfPCell(new Phrase(df.format(grandAdded - grandPaid), boldFont));
+            tgBalance.setHorizontalAlignment(Element.ALIGN_RIGHT);
+            table.addCell(tgBalance);
+
+            document.add(table);
+            document.close();
+
+            byte[] pdfBytes = baos.toByteArray();
+            externalContext.responseReset();
+            externalContext.setResponseContentType("application/pdf");
+            externalContext.setResponseContentLength(pdfBytes.length);
+            externalContext.setResponseHeader("Content-Disposition", "attachment; filename=\"" + fileName + "\"");
+
+            OutputStream out = externalContext.getResponseOutputStream();
+            out.write(pdfBytes);
+            out.flush();
+            facesContext.responseComplete();
+        } catch (Exception e) {
+            JsfUtil.addErrorMessage("Failed to generate PDF: " + e.getMessage());
+        }
+    }
+
+    // Issue #22803 - PDF export for the Detailed report.
+    public void downloadProfessionalPaymentDetailedPdf() {
+        if (professionalPaymentReportGroups == null || professionalPaymentReportGroups.isEmpty()) {
+            JsfUtil.addErrorMessage("No data to export. Please process the report first.");
+            return;
+        }
+
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            FacesContext facesContext = FacesContext.getCurrentInstance();
+            ExternalContext externalContext = facesContext.getExternalContext();
+
+            String fileName = "Inpatient_Professional_Payment_Detailed_"
+                    + new SimpleDateFormat("yyyyMMdd_HHmm").format(new Date()) + ".pdf";
+
+            com.lowagie.text.Document document = new com.lowagie.text.Document(
+                    com.lowagie.text.PageSize.A3.rotate(), 15, 15, 30, 20);
+            com.lowagie.text.pdf.PdfWriter.getInstance(document, baos);
+            document.open();
+
+            com.lowagie.text.Font titleFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 14);
+            com.lowagie.text.Font headerFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 8);
+            com.lowagie.text.Font normalFont = FontFactory.getFont(FontFactory.HELVETICA, 8);
+            com.lowagie.text.Font boldFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 8);
+
+            SimpleDateFormat sdf = new SimpleDateFormat("dd/MM/yyyy");
+            DecimalFormat df = new DecimalFormat("#,##0.00");
+
+            com.lowagie.text.Paragraph titlePara = new com.lowagie.text.Paragraph("Inpatient Professional Payment Report - Detailed", titleFont);
+            titlePara.setAlignment(Element.ALIGN_CENTER);
+            titlePara.setSpacingAfter(10);
+            document.add(titlePara);
+
+            String[] headers = {"BHT Number", "Admitted", "Discharged", "Final Bill Number",
+                "Consultant", "Speciality", "Added Fee Date", "Added Fee Value", "Paid Date",
+                "Paid Bill Number", "Paid Fee Value"};
+            PdfPTable table = new PdfPTable(headers.length);
+            table.setWidthPercentage(100);
+            float[] widths = {3f, 2.5f, 2.5f, 3f, 4f, 4f, 2.5f, 2.5f, 2.5f, 3f, 2.5f};
+            table.setWidths(widths);
+
+            for (String h : headers) {
+                PdfPCell cell = new PdfPCell(new Phrase(h, headerFont));
+                cell.setHorizontalAlignment(Element.ALIGN_CENTER);
+                table.addCell(cell);
+            }
+
+            for (InwardProfessionalPaymentAdmissionGroupDTO group : professionalPaymentReportGroups) {
+                int admissionSpan = detailedAdmissionRowSpan(group);
+                List<InwardProfessionalPaymentDetailRowDTO> detailedRows = group.getDetailedRows();
+
+                PdfPCell bhtCell = new PdfPCell(new Phrase(group.getBhtNo() != null ? group.getBhtNo() : "", normalFont));
+                bhtCell.setRowspan(admissionSpan);
+                table.addCell(bhtCell);
+
+                PdfPCell admittedCell = new PdfPCell(new Phrase(group.getDateOfAdmission() != null ? sdf.format(group.getDateOfAdmission()) : "", normalFont));
+                admittedCell.setRowspan(admissionSpan);
+                table.addCell(admittedCell);
+
+                PdfPCell dischargedCell = new PdfPCell(new Phrase(group.getDateOfDischarge() != null ? sdf.format(group.getDateOfDischarge()) : "", normalFont));
+                dischargedCell.setRowspan(admissionSpan);
+                table.addCell(dischargedCell);
+
+                PdfPCell finalBillCell = new PdfPCell(new Phrase(group.getFirstFinalBillNo() != null ? group.getFirstFinalBillNo() : "", normalFont));
+                finalBillCell.setRowspan(admissionSpan);
+                table.addCell(finalBillCell);
+
+                if (detailedRows == null || detailedRows.isEmpty()) {
+                    for (int i = 0; i < 7; i++) {
+                        table.addCell(new Phrase("", normalFont));
+                    }
+                    continue;
+                }
+
+                for (InwardProfessionalPaymentDetailRowDTO detail : detailedRows) {
+                    int blockSpan = detailedConsultantBlockRowSpan(detail);
+                    int dataRows = Math.max(detail.rowCount(), 1);
+
+                    PdfPCell consultantCell = new PdfPCell(new Phrase(detail.getConsultantName() != null ? detail.getConsultantName() : "", normalFont));
+                    consultantCell.setRowspan(blockSpan);
+                    table.addCell(consultantCell);
+
+                    PdfPCell specialityCell = new PdfPCell(new Phrase(detail.getSpecialityName() != null ? detail.getSpecialityName() : "", normalFont));
+                    specialityCell.setRowspan(blockSpan);
+                    table.addCell(specialityCell);
+
+                    for (int i = 0; i < dataRows; i++) {
+                        if (i < detail.getAddedFeeValues().size()) {
+                            Date addedDate = detail.getAddedFeeDates().get(i);
+                            table.addCell(new Phrase(addedDate != null ? sdf.format(addedDate) : "", normalFont));
+                            Double addedValue = detail.getAddedFeeValues().get(i);
+                            PdfPCell addedCell = new PdfPCell(new Phrase(df.format(addedValue != null ? addedValue : 0.0), normalFont));
+                            addedCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
+                            table.addCell(addedCell);
+                        } else {
+                            table.addCell(new Phrase("", normalFont));
+                            table.addCell(new Phrase("", normalFont));
+                        }
+
+                        if (i < detail.getPaidFeeValues().size()) {
+                            Date paidDate = detail.getPaidFeeDates().get(i);
+                            table.addCell(new Phrase(paidDate != null ? sdf.format(paidDate) : "", normalFont));
+                            String paidBillNo = detail.getPaidBillNumbers().get(i);
+                            table.addCell(new Phrase(paidBillNo != null ? paidBillNo : "", normalFont));
+                            Double paidValue = detail.getPaidFeeValues().get(i);
+                            PdfPCell paidCell = new PdfPCell(new Phrase(df.format(paidValue != null ? paidValue : 0.0), normalFont));
+                            paidCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
+                            table.addCell(paidCell);
+                        } else {
+                            table.addCell(new Phrase("", normalFont));
+                            table.addCell(new Phrase("", normalFont));
+                            table.addCell(new Phrase("", normalFont));
+                        }
+                    }
+
+                    PdfPCell totalLabelCell = new PdfPCell(new Phrase("Total", boldFont));
+                    table.addCell(totalLabelCell);
+                    PdfPCell totalAddedCell = new PdfPCell(new Phrase(df.format(detail.getSumAddedFee()), boldFont));
+                    totalAddedCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
+                    table.addCell(totalAddedCell);
+                    table.addCell(new Phrase("", normalFont));
+                    table.addCell(new Phrase("", normalFont));
+                    PdfPCell totalPaidCell = new PdfPCell(new Phrase(df.format(detail.getSumPaidFee()), boldFont));
+                    totalPaidCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
+                    table.addCell(totalPaidCell);
+
+                    PdfPCell balanceLabelCell = new PdfPCell(new Phrase("Balance to Pay", boldFont));
+                    table.addCell(balanceLabelCell);
+                    PdfPCell balanceValueCell = new PdfPCell(new Phrase(df.format(detail.getSumAddedFee() - detail.getSumPaidFee()), boldFont));
+                    balanceValueCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
+                    table.addCell(balanceValueCell);
+                    table.addCell(new Phrase("", normalFont));
+                    table.addCell(new Phrase("", normalFont));
+                    table.addCell(new Phrase("", normalFont));
+                }
+            }
+
+            document.add(table);
+            document.close();
+
+            byte[] pdfBytes = baos.toByteArray();
+            externalContext.responseReset();
+            externalContext.setResponseContentType("application/pdf");
+            externalContext.setResponseContentLength(pdfBytes.length);
+            externalContext.setResponseHeader("Content-Disposition", "attachment; filename=\"" + fileName + "\"");
+
+            OutputStream out = externalContext.getResponseOutputStream();
+            out.write(pdfBytes);
+            out.flush();
+            facesContext.responseComplete();
+        } catch (Exception e) {
+            JsfUtil.addErrorMessage("Failed to generate PDF: " + e.getMessage());
+        }
+    }
+
     private List<InwardProfessionalPaymentAdmissionGroupDTO> fetchInwardProfessionalPaymentReportGroups() {
         List<InwardProfessionalPaymentAdmissionDTO> admissions = fetchProfessionalPaymentAdmissionsForDepartment();
         List<InwardProfessionalPaymentFeeRowDTO> feeRows = fetchProfessionalFeeRowsForDepartment();
@@ -860,14 +1432,24 @@ public class InwardReportControllerBht implements Serializable {
             group.setBhtNo(admission.getBhtNo());
             group.setDateOfAdmission(admission.getDateOfAdmission());
             group.setDateOfDischarge(admission.getDateOfDischarge());
-            group.setConfirmedFinalBillNo(admission.getConfirmedFinalBillDeptId());
             group.setFirstFinalBillNo(firstFinalBillNoByEncounter.get(admission.getPatientEncounterId()));
 
             List<InwardProfessionalPaymentFeeRowDTO> rowsForAdmission
                     = feeRowsByEncounter.getOrDefault(admission.getPatientEncounterId(), new ArrayList<>());
             group.setDetailRows(groupIntoDetailRows(rowsForAdmission));
+            group.setDetailedRows(groupIntoDetailedRows(rowsForAdmission));
             groups.add(group);
         }
+
+        // Issue #22803 - "admissions without professional fees" filter.
+        // detailRows/detailedRows are always empty/non-empty together, since
+        // both are derived from the same feeRowsByEncounter map.
+        if (onlyAdmissionsWithoutProfessionalFees) {
+            groups = groups.stream()
+                    .filter(g -> g.getDetailRows() == null || g.getDetailRows().isEmpty())
+                    .collect(Collectors.toList());
+        }
+
         return groups;
     }
 
@@ -880,17 +1462,23 @@ public class InwardReportControllerBht implements Serializable {
                 + "COALESCE(fb.deptId, '')) "
                 + "FROM PatientEncounter pe "
                 + "LEFT JOIN pe.finalBill fb "
-                + "WHERE pe.department = :department "
-                + "AND pe.dateOfAdmission BETWEEN :fromDate AND :toDate ";
+                + "WHERE pe.department = :department ";
 
         Map<String, Object> params = new HashMap<>();
         params.put("department", department);
-        params.put("fromDate", fromDate);
-        params.put("toDate", toDate);
 
-        if (bhtNoFilter != null && !bhtNoFilter.trim().isEmpty()) {
-            jpql += "AND pe.bhtNo LIKE :bhtNo ";
-            params.put("bhtNo", "%" + bhtNoFilter.trim() + "%");
+        if ("bhtRange".equals(professionalPaymentSearchMode)
+                && admissionFromForProfessionalPaymentReport != null
+                && admissionToForProfessionalPaymentReport != null) {
+            long peIdFrom = Math.min(admissionFromForProfessionalPaymentReport.getId(), admissionToForProfessionalPaymentReport.getId());
+            long peIdTo = Math.max(admissionFromForProfessionalPaymentReport.getId(), admissionToForProfessionalPaymentReport.getId());
+            jpql += "AND pe.id BETWEEN :peIdFrom AND :peIdTo ";
+            params.put("peIdFrom", peIdFrom);
+            params.put("peIdTo", peIdTo);
+        } else {
+            jpql += "AND pe.dateOfAdmission BETWEEN :fromDate AND :toDate ";
+            params.put("fromDate", fromDate);
+            params.put("toDate", toDate);
         }
 
         jpql += "ORDER BY pe.dateOfAdmission, pe.id";
@@ -909,7 +1497,8 @@ public class InwardReportControllerBht implements Serializable {
                 + "bf.feeValue, "
                 + "bf.paidValue, "
                 + "COALESCE(rbfBill.deptId, ''), "
-                + "rbfBill.createdAt) "
+                + "rbfBill.createdAt, "
+                + "bf.createdAt) "
                 + "FROM BillFee bf "
                 + "JOIN bf.bill b "
                 + "JOIN b.patientEncounter pe "
@@ -922,18 +1511,24 @@ public class InwardReportControllerBht implements Serializable {
                 + "AND b.retired = false "
                 + "AND b.cancelled = false "
                 + "AND b.billType = :billType "
-                + "AND pe.department = :department "
-                + "AND pe.dateOfAdmission BETWEEN :fromDate AND :toDate ";
+                + "AND pe.department = :department ";
 
         Map<String, Object> params = new HashMap<>();
         params.put("billType", BillType.InwardProfessional);
         params.put("department", department);
-        params.put("fromDate", fromDate);
-        params.put("toDate", toDate);
 
-        if (bhtNoFilter != null && !bhtNoFilter.trim().isEmpty()) {
-            jpql += "AND pe.bhtNo LIKE :bhtNo ";
-            params.put("bhtNo", "%" + bhtNoFilter.trim() + "%");
+        if ("bhtRange".equals(professionalPaymentSearchMode)
+                && admissionFromForProfessionalPaymentReport != null
+                && admissionToForProfessionalPaymentReport != null) {
+            long peIdFrom = Math.min(admissionFromForProfessionalPaymentReport.getId(), admissionToForProfessionalPaymentReport.getId());
+            long peIdTo = Math.max(admissionFromForProfessionalPaymentReport.getId(), admissionToForProfessionalPaymentReport.getId());
+            jpql += "AND pe.id BETWEEN :peIdFrom AND :peIdTo ";
+            params.put("peIdFrom", peIdFrom);
+            params.put("peIdTo", peIdTo);
+        } else {
+            jpql += "AND pe.dateOfAdmission BETWEEN :fromDate AND :toDate ";
+            params.put("fromDate", fromDate);
+            params.put("toDate", toDate);
         }
 
         jpql += "ORDER BY pe.id, st.id, sp.id";
@@ -1015,6 +1610,67 @@ public class InwardReportControllerBht implements Serializable {
             result.add(row);
         }
         return result;
+    }
+
+    // Issue #22803 - Detailed report grouping. Same (staff, speciality) key
+    // as groupIntoDetailRows above, but keeps every individual fee row's
+    // Added/Paid values and dates (rather than aggregating into one summary
+    // row + comma-joined strings), for the Detailed report's per-consultant
+    // block layout. Settlement in this codebase is always full-value per fee
+    // (see InwardStaffPaymentBillController.saveBillCompo/
+    // saveBillItemForPaymentBill) - paidValue is either 0 or equal to
+    // feeValue - so a paid entry is only appended when paidValue > 0.
+    private List<InwardProfessionalPaymentDetailRowDTO> groupIntoDetailedRows(List<InwardProfessionalPaymentFeeRowDTO> rows) {
+        Map<String, InwardProfessionalPaymentDetailRowDTO> rowsByStaffAndSpeciality = new LinkedHashMap<>();
+
+        for (InwardProfessionalPaymentFeeRowDTO fee : rows) {
+            String key = fee.getStaffId() + "_" + fee.getSpecialityId();
+            InwardProfessionalPaymentDetailRowDTO row = rowsByStaffAndSpeciality.get(key);
+            if (row == null) {
+                row = new InwardProfessionalPaymentDetailRowDTO();
+                row.setConsultantName(fee.getStaffName());
+                row.setSpecialityName(fee.getSpecialityName());
+                rowsByStaffAndSpeciality.put(key, row);
+            }
+
+            double feeValue = fee.getFeeValue() != null ? fee.getFeeValue() : 0.0;
+            row.getAddedFeeValues().add(feeValue);
+            row.getAddedFeeDates().add(fee.getAddedFeeDate());
+            row.setSumAddedFee(row.getSumAddedFee() + feeValue);
+
+            if (fee.getPaidValue() != null && fee.getPaidValue() > 0) {
+                row.getPaidFeeValues().add(fee.getPaidValue());
+                row.getPaidFeeDates().add(fee.getReferenceBillCreatedAt());
+                row.getPaidBillNumbers().add(fee.getReferenceBillDeptId());
+                row.setSumPaidFee(row.getSumPaidFee() + fee.getPaidValue());
+            }
+        }
+
+        return new ArrayList<>(rowsByStaffAndSpeciality.values());
+    }
+
+    // Issue #22803 - Department-scoped BHT-range autocomplete for the
+    // "Admission From" / "Admission To" fields (BHT-range search mode).
+    // Deliberately not reusing AdmissionController.completeBht /
+    // completePatientEncounter - both are unfiltered by department and use a
+    // broken "c.patient" alias.
+    public List<PatientEncounter> completeAdmissionForProfessionalPaymentReport(String query) {
+        Department dept = department != null ? department : sessionController.getDepartment();
+        if (dept == null || query == null || query.trim().isEmpty()) {
+            return new ArrayList<>();
+        }
+        String jpql = "SELECT pe FROM PatientEncounter pe "
+                + "WHERE pe.department = :department "
+                + "AND pe.retired = false "
+                + "AND pe.bhtNo LIKE :bhtNo "
+                + "ORDER BY pe.bhtNo";
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("department", dept);
+        params.put("bhtNo", "%" + query.trim() + "%");
+
+        List<PatientEncounter> result = (List<PatientEncounter>) billFacade.findLightsByJpql(jpql, params, TemporalType.TIMESTAMP, 20);
+        return result != null ? result : new ArrayList<>();
     }
 
     // View button on the list row: load the bill into InwardSearch and open the
@@ -2772,5 +3428,45 @@ public class InwardReportControllerBht implements Serializable {
 
     public void setPatientNameFilter(String patientNameFilter) {
         this.patientNameFilter = patientNameFilter;
+    }
+
+    public String getProfessionalPaymentReportType() {
+        return professionalPaymentReportType;
+    }
+
+    public void setProfessionalPaymentReportType(String professionalPaymentReportType) {
+        this.professionalPaymentReportType = professionalPaymentReportType;
+    }
+
+    public String getProfessionalPaymentSearchMode() {
+        return professionalPaymentSearchMode;
+    }
+
+    public void setProfessionalPaymentSearchMode(String professionalPaymentSearchMode) {
+        this.professionalPaymentSearchMode = professionalPaymentSearchMode;
+    }
+
+    public PatientEncounter getAdmissionFromForProfessionalPaymentReport() {
+        return admissionFromForProfessionalPaymentReport;
+    }
+
+    public void setAdmissionFromForProfessionalPaymentReport(PatientEncounter admissionFromForProfessionalPaymentReport) {
+        this.admissionFromForProfessionalPaymentReport = admissionFromForProfessionalPaymentReport;
+    }
+
+    public PatientEncounter getAdmissionToForProfessionalPaymentReport() {
+        return admissionToForProfessionalPaymentReport;
+    }
+
+    public void setAdmissionToForProfessionalPaymentReport(PatientEncounter admissionToForProfessionalPaymentReport) {
+        this.admissionToForProfessionalPaymentReport = admissionToForProfessionalPaymentReport;
+    }
+
+    public boolean isOnlyAdmissionsWithoutProfessionalFees() {
+        return onlyAdmissionsWithoutProfessionalFees;
+    }
+
+    public void setOnlyAdmissionsWithoutProfessionalFees(boolean onlyAdmissionsWithoutProfessionalFees) {
+        this.onlyAdmissionsWithoutProfessionalFees = onlyAdmissionsWithoutProfessionalFees;
     }
 }

--- a/src/main/java/com/divudi/bean/inward/InwardReportControllerBht.java
+++ b/src/main/java/com/divudi/bean/inward/InwardReportControllerBht.java
@@ -860,6 +860,16 @@ public class InwardReportControllerBht implements Serializable {
         if (toDate == null) {
             toDate = new Date();
         }
+        // Issue #22805 review - without this guard, a BHT Range search left
+        // with either endpoint unselected silently falls back to the date
+        // range query below (dead giveaway: the filter panel still says "BHT
+        // Range" but the results are date-range results).
+        if ("bhtRange".equals(professionalPaymentSearchMode)
+                && (admissionFromForProfessionalPaymentReport == null
+                || admissionToForProfessionalPaymentReport == null)) {
+            JsfUtil.addErrorMessage("Select both From BHT and To BHT for a BHT Range search");
+            return null;
+        }
         professionalPaymentReportGroups = new ArrayList<>();
         try {
             professionalPaymentReportGroups = fetchInwardProfessionalPaymentReportGroups();
@@ -964,12 +974,21 @@ public class InwardReportControllerBht implements Serializable {
                 sheet.autoSizeColumn(c);
             }
 
+            // Issue #22805 review - serialize into memory first so a POI
+            // failure can't leave a truncated file on a half-committed
+            // response (matches the PDF exporters' existing pattern below).
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            workbook.write(baos);
+            byte[] bytes = baos.toByteArray();
+
             String filename = "Inpatient_Professional_Payment_Summary_"
                     + new SimpleDateFormat("yyyyMMdd_HHmm").format(new Date()) + ".xlsx";
+            response.reset();
             response.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
             response.setHeader("Content-Disposition", "attachment; filename=" + filename);
+            response.setContentLength(bytes.length);
             try (OutputStream out = response.getOutputStream()) {
-                workbook.write(out);
+                out.write(bytes);
             }
             facesContext.responseComplete();
         } catch (Exception e) {
@@ -1104,12 +1123,20 @@ public class InwardReportControllerBht implements Serializable {
                 sheet.autoSizeColumn(c);
             }
 
+            // Issue #22805 review - same buffer-first pattern as the Summary
+            // exporter above.
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            workbook.write(baos);
+            byte[] bytes = baos.toByteArray();
+
             String filename = "Inpatient_Professional_Payment_Detailed_"
                     + new SimpleDateFormat("yyyyMMdd_HHmm").format(new Date()) + ".xlsx";
+            response.reset();
             response.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
             response.setHeader("Content-Disposition", "attachment; filename=" + filename);
+            response.setContentLength(bytes.length);
             try (OutputStream out = response.getOutputStream()) {
-                workbook.write(out);
+                out.write(bytes);
             }
             facesContext.responseComplete();
         } catch (Exception e) {
@@ -1256,6 +1283,10 @@ public class InwardReportControllerBht implements Serializable {
             out.flush();
             facesContext.responseComplete();
         } catch (Exception e) {
+            // Issue #22805 review - e.getMessage() is often null for runtime
+            // failures (e.g. NPE); log the stack trace too, matching the
+            // Excel exporters above.
+            Logger.getLogger(InwardReportControllerBht.class.getName()).log(Level.SEVERE, "Error exporting professional payment summary to PDF", e);
             JsfUtil.addErrorMessage("Failed to generate PDF: " + e.getMessage());
         }
     }
@@ -1410,6 +1441,7 @@ public class InwardReportControllerBht implements Serializable {
             out.flush();
             facesContext.responseComplete();
         } catch (Exception e) {
+            Logger.getLogger(InwardReportControllerBht.class.getName()).log(Level.SEVERE, "Error exporting professional payment detailed report to PDF", e);
             JsfUtil.addErrorMessage("Failed to generate PDF: " + e.getMessage());
         }
     }
@@ -1453,6 +1485,23 @@ public class InwardReportControllerBht implements Serializable {
         return groups;
     }
 
+    // Issue #22805 review - shared by both query builders below, so the
+    // BHT-range/date-range predicate can't drift between them.
+    private String appendProfessionalPaymentRangePredicate(String jpql, Map<String, Object> params) {
+        if ("bhtRange".equals(professionalPaymentSearchMode)
+                && admissionFromForProfessionalPaymentReport != null
+                && admissionToForProfessionalPaymentReport != null) {
+            long peIdFrom = Math.min(admissionFromForProfessionalPaymentReport.getId(), admissionToForProfessionalPaymentReport.getId());
+            long peIdTo = Math.max(admissionFromForProfessionalPaymentReport.getId(), admissionToForProfessionalPaymentReport.getId());
+            params.put("peIdFrom", peIdFrom);
+            params.put("peIdTo", peIdTo);
+            return jpql + "AND pe.id BETWEEN :peIdFrom AND :peIdTo ";
+        }
+        params.put("fromDate", fromDate);
+        params.put("toDate", toDate);
+        return jpql + "AND pe.dateOfAdmission BETWEEN :fromDate AND :toDate ";
+    }
+
     private List<InwardProfessionalPaymentAdmissionDTO> fetchProfessionalPaymentAdmissionsForDepartment() {
         String jpql = "SELECT new com.divudi.core.data.dto.InwardProfessionalPaymentAdmissionDTO("
                 + "pe.id, "
@@ -1467,19 +1516,7 @@ public class InwardReportControllerBht implements Serializable {
         Map<String, Object> params = new HashMap<>();
         params.put("department", department);
 
-        if ("bhtRange".equals(professionalPaymentSearchMode)
-                && admissionFromForProfessionalPaymentReport != null
-                && admissionToForProfessionalPaymentReport != null) {
-            long peIdFrom = Math.min(admissionFromForProfessionalPaymentReport.getId(), admissionToForProfessionalPaymentReport.getId());
-            long peIdTo = Math.max(admissionFromForProfessionalPaymentReport.getId(), admissionToForProfessionalPaymentReport.getId());
-            jpql += "AND pe.id BETWEEN :peIdFrom AND :peIdTo ";
-            params.put("peIdFrom", peIdFrom);
-            params.put("peIdTo", peIdTo);
-        } else {
-            jpql += "AND pe.dateOfAdmission BETWEEN :fromDate AND :toDate ";
-            params.put("fromDate", fromDate);
-            params.put("toDate", toDate);
-        }
+        jpql = appendProfessionalPaymentRangePredicate(jpql, params);
 
         jpql += "ORDER BY pe.dateOfAdmission, pe.id";
 
@@ -1517,19 +1554,7 @@ public class InwardReportControllerBht implements Serializable {
         params.put("billType", BillType.InwardProfessional);
         params.put("department", department);
 
-        if ("bhtRange".equals(professionalPaymentSearchMode)
-                && admissionFromForProfessionalPaymentReport != null
-                && admissionToForProfessionalPaymentReport != null) {
-            long peIdFrom = Math.min(admissionFromForProfessionalPaymentReport.getId(), admissionToForProfessionalPaymentReport.getId());
-            long peIdTo = Math.max(admissionFromForProfessionalPaymentReport.getId(), admissionToForProfessionalPaymentReport.getId());
-            jpql += "AND pe.id BETWEEN :peIdFrom AND :peIdTo ";
-            params.put("peIdFrom", peIdFrom);
-            params.put("peIdTo", peIdTo);
-        } else {
-            jpql += "AND pe.dateOfAdmission BETWEEN :fromDate AND :toDate ";
-            params.put("fromDate", fromDate);
-            params.put("toDate", toDate);
-        }
+        jpql = appendProfessionalPaymentRangePredicate(jpql, params);
 
         jpql += "ORDER BY pe.id, st.id, sp.id";
 

--- a/src/main/java/com/divudi/core/data/dto/InwardProfessionalPaymentAdmissionGroupDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/InwardProfessionalPaymentAdmissionGroupDTO.java
@@ -17,8 +17,11 @@ public class InwardProfessionalPaymentAdmissionGroupDTO implements Serializable 
     private Date dateOfAdmission;
     private Date dateOfDischarge;
     private String firstFinalBillNo;
-    private String confirmedFinalBillNo;
     private List<InwardProfessionalPaymentReportRowDTO> detailRows = new ArrayList<>();
+    // Issue #22803 - per-consultant blocks (with per-fee-row detail) for the
+    // Detailed report; independent of detailRows above, which keeps feeding
+    // the Summary report.
+    private List<InwardProfessionalPaymentDetailRowDTO> detailedRows = new ArrayList<>();
 
     public InwardProfessionalPaymentAdmissionGroupDTO() {
     }
@@ -55,19 +58,41 @@ public class InwardProfessionalPaymentAdmissionGroupDTO implements Serializable 
         this.firstFinalBillNo = firstFinalBillNo;
     }
 
-    public String getConfirmedFinalBillNo() {
-        return confirmedFinalBillNo;
-    }
-
-    public void setConfirmedFinalBillNo(String confirmedFinalBillNo) {
-        this.confirmedFinalBillNo = confirmedFinalBillNo;
-    }
-
     public List<InwardProfessionalPaymentReportRowDTO> getDetailRows() {
         return detailRows;
     }
 
     public void setDetailRows(List<InwardProfessionalPaymentReportRowDTO> detailRows) {
         this.detailRows = detailRows;
+    }
+
+    public List<InwardProfessionalPaymentDetailRowDTO> getDetailedRows() {
+        return detailedRows;
+    }
+
+    public void setDetailedRows(List<InwardProfessionalPaymentDetailRowDTO> detailedRows) {
+        this.detailedRows = detailedRows;
+    }
+
+    // Issue #22803 - rowspan for the Summary table's shared admission columns
+    // (BHT/Admitted/Discharged/Final Bill Number): one row per consultant, or
+    // 1 for a bare admission with no professional fees.
+    public int getSummaryAdmissionRowSpan() {
+        return detailRows == null || detailRows.isEmpty() ? 1 : detailRows.size();
+    }
+
+    // Issue #22803 - rowspan for the Detailed table's shared admission
+    // columns: sum of every consultant block's own span (see
+    // InwardProfessionalPaymentDetailRowDTO.getBlockRowSpan()), or 1 for a
+    // bare admission with no professional fees.
+    public int getDetailedAdmissionRowSpan() {
+        if (detailedRows == null || detailedRows.isEmpty()) {
+            return 1;
+        }
+        int total = 0;
+        for (InwardProfessionalPaymentDetailRowDTO detail : detailedRows) {
+            total += detail.getBlockRowSpan();
+        }
+        return total;
     }
 }

--- a/src/main/java/com/divudi/core/data/dto/InwardProfessionalPaymentDetailRowDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/InwardProfessionalPaymentDetailRowDTO.java
@@ -1,0 +1,120 @@
+package com.divudi.core.data.dto;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * One consultant+speciality block within an admission of the Detailed
+ * Inpatient Professional Payment Report (issue #22803). Carries the full,
+ * per-fee-row Added/Paid detail (unlike the aggregated
+ * {@link InwardProfessionalPaymentReportRowDTO} used by the Summary report).
+ * Built in Java by grouping {@link InwardProfessionalPaymentFeeRowDTO} rows -
+ * not JPQL-constructed, since it carries nested collections.
+ */
+public class InwardProfessionalPaymentDetailRowDTO implements Serializable {
+
+    private String consultantName;
+    private String specialityName;
+    private List<Double> addedFeeValues = new ArrayList<>();
+    private List<Date> addedFeeDates = new ArrayList<>();
+    private List<Double> paidFeeValues = new ArrayList<>();
+    private List<Date> paidFeeDates = new ArrayList<>();
+    private List<String> paidBillNumbers = new ArrayList<>();
+    private double sumAddedFee;
+    private double sumPaidFee;
+
+    public InwardProfessionalPaymentDetailRowDTO() {
+    }
+
+    public String getConsultantName() {
+        return consultantName;
+    }
+
+    public void setConsultantName(String consultantName) {
+        this.consultantName = consultantName;
+    }
+
+    public String getSpecialityName() {
+        return specialityName;
+    }
+
+    public void setSpecialityName(String specialityName) {
+        this.specialityName = specialityName;
+    }
+
+    public List<Double> getAddedFeeValues() {
+        return addedFeeValues;
+    }
+
+    public void setAddedFeeValues(List<Double> addedFeeValues) {
+        this.addedFeeValues = addedFeeValues;
+    }
+
+    public List<Date> getAddedFeeDates() {
+        return addedFeeDates;
+    }
+
+    public void setAddedFeeDates(List<Date> addedFeeDates) {
+        this.addedFeeDates = addedFeeDates;
+    }
+
+    public List<Double> getPaidFeeValues() {
+        return paidFeeValues;
+    }
+
+    public void setPaidFeeValues(List<Double> paidFeeValues) {
+        this.paidFeeValues = paidFeeValues;
+    }
+
+    public List<Date> getPaidFeeDates() {
+        return paidFeeDates;
+    }
+
+    public void setPaidFeeDates(List<Date> paidFeeDates) {
+        this.paidFeeDates = paidFeeDates;
+    }
+
+    public List<String> getPaidBillNumbers() {
+        return paidBillNumbers;
+    }
+
+    public void setPaidBillNumbers(List<String> paidBillNumbers) {
+        this.paidBillNumbers = paidBillNumbers;
+    }
+
+    public double getSumAddedFee() {
+        return sumAddedFee;
+    }
+
+    public void setSumAddedFee(double sumAddedFee) {
+        this.sumAddedFee = sumAddedFee;
+    }
+
+    public double getSumPaidFee() {
+        return sumPaidFee;
+    }
+
+    public void setSumPaidFee(double sumPaidFee) {
+        this.sumPaidFee = sumPaidFee;
+    }
+
+    public int rowCount() {
+        return Math.max(addedFeeValues.size(), paidFeeValues.size());
+    }
+
+    // Issue #22803 - rowspan for this consultant block's own columns
+    // (Consultant/Speciality) and for the admission columns it contributes
+    // to: its data rows, plus the Total row and the Balance-to-Pay row.
+    public int getBlockRowSpan() {
+        return Math.max(rowCount(), 1) + 2;
+    }
+
+    // So the xhtml can ui:repeat over a plain index list without EL arithmetic.
+    public List<Integer> getIndexes() {
+        return IntStream.range(0, rowCount()).boxed().collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/divudi/core/data/dto/InwardProfessionalPaymentFeeRowDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/InwardProfessionalPaymentFeeRowDTO.java
@@ -20,6 +20,7 @@ public class InwardProfessionalPaymentFeeRowDTO implements Serializable {
     private Double paidValue;
     private String referenceBillDeptId;
     private Date referenceBillCreatedAt;
+    private Date addedFeeDate;
 
     public InwardProfessionalPaymentFeeRowDTO() {
     }
@@ -36,6 +37,18 @@ public class InwardProfessionalPaymentFeeRowDTO implements Serializable {
         this.paidValue = paidValue;
         this.referenceBillDeptId = referenceBillDeptId;
         this.referenceBillCreatedAt = referenceBillCreatedAt;
+    }
+
+    // Issue #22803 - Detailed report needs the charge-side BillFee.createdAt
+    // (when the professional fee was added) alongside everything the
+    // existing constructor already carries. New constructor only - the one
+    // above stays for backward compatibility.
+    public InwardProfessionalPaymentFeeRowDTO(Long patientEncounterId, Long staffId, String staffName,
+            Long specialityId, String specialityName, Double feeValue, Double paidValue,
+            String referenceBillDeptId, Date referenceBillCreatedAt, Date addedFeeDate) {
+        this(patientEncounterId, staffId, staffName, specialityId, specialityName, feeValue, paidValue,
+                referenceBillDeptId, referenceBillCreatedAt);
+        this.addedFeeDate = addedFeeDate;
     }
 
     public Long getPatientEncounterId() {
@@ -108,5 +121,13 @@ public class InwardProfessionalPaymentFeeRowDTO implements Serializable {
 
     public void setReferenceBillCreatedAt(Date referenceBillCreatedAt) {
         this.referenceBillCreatedAt = referenceBillCreatedAt;
+    }
+
+    public Date getAddedFeeDate() {
+        return addedFeeDate;
+    }
+
+    public void setAddedFeeDate(Date addedFeeDate) {
+        this.addedFeeDate = addedFeeDate;
     }
 }

--- a/src/main/webapp/inward/reports/inward_professional_payment_report_dto.xhtml
+++ b/src/main/webapp/inward/reports/inward_professional_payment_report_dto.xhtml
@@ -162,12 +162,12 @@
                                                                 <td>#{admissionRow.bhtNo}</td>
                                                                 <td>
                                                                     <h:outputText value="#{admissionRow.dateOfAdmission}">
-                                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" timeZone="Asia/Colombo" />
                                                                     </h:outputText>
                                                                 </td>
                                                                 <td>
                                                                     <h:outputText value="#{admissionRow.dateOfDischarge}" rendered="#{admissionRow.dateOfDischarge ne null}">
-                                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" timeZone="Asia/Colombo" />
                                                                     </h:outputText>
                                                                 </td>
                                                                 <td>#{admissionRow.firstFinalBillNo}</td>
@@ -180,12 +180,12 @@
                                                                     <td rowspan="#{admissionRow.summaryAdmissionRowSpan}">#{admissionRow.bhtNo}</td>
                                                                     <td rowspan="#{admissionRow.summaryAdmissionRowSpan}">
                                                                         <h:outputText value="#{admissionRow.dateOfAdmission}">
-                                                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" timeZone="Asia/Colombo" />
                                                                         </h:outputText>
                                                                     </td>
                                                                     <td rowspan="#{admissionRow.summaryAdmissionRowSpan}">
                                                                         <h:outputText value="#{admissionRow.dateOfDischarge}" rendered="#{admissionRow.dateOfDischarge ne null}">
-                                                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" timeZone="Asia/Colombo" />
                                                                         </h:outputText>
                                                                     </td>
                                                                     <td rowspan="#{admissionRow.summaryAdmissionRowSpan}">#{admissionRow.firstFinalBillNo}</td>
@@ -271,12 +271,12 @@
                                                                 <td>#{admissionRow.bhtNo}</td>
                                                                 <td>
                                                                     <h:outputText value="#{admissionRow.dateOfAdmission}">
-                                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" timeZone="Asia/Colombo" />
                                                                     </h:outputText>
                                                                 </td>
                                                                 <td>
                                                                     <h:outputText value="#{admissionRow.dateOfDischarge}" rendered="#{admissionRow.dateOfDischarge ne null}">
-                                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" timeZone="Asia/Colombo" />
                                                                     </h:outputText>
                                                                 </td>
                                                                 <td>#{admissionRow.firstFinalBillNo}</td>
@@ -290,12 +290,12 @@
                                                                         <td rowspan="#{admissionRow.detailedAdmissionRowSpan}">#{admissionRow.bhtNo}</td>
                                                                         <td rowspan="#{admissionRow.detailedAdmissionRowSpan}">
                                                                             <h:outputText value="#{admissionRow.dateOfAdmission}">
-                                                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" timeZone="Asia/Colombo" />
                                                                             </h:outputText>
                                                                         </td>
                                                                         <td rowspan="#{admissionRow.detailedAdmissionRowSpan}">
                                                                             <h:outputText value="#{admissionRow.dateOfDischarge}" rendered="#{admissionRow.dateOfDischarge ne null}">
-                                                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" timeZone="Asia/Colombo" />
                                                                             </h:outputText>
                                                                         </td>
                                                                         <td rowspan="#{admissionRow.detailedAdmissionRowSpan}">#{admissionRow.firstFinalBillNo}</td>
@@ -306,7 +306,7 @@
                                                                     </ui:fragment>
                                                                     <td>
                                                                         <h:outputText value="#{detail.addedFeeDates[i]}" rendered="#{i lt detail.addedFeeValues.size()}">
-                                                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                                                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" timeZone="Asia/Colombo" />
                                                                         </h:outputText>
                                                                     </td>
                                                                     <td class="text-end">
@@ -316,7 +316,7 @@
                                                                     </td>
                                                                     <td>
                                                                         <h:outputText value="#{detail.paidFeeDates[i]}" rendered="#{i lt detail.paidFeeValues.size()}">
-                                                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                                                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" timeZone="Asia/Colombo" />
                                                                         </h:outputText>
                                                                     </td>
                                                                     <td>

--- a/src/main/webapp/inward/reports/inward_professional_payment_report_dto.xhtml
+++ b/src/main/webapp/inward/reports/inward_professional_payment_report_dto.xhtml
@@ -15,22 +15,6 @@
                         <f:facet name="header">
                             <h:outputText styleClass="fa fa-user-md"></h:outputText>
                             <p:outputLabel value="&nbsp;&nbsp;&nbsp;Inpatient Professional Payment Report" class="m-2"></p:outputLabel>
-
-                            <p:commandButton
-                                value="Download"
-                                ajax="false"
-                                class="ui-button-primary m-1"
-                                icon="fa fa-download">
-                                <p:dataExporter fileName="Inpatient Professional Payment Report" target="tbl1" type="xlsx"></p:dataExporter>
-                            </p:commandButton>
-
-                            <p:commandButton
-                                value="Print"
-                                ajax="false"
-                                class="ui-button-primary m-1"
-                                icon="fa fa-print">
-                                <p:printer target="tbl1"></p:printer>
-                            </p:commandButton>
                         </f:facet>
 
                         <style>
@@ -43,29 +27,73 @@
 
                         <div class="row">
                             <div class="col-2">
-                                <h:outputLabel value="From Date" for="fromDate" />
-                                <p:calendar
-                                    styleClass="dateTimePicker"
-                                    id="fromDate"
-                                    value="#{inwardReportControllerBht.fromDate}"
-                                    navigator="false"
-                                    pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
-                                    class="w-100"
-                                    inputStyleClass="w-100">
-                                </p:calendar>
+                                <h:outputLabel value="Report Type" for="reportType" />
+                                <p:selectOneMenu id="reportType" value="#{inwardReportControllerBht.professionalPaymentReportType}" class="w-100">
+                                    <f:selectItem itemLabel="Summary" itemValue="summary"/>
+                                    <f:selectItem itemLabel="Detailed" itemValue="detailed"/>
+                                </p:selectOneMenu>
 
-                                <h:outputLabel value="To Date" for="toDate" />
-                                <p:calendar
-                                    id="toDate"
-                                    value="#{inwardReportControllerBht.toDate}"
-                                    navigator="false"
-                                    pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
-                                    class="w-100"
-                                    inputStyleClass="w-100">
-                                </p:calendar>
+                                <h:outputLabel value="Search By" for="searchMode" class="mt-2 d-block"/>
+                                <p:selectOneMenu id="searchMode" value="#{inwardReportControllerBht.professionalPaymentSearchMode}" class="w-100">
+                                    <f:selectItem itemLabel="Date Range" itemValue="dateRange"/>
+                                    <f:selectItem itemLabel="BHT Range" itemValue="bhtRange"/>
+                                </p:selectOneMenu>
 
-                                <h:outputLabel value="BHT No" for="bhtNo" />
-                                <p:inputText id="bhtNo" autocomplete="off" value="#{inwardReportControllerBht.bhtNoFilter}" class="w-100"/>
+                                <h:panelGroup rendered="#{inwardReportControllerBht.professionalPaymentSearchMode eq 'dateRange'}" layout="block">
+                                    <h:outputLabel value="From Date" for="fromDate" />
+                                    <p:calendar
+                                        styleClass="dateTimePicker"
+                                        id="fromDate"
+                                        value="#{inwardReportControllerBht.fromDate}"
+                                        navigator="false"
+                                        pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
+                                        class="w-100"
+                                        inputStyleClass="w-100">
+                                    </p:calendar>
+
+                                    <h:outputLabel value="To Date" for="toDate" />
+                                    <p:calendar
+                                        id="toDate"
+                                        value="#{inwardReportControllerBht.toDate}"
+                                        navigator="false"
+                                        pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
+                                        class="w-100"
+                                        inputStyleClass="w-100">
+                                    </p:calendar>
+                                </h:panelGroup>
+
+                                <h:panelGroup rendered="#{inwardReportControllerBht.professionalPaymentSearchMode eq 'bhtRange'}" layout="block">
+                                    <h:outputLabel value="From BHT" for="admissionFrom" />
+                                    <p:autoComplete
+                                        id="admissionFrom"
+                                        value="#{inwardReportControllerBht.admissionFromForProfessionalPaymentReport}"
+                                        completeMethod="#{inwardReportControllerBht.completeAdmissionForProfessionalPaymentReport}"
+                                        var="apt"
+                                        itemLabel="#{apt.bhtNo}"
+                                        itemValue="#{apt}"
+                                        forceSelection="true"
+                                        class="w-100"
+                                        inputStyleClass="w-100">
+                                    </p:autoComplete>
+
+                                    <h:outputLabel value="To BHT" for="admissionTo" />
+                                    <p:autoComplete
+                                        id="admissionTo"
+                                        value="#{inwardReportControllerBht.admissionToForProfessionalPaymentReport}"
+                                        completeMethod="#{inwardReportControllerBht.completeAdmissionForProfessionalPaymentReport}"
+                                        var="apt"
+                                        itemLabel="#{apt.bhtNo}"
+                                        itemValue="#{apt}"
+                                        forceSelection="true"
+                                        class="w-100"
+                                        inputStyleClass="w-100">
+                                    </p:autoComplete>
+                                </h:panelGroup>
+
+                                <h:panelGroup layout="block" styleClass="mt-2">
+                                    <p:selectBooleanCheckbox id="onlyWithoutFees" value="#{inwardReportControllerBht.onlyAdmissionsWithoutProfessionalFees}"/>
+                                    <h:outputLabel value=" List admissions without any professional fees" for="onlyWithoutFees" class="mx-1"/>
+                                </h:panelGroup>
 
                                 <p:commandButton
                                     ajax="false"
@@ -77,88 +105,261 @@
                             </div>
 
                             <div class="col-10">
-                                <p:dataTable
-                                    id="tbl1"
-                                    value="#{inwardReportControllerBht.professionalPaymentReportGroups}"
-                                    var="admissionRow">
 
-                                    <p:columnGroup type="header">
-                                        <p:row>
-                                            <p:column headerText="Consultant" width="14em"/>
-                                            <p:column headerText="Speciality" width="10em"/>
-                                            <p:column headerText="Added Fee" width="8em" styleClass="text-end"/>
-                                            <p:column headerText="Paid Fee" width="8em" styleClass="text-end"/>
-                                            <p:column headerText="Payment Bill Numbers" width="14em"/>
-                                            <p:column headerText="Payment Dates" width="10em"/>
-                                        </p:row>
-                                    </p:columnGroup>
+                                <h:panelGroup rendered="#{inwardReportControllerBht.professionalPaymentReportType eq 'summary'}" layout="block">
+                                    <p:panel>
+                                        <f:facet name="header">
+                                            <h:outputText styleClass="fa fa-user-md"></h:outputText>
+                                            <p:outputLabel value="&nbsp;&nbsp;&nbsp;Summary" class="m-2"></p:outputLabel>
 
-                                    <p:subTable value="#{admissionRow.detailRows}" var="detail">
-                                        <p:columnGroup type="header">
-                                            <p:row style="background-color: #d3dbea; font-weight: bold;">
-                                                <p:column>
-                                                    <f:facet name="header">
-                                                        <h:outputText value="BHT: #{admissionRow.bhtNo}" style="font-weight: bold;"/>
-                                                    </f:facet>
-                                                </p:column>
-                                                <p:column>
-                                                    <f:facet name="header">
-                                                        <h:outputText value="Admitted: " style="font-weight: bold;"/>
-                                                        <h:outputText value="#{admissionRow.dateOfAdmission}" style="font-weight: bold;">
-                                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
-                                                        </h:outputText>
-                                                    </f:facet>
-                                                </p:column>
-                                                <p:column>
-                                                    <f:facet name="header">
-                                                        <h:outputText value="Discharged: " style="font-weight: bold;"/>
-                                                        <h:outputText value="#{admissionRow.dateOfDischarge}" style="font-weight: bold;" rendered="#{admissionRow.dateOfDischarge ne null}">
-                                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
-                                                        </h:outputText>
-                                                    </f:facet>
-                                                </p:column>
-                                                <p:column>
-                                                    <f:facet name="header">
-                                                        <h:outputText value="1st Final Bill: #{admissionRow.firstFinalBillNo}" style="font-weight: bold;"/>
-                                                    </f:facet>
-                                                </p:column>
-                                                <p:column>
-                                                    <f:facet name="header">
-                                                        <h:outputText value="Confirmed Final Bill: #{admissionRow.confirmedFinalBillNo}" style="font-weight: bold;"/>
-                                                    </f:facet>
-                                                </p:column>
-                                                <p:column>
-                                                    <f:facet name="header">
-                                                        <h:outputText value="-" style="font-weight: bold;"/>
-                                                    </f:facet>
-                                                </p:column>
-                                            </p:row>
-                                        </p:columnGroup>
+                                            <p:commandButton
+                                                value="Excel"
+                                                ajax="false"
+                                                class="ui-button-success m-1"
+                                                icon="fas fa-file-excel"
+                                                action="#{inwardReportControllerBht.downloadProfessionalPaymentSummaryExcel()}">
+                                            </p:commandButton>
 
-                                        <p:column>
-                                            <h:outputText value="#{detail.consultantName}" />
-                                        </p:column>
-                                        <p:column>
-                                            <h:outputText value="#{detail.specialityName}" />
-                                        </p:column>
-                                        <p:column styleClass="text-end">
-                                            <h:outputText value="#{detail.sumAddedFee}">
-                                                <f:convertNumber pattern="#,##0.00"/>
-                                            </h:outputText>
-                                        </p:column>
-                                        <p:column styleClass="text-end">
-                                            <h:outputText value="#{detail.sumPaidFee}">
-                                                <f:convertNumber pattern="#,##0.00"/>
-                                            </h:outputText>
-                                        </p:column>
-                                        <p:column>
-                                            <h:outputText value="#{detail.paymentBillNumbers}" />
-                                        </p:column>
-                                        <p:column>
-                                            <h:outputText value="#{detail.paymentDates}" />
-                                        </p:column>
-                                    </p:subTable>
-                                </p:dataTable>
+                                            <p:commandButton
+                                                value="PDF"
+                                                ajax="false"
+                                                class="ui-button-danger m-1"
+                                                icon="fas fa-file-pdf"
+                                                action="#{inwardReportControllerBht.downloadProfessionalPaymentSummaryPdf()}">
+                                            </p:commandButton>
+
+                                            <p:commandButton
+                                                value="Print"
+                                                ajax="false"
+                                                class="ui-button-primary m-1"
+                                                icon="fa fa-print">
+                                                <p:printer target="summaryTbl"></p:printer>
+                                            </p:commandButton>
+                                        </f:facet>
+
+                                        <h:panelGroup id="summaryTbl" layout="block" style="overflow-x: auto;">
+                                            <table class="table table-bordered table-sm">
+                                                <thead>
+                                                    <tr>
+                                                        <th>BHT Number</th>
+                                                        <th>Admitted</th>
+                                                        <th>Discharged</th>
+                                                        <th>Final Bill Number</th>
+                                                        <th>Consultant</th>
+                                                        <th>Speciality</th>
+                                                        <th class="text-end">Sum Added Fee</th>
+                                                        <th class="text-end">Sum Paid Fee</th>
+                                                        <th class="text-end">Balance to Pay</th>
+                                                    </tr>
+                                                </thead>
+                                                <tbody>
+                                                    <ui:repeat value="#{inwardReportControllerBht.professionalPaymentReportGroups}" var="admissionRow">
+                                                        <ui:fragment rendered="#{empty admissionRow.detailRows}">
+                                                            <tr>
+                                                                <td>#{admissionRow.bhtNo}</td>
+                                                                <td>
+                                                                    <h:outputText value="#{admissionRow.dateOfAdmission}">
+                                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                                                    </h:outputText>
+                                                                </td>
+                                                                <td>
+                                                                    <h:outputText value="#{admissionRow.dateOfDischarge}" rendered="#{admissionRow.dateOfDischarge ne null}">
+                                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                                                    </h:outputText>
+                                                                </td>
+                                                                <td>#{admissionRow.firstFinalBillNo}</td>
+                                                                <td colspan="5">-</td>
+                                                            </tr>
+                                                        </ui:fragment>
+                                                        <ui:repeat value="#{admissionRow.detailRows}" var="detail" varStatus="rowStatus">
+                                                            <tr>
+                                                                <ui:fragment rendered="#{rowStatus.first}">
+                                                                    <td rowspan="#{admissionRow.summaryAdmissionRowSpan}">#{admissionRow.bhtNo}</td>
+                                                                    <td rowspan="#{admissionRow.summaryAdmissionRowSpan}">
+                                                                        <h:outputText value="#{admissionRow.dateOfAdmission}">
+                                                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                                                        </h:outputText>
+                                                                    </td>
+                                                                    <td rowspan="#{admissionRow.summaryAdmissionRowSpan}">
+                                                                        <h:outputText value="#{admissionRow.dateOfDischarge}" rendered="#{admissionRow.dateOfDischarge ne null}">
+                                                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                                                        </h:outputText>
+                                                                    </td>
+                                                                    <td rowspan="#{admissionRow.summaryAdmissionRowSpan}">#{admissionRow.firstFinalBillNo}</td>
+                                                                </ui:fragment>
+                                                                <td>#{detail.consultantName}</td>
+                                                                <td>#{detail.specialityName}</td>
+                                                                <td class="text-end">
+                                                                    <h:outputText value="#{detail.sumAddedFee}">
+                                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                                    </h:outputText>
+                                                                </td>
+                                                                <td class="text-end">
+                                                                    <h:outputText value="#{detail.sumPaidFee}">
+                                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                                    </h:outputText>
+                                                                </td>
+                                                                <td class="text-end">
+                                                                    <h:outputText value="#{detail.sumAddedFee - detail.sumPaidFee}">
+                                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                                    </h:outputText>
+                                                                </td>
+                                                            </tr>
+                                                        </ui:repeat>
+                                                    </ui:repeat>
+                                                </tbody>
+                                            </table>
+                                        </h:panelGroup>
+                                    </p:panel>
+                                </h:panelGroup>
+
+                                <h:panelGroup rendered="#{inwardReportControllerBht.professionalPaymentReportType eq 'detailed'}" layout="block">
+                                    <p:panel>
+                                        <f:facet name="header">
+                                            <h:outputText styleClass="fa fa-user-md"></h:outputText>
+                                            <p:outputLabel value="&nbsp;&nbsp;&nbsp;Detailed" class="m-2"></p:outputLabel>
+
+                                            <p:commandButton
+                                                value="Excel"
+                                                ajax="false"
+                                                class="ui-button-success m-1"
+                                                icon="fas fa-file-excel"
+                                                action="#{inwardReportControllerBht.downloadProfessionalPaymentDetailedExcel()}">
+                                            </p:commandButton>
+
+                                            <p:commandButton
+                                                value="PDF"
+                                                ajax="false"
+                                                class="ui-button-danger m-1"
+                                                icon="fas fa-file-pdf"
+                                                action="#{inwardReportControllerBht.downloadProfessionalPaymentDetailedPdf()}">
+                                            </p:commandButton>
+
+                                            <p:commandButton
+                                                value="Print"
+                                                ajax="false"
+                                                class="ui-button-primary m-1"
+                                                icon="fa fa-print">
+                                                <p:printer target="detailedTbl"></p:printer>
+                                            </p:commandButton>
+                                        </f:facet>
+
+                                        <h:panelGroup id="detailedTbl" layout="block" style="overflow-x: auto;">
+                                            <table class="table table-bordered table-sm">
+                                                <thead>
+                                                    <tr>
+                                                        <th>BHT Number</th>
+                                                        <th>Admitted</th>
+                                                        <th>Discharged</th>
+                                                        <th>Final Bill Number</th>
+                                                        <th>Consultant</th>
+                                                        <th>Speciality</th>
+                                                        <th>Added Fee Date</th>
+                                                        <th class="text-end">Added Fee Value</th>
+                                                        <th>Paid Date</th>
+                                                        <th>Paid Bill Number</th>
+                                                        <th class="text-end">Paid Fee Value</th>
+                                                    </tr>
+                                                </thead>
+                                                <tbody>
+                                                    <ui:repeat value="#{inwardReportControllerBht.professionalPaymentReportGroups}" var="admissionRow">
+                                                        <ui:fragment rendered="#{empty admissionRow.detailedRows}">
+                                                            <tr>
+                                                                <td>#{admissionRow.bhtNo}</td>
+                                                                <td>
+                                                                    <h:outputText value="#{admissionRow.dateOfAdmission}">
+                                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                                                    </h:outputText>
+                                                                </td>
+                                                                <td>
+                                                                    <h:outputText value="#{admissionRow.dateOfDischarge}" rendered="#{admissionRow.dateOfDischarge ne null}">
+                                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                                                    </h:outputText>
+                                                                </td>
+                                                                <td>#{admissionRow.firstFinalBillNo}</td>
+                                                                <td colspan="7">-</td>
+                                                            </tr>
+                                                        </ui:fragment>
+                                                        <ui:repeat value="#{admissionRow.detailedRows}" var="detail" varStatus="blockStatus">
+                                                            <ui:repeat value="#{detail.indexes}" var="i" varStatus="rowStatus">
+                                                                <tr>
+                                                                    <ui:fragment rendered="#{blockStatus.first and rowStatus.first}">
+                                                                        <td rowspan="#{admissionRow.detailedAdmissionRowSpan}">#{admissionRow.bhtNo}</td>
+                                                                        <td rowspan="#{admissionRow.detailedAdmissionRowSpan}">
+                                                                            <h:outputText value="#{admissionRow.dateOfAdmission}">
+                                                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                                                            </h:outputText>
+                                                                        </td>
+                                                                        <td rowspan="#{admissionRow.detailedAdmissionRowSpan}">
+                                                                            <h:outputText value="#{admissionRow.dateOfDischarge}" rendered="#{admissionRow.dateOfDischarge ne null}">
+                                                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                                                            </h:outputText>
+                                                                        </td>
+                                                                        <td rowspan="#{admissionRow.detailedAdmissionRowSpan}">#{admissionRow.firstFinalBillNo}</td>
+                                                                    </ui:fragment>
+                                                                    <ui:fragment rendered="#{rowStatus.first}">
+                                                                        <td rowspan="#{detail.blockRowSpan}">#{detail.consultantName}</td>
+                                                                        <td rowspan="#{detail.blockRowSpan}">#{detail.specialityName}</td>
+                                                                    </ui:fragment>
+                                                                    <td>
+                                                                        <h:outputText value="#{detail.addedFeeDates[i]}" rendered="#{i lt detail.addedFeeValues.size()}">
+                                                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                                                                        </h:outputText>
+                                                                    </td>
+                                                                    <td class="text-end">
+                                                                        <h:outputText value="#{detail.addedFeeValues[i]}" rendered="#{i lt detail.addedFeeValues.size()}">
+                                                                            <f:convertNumber pattern="#,##0.00"/>
+                                                                        </h:outputText>
+                                                                    </td>
+                                                                    <td>
+                                                                        <h:outputText value="#{detail.paidFeeDates[i]}" rendered="#{i lt detail.paidFeeValues.size()}">
+                                                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                                                                        </h:outputText>
+                                                                    </td>
+                                                                    <td>
+                                                                        <h:outputText value="#{detail.paidBillNumbers[i]}" rendered="#{i lt detail.paidFeeValues.size()}"/>
+                                                                    </td>
+                                                                    <td class="text-end">
+                                                                        <h:outputText value="#{detail.paidFeeValues[i]}" rendered="#{i lt detail.paidFeeValues.size()}">
+                                                                            <f:convertNumber pattern="#,##0.00"/>
+                                                                        </h:outputText>
+                                                                    </td>
+                                                                </tr>
+                                                            </ui:repeat>
+                                                            <tr style="background-color: #f8f9fa; font-weight: bold;">
+                                                                <td>Total</td>
+                                                                <td class="text-end">
+                                                                    <h:outputText value="#{detail.sumAddedFee}">
+                                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                                    </h:outputText>
+                                                                </td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td class="text-end">
+                                                                    <h:outputText value="#{detail.sumPaidFee}">
+                                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                                    </h:outputText>
+                                                                </td>
+                                                            </tr>
+                                                            <tr style="font-weight: bold;">
+                                                                <td>Balance to Pay</td>
+                                                                <td class="text-end">
+                                                                    <h:outputText value="#{detail.sumAddedFee - detail.sumPaidFee}">
+                                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                                    </h:outputText>
+                                                                </td>
+                                                                <td></td>
+                                                                <td></td>
+                                                                <td></td>
+                                                            </tr>
+                                                        </ui:repeat>
+                                                    </ui:repeat>
+                                                </tbody>
+                                            </table>
+                                        </h:panelGroup>
+                                    </p:panel>
+                                </h:panelGroup>
+
                             </div>
                         </div>
                     </p:panel>

--- a/src/main/webapp/inward/reports/inward_professional_payment_report_dto.xhtml
+++ b/src/main/webapp/inward/reports/inward_professional_payment_report_dto.xhtml
@@ -37,8 +37,10 @@
                                 <p:selectOneMenu id="searchMode" value="#{inwardReportControllerBht.professionalPaymentSearchMode}" class="w-100">
                                     <f:selectItem itemLabel="Date Range" itemValue="dateRange"/>
                                     <f:selectItem itemLabel="BHT Range" itemValue="bhtRange"/>
+                                    <p:ajax update="rangeInputs"/>
                                 </p:selectOneMenu>
 
+                                <h:panelGroup id="rangeInputs" layout="block">
                                 <h:panelGroup rendered="#{inwardReportControllerBht.professionalPaymentSearchMode eq 'dateRange'}" layout="block">
                                     <h:outputLabel value="From Date" for="fromDate" />
                                     <p:calendar
@@ -88,6 +90,7 @@
                                         class="w-100"
                                         inputStyleClass="w-100">
                                     </p:autoComplete>
+                                </h:panelGroup>
                                 </h:panelGroup>
 
                                 <h:panelGroup layout="block" styleClass="mt-2">


### PR DESCRIPTION
## Summary

Reworks the Inpatient Professional Payment Report (`inward_professional_payment_report_dto.xhtml`, from #22800) per #22803:

- **Report Type** selector (Summary / Detailed) and **Search By** selector (Date Range / BHT Range), following the `consumption_dto.xhtml` toggle pattern.
- **Summary**: shared admission columns (BHT Number / Admitted / Discharged / Final Bill Number) merged via real HTML `rowspan` across all consultant rows for that admission (previously a `p:subTable` header band, which can't merge cells this way); Consultant / Speciality / Sum Added Fee / Sum Paid Fee / Balance to Pay.
- **Detailed** (new): admission rowspan + a consultant/speciality block rowspan. Added-fee entries and Paid-fee entries are unrelated events, packed side by side purely for compactness (not index-matched), followed by a Total row and a Balance to Pay row per consultant block.
- **"List admissions without any professional fees"** checkbox — audit view isolating admissions with zero professional-fee entries, available on both report types.
- **Excel** (Apache POI, per `developer_docs/feature/excel-export-html-table.md`) and **PDF** (OpenPDF, mirroring `InwardReportController.downloadSurgeryCostEstimationPdf()`) exports for both report types — neither table is a `p:dataTable` anymore so `p:dataExporter` can't be used. Both exports reuse the exact same rowspan-computation getters (`getSummaryAdmissionRowSpan()`, `getDetailedAdmissionRowSpan()`, `getBlockRowSpan()`) the view binds `rowspan` to, so exports can't drift from the on-screen table.
- Old free-text BHT filter removed from this page (the `bhtNoFilter` field stays on `InwardReportControllerBht` for other reports); replaced by department-scoped From/To BHT autocompletes for BHT Range mode (new `completeAdmissionForProfessionalPaymentReport`, not the existing unfiltered/broken `AdmissionController.completeBht`/`completePatientEncounter`).

### DTO changes
- New `InwardProfessionalPaymentDetailRowDTO` — one consultant+speciality block for the Detailed report, carrying parallel Added/Paid lists.
- `InwardProfessionalPaymentFeeRowDTO` — added `addedFeeDate` (new constructor, old one untouched).
- `InwardProfessionalPaymentAdmissionGroupDTO` — dropped the unused `confirmedFinalBillNo` (only consumer was the view being reworked; confirmed no other references), added `detailedRows` + the two rowspan getters.

## Verification

Built and redeployed locally, then created **real** professional-fee data through the actual UI (Add Professional Fee → Settle Professional Payment via Cheque, not raw SQL) against the local `coop` DB, department **Inward**:

- **BHT/55359**: Dr. R.R Weerakoon / PHYSICIAN — 3 added fees (1000, 1000, 2000), settled 2 of them (1000 + 2000 paid via Cheque), 1000 left outstanding; Dr. Nadeeja Seneviratne / CARDIOLOGIST — 1 added fee (1500), unpaid.
- **BHT/55358**: left with zero professional fees, for the checkbox test.
- Ran both report types with Search By = BHT Range (BHT/55357 → BHT/55359), toggled the no-fee checkbox, downloaded Excel + PDF for both report types.

All on-screen numbers matched the DB exactly (Balance = Added − Paid); the checkbox correctly isolated the zero-fee admissions; the downloaded Excel's merged-cell regions (inspected directly in the `.xlsx` XML) matched the on-screen rowspans exactly; the PDF downloaded as a valid single-page document.

**Summary report:**
![Summary](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/professional_payment_report_summary.png)

**Detailed report** (3 Added-fee rows packed against 2 unrelated Paid-fee rows):
![Detailed](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/professional_payment_report_detailed.png)

Full test evidence and discussion: #22803 (comment).

Closes #22803

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added summary and detailed professional-payment reports with Excel, PDF, and print export.
  * Added date-range, BHT-range, admission, and professional-fee filtering.
  * Added admission autocomplete and selectable report and search modes.
  * Detailed reports now group admissions and consultants, showing fee details, totals, balances, and payment dates.
* **Bug Fixes**
  * Improved filtering using reference-bill and fee-creation dates.
  * Added validation for incomplete BHT ranges and empty report results.
  * Improved report formatting, grouping, merged cells, and totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->