### PR TITLE
fix(inward): refunded payment bills can still be cancelled; add Refund button to bill view

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardRefundController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardRefundController.java
@@ -95,6 +95,35 @@ public class InwardRefundController implements Serializable {
         return "/inward/inward_bill_refund?faces-redirect=true";
     }
 
+    /**
+     * Navigate to the inward deposit refund page with a specific payment bill
+     * pre-selected, for the "Refund" button on the Payment Reprint view page
+     * (issue #22820). Reuses the same eligibility filtering as the manual
+     * bill picker (loadEligiblePaymentBills()) so this can't be tricked into
+     * pre-selecting an ineligible (cancelled / fully refunded) bill.
+     */
+    public String navigateToRefundFromPaymentBill(Bill originPaymentBill) {
+        makeNull();
+        if (originPaymentBill == null || originPaymentBill.getPatientEncounter() == null) {
+            JsfUtil.addErrorMessage("No bill is selected");
+            return "";
+        }
+        financialTransactionController.findNonClosedShiftStartFundBillIsAvailable();
+        if (financialTransactionController.getNonClosedShiftStartFundBill() == null) {
+            JsfUtil.addErrorMessage("Start Your Shift First !");
+            return "/cashier/index?faces-redirect=true";
+        }
+        getCurrent().setPatientEncounter(originPaymentBill.getPatientEncounter());
+        loadEligiblePaymentBills();
+        if (!getEligiblePaymentBills().contains(originPaymentBill)) {
+            JsfUtil.addErrorMessage("This bill is not eligible for refund (already cancelled or fully refunded).");
+            return "";
+        }
+        originalBillToRefund = originPaymentBill;
+        selectBillToRefundListener();
+        return "/inward/inward_bill_refund?faces-redirect=true";
+    }
+
     public PaymentMethod[] getPaymentMethods() {
         return PaymentMethod.values();
     }
