### PR TITLE
Lab Patient Report: warn on Patient Name/Age/Gender mismatch (config-gated)

### DIFF
--- a/src/main/java/com/divudi/bean/lab/PatientReportController.java
+++ b/src/main/java/com/divudi/bean/lab/PatientReportController.java
@@ -314,8 +314,11 @@ public class PatientReportController implements Serializable {
         String registeredName = getRegisteredPatientName();
         String reportName = currentPatientReport == null ? null : currentPatientReport.getPatientName();
 
-        if (reportName == null || registeredName == null) {
+        if (reportName == null && registeredName == null) {
             return false;
+        }
+        if (reportName == null || registeredName == null) {
+            return true;
         }
 
         return !reportName.trim().equals(registeredName.trim());
@@ -325,8 +328,11 @@ public class PatientReportController implements Serializable {
         String registeredAge = getRegisteredPatientAge();
         String reportAge = currentPatientReport == null ? null : currentPatientReport.getPatientAge();
 
-        if (reportAge == null || registeredAge == null) {
+        if (reportAge == null && registeredAge == null) {
             return false;
+        }
+        if (reportAge == null || registeredAge == null) {
+            return true;
         }
 
         return !reportAge.trim().equals(registeredAge.trim());
@@ -336,8 +342,11 @@ public class PatientReportController implements Serializable {
         String registeredGender = getRegisteredPatientGender();
         String reportGender = currentPatientReport == null ? null : currentPatientReport.getPatientGender();
 
-        if (reportGender == null || registeredGender == null) {
+        if (reportGender == null && registeredGender == null) {
             return false;
+        }
+        if (reportGender == null || registeredGender == null) {
+            return true;
         }
 
         return !reportGender.trim().equals(registeredGender.trim());
@@ -347,40 +356,56 @@ public class PatientReportController implements Serializable {
         return isPatientNameMismatched() || isPatientAgeMismatched() || isPatientGenderMismatched();
     }
 
-    public String getRegisteredPatientName() {
+    private Patient freshRegisteredPatient;
+    private Long freshRegisteredPatientId;
+
+    private Patient getFreshRegisteredPatient() {
         if (currentPatientReport == null
                 || currentPatientReport.getPatientInvestigation() == null
-                || currentPatientReport.getPatientInvestigation().getPatient() == null
-                || currentPatientReport.getPatientInvestigation().getPatient().getPerson() == null) {
+                || currentPatientReport.getPatientInvestigation().getPatient() == null) {
             return null;
         }
 
-        return currentPatientReport.getPatientInvestigation().getPatient().getPerson().getNameWithTitle();
+        Long patientId = currentPatientReport.getPatientInvestigation().getPatient().getId();
+        if (patientId == null) {
+            return null;
+        }
+
+        if (freshRegisteredPatient == null || !patientId.equals(freshRegisteredPatientId)) {
+            freshRegisteredPatient = patientFacade.findWithoutCache(patientId);
+            freshRegisteredPatientId = patientId;
+        }
+
+        return freshRegisteredPatient;
+    }
+
+    public String getRegisteredPatientName() {
+        Patient pt = getFreshRegisteredPatient();
+        if (pt == null || pt.getPerson() == null) {
+            return null;
+        }
+
+        return pt.getPerson().getNameWithTitle();
     }
 
     public String getRegisteredPatientAge() {
-        if (currentPatientReport == null
-                || currentPatientReport.getPatientInvestigation() == null
-                || currentPatientReport.getPatientInvestigation().getPatient() == null
+        Patient pt = getFreshRegisteredPatient();
+        if (pt == null
                 || currentPatientReport.getPatientInvestigation().getBillItem() == null
                 || currentPatientReport.getPatientInvestigation().getBillItem().getBill() == null) {
             return null;
         }
 
-        return currentPatientReport.getPatientInvestigation().getPatient()
-                .getAgeOnBilledDate(currentPatientReport.getPatientInvestigation().getBillItem().getBill().getCreatedAt());
+        return pt.getAgeOnBilledDate(currentPatientReport.getPatientInvestigation().getBillItem().getBill().getCreatedAt());
     }
 
     public String getRegisteredPatientGender() {
-        if (currentPatientReport == null
-                || currentPatientReport.getPatientInvestigation() == null
-                || currentPatientReport.getPatientInvestigation().getPatient() == null
-                || currentPatientReport.getPatientInvestigation().getPatient().getPerson() == null
-                || currentPatientReport.getPatientInvestigation().getPatient().getPerson().getSex() == null) {
+        Patient pt = getFreshRegisteredPatient();
+        if (pt == null || pt.getPerson() == null || pt.getPerson().getSex() == null) {
             return null;
         }
 
-        return currentPatientReport.getPatientInvestigation().getPatient().getPerson().getSex().getLabel();
+        return pt.getPerson().getSex().getLabel();
     }
 
     public String navigateToPrintPatientReport(PatientReport pr) {

--- a/src/main/java/com/divudi/bean/lab/PatientReportController.java
+++ b/src/main/java/com/divudi/bean/lab/PatientReportController.java
@@ -314,11 +314,8 @@ public class PatientReportController implements Serializable {
         String registeredName = getRegisteredPatientName();
         String reportName = currentPatientReport == null ? null : currentPatientReport.getPatientName();
 
-        if (reportName == null && registeredName == null) {
-            return false;
-        }
         if (reportName == null || registeredName == null) {
-            return true;
+            return false;
         }
 
         return !reportName.trim().equals(registeredName.trim());
@@ -328,11 +325,8 @@ public class PatientReportController implements Serializable {
         String registeredAge = getRegisteredPatientAge();
         String reportAge = currentPatientReport == null ? null : currentPatientReport.getPatientAge();
 
-        if (reportAge == null && registeredAge == null) {
-            return false;
-        }
         if (reportAge == null || registeredAge == null) {
-            return true;
+            return false;
         }
 
         return !reportAge.trim().equals(registeredAge.trim());
@@ -342,11 +336,8 @@ public class PatientReportController implements Serializable {
         String registeredGender = getRegisteredPatientGender();
         String reportGender = currentPatientReport == null ? null : currentPatientReport.getPatientGender();
 
-        if (reportGender == null && registeredGender == null) {
-            return false;
-        }
         if (reportGender == null || registeredGender == null) {
-            return true;
+            return false;
         }
 
         return !reportGender.trim().equals(registeredGender.trim());
@@ -356,56 +347,40 @@ public class PatientReportController implements Serializable {
         return isPatientNameMismatched() || isPatientAgeMismatched() || isPatientGenderMismatched();
     }
 
-    private Patient freshRegisteredPatient;
-    private Long freshRegisteredPatientId;
-
-    private Patient getFreshRegisteredPatient() {
+    public String getRegisteredPatientName() {
         if (currentPatientReport == null
                 || currentPatientReport.getPatientInvestigation() == null
-                || currentPatientReport.getPatientInvestigation().getPatient() == null) {
+                || currentPatientReport.getPatientInvestigation().getPatient() == null
+                || currentPatientReport.getPatientInvestigation().getPatient().getPerson() == null) {
             return null;
         }
 
-        Long patientId = currentPatientReport.getPatientInvestigation().getPatient().getId();
-        if (patientId == null) {
-            return null;
-        }
-
-        if (freshRegisteredPatient == null || !patientId.equals(freshRegisteredPatientId)) {
-            freshRegisteredPatient = patientFacade.findWithoutCache(patientId);
-            freshRegisteredPatientId = patientId;
-        }
-
-        return freshRegisteredPatient;
-    }
-
-    public String getRegisteredPatientName() {
-        Patient pt = getFreshRegisteredPatient();
-        if (pt == null || pt.getPerson() == null) {
-            return null;
-        }
-
-        return pt.getPerson().getNameWithTitle();
+        return currentPatientReport.getPatientInvestigation().getPatient().getPerson().getNameWithTitle();
     }
 
     public String getRegisteredPatientAge() {
-        Patient pt = getFreshRegisteredPatient();
-        if (pt == null
+        if (currentPatientReport == null
+                || currentPatientReport.getPatientInvestigation() == null
+                || currentPatientReport.getPatientInvestigation().getPatient() == null
                 || currentPatientReport.getPatientInvestigation().getBillItem() == null
                 || currentPatientReport.getPatientInvestigation().getBillItem().getBill() == null) {
             return null;
         }
 
-        return pt.getAgeOnBilledDate(currentPatientReport.getPatientInvestigation().getBillItem().getBill().getCreatedAt());
+        return currentPatientReport.getPatientInvestigation().getPatient()
+                .getAgeOnBilledDate(currentPatientReport.getPatientInvestigation().getBillItem().getBill().getCreatedAt());
     }
 
     public String getRegisteredPatientGender() {
-        Patient pt = getFreshRegisteredPatient();
-        if (pt == null || pt.getPerson() == null || pt.getPerson().getSex() == null) {
+        if (currentPatientReport == null
+                || currentPatientReport.getPatientInvestigation() == null
+                || currentPatientReport.getPatientInvestigation().getPatient() == null
+                || currentPatientReport.getPatientInvestigation().getPatient().getPerson() == null
+                || currentPatientReport.getPatientInvestigation().getPatient().getPerson().getSex() == null) {
             return null;
         }
 
-        return pt.getPerson().getSex().getLabel();
+        return currentPatientReport.getPatientInvestigation().getPatient().getPerson().getSex().getLabel();
     }
 
     public String navigateToPrintPatientReport(PatientReport pr) {

--- a/src/main/java/com/divudi/bean/lab/PatientReportController.java
+++ b/src/main/java/com/divudi/bean/lab/PatientReportController.java
@@ -310,6 +310,79 @@ public class PatientReportController implements Serializable {
 
     }
 
+    public boolean isPatientNameMismatched() {
+        String registeredName = getRegisteredPatientName();
+        String reportName = currentPatientReport == null ? null : currentPatientReport.getPatientName();
+
+        if (reportName == null || registeredName == null) {
+            return false;
+        }
+
+        return !reportName.trim().equals(registeredName.trim());
+    }
+
+    public boolean isPatientAgeMismatched() {
+        String registeredAge = getRegisteredPatientAge();
+        String reportAge = currentPatientReport == null ? null : currentPatientReport.getPatientAge();
+
+        if (reportAge == null || registeredAge == null) {
+            return false;
+        }
+
+        return !reportAge.trim().equals(registeredAge.trim());
+    }
+
+    public boolean isPatientGenderMismatched() {
+        String registeredGender = getRegisteredPatientGender();
+        String reportGender = currentPatientReport == null ? null : currentPatientReport.getPatientGender();
+
+        if (reportGender == null || registeredGender == null) {
+            return false;
+        }
+
+        return !reportGender.trim().equals(registeredGender.trim());
+    }
+
+    public boolean isPatientDetailsMismatched() {
+        return isPatientNameMismatched() || isPatientAgeMismatched() || isPatientGenderMismatched();
+    }
+
+    public String getRegisteredPatientName() {
+        if (currentPatientReport == null
+                || currentPatientReport.getPatientInvestigation() == null
+                || currentPatientReport.getPatientInvestigation().getPatient() == null
+                || currentPatientReport.getPatientInvestigation().getPatient().getPerson() == null) {
+            return null;
+        }
+
+        return currentPatientReport.getPatientInvestigation().getPatient().getPerson().getNameWithTitle();
+    }
+
+    public String getRegisteredPatientAge() {
+        if (currentPatientReport == null
+                || currentPatientReport.getPatientInvestigation() == null
+                || currentPatientReport.getPatientInvestigation().getPatient() == null
+                || currentPatientReport.getPatientInvestigation().getBillItem() == null
+                || currentPatientReport.getPatientInvestigation().getBillItem().getBill() == null) {
+            return null;
+        }
+
+        return currentPatientReport.getPatientInvestigation().getPatient()
+                .getAgeOnBilledDate(currentPatientReport.getPatientInvestigation().getBillItem().getBill().getCreatedAt());
+    }
+
+    public String getRegisteredPatientGender() {
+        if (currentPatientReport == null
+                || currentPatientReport.getPatientInvestigation() == null
+                || currentPatientReport.getPatientInvestigation().getPatient() == null
+                || currentPatientReport.getPatientInvestigation().getPatient().getPerson() == null
+                || currentPatientReport.getPatientInvestigation().getPatient().getPerson().getSex() == null) {
+            return null;
+        }
+
+        return currentPatientReport.getPatientInvestigation().getPatient().getPerson().getSex().getLabel();
+    }
+
     public String navigateToPrintPatientReport(PatientReport pr) {
         if (pr == null) {
             JsfUtil.addErrorMessage("No Select Patient Report");

--- a/src/main/java/com/divudi/bean/lab/PatientReportController.java
+++ b/src/main/java/com/divudi/bean/lab/PatientReportController.java
@@ -347,40 +347,56 @@ public class PatientReportController implements Serializable {
         return isPatientNameMismatched() || isPatientAgeMismatched() || isPatientGenderMismatched();
     }
 
-    public String getRegisteredPatientName() {
+    private Patient freshRegisteredPatient;
+    private Long freshRegisteredPatientId;
+
+    private Patient getFreshRegisteredPatient() {
         if (currentPatientReport == null
                 || currentPatientReport.getPatientInvestigation() == null
-                || currentPatientReport.getPatientInvestigation().getPatient() == null
-                || currentPatientReport.getPatientInvestigation().getPatient().getPerson() == null) {
+                || currentPatientReport.getPatientInvestigation().getPatient() == null) {
             return null;
         }
 
-        return currentPatientReport.getPatientInvestigation().getPatient().getPerson().getNameWithTitle();
+        Long patientId = currentPatientReport.getPatientInvestigation().getPatient().getId();
+        if (patientId == null) {
+            return null;
+        }
+
+        if (freshRegisteredPatient == null || !patientId.equals(freshRegisteredPatientId)) {
+            freshRegisteredPatient = patientFacade.findWithoutCache(patientId);
+            freshRegisteredPatientId = patientId;
+        }
+
+        return freshRegisteredPatient;
+    }
+
+    public String getRegisteredPatientName() {
+        Patient pt = getFreshRegisteredPatient();
+        if (pt == null || pt.getPerson() == null) {
+            return null;
+        }
+
+        return pt.getPerson().getNameWithTitle();
     }
 
     public String getRegisteredPatientAge() {
-        if (currentPatientReport == null
-                || currentPatientReport.getPatientInvestigation() == null
-                || currentPatientReport.getPatientInvestigation().getPatient() == null
+        Patient pt = getFreshRegisteredPatient();
+        if (pt == null
                 || currentPatientReport.getPatientInvestigation().getBillItem() == null
                 || currentPatientReport.getPatientInvestigation().getBillItem().getBill() == null) {
             return null;
         }
 
-        return currentPatientReport.getPatientInvestigation().getPatient()
-                .getAgeOnBilledDate(currentPatientReport.getPatientInvestigation().getBillItem().getBill().getCreatedAt());
+        return pt.getAgeOnBilledDate(currentPatientReport.getPatientInvestigation().getBillItem().getBill().getCreatedAt());
     }
 
     public String getRegisteredPatientGender() {
-        if (currentPatientReport == null
-                || currentPatientReport.getPatientInvestigation() == null
-                || currentPatientReport.getPatientInvestigation().getPatient() == null
-                || currentPatientReport.getPatientInvestigation().getPatient().getPerson() == null
-                || currentPatientReport.getPatientInvestigation().getPatient().getPerson().getSex() == null) {
+        Patient pt = getFreshRegisteredPatient();
+        if (pt == null || pt.getPerson() == null || pt.getPerson().getSex() == null) {
             return null;
         }
 
-        return currentPatientReport.getPatientInvestigation().getPatient().getPerson().getSex().getLabel();
+        return pt.getPerson().getSex().getLabel();
     }
 
     public String navigateToPrintPatientReport(PatientReport pr) {

--- a/src/main/webapp/lab/patient_report.xhtml
+++ b/src/main/webapp/lab/patient_report.xhtml
@@ -963,6 +963,36 @@
                                         action="#{laboratoryManagementController.navigateToOtherPatientReport(patientReportController.currentPatientReport.patientInvestigation.billItem.bill)}">
                                     </p:commandButton>
                                 </h:panelGroup>
+                                
+                                <h:panelGroup id="patientDetailsUpdateRequerdNotice" class="w-100" rendered="#{!patientReportController.currentPatientReport.approved and patientReportController.patientDetailsMismatched}">
+                                    <div class="alert alert-danger w-100 mb-3 text-center" role="alert" style="border-left: 4px solid #c0392b;">
+                                        <div class="d-flex align-items-center justify-content-center gap-2">
+                                            <i class="fa fa-exclamation-triangle" aria-hidden="true" style="font-size: 32px; color: #c0392b;"></i>
+                                            <strong style="font-size: 22px; background-color: #c0392b; color: #ffffff; padding: 2px 12px; border-radius: 4px;">Patient Details Mismatch</strong>
+                                        </div>
+                                        <h:panelGroup rendered="#{patientReportController.patientNameMismatched}">
+                                            <div class="mt-1">
+                                                Name: <strong>"#{patientReportController.currentPatientReport.patientName}"</strong>
+                                                vs Registered: <strong>"#{patientReportController.registeredPatientName}"</strong>
+                                            </div>
+                                        </h:panelGroup>
+                                        <h:panelGroup rendered="#{patientReportController.patientAgeMismatched}">
+                                            <div class="mt-1">
+                                                Age: <strong>"#{patientReportController.currentPatientReport.patientAge}"</strong>
+                                                vs Registered: <strong>"#{patientReportController.registeredPatientAge}"</strong>
+                                            </div>
+                                        </h:panelGroup>
+                                        <h:panelGroup rendered="#{patientReportController.patientGenderMismatched}">
+                                            <div class="mt-1">
+                                                Gender: <strong>"#{patientReportController.currentPatientReport.patientGender}"</strong>
+                                                vs Registered: <strong>"#{patientReportController.registeredPatientGender}"</strong>
+                                            </div>
+                                        </h:panelGroup>
+                                        <div class="mt-1" style="font-size: 18px; color: #c0392b;">
+                                            <strong>Please verify.</strong>
+                                        </div>
+                                    </div>
+                                </h:panelGroup>
 
                                 <div class="mb-1 row w-100" >
                                     <div class="col-md-5">

--- a/src/main/webapp/lab/patient_report.xhtml
+++ b/src/main/webapp/lab/patient_report.xhtml
@@ -964,7 +964,7 @@
                                     </p:commandButton>
                                 </h:panelGroup>
                                 
-                                <h:panelGroup id="patientDetailsUpdateRequerdNotice" class="w-100" rendered="#{!patientReportController.currentPatientReport.approved and patientReportController.patientDetailsMismatched}">
+                                <h:panelGroup id="patientDetailsUpdateRequerdNotice" class="w-100" rendered="#{!patientReportController.currentPatientReport.approved and patientReportController.patientDetailsMismatched and configOptionApplicationController.getBooleanValueByKey('Lab Patient Report - Display Patient Details Mismatch Warning', false)}">
                                     <div class="alert alert-danger w-100 mb-3 text-center" role="alert" style="border-left: 4px solid #c0392b;">
                                         <div class="d-flex align-items-center justify-content-center gap-2">
                                             <i class="fa fa-exclamation-triangle" aria-hidden="true" style="font-size: 32px; color: #c0392b;"></i>


### PR DESCRIPTION
## Summary
- Detect when the manually-editable Patient Details (Report Header) fields (Patient Name, Age, Gender) no longer match the patient's live registered details.
- Show a red, centered warning banner on unapproved reports listing only the specific field(s) that mismatch, with report vs. registered values side by side.
- Add config key `Lab Patient Report - Display Patient Details Mismatch Warning` (boolean, default `false`) so the warning stays hidden institution-wide until an admin opts in.

## Changes
- `src/main/java/com/divudi/bean/lab/PatientReportController.java`: `isPatientNameMismatched`, `isPatientAgeMismatched`, `isPatientGenderMismatched`, `isPatientDetailsMismatched`, and `getRegisteredPatientName/Age/Gender` getters.
- `src/main/webapp/lab/patient_report.xhtml`: warning banner markup above the Patient Details panel, gated by the new config key.

Closes #22818

## Test plan
- [ ] Config unset (default `false`): no warning shown even when fields mismatch.
- [ ] Config `true`, unapproved report, Name/Age/Gender all match: no warning shown.
- [ ] Config `true`, unapproved report, one or more fields differ: warning shows only the mismatched field(s) with correct report/registered values.
- [ ] Approved report: warning never shown regardless of config or mismatch.
- [ ] JSF + Java change — rebuild/redeploy required to verify.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added patient-detail consistency checks for name, age, and gender.
  * Added a warning when report details differ from registered patient information.
  * Displays reported and registered values for verification when applicable.
  * Warnings can be enabled through configuration and appear only for unapproved reports.
  * Handles missing or extra spaces in patient details when checking for differences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->