### PR TITLE
Lab Patient Report: config option to disable manual update of Patient Details

### DIFF
--- a/src/main/webapp/lab/patient_report.xhtml
+++ b/src/main/webapp/lab/patient_report.xhtml
@@ -991,24 +991,24 @@
                                                         <p:outputLabel for="PatientName" value="Patient Name"  class="mt-2"></p:outputLabel>
                                                     </div>
                                                     <div class="col-md-7">
-                                                        <p:inputText 
-                                                            id="PatientName" 
-                                                            readonly="#{patientReportController.currentPatientReport.approved || !webUserController.hasPrivilege('LabDeAutherizing')}"
-                                                            value="#{patientReportController.currentPatientReport.patientName}" 
+                                                        <p:inputText
+                                                            id="PatientName"
+                                                            readonly="#{patientReportController.currentPatientReport.approved || !webUserController.hasPrivilege('LabDeAutherizing') || configOptionApplicationController.getBooleanValueByKey('Lab Patient Report - Disable Manual Update of Patient Details', false)}"
+                                                            value="#{patientReportController.currentPatientReport.patientName}"
                                                             class="w-100">
                                                         </p:inputText>
                                                     </div>
                                                 </div>
-
+                                               
                                                 <div class="row my-2">
                                                     <div class="col-md-5">
                                                         <p:outputLabel for="PatientAge" value="Patient Age (for Bill Date)" class="mt-2"></p:outputLabel>
                                                     </div>
                                                     <div class="col-md-7">
-                                                        <p:inputText 
-                                                            id="PatientAge" 
-                                                            readonly="#{patientReportController.currentPatientReport.approved || !webUserController.hasPrivilege('LabDeAutherizing')}"
-                                                            value="#{patientReportController.currentPatientReport.patientAge}" 
+                                                        <p:inputText
+                                                            id="PatientAge"
+                                                            readonly="#{patientReportController.currentPatientReport.approved || !webUserController.hasPrivilege('LabDeAutherizing') || configOptionApplicationController.getBooleanValueByKey('Lab Patient Report - Disable Manual Update of Patient Details', false)}"
+                                                            value="#{patientReportController.currentPatientReport.patientAge}"
                                                             class="w-100">
                                                         </p:inputText>
                                                     </div>
@@ -1019,10 +1019,10 @@
                                                         <p:outputLabel for="PatientGender" value="Patient Gender"  class="mt-2"></p:outputLabel>
                                                     </div>
                                                     <div class="col-md-7">
-                                                        <p:inputText 
-                                                            id="PatientGender" 
-                                                            readonly="#{patientReportController.currentPatientReport.approved || !webUserController.hasPrivilege('LabDeAutherizing')}"
-                                                            value="#{patientReportController.currentPatientReport.patientGender}" 
+                                                        <p:inputText
+                                                            id="PatientGender"
+                                                            readonly="#{patientReportController.currentPatientReport.approved || !webUserController.hasPrivilege('LabDeAutherizing') || configOptionApplicationController.getBooleanValueByKey('Lab Patient Report - Disable Manual Update of Patient Details', false)}"
+                                                            value="#{patientReportController.currentPatientReport.patientGender}"
                                                             class="w-100">
                                                         </p:inputText>
                                                     </div>

--- a/src/main/webapp/lab/patient_report.xhtml
+++ b/src/main/webapp/lab/patient_report.xhtml
@@ -993,7 +993,7 @@
                                                     <div class="col-md-7">
                                                         <p:inputText
                                                             id="PatientName"
-                                                            readonly="#{patientReportController.currentPatientReport.approved || !webUserController.hasPrivilege('LabDeAutherizing') || configOptionApplicationController.getBooleanValueByKey('Lab Patient Report - Disable Manual Update of Patient Details', false)}"
+                                                            readonly="#{patientReportController.currentPatientReport.approved || !webUserController.hasPrivilege('LabDeAutherizing') || configOptionApplicationController.getBooleanValueByKey('Lab Patient Report - Disable Manual Update of Patient Details', true)}"
                                                             value="#{patientReportController.currentPatientReport.patientName}"
                                                             class="w-100">
                                                         </p:inputText>
@@ -1007,7 +1007,7 @@
                                                     <div class="col-md-7">
                                                         <p:inputText
                                                             id="PatientAge"
-                                                            readonly="#{patientReportController.currentPatientReport.approved || !webUserController.hasPrivilege('LabDeAutherizing') || configOptionApplicationController.getBooleanValueByKey('Lab Patient Report - Disable Manual Update of Patient Details', false)}"
+                                                            readonly="#{patientReportController.currentPatientReport.approved || !webUserController.hasPrivilege('LabDeAutherizing') || configOptionApplicationController.getBooleanValueByKey('Lab Patient Report - Disable Manual Update of Patient Details', true)}"
                                                             value="#{patientReportController.currentPatientReport.patientAge}"
                                                             class="w-100">
                                                         </p:inputText>
@@ -1021,7 +1021,7 @@
                                                     <div class="col-md-7">
                                                         <p:inputText
                                                             id="PatientGender"
-                                                            readonly="#{patientReportController.currentPatientReport.approved || !webUserController.hasPrivilege('LabDeAutherizing') || configOptionApplicationController.getBooleanValueByKey('Lab Patient Report - Disable Manual Update of Patient Details', false)}"
+                                                            readonly="#{patientReportController.currentPatientReport.approved || !webUserController.hasPrivilege('LabDeAutherizing') || configOptionApplicationController.getBooleanValueByKey('Lab Patient Report - Disable Manual Update of Patient Details', true)}"
                                                             value="#{patientReportController.currentPatientReport.patientGender}"
                                                             class="w-100">
                                                         </p:inputText>


### PR DESCRIPTION
## Summary
- Add a new application config key `Lab Patient Report - Disable Manual Update of Patient Details` (boolean) that gates the manual-edit fields on the **Patient Details (Report Header)** panel of the Lab Patient Report page.
- When enabled, Patient Name / Patient Age / Patient Gender are forced read-only for **all** users, regardless of the `LabDeAutherizing` privilege — layered on top of the existing `approved`/privilege checks (only ever tightens access, never loosens it).
- Default is `true`, so manual update is **off out of the box**; admins can set the key to `false` to restore the previous behavior (editable for `LabDeAutherizing` users on unapproved reports).

## Changes
- `src/main/webapp/lab/patient_report.xhtml`: `readonly` expression on the three report-header input fields now also checks the new config key.

Closes #22815

## Test plan
- [ ] With config unset (default `true`): confirm Patient Name/Age/Gender are read-only for a `LabDeAutherizing` user on an unapproved report.
- [ ] Set config key to `false`: confirm a `LabDeAutherizing` user can edit those fields on an unapproved report, and that non-privileged/approved-report behavior is unchanged.
- [ ] JSF-only change — no server rebuild required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Patient Name, Age, and Gender fields are now read-only when manual updates to patient details are disabled in configuration.
  * Existing approval and permission-based restrictions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->