### PR TITLE
Add Inpatient Dashboard navigation button to bill reprint pages

### DIFF
--- a/src/main/webapp/inward/inward_reprint_bill_payment.xhtml
+++ b/src/main/webapp/inward/inward_reprint_bill_payment.xhtml
@@ -79,6 +79,20 @@
                                         actionListener="#{bhtSummeryController.createTables()}"
                                         >
                                     </p:commandButton>
+
+                                    <p:commandButton
+                                        id="btnInpatientDashboard"
+                                        ajax="false"
+                                        icon="fas fa-id-card"
+                                        class="ui-button-secondary "
+                                        value="Inpatient Dashboard"
+                                        action="#{bhtSummeryController.navigateToInpatientProfile()}"
+                                        >
+                                        <f:setPropertyActionListener
+                                            value="#{bhtSummeryController.patientEncounter}"
+                                            target="#{admissionController.current}" >
+                                        </f:setPropertyActionListener>
+                                    </p:commandButton>
                                 </div>
                             </div>
                         </f:facet>

--- a/src/main/webapp/inward/inward_reprint_bill_post_final_payment.xhtml
+++ b/src/main/webapp/inward/inward_reprint_bill_post_final_payment.xhtml
@@ -59,6 +59,20 @@
                                         actionListener="#{bhtSummeryController.createTables()}"
                                         >
                                     </p:commandButton>
+
+                                    <p:commandButton
+                                        id="btnInpatientDashboard"
+                                        ajax="false"
+                                        icon="fas fa-id-card"
+                                        class="ui-button-secondary "
+                                        value="Inpatient Dashboard"
+                                        action="#{bhtSummeryController.navigateToInpatientProfile()}"
+                                        >
+                                        <f:setPropertyActionListener
+                                            value="#{bhtSummeryController.patientEncounter}"
+                                            target="#{admissionController.current}" >
+                                        </f:setPropertyActionListener>
+                                    </p:commandButton>
                                 </div>
                             </div>
                         </f:facet>

--- a/src/main/webapp/inward/inward_reprint_bill_refund.xhtml
+++ b/src/main/webapp/inward/inward_reprint_bill_refund.xhtml
@@ -46,6 +46,19 @@
                                                  icon="fa fa-backward"
                                                  actionListener="#{bhtSummeryController.createTables()}"
                                                   />
+                                <p:commandButton
+                                    id="btnInpatientDashboard"
+                                    ajax="false"
+                                    icon="fas fa-id-card"
+                                    class="ui-button-secondary mx-1"
+                                    value="Inpatient Dashboard"
+                                    action="#{bhtSummeryController.navigateToInpatientProfile()}"
+                                    >
+                                    <f:setPropertyActionListener
+                                        value="#{bhtSummeryController.patientEncounter}"
+                                        target="#{admissionController.current}" >
+                                    </f:setPropertyActionListener>
+                                </p:commandButton>
                          </div>
                                 </div>
                         </f:facet>    


### PR DESCRIPTION
## Summary
Added "Inpatient Dashboard" navigation buttons to three inward bill reprint pages, allowing users to quickly access the inpatient profile from the billing workflow.

## Changes
- **inward_reprint_bill_payment.xhtml**: Added `btnInpatientDashboard` command button that navigates to the inpatient profile and passes the current patient encounter to the admission controller
- **inward_reprint_bill_post_final_payment.xhtml**: Added identical `btnInpatientDashboard` button for consistency across post-final-payment billing flow
- **inward_reprint_bill_refund.xhtml**: Added `btnInpatientDashboard` button with slightly adjusted styling (`mx-1` margin class) to match the refund page layout

## Implementation Details
- All buttons use `ajax="false"` for full-page navigation
- Icon: `fas fa-id-card` for visual consistency
- Action: `#{bhtSummeryController.navigateToInpatientProfile()}`
- Uses `f:setPropertyActionListener` to pass `patientEncounter` from `bhtSummeryController` to `admissionController.current` before navigation
- Styled as secondary buttons (`ui-button-secondary`) to distinguish from primary actions

https://claude.ai/code/session_01SVebnhtfv8Bz2FHeKomzmn