@@ -110,6 +139,11 @@ public class InwardRefundController implements Serializable {
 
         if (getOriginalBillToRefund() == null) {
             JsfUtil.addErrorMessage("Select a Payment Bill to Refund");
+            return true;
+        }
+
+        if (getOriginalBillToRefund().isCancelled()) {
+            JsfUtil.addErrorMessage("This bill has been cancelled and cannot be refunded.");
             return true;
         }
 
@@ -150,6 +184,7 @@ public class InwardRefundController implements Serializable {
         saveBillItem();
 
         getOriginalBillToRefund().setRefunded(true);
+        getOriginalBillToRefund().setRefundedBill(getCurrent());
         getBillFacade().edit(getOriginalBillToRefund());
 
         printPreview = true;

--- a/src/main/java/com/divudi/bean/inward/InwardSearch.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSearch.java
@@ -335,6 +335,10 @@ public class InwardSearch implements Serializable {
             JsfUtil.addErrorMessage("This bill is already checked. A checked bill cannot be cancelled.");
             return "";
         }
+        if (bill.isRefunded()) {
+            JsfUtil.addErrorMessage("This bill has already been refunded and cannot be cancelled.");
+            return "";
+        }
         switch (bill.getBillTypeAtomic()) {
             case INWARD_PAYMENT:
                 inwardDepositCancelationPaymentMethods = new ArrayList<>();
@@ -1726,6 +1730,11 @@ public class InwardSearch implements Serializable {
 
             if (getBill().getCheckedBy() != null) {
                 JsfUtil.addErrorMessage("Checked Bill. Can not cancel");
+                return;
+            }
+
+            if (getBill().isRefunded()) {
+                JsfUtil.addErrorMessage("This bill has already been refunded and cannot be cancelled.");
                 return;
             }
 

--- a/src/main/java/com/divudi/bean/inward/PostFinalBillInwardPaymentController.java
+++ b/src/main/java/com/divudi/bean/inward/PostFinalBillInwardPaymentController.java
@@ -779,6 +779,7 @@ public class PostFinalBillInwardPaymentController implements Serializable, Contr
         saveRefundBillItem();
 
         getOriginalBillToRefund().setRefunded(true);
+        getOriginalBillToRefund().setRefundedBill(getRefundCurrent());
         getBillFacade().edit(getOriginalBillToRefund());
 
         printPreview = true;
@@ -807,6 +808,38 @@ public class PostFinalBillInwardPaymentController implements Serializable, Contr
             JsfUtil.addErrorMessage("Start Your Shift First !");
             return "/cashier/index?faces-redirect=true";
         }
+        return "/inward/inward_bill_post_final_payment_refund?faces-redirect=true";
+    }
+
+    /**
+     * Navigate to the post final bill inward payment refund page with a
+     * specific payment bill pre-selected, for the "Refund" button on the
+     * Post Final Bill Payment Reprint view page (issue #22820).
+     */
+    public String navigateToRefundFromPostFinalPaymentBill(Bill originPaymentBill) {
+        refundCurrent = null;
+        paidAmount = 0.0;
+        printPreview = false;
+        eligiblePostFinalPaymentBills = null;
+        originalBillToRefund = null;
+        remainingRefundableAmountCache = null;
+        if (originPaymentBill == null || originPaymentBill.getPatientEncounter() == null) {
+            JsfUtil.addErrorMessage("No bill is selected");
+            return "";
+        }
+        financialTransactionController.findNonClosedShiftStartFundBillIsAvailable();
+        if (financialTransactionController.getNonClosedShiftStartFundBill() == null) {
+            JsfUtil.addErrorMessage("Start Your Shift First !");
+            return "/cashier/index?faces-redirect=true";
+        }
+        getRefundCurrent().setPatientEncounter(originPaymentBill.getPatientEncounter());
+        loadEligiblePostFinalPaymentBills();
+        if (!getEligiblePostFinalPaymentBills().contains(originPaymentBill)) {
+            JsfUtil.addErrorMessage("This bill is not eligible for refund (already cancelled or fully refunded).");
+            return "";
+        }
+        originalBillToRefund = originPaymentBill;
+        selectBillToRefundListener();
         return "/inward/inward_bill_post_final_payment_refund?faces-redirect=true";
     }
 
@@ -929,6 +962,11 @@ public class PostFinalBillInwardPaymentController implements Serializable, Contr
 
         if (getOriginalBillToRefund() == null) {
             JsfUtil.addErrorMessage("Select a Payment Bill to Refund");
+            return true;
+        }
+
+        if (getOriginalBillToRefund().isCancelled()) {
+            JsfUtil.addErrorMessage("This bill has been cancelled and cannot be refunded.");
             return true;
         }
 

--- a/src/main/webapp/inward/inward_bill_intrim.xhtml
+++ b/src/main/webapp/inward/inward_bill_intrim.xhtml
@@ -1342,6 +1342,12 @@
                                                     <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
                                                 </h:outputLabel>
                                             </h:panelGroup>
+                                            <h:panelGroup rendered="#{p.refunded}" class="d-flex gap-2">
+                                                <h:outputLabel style="color: red;" value="Refunded at " />
+                                                <h:outputLabel style="color: red;" value="#{p.refundedBill.createdAt}" >
+                                                    <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                                </h:outputLabel>
+                                            </h:panelGroup>
                                         </p:column>
 
                                         <p:column headerText="Added User">
@@ -1349,8 +1355,14 @@
                                             <br/>
                                             <h:panelGroup rendered="#{p.cancelled}" class="d-flex gap-2">
                                                 <h:outputLabel style="color: red;" value="Cancelled By " />
-                                                <h:outputLabel 
+                                                <h:outputLabel
                                                     style="color: red;" value="#{p.cancelledBill.creater.webUserPerson.nameWithTitle}" >
+                                                </h:outputLabel>
+                                            </h:panelGroup>
+                                            <h:panelGroup rendered="#{p.refunded}" class="d-flex gap-2">
+                                                <h:outputLabel style="color: red;" value="Refunded By " />
+                                                <h:outputLabel
+                                                    style="color: red;" value="#{p.refundedBill.creater.webUserPerson.nameWithTitle}" >
                                                 </h:outputLabel>
                                             </h:panelGroup>
                                         </p:column>
@@ -1407,6 +1419,12 @@
                                                     <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
                                                 </h:outputLabel>
                                             </h:panelGroup>
+                                            <h:panelGroup rendered="#{p.refunded}" class="d-flex gap-2">
+                                                <h:outputLabel style="color: red;" value="Refunded at " />
+                                                <h:outputLabel style="color: red;" value="#{p.refundedBill.createdAt}" >
+                                                    <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                                </h:outputLabel>
+                                            </h:panelGroup>
                                         </p:column>
 
                                         <p:column headerText="Added User">
@@ -1416,6 +1434,12 @@
                                                 <h:outputLabel style="color: red;" value="Cancelled By " />
                                                 <h:outputLabel
                                                     style="color: red;" value="#{p.cancelledBill.creater.webUserPerson.nameWithTitle}" >
+                                                </h:outputLabel>
+                                            </h:panelGroup>
+                                            <h:panelGroup rendered="#{p.refunded}" class="d-flex gap-2">
+                                                <h:outputLabel style="color: red;" value="Refunded By " />
+                                                <h:outputLabel
+                                                    style="color: red;" value="#{p.refundedBill.creater.webUserPerson.nameWithTitle}" >
                                                 </h:outputLabel>
                                             </h:panelGroup>
                                         </p:column>

--- a/src/main/webapp/inward/inward_reprint_bill_payment.xhtml
+++ b/src/main/webapp/inward/inward_reprint_bill_payment.xhtml
@@ -28,7 +28,16 @@
                                         class="ui-button-danger"
                                         icon="fa fa-ban"
                                         action="#{inwardSearch.navigateToPaymentBillCancellation()}"
-                                        disabled="#{inwardSearch.bill.cancelled}"  >
+                                        disabled="#{inwardSearch.bill.cancelled or inwardSearch.bill.refunded}"  >
+                                    </p:commandButton>
+
+                                    <p:commandButton
+                                        id="btnToRefund"
+                                        ajax="false" value="Refund"
+                                        class="ui-button-warning"
+                                        icon="fa fa-money-bill-transfer"
+                                        action="#{inwardRefundController.navigateToRefundFromPaymentBill(inwardSearch.bill)}"
+                                        disabled="#{inwardSearch.bill.cancelled or inwardSearch.bill.refunded}"  >
                                     </p:commandButton>
 
                                     <p:commandButton

--- a/src/main/webapp/inward/inward_reprint_bill_post_final_payment.xhtml
+++ b/src/main/webapp/inward/inward_reprint_bill_post_final_payment.xhtml
@@ -28,7 +28,16 @@
                                         icon="fa fa-ban"
                                         onclick="if (!confirm('Cancel this post-final payment?')) return false;"
                                         action="#{postFinalBillInwardPaymentController.cancelPostFinalPayment()}"
-                                        disabled="#{postFinalBillInwardPaymentController.current.cancelled}"  >
+                                        disabled="#{postFinalBillInwardPaymentController.current.cancelled or postFinalBillInwardPaymentController.current.refunded}"  >
+                                    </p:commandButton>
+
+                                    <p:commandButton
+                                        id="btnToRefund"
+                                        ajax="false" value="Refund"
+                                        class="ui-button-warning"
+                                        icon="fa fa-money-bill-transfer"
+                                        action="#{postFinalBillInwardPaymentController.navigateToRefundFromPostFinalPaymentBill(postFinalBillInwardPaymentController.current)}"
+                                        disabled="#{postFinalBillInwardPaymentController.current.cancelled or postFinalBillInwardPaymentController.current.refunded}"  >
                                     </p:commandButton>
 
                                     <p:commandButton


### PR DESCRIPTION
## Summary

Fixes #22820: a refunded Inward payment bill could still be cancelled (a real double-reversal hole), and the only way to refund a payment was to leave its bill-view page entirely and re-pick the BHT/bill from scratch.

## What changed

- **`InwardSearch`**: `navigateToPaymentBillCancellation()` / `cancelDepositBillPayment()` now reject cancelling an already-refunded bill, mirroring the guard `PostFinalBillInwardPaymentController.cancelPostFinalPayment()` already had (added when #22627/#22637 fixed the refund reciprocal linkage for the newer post-final module, but never backported to this older pre-final module).
- **`InwardRefundController` / `PostFinalBillInwardPaymentController`**: added an explicit `isCancelled()` guard in `errorCheck()`/`errorCheckForRefund()` — defense-in-depth on top of the existing eligible-bills picker filtering (which already excluded cancelled bills, but had no server-side re-check).
- **Both refund `pay()`/`refundPostFinalPayment()` methods**: now also call `setRefundedBill(...)` alongside the existing `setRefunded(true)`, mirroring the `setCancelledBill` pattern — this reverse link was never populated before, which the new UI annotation below depends on.
- **`inward_reprint_bill_payment.xhtml` / `inward_reprint_bill_post_final_payment.xhtml`**: "To Cancel" now disables when the bill is refunded (previously only checked `cancelled`); added a new "Refund" button that navigates straight to the refund page with the current bill pre-selected, instead of requiring the BHT/bill to be re-picked from the standalone Refund page.
- **`inward_bill_intrim.xhtml`**: Payments/Post Final Payments tabs now show a "Refunded at / Refunded By" inline annotation on a refunded row, mirroring the existing "Cancelled at / Cancelled By" annotation.

## Verification (local dev, BHT/56755)

Full before/after flow reproduced live with Playwright + DB checks:

1. **Reproduced the bug pre-fix**: refunded a deposit (`InwardINWREF/1`), then confirmed "To Cancel" was still clickable on the refunded bill and navigated cleanly into the cancellation form with no error.
2. **After the fix**: on the same bill and a fresh one, "To Cancel" **and** the new "Refund" button both correctly disable once a bill is refunded.
3. **New Refund button**: from `inward_reprint_bill_payment.xhtml`, clicking "Refund" landed pre-filled on the refund page (`Bill No`, `Net Total`, `Amount` all pre-populated) — no BHT/bill re-selection needed. Completed the refund (`InwardINWREF/2`, -1,000.00) successfully.
4. **Cancelled bills still excluded from refund**: the refund bill-picker correctly excluded the already-cancelled `Inward//26/037998`.
5. **Interim bill correctness**: `inward_bill_intrim.xhtml` Payments tab correctly nets refunds into "Paid By Patient" (verified it dropped to 0.00 after refunding the only outstanding deposit), and the new row now shows "Refunded at 10 Aug 2026 14:27:41 / Refunded By Dr. Buddhika".
6. **DB verification** (`BILL` table, `coop` schema):

   | DEPTID | NETTOTAL | CANCELLED | REFUNDED | REFUNDEDBILL_ID | CANCELLEDBILL_ID |
   |---|---|---|---|---|---|
   | Inward//26/037998 | 2000 | 1 | 0 | NULL | → Inward/INWCAN/1 |
   | Inward//26/037999 | 1500 | 0 | 1 | NULL *(pre-fix refund, expected)* | NULL |
   | Inward//26/038000 | 1000 | 0 | 1 | → InwardINWREF/2 ✅ | NULL |

   The last row (`Inward//26/038000`) was refunded *after* deploying this fix and correctly has `REFUNDEDBILL_ID` populated, confirming the new reverse link works.

**Not independently E2E-verified**: the `PostFinalBillInwardPaymentController` side of this fix (same pattern, same guards) wasn't driven through Playwright, since exercising it requires a full clinical/room/physical discharge → Create Final Bill → post-final-payment sequence on top of everything above. It's code-reviewed and structurally identical to the pre-final path proven above (same guard, same `setRefundedBill` addition, same button addition) — flagging this explicitly per the user's call to ship on code-review confidence for that half.

## Related

- #22627 (closed) — original discovery of the missing `refunded`/`refundedBill` linkage this fix depends on.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
