### PR TITLE
fix(lab): auto-send SMS after lab report approval never fires (sendingFailed NULL)

### DIFF
--- a/src/main/java/com/divudi/bean/lab/PatientReportController.java
+++ b/src/main/java/com/divudi/bean/lab/PatientReportController.java
@@ -2284,6 +2284,7 @@ public class PatientReportController implements Serializable {
                 e.setDepartment(sessionController.getLoggedUser().getDepartment());
                 e.setInstitution(sessionController.getLoggedUser().getInstitution());
                 e.setSentSuccessfully(false);
+                e.setSendingFailed(false);
                 getSmsFacade().create(e);
 
                 if (configOptionApplicationController.getBooleanValueByKey("Lab Test History Enabled", false)) {
@@ -2310,6 +2311,7 @@ public class PatientReportController implements Serializable {
                         e.setDepartment(getSessionController().getLoggedUser().getDepartment());
                         e.setInstitution(getSessionController().getLoggedUser().getInstitution());
                         e.setSentSuccessfully(false);
+                        e.setSendingFailed(false);
                         getSmsFacade().create(e);
                     }
                 }
@@ -2424,6 +2426,7 @@ public class PatientReportController implements Serializable {
                 e.setDepartment(getSessionController().getLoggedUser().getDepartment());
                 e.setInstitution(getSessionController().getLoggedUser().getInstitution());
                 e.setPending(true);
+                e.setSendingFailed(false);
                 getSmsFacade().create(e);
 
                 currentSMS = e;

--- a/src/main/java/com/divudi/ejb/SmsManagerEjb.java
+++ b/src/main/java/com/divudi/ejb/SmsManagerEjb.java
@@ -144,12 +144,11 @@ public class SmsManagerEjb {
         minCreatedAt.add(Calendar.HOUR_OF_DAY, -24);
 
         String jpql = "Select e from Sms e where e.pending=true and e.retired=false "
-                + " and e.smsType = :smsType and e.sendingFailed =:failed "
+                + " and e.smsType = :smsType and (e.sendingFailed = false or e.sendingFailed is null) "
                 + " and e.createdAt between :from and :to";
         Map<String, Object> params = new HashMap<>();
         params.put("from", minCreatedAt.getTime());
         params.put("to", delayThreshold.getTime());
-        params.put("failed", false);
         params.put("smsType", MessageType.LabReport);
 
         List<Sms> smses = smsFacade.findByJpql(jpql, params, TemporalType.TIMESTAMP);


### PR DESCRIPTION
## Summary
Fixes #22827 — after a lab report is approved, the "send SMS after N minutes" auto-send never fires; the SMS stays queued forever.

## Root Cause
Queued `Sms` rows created on report approval (and via the manual "Send SMS" button) never set `sendingFailed`, leaving it `NULL`. The auto-send scheduler in `SmsManagerEjb` filters candidates with `e.sendingFailed = :failed` (`failed=false`), and in JPQL/SQL `NULL = false` never matches — so every queued lab report SMS is invisible to the timer and never gets picked up, regardless of the configured delay strategy (e.g. "Send after 10 minutes").

Confirmed against the local database: every recent LabReport `Sms` row is stuck `PENDING=1, SENDINGFAILED=NULL`.

## Changes
- `PatientReportController.java`: explicitly set `sendingFailed(false)` at the three sites that queue a lab report `Sms` (patient SMS on approval, collecting-centre SMS on approval, manual "Send SMS" button).
- `SmsManagerEjb.java`: scheduler query now treats `sendingFailed IS NULL` as not-failed, so already-stuck recent records (within the existing 24h lookback window) also get swept up and sent, not just newly created ones.

## Test plan
- [ ] Approve a lab patient report for a patient with an SMS number and `Investigation.allowToSendSMS` enabled.
- [ ] Confirm the created `Sms` row has `sendingFailed=false` (not `NULL`) immediately after approval.
- [ ] Wait past the configured "Sending SMS After Lab Report Approval Strategy" delay and confirm the SMS is sent and the row flips to `pending=false`, `sentSuccessfully=true`.
- [ ] Confirm pre-existing recent stuck rows (`sendingFailed=NULL`, `pending=true`, created within the last 24h) also get sent by the scheduler after this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of lab report SMS sending by correctly initializing message status.
  * Pending lab-report messages with an unset or unsuccessful status are now eligible for processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->