### PR TITLE
Hide Action column from pharmacy adjustment bill export

### DIFF
--- a/src/main/webapp/pharmacy/adjustments/pharmacy_search_adjustment_bill_item.xhtml
+++ b/src/main/webapp/pharmacy/adjustments/pharmacy_search_adjustment_bill_item.xhtml
@@ -196,7 +196,7 @@
                                         </h:panelGroup>
                                     </p:column>
 
-                                    <p:column headerText="Action" style="width:100px; text-align:center;">
+                                    <p:column headerText="Action" style="width:100px; text-align:center;" exportable="false">
                                         <p:commandButton id="btnViewReceipt"
                                                          ajax="false"
                                                          value="View"


### PR DESCRIPTION
## Summary
Prevents the Action column from being included when exporting pharmacy adjustment bill search results to external formats (Excel, PDF, etc.).

## Changes
- Added `exportable="false"` attribute to the Action column in the pharmacy adjustment bill item search table
  - This ensures action buttons (View, Edit, Delete) are excluded from exports while remaining visible in the UI

## Implementation Details
The change is a simple UI configuration update that leverages PrimeFaces DataTable's built-in export filtering. The Action column contains interactive command buttons that are not meaningful in exported documents, so excluding them improves the quality and usability of exported reports.

https://claude.ai/code/session_01BkbC4FYwQ7GUaLeSApCAJy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Excel exports from the pharmacy adjustment bill item results now exclude the action column.
  * The action column remains visible in the on-screen results table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->