### PR TITLE
Support partial payment for professional fees (inward, surgery, OPD, channel)

### DIFF
--- a/src/main/java/com/divudi/bean/channel/ChannelStaffPaymentBillController.java
+++ b/src/main/java/com/divudi/bean/channel/ChannelStaffPaymentBillController.java
@@ -534,6 +534,10 @@ public class ChannelStaffPaymentBillController implements Serializable {
         nonRefundableBillFees = billFeeFacade.findByJpql(sql, m, TemporalType.TIMESTAMP);
         dueBillFees.addAll(nonRefundableBillFees);
 
+        for (BillFee bf : dueBillFees) {
+            bf.setPayingAmount(bf.getFeeValue() - bf.getPaidValue());
+        }
+
     }
 
     public void calculateSessionDueFees() {
@@ -759,7 +763,10 @@ public class ChannelStaffPaymentBillController implements Serializable {
     public void calculateTotalPay() {
         totalPaying = 0;
         for (BillFee f : payingBillFees) {
-            totalPaying = totalPaying + (f.getFeeValue() - f.getPaidValue());
+            double amountToPay = f.getPayingAmount() != null
+                    ? f.getPayingAmount()
+                    : (f.getFeeValue() - f.getPaidValue());
+            totalPaying = totalPaying + amountToPay;
         }
     }
 
@@ -972,6 +979,18 @@ public class ChannelStaffPaymentBillController implements Serializable {
         if (checkBillFeeValue()) {
             JsfUtil.addErrorMessage("There is a Credit Bill");
             return true;
+        }
+
+        for (BillFee bf : getPayingBillFees()) {
+            double outstanding = bf.getFeeValue() - bf.getPaidValue();
+            if (bf.getPayingAmount() == null || bf.getPayingAmount() <= 0) {
+                JsfUtil.addErrorMessage("Please enter a valid paying amount for all selected fees");
+                return true;
+            }
+            if (bf.getPayingAmount() - outstanding > 0.1) {
+                JsfUtil.addErrorMessage("Paying amount cannot exceed the due amount for a fee");
+                return true;
+            }
         }
 
         performCalculations();
@@ -1333,21 +1352,24 @@ public class ChannelStaffPaymentBillController implements Serializable {
     private List<BillItem> saveBillItemsAndFees(Bill b) {
         List<BillItem> bis = new ArrayList<>();
         for (BillFee bf : getPayingBillFees()) {
-            BillItem i = saveBillItemForPaymentBill(b, bf);
-            bf.setPaidValue(bf.getFeeValue());
+            double amountPaidNow = bf.getPayingAmount() != null
+                    ? bf.getPayingAmount()
+                    : (bf.getFeeValue() - bf.getPaidValue());
+            BillItem i = saveBillItemForPaymentBill(b, bf, amountPaidNow);
+            bf.setPaidValue(bf.getPaidValue() + amountPaidNow);
             getBillFeeFacade().edit(bf);
             BillFee nbf = new BillFee();
             nbf.setBillItem(i);
             nbf.setBill(b);
             nbf.setReferenceBillFee(bf);
-            nbf.setFeeValue(bf.getFeeValue());
+            nbf.setFeeValue(amountPaidNow);
             billFeeFacade.create(nbf);
             bis.add(i);
         }
         return bis;
     }
 
-    private BillItem saveBillItemForPaymentBill(Bill b, BillFee bf) {
+    private BillItem saveBillItemForPaymentBill(Bill b, BillFee bf, double amountPaidNow) {
         BillItem i = new BillItem();
         i.setReferanceBillItem(bf.getBillItem());
         i.setReferenceBill(bf.getBill());
@@ -1356,10 +1378,10 @@ public class ChannelStaffPaymentBillController implements Serializable {
         i.setCreatedAt(Calendar.getInstance().getTime());
         i.setCreater(getSessionController().getLoggedUser());
         i.setDiscount(0.0);
-        i.setGrossValue(bf.getFeeValue());
-        i.setNetValue(bf.getFeeValue());
+        i.setGrossValue(amountPaidNow);
+        i.setNetValue(amountPaidNow);
         i.setQty(1.0);
-        i.setRate(bf.getFeeValue());
+        i.setRate(amountPaidNow);
         getBillItemFacade().create(i);
         b.getBillItems().add(i);
         return i;

--- a/src/main/java/com/divudi/bean/channel/ChannelStaffPaymentBillController.java
+++ b/src/main/java/com/divudi/bean/channel/ChannelStaffPaymentBillController.java
@@ -1357,6 +1357,7 @@ public class ChannelStaffPaymentBillController implements Serializable {
                     : (bf.getFeeValue() - bf.getPaidValue());
             BillItem i = saveBillItemForPaymentBill(b, bf, amountPaidNow);
             bf.setPaidValue(bf.getPaidValue() + amountPaidNow);
+            bf.setSettleValue(bf.getSettleValue() + amountPaidNow);
             getBillFeeFacade().edit(bf);
             BillFee nbf = new BillFee();
             nbf.setBillItem(i);

--- a/src/main/java/com/divudi/bean/common/StaffPaymentBillController.java
+++ b/src/main/java/com/divudi/bean/common/StaffPaymentBillController.java
@@ -421,6 +421,7 @@ public class StaffPaymentBillController implements Serializable {
             }
             dueBillFees.removeAll(removeingBillFees);
         }
+        initializePayingAmounts(dueBillFees);
         calculateTotalPaymentsForTheProfessionalForCurrentMonthForCurrentInstitution();
         performCalculations();
     }
@@ -468,6 +469,7 @@ public class StaffPaymentBillController implements Serializable {
                 dueBillFees.removeAll(removeingBillFees);
             }
 
+            initializePayingAmounts(dueBillFees);
         }
     }
 
@@ -517,6 +519,7 @@ public class StaffPaymentBillController implements Serializable {
                 dueBillFees.removeAll(removeingBillFees);
             }
 
+            initializePayingAmounts(dueBillFees);
         }
     }
 
@@ -524,6 +527,20 @@ public class StaffPaymentBillController implements Serializable {
         totalDue = 0;
         for (BillFee f : dueBillFees) {
             totalDue = totalDue + f.getFeeValue() - f.getPaidValue();
+        }
+    }
+
+    /**
+     * Defaults the UI-only, transient payingAmount for each due BillFee to
+     * the full outstanding balance (feeValue - paidValue). The cashier can
+     * then reduce this amount on the UI to make a partial payment.
+     */
+    private void initializePayingAmounts(List<BillFee> fees) {
+        if (fees == null) {
+            return;
+        }
+        for (BillFee bf : fees) {
+            bf.setPayingAmount(bf.getFeeValue() - bf.getPaidValue());
         }
     }
 
@@ -549,7 +566,9 @@ public class StaffPaymentBillController implements Serializable {
     public void calculatePaymentsSelected() {
         totalPaying = 0;
         for (BillFee f : payingBillFees) {
-            totalPaying = totalPaying + (f.getFeeValue() - f.getPaidValue());
+            double outstanding = f.getFeeValue() - f.getPaidValue();
+            double amount = f.getPayingAmount() != null ? f.getPayingAmount() : outstanding;
+            totalPaying = totalPaying + amount;
         }
     }
 
@@ -718,6 +737,19 @@ public class StaffPaymentBillController implements Serializable {
             JsfUtil.addErrorMessage("Please select payments to update");
             return true;
         }
+        if (payingBillFees != null) {
+            for (BillFee f : payingBillFees) {
+                double outstanding = f.getFeeValue() - f.getPaidValue();
+                if (f.getPayingAmount() == null || f.getPayingAmount() <= 0) {
+                    JsfUtil.addErrorMessage("Please enter a valid paying amount for all selected fees");
+                    return true;
+                }
+                if (f.getPayingAmount() - outstanding > 0.1) {
+                    JsfUtil.addErrorMessage("Paying amount cannot exceed the outstanding due amount");
+                    return true;
+                }
+            }
+        }
         performCalculations();
         if (totalPaying == 0) {
             JsfUtil.addErrorMessage("Please select payments to update");
@@ -772,11 +804,14 @@ public class StaffPaymentBillController implements Serializable {
 
     private void saveBillCompo(Bill paymentBill, Payment paymentBillPayment) {
         for (BillFee originalBillFee : getPayingBillFees()) {
+            double amountPaidNow = originalBillFee.getPayingAmount() != null
+                    ? originalBillFee.getPayingAmount()
+                    : (originalBillFee.getFeeValue() - originalBillFee.getPaidValue());
 //            saveBillItemForPaymentBill(b, bf); //for create bill fees and billfee payments
-            saveBillItemForPaymentBill(paymentBill, originalBillFee, paymentBillPayment);
+            saveBillItemForPaymentBill(paymentBill, originalBillFee, paymentBillPayment, amountPaidNow);
 //            saveBillFeeForPaymentBill(b,bf); No need to add fees for this bill
-            originalBillFee.setPaidValue(originalBillFee.getFeeValue());
-            originalBillFee.setSettleValue(originalBillFee.getFeeValue());
+            originalBillFee.setPaidValue(originalBillFee.getPaidValue() + amountPaidNow);
+            originalBillFee.setSettleValue(originalBillFee.getSettleValue() + amountPaidNow);
             getBillFeeFacade().edit(originalBillFee);
             //////// // System.out.println("marking as paid");
         }
@@ -802,7 +837,7 @@ public class StaffPaymentBillController implements Serializable {
         b.getBillItems().add(i);
     }
 
-    private void saveBillItemForPaymentBill(Bill newPaymentBill, BillFee originalBillFee, Payment p) {
+    private void saveBillItemForPaymentBill(Bill newPaymentBill, BillFee originalBillFee, Payment p, double amountPaidNow) {
         BillItem newlyCreatedPayingBillItem = new BillItem();
         newlyCreatedPayingBillItem.setReferanceBillItem(originalBillFee.getBillItem());
         newlyCreatedPayingBillItem.setReferenceBill(originalBillFee.getBill());
@@ -811,10 +846,10 @@ public class StaffPaymentBillController implements Serializable {
         newlyCreatedPayingBillItem.setCreatedAt(Calendar.getInstance().getTime());
         newlyCreatedPayingBillItem.setCreater(getSessionController().getLoggedUser());
         newlyCreatedPayingBillItem.setDiscount(0.0);
-        newlyCreatedPayingBillItem.setGrossValue(originalBillFee.getFeeValue());
-        newlyCreatedPayingBillItem.setNetValue(originalBillFee.getFeeValue());
+        newlyCreatedPayingBillItem.setGrossValue(amountPaidNow);
+        newlyCreatedPayingBillItem.setNetValue(amountPaidNow);
         newlyCreatedPayingBillItem.setQty(1.0);
-        newlyCreatedPayingBillItem.setRate(originalBillFee.getFeeValue());
+        newlyCreatedPayingBillItem.setRate(amountPaidNow);
         getBillItemFacade().create(newlyCreatedPayingBillItem);
 
         BillFee newlyCreatedBillFee = saveBillFee(newlyCreatedPayingBillItem, p);

--- a/src/main/java/com/divudi/bean/inward/InwardStaffPaymentBillController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardStaffPaymentBillController.java
@@ -363,6 +363,13 @@ public class InwardStaffPaymentBillController implements Serializable {
         }
         dueBillFees.removeAll(removeingBillFees);
 
+        // Default each due fee's UI-only paying amount to "pay in full" (the
+        // outstanding balance) unless the cashier edits it down for a partial
+        // payment — issue #22821.
+        for (BillFee bf : dueBillFees) {
+            bf.setPayingAmount(bf.getFeeValue() - bf.getPaidValue());
+        }
+
 //        if (configOptionApplicationController.getBooleanValueByKey("Remove Refunded Bill From OPD Staff Payment")) {
 //            List<BillFee> removeingBillFees = new ArrayList<>();
 //            for (BillFee bf : dueBillFees) {
@@ -464,17 +471,25 @@ public class InwardStaffPaymentBillController implements Serializable {
 
     private void saveBillCompo(Bill paymentBill, Payment paymentBillPayment) {
         for (BillFee originalBillFee : getPayingBillFees()) {
+            // Partial payment support (#22821): pay only the amount the cashier
+            // entered for this fee, not necessarily the full outstanding due.
+            // Fall back to the full outstanding balance if payingAmount was
+            // somehow left unset (defensive — should always be set by
+            // calculateDueFeesForInwardForSelectedPeriod()).
+            double amountPaidNow = originalBillFee.getPayingAmount() != null
+                    ? originalBillFee.getPayingAmount()
+                    : (originalBillFee.getFeeValue() - originalBillFee.getPaidValue());
 //            saveBillItemForPaymentBill(b, bf); //for create bill fees and billfee payments
-            saveBillItemForPaymentBill(paymentBill, originalBillFee, paymentBillPayment);
+            saveBillItemForPaymentBill(paymentBill, originalBillFee, paymentBillPayment, amountPaidNow);
 //            saveBillFeeForPaymentBill(b,bf); No need to add fees for this bill
-            originalBillFee.setPaidValue(originalBillFee.getFeeValue());
-            originalBillFee.setSettleValue(originalBillFee.getFeeValue());
+            originalBillFee.setPaidValue(originalBillFee.getPaidValue() + amountPaidNow);
+            originalBillFee.setSettleValue(originalBillFee.getSettleValue() + amountPaidNow);
             getBillFeeFacade().edit(originalBillFee);
             //////// // System.out.println("marking as paid");
         }
     }
 
-    private void saveBillItemForPaymentBill(Bill newPaymentBill, BillFee originalBillFee, Payment p) {
+    private void saveBillItemForPaymentBill(Bill newPaymentBill, BillFee originalBillFee, Payment p, double amountPaidNow) {
         BillItem newlyCreatedPayingBillItem = new BillItem();
         newlyCreatedPayingBillItem.setReferanceBillItem(originalBillFee.getBillItem());
         newlyCreatedPayingBillItem.setReferenceBill(originalBillFee.getBill());
@@ -483,10 +498,10 @@ public class InwardStaffPaymentBillController implements Serializable {
         newlyCreatedPayingBillItem.setCreatedAt(Calendar.getInstance().getTime());
         newlyCreatedPayingBillItem.setCreater(getSessionController().getLoggedUser());
         newlyCreatedPayingBillItem.setDiscount(0.0);
-        newlyCreatedPayingBillItem.setGrossValue(originalBillFee.getFeeValue());
-        newlyCreatedPayingBillItem.setNetValue(originalBillFee.getFeeValue());
+        newlyCreatedPayingBillItem.setGrossValue(amountPaidNow);
+        newlyCreatedPayingBillItem.setNetValue(amountPaidNow);
         newlyCreatedPayingBillItem.setQty(1.0);
-        newlyCreatedPayingBillItem.setRate(originalBillFee.getFeeValue());
+        newlyCreatedPayingBillItem.setRate(amountPaidNow);
         getBillItemFacade().create(newlyCreatedPayingBillItem);
 
         BillFee newlyCreatedBillFee = saveBillFee(newlyCreatedPayingBillItem, p);
@@ -1407,7 +1422,8 @@ public class InwardStaffPaymentBillController implements Serializable {
             return;
         }
         for (BillFee f : payingBillFees) {
-            totalPaying = totalPaying + (f.getFeeValue() - f.getPaidValue());
+            Double payingAmount = f.getPayingAmount();
+            totalPaying = totalPaying + (payingAmount != null ? payingAmount : (f.getFeeValue() - f.getPaidValue()));
         }
     }
 
@@ -1775,6 +1791,16 @@ public class InwardStaffPaymentBillController implements Serializable {
         if (dueBillFees == null) {
             JsfUtil.addErrorMessage("Please select payments to update 1");
             return true;
+        }
+        if (payingBillFees != null) {
+            for (BillFee f : payingBillFees) {
+                double outstanding = f.getFeeValue() - f.getPaidValue();
+                Double amt = f.getPayingAmount();
+                if (amt == null || amt <= 0 || amt > outstanding + 0.1) {
+                    JsfUtil.addErrorMessage("Amount to pay for one of the selected fees is invalid or exceeds the due amount");
+                    return true;
+                }
+            }
         }
         System.out.println("totalPaying666 = " + totalPaying);
         if (totalPaying == 0) {

--- a/src/main/java/com/divudi/bean/inward/InwardSurgeryPaymentBillController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSurgeryPaymentBillController.java
@@ -205,6 +205,13 @@ public class InwardSurgeryPaymentBillController implements Serializable {
         }
         dueSurgeryFees.removeAll(removeingBillFees);
 
+        // Default the UI-only "amount to pay now" to the full outstanding
+        // balance for each due fee, so existing full-payment behaviour is
+        // unchanged unless the cashier edits it down for a partial payment.
+        for (BillFee sf : dueSurgeryFees) {
+            sf.setPayingAmount(sf.getFeeValue() - sf.getPaidValue());
+        }
+
         calculateTotalPaymentsForTheSurgeonForCurrentMonthForCurrentInstitution();
         performCalculations();
     }
@@ -262,7 +269,8 @@ public class InwardSurgeryPaymentBillController implements Serializable {
             return;
         }
         for (BillFee f : payingSurgeryFees) {
-            totalPaying = totalPaying + (f.getFeeValue() - f.getPaidValue());
+            Double payingAmount = f.getPayingAmount();
+            totalPaying = totalPaying + (payingAmount != null ? payingAmount : (f.getFeeValue() - f.getPaidValue()));
         }
     }
 
@@ -597,8 +605,12 @@ public class InwardSurgeryPaymentBillController implements Serializable {
 
         // Update bill fees without creating payment records
         for (BillFee originalBillFee : getPayingSurgeryFees()) {
-            originalBillFee.setPaidValue(originalBillFee.getFeeValue());
-            originalBillFee.setSettleValue(originalBillFee.getFeeValue());
+            double outstanding = originalBillFee.getFeeValue() - originalBillFee.getPaidValue();
+            Double payingAmount = originalBillFee.getPayingAmount();
+            double amountPaidNow = payingAmount != null ? payingAmount : outstanding;
+
+            originalBillFee.setPaidValue(originalBillFee.getPaidValue() + amountPaidNow);
+            originalBillFee.setSettleValue(originalBillFee.getSettleValue() + amountPaidNow);
 
             // Mark as collected by doctor if flag is set
             if (feeCollectedByDoctor) {
@@ -631,6 +643,20 @@ public class InwardSurgeryPaymentBillController implements Serializable {
         if (dueSurgeryFees == null) {
             JsfUtil.addErrorMessage("Please select surgeries to pay");
             return true;
+        }
+        if (getPayingSurgeryFees() != null) {
+            for (BillFee f : getPayingSurgeryFees()) {
+                double outstanding = f.getFeeValue() - f.getPaidValue();
+                Double payingAmount = f.getPayingAmount();
+                if (payingAmount == null || payingAmount <= 0) {
+                    JsfUtil.addErrorMessage("Please enter a valid paying amount for all selected surgery fees");
+                    return true;
+                }
+                if (payingAmount - outstanding > 0.1) {
+                    JsfUtil.addErrorMessage("Paying amount cannot exceed the outstanding due amount for a surgery fee");
+                    return true;
+                }
+            }
         }
         if (totalPaying == 0) {
             JsfUtil.addErrorMessage("Please select surgeries to pay");
@@ -693,20 +719,24 @@ public class InwardSurgeryPaymentBillController implements Serializable {
 
     private void saveBillCompo(Bill paymentBill, Payment paymentBillPayment) {
         for (BillFee originalBillFee : getPayingSurgeryFees()) {
-            saveBillItemForPaymentBill(paymentBill, originalBillFee, paymentBillPayment);
-            originalBillFee.setPaidValue(originalBillFee.getFeeValue());
-            originalBillFee.setSettleValue(originalBillFee.getFeeValue());
-            
+            double outstanding = originalBillFee.getFeeValue() - originalBillFee.getPaidValue();
+            Double payingAmount = originalBillFee.getPayingAmount();
+            double amountPaidNow = payingAmount != null ? payingAmount : outstanding;
+
+            saveBillItemForPaymentBill(paymentBill, originalBillFee, paymentBillPayment, amountPaidNow);
+            originalBillFee.setPaidValue(originalBillFee.getPaidValue() + amountPaidNow);
+            originalBillFee.setSettleValue(originalBillFee.getSettleValue() + amountPaidNow);
+
             // Mark as collected by doctor if flag is set
             if (feeCollectedByDoctor) {
                 originalBillFee.setFeeCollectedByDoctor(true);
             }
-            
+
             getBillFeeFacade().edit(originalBillFee);
         }
     }
 
-    private void saveBillItemForPaymentBill(Bill newPaymentBill, BillFee originalBillFee, Payment p) {
+    private void saveBillItemForPaymentBill(Bill newPaymentBill, BillFee originalBillFee, Payment p, double amountPaidNow) {
         BillItem newlyCreatedPayingBillItem = new BillItem();
         newlyCreatedPayingBillItem.setReferanceBillItem(originalBillFee.getBillItem());
         newlyCreatedPayingBillItem.setReferenceBill(originalBillFee.getBill());
@@ -715,10 +745,10 @@ public class InwardSurgeryPaymentBillController implements Serializable {
         newlyCreatedPayingBillItem.setCreatedAt(Calendar.getInstance().getTime());
         newlyCreatedPayingBillItem.setCreater(getSessionController().getLoggedUser());
         newlyCreatedPayingBillItem.setDiscount(0.0);
-        newlyCreatedPayingBillItem.setGrossValue(originalBillFee.getFeeValue());
-        newlyCreatedPayingBillItem.setNetValue(originalBillFee.getFeeValue());
+        newlyCreatedPayingBillItem.setGrossValue(amountPaidNow);
+        newlyCreatedPayingBillItem.setNetValue(amountPaidNow);
         newlyCreatedPayingBillItem.setQty(1.0);
-        newlyCreatedPayingBillItem.setRate(originalBillFee.getFeeValue());
+        newlyCreatedPayingBillItem.setRate(amountPaidNow);
         getBillItemFacade().create(newlyCreatedPayingBillItem);
 
         BillFee newlyCreatedBillFee = saveBillFee(newlyCreatedPayingBillItem, p);

--- a/src/main/java/com/divudi/core/entity/BillFee.java
+++ b/src/main/java/com/divudi/core/entity/BillFee.java
@@ -96,6 +96,12 @@ public class BillFee implements Serializable, RetirableEntity {
     @Transient
     private boolean userChangedTheGrossValueTransient;
 
+    // Amount the cashier is choosing to pay for this fee right now, editable in
+    // professional-payment settlement screens to support partial payment (#22821).
+    // Defaults to the full outstanding balance (feeValue - paidValue).
+    @Transient
+    private Double payingAmount;
+
     double feeMargin;
     double feeAdjusted;
 
@@ -919,6 +925,14 @@ public class BillFee implements Serializable, RetirableEntity {
 
     public void setUserChangedTheGrossValueTransient(boolean userChangedTheGrossValueTransient) {
         this.userChangedTheGrossValueTransient = userChangedTheGrossValueTransient;
+    }
+
+    public Double getPayingAmount() {
+        return payingAmount;
+    }
+
+    public void setPayingAmount(Double payingAmount) {
+        this.payingAmount = payingAmount;
     }
 
     public boolean isFeeCollectedByDoctor() {

--- a/src/main/webapp/channel/channel_payment_staff_bill.xhtml
+++ b/src/main/webapp/channel/channel_payment_staff_bill.xhtml
@@ -233,6 +233,17 @@
                                     <h:outputLabel  value="#{bf.feeValue}" />
                                 </p:column>
 
+                                <p:column headerText="Amount to Pay" width="9em;" class="text-end">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Amount to Pay"/>
+                                    </f:facet>
+                                    <p:inputNumber value="#{bf.payingAmount}" decimalPlaces="2" class="w-100">
+                                        <f:ajax event="blur" execute="@this"
+                                                listener="#{channelStaffPaymentBillController.performCalculations()}"
+                                                render=":#{p:resolveFirstComponentWithId('lblDue',view).clientId} :#{p:resolveFirstComponentWithId('lblPay',view).clientId}" />
+                                    </p:inputNumber>
+                                </p:column>
+
                             </p:dataTable>
 
 

--- a/src/main/webapp/inward/inward_bill_professional_payment.xhtml
+++ b/src/main/webapp/inward/inward_bill_professional_payment.xhtml
@@ -156,6 +156,17 @@
                                     </h:outputLabel>
                                 </p:column>
 
+                                <p:column headerText="Amount to Pay" width="9em;" class="text-end">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Amount to Pay"/>
+                                    </f:facet>
+                                    <p:inputNumber value="#{bf.payingAmount}" decimalPlaces="2" class="w-100">
+                                        <p:ajax event="blur" process="@this"
+                                                listener="#{inwardStaffPaymentBillController.onSelectionChanged()}"
+                                                update=":#{p:resolveFirstComponentWithId('pTotals',view).clientId} :#{p:resolveFirstComponentWithId('pnlHoldOverride',view).clientId}" />
+                                    </p:inputNumber>
+                                </p:column>
+
                                 <p:column headerText="Hold Status" width="14em;">
                                     <f:facet name="header">
                                         <h:outputLabel value="Hold Status"/>

--- a/src/main/webapp/inward/inward_bill_surgery_payment.xhtml
+++ b/src/main/webapp/inward/inward_bill_surgery_payment.xhtml
@@ -156,6 +156,17 @@
                                     </h:outputLabel>
                                 </p:column>
 
+                                <p:column headerText="Amount to Pay" width="9em;" class="text-end">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Amount to Pay"/>
+                                    </f:facet>
+                                    <p:inputNumber value="#{bf.payingAmount}" decimalPlaces="2" class="w-100">
+                                        <p:ajax event="blur" process="@this"
+                                                listener="#{inwardSurgeryPaymentBillController.onSelectionChanged()}"
+                                                update=":#{p:resolveFirstComponentWithId('pTotals',view).clientId} :#{p:resolveFirstComponentWithId('pnlHoldOverride',view).clientId}" />
+                                    </p:inputNumber>
+                                </p:column>
+
                                 <p:column headerText="Hold Status" width="14em;">
                                     <f:facet name="header">
                                         <h:outputLabel value="Hold Status"/>

--- a/src/main/webapp/opd/professional_payments/payment_staff_bill.xhtml
+++ b/src/main/webapp/opd/professional_payments/payment_staff_bill.xhtml
@@ -213,10 +213,21 @@
                                 <p:column headerText="Charge" width="6em;" class="text-end">
                                     <f:facet name="header">
                                         <h:outputLabel value="Charge"/>
-                                    </f:facet>    
+                                    </f:facet>
                                     <h:outputLabel value="#{bf.feeValue}" >
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
+                                </p:column>
+
+                                <p:column headerText="Amount to Pay" width="9em;" class="text-end">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Amount to Pay"/>
+                                    </f:facet>
+                                    <p:inputNumber value="#{bf.payingAmount}" decimalPlaces="2" class="w-100">
+                                        <p:ajax event="blur" process="@this"
+                                                listener="#{staffPaymentBillController.performCalculations()}"
+                                                update=":#{p:resolveFirstComponentWithId('pTotals',view).clientId}" />
+                                    </p:inputNumber>
                                 </p:column>
 
                             </p:dataTable>


### PR DESCRIPTION
## Summary

Adds partial-payment support for professional fees, closing #22821. Previously a due fee could only be settled in full (e.g. must pay all 5,000 in one shot). Cashiers can now enter a smaller amount per fee row, leaving the remainder due for a later payment.

- `BillFee` gains a transient `payingAmount` field (UI-only, not persisted) — the amount the cashier is choosing to pay right now, defaulting to the full outstanding balance.
- Applied consistently across the 4 screens that settle professional fees:
  - `inward/inward_bill_professional_payment.xhtml` (`InwardStaffPaymentBillController`)
  - `inward/inward_bill_surgery_payment.xhtml` (`InwardSurgeryPaymentBillController`, including its no-payment-record `settleWithoutPayment()` path)
  - `opd/professional_payments/payment_staff_bill.xhtml` (`StaffPaymentBillController`)
  - `channel/channel_payment_staff_bill.xhtml` (`ChannelStaffPaymentBillController`)
- Settlement now *accumulates* `paidValue`/`settleValue` by the entered amount instead of overwriting with the full fee value, and the generated payment bill/receipt reflects the actual amount paid.
- WHT (where applicable) and drawer-balance checks derive from the entered amount, matching existing behavior for full payments.

Out of scope (per design discussion): a separate legacy settlement flow on `inward_bill_staff_payment.xhtml` (not the target screen), and `WorkingTimeController` (HR payroll, unrelated domain).

## Test plan

Verified end-to-end against a local build on the Inward Professional Payment screen (dept "Inward", Dr. (MRS) R.R WEERAKOON, BHT/56755, Rs. 5,000.00 due fee):

- [x] Amount to Pay defaults to the full outstanding balance
- [x] Reducing it to 3,000 and settling produces a payment voucher for 3,000.00, not 5,000.00
- [x] `BILLFEE.PAIDVALUE`/`SETTLEVALUE` become 3000 (accumulated), not overwritten to 5000
- [x] The fee reappears in the due list with Amount to Pay pre-filled at the new remaining balance (2,000.00)
- [x] The other 3 screens render the new "Amount to Pay" column with no errors (UI smoke test); their settlement logic mirrors the verified pattern (code-reviewed)

Full verification writeup with screenshots: https://github.com/hmislk/hmis/issues/22821#issuecomment-5238641756

🤖 Generated with [Claude Code](https://claude.ai/code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for partial payments across staff, professional, inward professional, and surgery fee payments.
  * Added editable “Amount to Pay” fields for individual fees, defaulting to the outstanding balance.
  * Payment totals and settlement records now reflect the amount entered for each fee.
* **Bug Fixes**
  * Added validation to reject missing, non-positive, or excessive payment amounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->