### PR TITLE
feat(inward): Deposit cancellation/refund workflow with independent serial numbers

### DIFF
--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -16587,6 +16587,7 @@ public class SearchController implements Serializable {
         Map temMap = new HashMap();
         sql = "select b from BilledBill b where"
                 + " b.billType = :billType "
+                + " and b.billTypeAtomic = :bta "
                 + " and b.createdAt between :fromDate and :toDate "
                 + " and b.retired=false  ";
 
@@ -16623,6 +16624,59 @@ public class SearchController implements Serializable {
         sql += " order by b.deptId desc  ";
 
         temMap.put("billType", BillType.InwardPaymentBill);
+        temMap.put("bta", BillTypeAtomic.INWARD_PAYMENT);
+        temMap.put("toDate", toDate);
+        temMap.put("fromDate", fromDate);
+
+        bills = getBillFacade().findByJpql(sql, temMap, TemporalType.TIMESTAMP, 50);
+
+    }
+
+    public void createInwardDepositBills() {
+        Date startTime = new Date();
+
+        String sql;
+        Map temMap = new HashMap();
+        sql = "select b from BilledBill b where"
+                + " b.billType = :billType "
+                + " and b.billTypeAtomic = :bta "
+                + " and b.createdAt between :fromDate and :toDate "
+                + " and b.retired=false  ";
+
+        if (getSearchKeyword().getPatientName() != null && !getSearchKeyword().getPatientName().trim().equals("")) {
+            sql += " and  ((b.patientEncounter.patient.person.name) like :patientName )";
+            temMap.put("patientName", "%" + getSearchKeyword().getPatientName().trim().toUpperCase() + "%");
+        }
+
+        if (getSearchKeyword().getNumber() != null && !getSearchKeyword().getNumber().trim().equals("")) {
+            sql += " and  (((b.patientEncounter.patient.code) =:number ) or ((b.patientEncounter.patient.phn) =:number )) ";
+            temMap.put("number", getSearchKeyword().getNumber().trim().toUpperCase());
+        }
+
+        if (getSearchKeyword().getPatientPhone() != null && !getSearchKeyword().getPatientPhone().trim().equals("")) {
+            sql += " and  ((b.patientEncounter.patient.person.phone) like :patientPhone )";
+            temMap.put("patientPhone", "%" + getSearchKeyword().getPatientPhone().trim().toUpperCase() + "%");
+        }
+
+        if (getSearchKeyword().getBhtNo() != null && !getSearchKeyword().getBhtNo().trim().equals("")) {
+            sql += " and  ((b.patientEncounter.bhtNo) like :bht )";
+            temMap.put("bht", "%" + getSearchKeyword().getBhtNo().trim().toUpperCase() + "%");
+        }
+
+        if (getSearchKeyword().getBillNo() != null && !getSearchKeyword().getBillNo().trim().equals("")) {
+            sql += " and  ((b.insId) like :billNo )";
+            temMap.put("billNo", "%" + getSearchKeyword().getBillNo().trim().toUpperCase() + "%");
+        }
+
+        if (getSearchKeyword().getNetTotal() != null && !getSearchKeyword().getNetTotal().trim().equals("")) {
+            sql += " and  ((b.netTotal) = :netTotal )";
+            temMap.put("netTotal", "%" + getSearchKeyword().getNetTotal().trim().toUpperCase() + "%");
+        }
+
+        sql += " order by b.deptId desc  ";
+
+        temMap.put("billType", BillType.InwardPaymentBill);
+        temMap.put("bta", BillTypeAtomic.INWARD_DEPOSIT);
         temMap.put("toDate", toDate);
         temMap.put("fromDate", fromDate);
 

--- a/src/main/java/com/divudi/bean/inward/InwardRefundController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardRefundController.java
@@ -10,7 +10,9 @@ package com.divudi.bean.inward;
 
 import com.divudi.bean.cashTransaction.FinancialTransactionController;
 import com.divudi.bean.common.BillBeanController;
+import com.divudi.bean.common.ConfigOptionApplicationController;
 import com.divudi.bean.common.SessionController;
+import com.divudi.core.entity.inward.AdmissionType;
 import com.divudi.core.util.JsfUtil;
 import com.divudi.bean.membership.PaymentSchemeController;
 import com.divudi.core.data.*;
@@ -66,6 +68,8 @@ public class InwardRefundController implements Serializable {
     private boolean printPreview;
     @Inject
     private InwardBeanController inwardBean;
+    @Inject
+    private ConfigOptionApplicationController configOptionApplicationController;
     private List<Bill> eligiblePaymentBills;
     private Bill originalBillToRefund;
     private Map<Long, Double> remainingRefundableAmountCache;
@@ -120,6 +124,35 @@ public class InwardRefundController implements Serializable {
             return "";
         }
         originalBillToRefund = originPaymentBill;
+        selectBillToRefundListener();
+        return "/inward/inward_bill_refund?faces-redirect=true";
+    }
+
+    /**
+     * Navigate to the inward deposit refund page with a specific deposit bill
+     * pre-selected, for the "Refund" button on the Deposit Reprint view page
+     * (issue #22826). Reuses the same eligibility filtering as the manual
+     * bill picker (loadEligiblePaymentBills()) so this can't be tricked into
+     * pre-selecting an ineligible (cancelled / fully refunded) bill.
+     */
+    public String navigateToRefundFromDepositBill(Bill originDepositBill) {
+        makeNull();
+        if (originDepositBill == null || originDepositBill.getPatientEncounter() == null) {
+            JsfUtil.addErrorMessage("No bill is selected");
+            return "";
+        }
+        financialTransactionController.findNonClosedShiftStartFundBillIsAvailable();
+        if (financialTransactionController.getNonClosedShiftStartFundBill() == null) {
+            JsfUtil.addErrorMessage("Start Your Shift First !");
+            return "/cashier/index?faces-redirect=true";
+        }
+        getCurrent().setPatientEncounter(originDepositBill.getPatientEncounter());
+        loadEligiblePaymentBills();
+        if (!getEligiblePaymentBills().contains(originDepositBill)) {
+            JsfUtil.addErrorMessage("This bill is not eligible for refund (already cancelled or fully refunded).");
+            return "";
+        }
+        originalBillToRefund = originDepositBill;
         selectBillToRefundListener();
         return "/inward/inward_bill_refund?faces-redirect=true";
     }
@@ -179,7 +212,6 @@ public class InwardRefundController implements Serializable {
         }
 
         saveBill();
-        getCurrent().setBillTypeAtomic(BillTypeAtomic.INWARD_PAYMENT_REFUND);
         getBillFacade().edit(getCurrent());
         saveBillItem();
 
@@ -217,8 +249,24 @@ public class InwardRefundController implements Serializable {
         getCurrent().setInstitution(getSessionController().getInstitution());
         getCurrent().setDepartment(getSessionController().getDepartment());
         getCurrent().setReferenceBill(getOriginalBillToRefund());
-        getCurrent().setDeptId(getBillNumberBean().institutionBillNumberGenerator(getSessionController().getDepartment(), getCurrent().getBillType(), BillClassType.RefundBill, BillNumberSuffix.INWREF));
-        getCurrent().setInsId(getBillNumberBean().institutionBillNumberGenerator(getSessionController().getInstitution(), getCurrent().getBillType(), BillClassType.RefundBill, BillNumberSuffix.INWREF));
+
+        BillTypeAtomic refundAtomic = getOriginalBillToRefund().getBillTypeAtomic() == BillTypeAtomic.INWARD_DEPOSIT
+                ? BillTypeAtomic.INWARD_DEPOSIT_REFUND
+                : BillTypeAtomic.INWARD_PAYMENT_REFUND;
+        getCurrent().setBillTypeAtomic(refundAtomic);
+
+        AdmissionType admissionTypeForBillNumber = getCurrent().getPatientEncounter() != null
+                ? getCurrent().getPatientEncounter().getAdmissionType() : null;
+        boolean uniqueSerialPerAdmissionType = admissionTypeForBillNumber != null
+                && configOptionApplicationController.getBooleanValueByKey(
+                        "Bill Number Generation Strategy - Unique Serial Per Admission Type for Inward Payments", false);
+        if (uniqueSerialPerAdmissionType) {
+            getCurrent().setDeptId(getBillNumberBean().departmentBillNumberGeneratorYearly(getSessionController().getDepartment(), refundAtomic, admissionTypeForBillNumber));
+            getCurrent().setInsId(getBillNumberBean().institutionBillNumberGeneratorYearly(getSessionController().getInstitution(), refundAtomic, admissionTypeForBillNumber));
+        } else {
+            getCurrent().setDeptId(getBillNumberBean().departmentBillNumberGeneratorYearly(getSessionController().getDepartment(), refundAtomic));
+            getCurrent().setInsId(getBillNumberBean().institutionBillNumberGeneratorYearly(getSessionController().getInstitution(), refundAtomic));
+        }
 
         double dbl = Math.abs(getCurrent().getTotal());
 
@@ -418,6 +466,13 @@ public class InwardRefundController implements Serializable {
 
     public void setOriginalBillToRefund(Bill originalBillToRefund) {
         this.originalBillToRefund = originalBillToRefund;
+    }
+
+    public String getFeatureLabel(Bill b) {
+        if (b == null || b.getBillTypeAtomic() == null) {
+            return "";
+        }
+        return b.getBillTypeAtomic() == BillTypeAtomic.INWARD_DEPOSIT ? "Deposit" : "Payment";
     }
 
     public void calculteFinalBillMax() {

--- a/src/main/java/com/divudi/bean/inward/InwardSearch.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSearch.java
@@ -376,6 +376,10 @@ public class InwardSearch implements Serializable {
             JsfUtil.addErrorMessage("This bill has already been refunded and cannot be cancelled.");
             return "";
         }
+        if (bill.getBillTypeAtomic() != BillTypeAtomic.INWARD_DEPOSIT) {
+            JsfUtil.addErrorMessage("Selected bill is not an Inward Deposit bill.");
+            return "";
+        }
         inwardDepositCancelationPaymentMethods = new ArrayList<>();
         getInwardDepositCancelationPaymentMethods().add(PaymentMethod.Cash);
         if (bill.getPaymentMethod() != PaymentMethod.Cash) {
@@ -1872,6 +1876,7 @@ public class InwardSearch implements Serializable {
 
             if (dbl < getBill().getNetTotal()) {
                 JsfUtil.addErrorMessage("This Bht has No Enough Vallue To Cancel");
+                return;
             }
 
             CancelledBill cb = createCancelInwardDepositBill();

--- a/src/main/java/com/divudi/bean/inward/InwardSearch.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSearch.java
@@ -29,6 +29,7 @@ import com.divudi.ejb.CashTransactionBean;
 import com.divudi.ejb.EjbApplication;
 import com.divudi.core.entity.*;
 import com.divudi.core.entity.inward.Admission;
+import com.divudi.core.entity.inward.AdmissionType;
 import com.divudi.core.entity.inward.EncounterComponent;
 import com.divudi.core.entity.lab.PatientInvestigation;
 import com.divudi.core.facade.BillComponentFacade;
@@ -362,6 +363,31 @@ public class InwardSearch implements Serializable {
         }
     }
 
+    public String navigateToDepositBillCancellation() {
+        if (bill == null) {
+            JsfUtil.addErrorMessage("No bill is selected");
+            return "";
+        }
+        if (bill.getCheckeAt() != null) {
+            JsfUtil.addErrorMessage("This bill is already checked. A checked bill cannot be cancelled.");
+            return "";
+        }
+        if (bill.isRefunded()) {
+            JsfUtil.addErrorMessage("This bill has already been refunded and cannot be cancelled.");
+            return "";
+        }
+        inwardDepositCancelationPaymentMethods = new ArrayList<>();
+        getInwardDepositCancelationPaymentMethods().add(PaymentMethod.Cash);
+        if (bill.getPaymentMethod() != PaymentMethod.Cash) {
+            inwardDepositCancelationPaymentMethods.add(bill.getPaymentMethod());
+        }
+        originalBillPaymentMethodData = new PaymentMethodData();
+        originalBillPaymentMethodData = loadCurrentBillPaymentMethodData(bill);
+        paymentMethodData = new PaymentMethodData();
+        refillPaymentDetail();
+        return "inward_cancel_bill_deposit?faces-redirect=true";
+    }
+
     public String navigateToCancelInwardServiceBillFromReprint() {
         if (bill == null) {
             JsfUtil.addErrorMessage("No bill is selected");
@@ -395,6 +421,43 @@ public class InwardSearch implements Serializable {
         billItems = null;
         printPreview = true;
         return "/inward/inward_deposit_cancel_bill_payment?faces-redirect=true";
+    }
+
+    public String navigateToViewDepositBillCancellation(Bill b) {
+        if (b == null || b.getCancelledBill() == null) {
+            JsfUtil.addErrorMessage("No cancellation bill found");
+            return "";
+        }
+        bill = b;
+        billItems = null;
+        printPreview = true;
+        return "/inward/inward_cancel_bill_deposit?faces-redirect=true";
+    }
+
+    /**
+     * Reprint navigation for a row in the Interim Bill's Payments tab, which
+     * can hold Payment bills, Deposit bills, and either feature's Refund
+     * bills all mixed together (issue #22826). Routes each to the correct
+     * reprint page: Refund bills (either feature) go to the shared generic
+     * refund reprint page; Deposit pay bills go to the new Deposit reprint
+     * page; everything else (Payment pay bills) keeps the existing Payment
+     * reprint page.
+     */
+    public String navigateToPaymentOrDepositReprint(Bill b) {
+        if (b == null) {
+            JsfUtil.addErrorMessage("No bill is selected");
+            return "";
+        }
+        bill = b;
+        billItems = null;
+        printPreview = false;
+        if (b instanceof RefundBill) {
+            return "/inward/inward_reprint_bill_refund?faces-redirect=true";
+        }
+        if (b.getBillTypeAtomic() == BillTypeAtomic.INWARD_DEPOSIT) {
+            return "/inward/inward_reprint_bill_deposit?faces-redirect=true";
+        }
+        return "/inward/inward_reprint_bill_payment?faces-redirect=true";
     }
 
     public void editBillDetails() {
@@ -1788,6 +1851,66 @@ public class InwardSearch implements Serializable {
 
     }
 
+    public void cancelInwardDepositBill() {
+        if (getBill() != null && getBill().getId() != null && getBill().getId() != 0) {
+
+            if (check()) {
+                return;
+            }
+
+            if (getBill().getCheckedBy() != null) {
+                JsfUtil.addErrorMessage("Checked Bill. Can not cancel");
+                return;
+            }
+
+            if (getBill().isRefunded()) {
+                JsfUtil.addErrorMessage("This bill has already been refunded and cannot be cancelled.");
+                return;
+            }
+
+            double dbl = getInwardBean().getPaidValue(getBill().getPatientEncounter());
+
+            if (dbl < getBill().getNetTotal()) {
+                JsfUtil.addErrorMessage("This Bht has No Enough Vallue To Cancel");
+            }
+
+            CancelledBill cb = createCancelInwardDepositBill();
+
+            getBillFacade().create(cb);
+            cancelBillItems(cb);
+            getBill().setCancelled(true);
+            getBill().setCancelledBill(cb);
+            getBillFacade().edit((BilledBill) getBill());
+
+            getBillBean().updateInwardDipositList(getBill().getPatientEncounter(), cb);
+
+            paymentService.createPayment(
+                cb,
+                cb.getPaymentMethod(),
+                paymentMethodData,
+                sessionController.getInstitution(),
+                sessionController.getDepartment(),
+                sessionController.getLoggedUser());
+
+            if (getBill().getPatientEncounter().isPaymentFinalized()) {
+                getInwardBean().updateFinalFill(getBill().getPatientEncounter());
+                if (getBill().getPatientEncounter().getPaymentMethod() == PaymentMethod.Credit) {
+                    getInwardBean().updateCreditDetail(getBill().getPatientEncounter(), getBill().getPatientEncounter().getFinalBill().getNetTotal());
+                }
+
+            }
+
+            WebUser wb = getCashTransactionBean().saveBillCashOutTransaction(cb, getSessionController().getLoggedUser());
+            getSessionController().setLoggedUser(wb);
+            JsfUtil.addSuccessMessage("Cancelled");
+
+            printPreview = true;
+
+        } else {
+            JsfUtil.addErrorMessage("No Bill to cancel");
+        }
+    }
+
     public CashTransactionBean getCashTransactionBean() {
         return cashTransactionBean;
     }
@@ -1808,12 +1931,16 @@ public class InwardSearch implements Serializable {
                 return;
             }
 
+            if (getBill().isCancelled()) {
+                JsfUtil.addErrorMessage("This bill has already been cancelled.");
+                return;
+            }
+
 //            if (getBill().getPatientEncounter().isPaymentFinalized()) {
 //                JsfUtil.addErrorMessage("Final Payment is Finalized You can't Cancel");
 //                return;
 //            }
             RefundBill cb = createRefundCancelBill();
-            cb.setBillTypeAtomic(BillTypeAtomic.INWARD_PAYMENT_REFUND_CANCELLATION);
             //Copy & paste
             getBillFacade().create(cb);
             cancelBillItems(cb);
@@ -2172,10 +2299,62 @@ public class InwardSearch implements Serializable {
         cb.setDepartment(getSessionController().getDepartment());
         cb.setInstitution(getSessionController().getInstitution());
 
-        cb.setDeptId(getBillNumberBean().departmentBillNumberGenerator(getSessionController().getDepartment(), getBill().getBillType(), BillClassType.CancelledBill, BillNumberSuffix.INWCAN));
-        cb.setInsId(getBillNumberBean().institutionBillNumberGenerator(getSessionController().getInstitution(), getBill().getBillType(), BillClassType.CancelledBill, BillNumberSuffix.INWCAN));
 //        cb.setBillType(BillType.InwardProfessional);
         cb.setBillTypeAtomic(BillTypeAtomic.INWARD_PAYMENT_CANCELLATION);
+
+        AdmissionType admissionTypeForBillNumber = getBill().getPatientEncounter() != null
+                ? getBill().getPatientEncounter().getAdmissionType() : null;
+        boolean uniqueSerialPerAdmissionType = admissionTypeForBillNumber != null
+                && configOptionApplicationController.getBooleanValueByKey(
+                        "Bill Number Generation Strategy - Unique Serial Per Admission Type for Inward Payments", false);
+        if (uniqueSerialPerAdmissionType) {
+            cb.setDeptId(getBillNumberBean().departmentBillNumberGeneratorYearly(getSessionController().getDepartment(), cb.getBillTypeAtomic(), admissionTypeForBillNumber));
+            cb.setInsId(getBillNumberBean().institutionBillNumberGeneratorYearly(getSessionController().getInstitution(), cb.getBillTypeAtomic(), admissionTypeForBillNumber));
+        } else {
+            cb.setDeptId(getBillNumberBean().departmentBillNumberGeneratorYearly(getSessionController().getDepartment(), cb.getBillTypeAtomic()));
+            cb.setInsId(getBillNumberBean().institutionBillNumberGeneratorYearly(getSessionController().getInstitution(), cb.getBillTypeAtomic()));
+        }
+        return cb;
+    }
+
+    private CancelledBill createCancelInwardDepositBill() {
+        CancelledBill cb = new CancelledBill();
+        cb.copy(getBill());
+        cb.invertAndAssignValuesFromOtherBill(getBill());
+        cb.setBilledBill(getBill());
+        if (getBill().getPatient() != null) {
+            cb.setPatient(getBill().getPatient());
+        } else if (getBill().getPatientEncounter() != null) {
+            cb.setPatient(getBill().getPatientEncounter().getPatient());
+        }
+
+        ////////////
+        cb.setBillDate(new Date());
+        cb.setBillTime(new Date());
+        cb.setCreatedAt(new Date());
+        cb.setCreater(getSessionController().getLoggedUser());
+        cb.setComments(comment);
+        cb.setPaymentMethod(paymentMethod);
+        //TODO: Find null Point Exception
+
+        cb.setDepartment(getSessionController().getDepartment());
+        cb.setInstitution(getSessionController().getInstitution());
+
+        cb.setBillTypeAtomic(BillTypeAtomic.INWARD_DEPOSIT_CANCELLATION);
+
+        AdmissionType admissionTypeForBillNumber = getBill().getPatientEncounter() != null
+                ? getBill().getPatientEncounter().getAdmissionType() : null;
+        boolean uniqueSerialPerAdmissionType = admissionTypeForBillNumber != null
+                && configOptionApplicationController.getBooleanValueByKey(
+                        "Bill Number Generation Strategy - Unique Serial Per Admission Type for Inward Payments", false);
+        if (uniqueSerialPerAdmissionType) {
+            cb.setDeptId(getBillNumberBean().departmentBillNumberGeneratorYearly(getSessionController().getDepartment(), cb.getBillTypeAtomic(), admissionTypeForBillNumber));
+            cb.setInsId(getBillNumberBean().institutionBillNumberGeneratorYearly(getSessionController().getInstitution(), cb.getBillTypeAtomic(), admissionTypeForBillNumber));
+        } else {
+            cb.setDeptId(getBillNumberBean().departmentBillNumberGeneratorYearly(getSessionController().getDepartment(), cb.getBillTypeAtomic()));
+            cb.setInsId(getBillNumberBean().institutionBillNumberGeneratorYearly(getSessionController().getInstitution(), cb.getBillTypeAtomic()));
+        }
+
         return cb;
     }
 
@@ -2226,8 +2405,23 @@ public class InwardSearch implements Serializable {
         cb.setDepartment(getSessionController().getLoggedUser().getDepartment());
         cb.setInstitution(getSessionController().getInstitution());
 
-        cb.setDeptId(getBillNumberBean().institutionBillNumberGenerator(getSessionController().getDepartment(), getBill().getBillType(), BillClassType.RefundBill, BillNumberSuffix.INWREFCAN));
-        cb.setInsId(getBillNumberBean().institutionBillNumberGenerator(getSessionController().getInstitution(), getBill().getBillType(), BillClassType.RefundBill, BillNumberSuffix.INWREFCAN));
+        BillTypeAtomic cancelAtomic = getBill().getBillTypeAtomic() == BillTypeAtomic.INWARD_DEPOSIT_REFUND
+                ? BillTypeAtomic.INWARD_DEPOSIT_REFUND_CANCELLATION
+                : BillTypeAtomic.INWARD_PAYMENT_REFUND_CANCELLATION;
+        cb.setBillTypeAtomic(cancelAtomic);
+
+        AdmissionType admissionTypeForBillNumber = getBill().getPatientEncounter() != null
+                ? getBill().getPatientEncounter().getAdmissionType() : null;
+        boolean uniqueSerialPerAdmissionType = admissionTypeForBillNumber != null
+                && configOptionApplicationController.getBooleanValueByKey(
+                        "Bill Number Generation Strategy - Unique Serial Per Admission Type for Inward Payments", false);
+        if (uniqueSerialPerAdmissionType) {
+            cb.setDeptId(getBillNumberBean().departmentBillNumberGeneratorYearly(getSessionController().getDepartment(), cancelAtomic, admissionTypeForBillNumber));
+            cb.setInsId(getBillNumberBean().institutionBillNumberGeneratorYearly(getSessionController().getInstitution(), cancelAtomic, admissionTypeForBillNumber));
+        } else {
+            cb.setDeptId(getBillNumberBean().departmentBillNumberGeneratorYearly(getSessionController().getDepartment(), cancelAtomic));
+            cb.setInsId(getBillNumberBean().institutionBillNumberGeneratorYearly(getSessionController().getInstitution(), cancelAtomic));
+        }
 
         cb.invertAndAssignValuesFromOtherBill(getBill());
         return cb;

--- a/src/main/webapp/inward/inward_bill_deposit.xhtml
+++ b/src/main/webapp/inward/inward_bill_deposit.xhtml
@@ -442,6 +442,23 @@
                                 action="#{inwardDepositController.makeNull}" >
                             </p:commandButton>
                             <p:commandButton
+                                id="btnToCancel"
+                                ajax="false" value="To Cancel"
+                                class="ui-button-danger"
+                                icon="fa fa-ban"
+                                action="#{inwardSearch.navigateToDepositBillCancellation()}"
+                                disabled="#{inwardDepositController.current.cancelled or inwardDepositController.current.refunded}">
+                                <f:setPropertyActionListener value="#{inwardDepositController.current}" target="#{inwardSearch.bill}"/>
+                            </p:commandButton>
+                            <p:commandButton
+                                id="btnToRefund"
+                                ajax="false" value="Refund"
+                                class="ui-button-warning"
+                                icon="fa fa-money-bill-transfer"
+                                action="#{inwardRefundController.navigateToRefundFromDepositBill(inwardDepositController.current)}"
+                                disabled="#{inwardDepositController.current.cancelled or inwardDepositController.current.refunded}">
+                            </p:commandButton>
+                            <p:commandButton
                                 value="Print"
                                 ajax="false"
                                 icon="fa fa-print"

--- a/src/main/webapp/inward/inward_bill_intrim.xhtml
+++ b/src/main/webapp/inward/inward_bill_intrim.xhtml
@@ -1329,6 +1329,7 @@
                                                          (p.refundedBill eq null and p.billClass eq 'class com.divudi.core.entity.RefundBill'))? '':'noDisplayRow'}" >
                                         <p:column headerText="Bill No">
                                             #{p.deptId}
+                                            <h:outputLabel value="Deposit" rendered="#{p.billTypeAtomic eq 'INWARD_DEPOSIT' or p.billTypeAtomic eq 'INWARD_DEPOSIT_REFUND'}" style="color: blue;" class="mx-1"/>
                                         </p:column>
 
                                         <p:column headerText="Paid At">
@@ -1388,8 +1389,7 @@
                                         </p:column>
 
                                         <p:column headerText="Action" width="6em;">
-                                            <p:commandButton ajax="false" action="inward_reprint_bill_payment?faces-redirect=true" value="View Bill" >
-                                                <f:setPropertyActionListener value="#{p}" target="#{inwardSearch.bill}"/>
+                                            <p:commandButton ajax="false" action="#{inwardSearch.navigateToPaymentOrDepositReprint(p)}" value="View Bill" >
                                             </p:commandButton>
                                         </p:column>
                                     </p:dataTable>

--- a/src/main/webapp/inward/inward_bill_refund.xhtml
+++ b/src/main/webapp/inward/inward_bill_refund.xhtml
@@ -113,6 +113,9 @@
                                         <p:column headerText="Bill No">
                                             <h:outputText value="#{eb.deptId}"/>
                                         </p:column>
+                                        <p:column headerText="Type">
+                                            <h:outputText value="#{inwardRefundController.getFeatureLabel(eb)}"/>
+                                        </p:column>
                                         <p:column headerText="Paid At">
                                             <h:outputText value="#{eb.createdAt}">
                                                 <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>

--- a/src/main/webapp/inward/inward_cancel_bill_deposit.xhtml
+++ b/src/main/webapp/inward/inward_cancel_bill_deposit.xhtml
@@ -1,0 +1,324 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:bi="http://xmlns.jcp.org/jsf/composite/inward/bill"
+      xmlns:bill="http://xmlns.jcp.org/jsf/composite/inward/bill/payment"
+      xmlns:pa="http://xmlns.jcp.org/jsf/composite/paymentMethod">
+
+    <h:body>
+        <ui:composition template="/resources/template/template.xhtml">
+            <ui:define name="content">
+                <h:form id="cancelDepositPaymentForm">
+                    <h:panelGroup rendered="#{!inwardSearch.printPreview}" styleClass="alignTop">
+                        <p:panel>
+                            <f:facet name="header">
+                                <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
+                                    <h:outputText value="Inward Deposit Cancellation" styleClass="fw-bold"/>
+                                    <div class="d-flex align-items-center flex-wrap gap-2">
+                                        <p:commandButton
+                                            id="btnBackToReprintBillPayment"
+                                            value="Back to Reprint Deposit"
+                                            action="/inward/inward_reprint_bill_deposit?faces-redirect=true"
+                                            ajax="false"
+                                            styleClass="ui-button-info ui-button-outlined"
+                                            icon="fa fa-arrow-left"
+                                            title="Go to Reprint Bill Deposit">
+                                        </p:commandButton>
+                                        <p:commandButton
+                                            id="btnBackToSearchPayment"
+                                            value="Back to Bill List"
+                                            action="/inward/inward_search_deposit?faces-redirect=true"
+                                            ajax="false"
+                                            styleClass="ui-button-info ui-button-outlined"
+                                            icon="fa fa-arrow-left"
+                                            title="Go to Deposit Bill Search">
+                                        </p:commandButton>
+                                    </div>
+                                </div>
+                            </f:facet>
+
+                            <div class="d-flex justify-content-between align-items-center flex-wrap gap-2 my-3">
+                                <div class="d-flex gap-2 align-items-center flex-wrap">
+                                    <p:outputLabel for="cmbPs" value="Payment Method" styleClass="fw-bold"/>
+                                    <p:selectOneMenu
+                                        id="cmbPs"
+                                        value="#{inwardSearch.paymentMethod}"
+                                        required="true"
+                                        style="width: 320px;">
+                                        <f:selectItem itemLabel="Select Payment Method"/>
+                                        <f:selectItems value="#{inwardSearch.inwardDepositCancelationPaymentMethods}"/>
+                                        <p:ajax
+                                            process="cmbPs"
+                                            update="paymentDetails :#{p:resolveFirstComponentWithId('updateData',view).clientId}"
+                                            event="change"
+                                            listener="#{inwardSearch.listnerForPaymentMethodChange(inwardSearch.bill)}">
+                                        </p:ajax>
+                                    </p:selectOneMenu>
+
+
+
+                                    <h:panelGroup id="paymentDetails" layout="block" class="d-flex gap-2 align-items-center ms-2">
+
+                                        <p:commandButton
+                                            id="updateData"
+                                            class="ui-button-warning "
+                                            rendered="#{inwardSearch.paymentMethod ne 'Cash'}"
+                                            process="@this"
+                                            update="paymentDetails"
+                                            icon="fas fa-gear"
+                                            title="Re-Fill Payment Details"
+                                            action="#{inwardSearch.refillPaymentDetail()}">
+                                        </p:commandButton>
+
+                                        <h:panelGroup rendered="#{inwardSearch.paymentMethod eq 'Card'}">
+                                            <pa:creditCard paymentMethodData="#{inwardSearch.paymentMethodData}" valueRequired="false" />
+                                        </h:panelGroup>
+
+                                        <h:panelGroup rendered="#{inwardSearch.paymentMethod eq 'Cheque'}">
+                                            <pa:cheque paymentMethodData="#{inwardSearch.paymentMethodData}" valueRequired="false"/>
+                                        </h:panelGroup>
+
+                                        <h:panelGroup rendered="#{inwardSearch.paymentMethod eq 'Slip'}">
+                                            <pa:slip paymentMethodData="#{inwardSearch.paymentMethodData}" valueRequired="false"/>
+                                        </h:panelGroup>
+
+                                        <h:panelGroup rendered="#{inwardSearch.paymentMethod eq 'ewallet'}">
+                                            <pa:ewallet paymentMethodData="#{inwardSearch.paymentMethodData}" valueRequired="false"/>
+                                        </h:panelGroup>
+
+                                        <h:panelGroup rendered="#{inwardSearch.paymentMethod eq 'PatientDeposit'}">
+                                            <pa:patient_deposit paymentMethodData="#{inwardSearch.paymentMethodData}" valueRequired="false"/>
+                                        </h:panelGroup>
+
+                                        <h:panelGroup rendered="#{inwardSearch.paymentMethod eq 'OnlineSettlement'}">
+                                            <pa:online_settlement paymentMethodData="#{inwardSearch.paymentMethodData}" valueRequired="false"/>
+                                        </h:panelGroup>
+
+                                    </h:panelGroup>
+                                </div>
+                                <div class="d-flex gap-2">
+                                    <p:inputText
+                                        id="txtCancellationComment"
+                                        value="#{inwardSearch.comment}"
+                                        style="width: 750px;"
+                                        title="Reason for cancelling this deposit bill"
+                                        placeholder="Enter a cancellation reason">
+                                    </p:inputText>
+                                    <p:commandButton
+                                        id="btnCancelPaymentBill"
+                                        value="Cancel Deposit Bill"
+                                        styleClass="ui-button-danger"
+                                        ajax="false"
+                                        icon="fas fa-ban"
+                                        title="Cancel this deposit bill"
+                                        onclick="return confirm('Are you sure you want to cancel this deposit bill? This action cannot be undone.');"
+                                        action="#{inwardSearch.cancelInwardDepositBill()}">
+                                    </p:commandButton>
+                                </div>
+                            </div>
+
+                            <div class="row mt-2">
+                                <div class="col-12 col-md-4 mb-2">
+                                    <p:panel header="Patient Details" styleClass="h-100">
+                                        <p:panelGrid columns="2" layout="tabular" styleClass="w-100">
+                                            <h:outputLabel value="Patient Name:" styleClass="fw-bold"/>
+                                            <h:outputLabel value="#{inwardSearch.bill.patientEncounter.patient.person.nameWithTitle}"/>
+                                            <h:outputLabel value="Bht No:" styleClass="fw-bold"/>
+                                            <h:outputLabel value="#{inwardSearch.bill.patientEncounter.bhtNo}"/>
+                                            <h:outputLabel value="Age:" styleClass="fw-bold"/>
+                                            <h:outputLabel value="#{inwardSearch.bill.patientEncounter.patient.age}"/>
+                                            <h:outputLabel value="Sex:" styleClass="fw-bold"/>
+                                            <h:outputLabel value="#{inwardSearch.bill.patientEncounter.patient.person.sex}"/>
+                                            <h:outputLabel value="Phone:" styleClass="fw-bold"/>
+                                            <h:outputLabel value="#{inwardSearch.bill.patientEncounter.patient.person.phone}"/>
+                                        </p:panelGrid>
+                                    </p:panel>
+                                </div>
+                                <div class="col-12 col-md-4 mb-2">
+                                    <p:panel header="Bill Details" styleClass="h-100">
+                                        <p:panelGrid columns="2" layout="tabular" styleClass="w-100">
+                                            <h:outputLabel value="Bill No:" styleClass="fw-bold"/>
+                                            <h:outputLabel value="#{inwardSearch.bill.deptId}"/>
+                                            <h:outputLabel value="Total:" styleClass="fw-bold"/>
+                                            <h:outputLabel value="#{inwardSearch.bill.total}" styleClass="text-end d-block">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputLabel>
+                                            <h:outputLabel value="Discount:" styleClass="fw-bold"/>
+                                            <h:outputLabel value="#{inwardSearch.bill.discount}" styleClass="text-end d-block">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputLabel>
+                                            <h:outputLabel value="Net Total:" styleClass="fw-bold"/>
+                                            <h:outputLabel value="#{inwardSearch.bill.netTotal}" styleClass="text-end d-block">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputLabel>
+                                        </p:panelGrid>
+                                    </p:panel>
+                                </div>
+                                <div class="col-12 col-md-4 mb-2">
+                                    <p:panel header="Original Payment Details" styleClass="h-100">
+                                        <div class="d-flex align-items-center justify-content-between gap-2 mb-3 px-3 py-2 rounded-3 bg-light text-dark border shadow-sm">
+                                            <span class="d-flex align-items-center gap-2">
+                                                <i class="fas fa-money-check-alt fs-5 text-primary"/>
+                                                <h:outputText value="Payment Method" styleClass="text-uppercase small fw-semibold text-muted"/>
+                                            </span>
+                                            <h:outputText value="#{inwardSearch.bill.paymentMethod}"
+                                                          styleClass="fs-5 fw-bold"/>
+                                        </div>
+
+                                        <h:panelGroup rendered="#{inwardSearch.bill.paymentMethod eq 'Cash'}">
+                                            <pa:cash_view paymentMethodData="#{inwardSearch.originalBillPaymentMethodData}"/>
+                                        </h:panelGroup>
+                                        <h:panelGroup rendered="#{inwardSearch.bill.paymentMethod eq 'Card'}">
+                                            <pa:creditCard_view paymentMethodData="#{inwardSearch.originalBillPaymentMethodData}"/>
+                                        </h:panelGroup>
+                                        <h:panelGroup rendered="#{inwardSearch.bill.paymentMethod eq 'Cheque'}">
+                                            <pa:cheque_view paymentMethodData="#{inwardSearch.originalBillPaymentMethodData}"/>
+                                        </h:panelGroup>
+                                        <h:panelGroup rendered="#{inwardSearch.bill.paymentMethod eq 'Slip'}">
+                                            <pa:slip_view paymentMethodData="#{inwardSearch.originalBillPaymentMethodData}"/>
+                                        </h:panelGroup>
+                                        <h:panelGroup rendered="#{inwardSearch.bill.paymentMethod eq 'ewallet'}">
+                                            <pa:ewallet_view paymentMethodData="#{inwardSearch.originalBillPaymentMethodData}"/>
+                                        </h:panelGroup>
+                                        <h:panelGroup rendered="#{inwardSearch.bill.paymentMethod eq 'PatientDeposit'}">
+                                            <pa:patient_deposit_view paymentMethodData="#{inwardSearch.originalBillPaymentMethodData}"/>
+                                        </h:panelGroup>
+                                        <h:panelGroup rendered="#{inwardSearch.bill.paymentMethod eq 'OnlineSettlement'}">
+                                            <pa:online_settlement_view paymentMethodData="#{inwardSearch.originalBillPaymentMethodData}"/>
+                                        </h:panelGroup>
+                                    </p:panel>
+                                </div>
+                            </div>
+
+                            <div class="row mt-2">
+                                <div class="col-12">
+                                    <p:panel>
+                                        <f:facet name="header">
+                                            <div class="d-flex align-items-center justify-content-between">
+                                                <h:outputText value="Deposit Bill"/>
+                                                <p:commandButton
+                                                    id="btnPrintPaymentBill"
+                                                    styleClass="ui-button-info"
+                                                    icon="fas fa-print"
+                                                    title="Print deposit bill"
+                                                    value="Print">
+                                                    <p:printer target="gpBillPreview"/>
+                                                </p:commandButton>
+                                            </div>
+                                        </f:facet>
+                                        <div class="d-flex justify-content-center align-items-center">
+                                            <h:panelGroup id="gpBillPreview">
+                                                <bill:FiveFivePaymentBill bill="#{inwardSearch.bill}" duplicate="true"/>
+                                            </h:panelGroup>
+                                        </div>
+                                    </p:panel>
+                                </div>
+                            </div>
+                        </p:panel>
+
+                    </h:panelGroup>
+
+                    <h:panelGroup rendered="#{inwardSearch.printPreview}">
+                        <p:panel>
+                            <f:facet name="header">
+                                <div class="d-flex justify-content-between align-items-center">
+                                    <h:outputText value="Cancellation Bill"/>
+                                    <div class="d-flex gap-2">
+                                        <p:commandButton
+                                            id="btnCancelBillSettings"
+                                            rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
+                                            value="Settings"
+                                            icon="fas fa-cog"
+                                            styleClass="ui-button-secondary"
+                                            type="button"
+                                            title="Configure cancellation bill paper"
+                                            onclick="PF('inwardPaymentConfigDialog').show();"/>
+                                        <p:commandButton
+                                            id="btnPrintCancelBill"
+                                            value="Print"
+                                            styleClass="ui-button-info"
+                                            icon="fas fa-print"
+                                            title="Print cancellation bill">
+                                            <p:printer target="gpCancelBillPreview"/>
+                                        </p:commandButton>
+                                        <p:commandButton
+                                            id="btnBackToBillList"
+                                            value="Back to Bill List"
+                                            action="/inward/inward_search_deposit?faces-redirect=true"
+                                            ajax="false"
+                                            styleClass="ui-button-warning"
+                                            icon="fa fa-arrow-left"
+                                            title="Return to the deposit bill list">
+                                        </p:commandButton>
+                                    </div>
+                                </div>
+                            </f:facet>
+
+                            <div class="d-flex justify-content-center align-items-center">
+                                <h:panelGroup id="gpCancelBillPreview">
+                                    <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Payment Bill POS Paper', true)}" style="align-items: center;">
+                                        <bill:posPaperCancellationBill bill="#{inwardSearch.bill.cancelledBill}" duplicate="false"/>
+                                    </h:panelGroup>
+                                </h:panelGroup>
+                            </div>
+                        </p:panel>
+                    </h:panelGroup>
+
+                </h:form>
+
+                <p:dialog id="inwardPaymentConfigDialog"
+                          header="Inward Payment Bill Printer Configuration"
+                          widgetVar="inwardPaymentConfigDialog"
+                          modal="true"
+                          width="560"
+                          resizable="false"
+                          closeOnEscape="true">
+                    <p:ajax event="open" listener="#{pharmacyConfigController.loadCurrentConfig}" update="inwardPaymentConfigForm"/>
+                    <h:form id="inwardPaymentConfigForm">
+                        <div class="card config-section">
+                            <div class="card-header">
+                                <i class="fas fa-file-alt me-2"/>
+                                <h:outputText value="Paper Format Settings"/>
+                            </div>
+                            <div class="card-body">
+                                <div class="mb-3">
+                                    <h:selectBooleanCheckbox id="inwardPaymentPOS" value="#{pharmacyConfigController.inwardPaymentPosPaper}"/>
+                                    <h:outputLabel for="inwardPaymentPOS" value="POS Paper" class="ms-2"/>
+                                </div>
+                                <div class="mb-3">
+                                    <h:selectBooleanCheckbox id="inwardPaymentFiveFive" value="#{pharmacyConfigController.inwardPaymentFiveFivePaper}"/>
+                                    <h:outputLabel for="inwardPaymentFiveFive" value="5×5 Paper" class="ms-2"/>
+                                </div>
+                                <div class="mb-3">
+                                    <h:selectBooleanCheckbox id="inwardPaymentFiveFiveCustom3" value="#{pharmacyConfigController.inwardPaymentFiveFiveCustom3Paper}"/>
+                                    <h:outputLabel for="inwardPaymentFiveFiveCustom3" value="5×5 Custom 3 Paper" class="ms-2"/>
+                                </div>
+                                <div class="mb-3">
+                                    <h:selectBooleanCheckbox id="inwardPaymentA4" value="#{pharmacyConfigController.inwardPaymentA4Paper}"/>
+                                    <h:outputLabel for="inwardPaymentA4" value="A4 Paper" class="ms-2"/>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="d-flex gap-2 mt-3">
+                            <p:commandButton value="Apply &amp; Close"
+                                             icon="fas fa-save"
+                                             class="ui-button-success"
+                                             ajax="false"
+                                             action="#{pharmacyConfigController.saveInwardPaymentConfig}"/>
+                            <p:commandButton value="Cancel"
+                                             icon="fas fa-times"
+                                             class="ui-button-secondary"
+                                             type="button"
+                                             onclick="PF('inwardPaymentConfigDialog').hide(); return false;"/>
+                        </div>
+                    </h:form>
+                </p:dialog>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/inward/inward_reprint_bill_deposit.xhtml
+++ b/src/main/webapp/inward/inward_reprint_bill_deposit.xhtml
@@ -1,0 +1,240 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:in="http://xmlns.jcp.org/jsf/composite/inward"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:bill="http://xmlns.jcp.org/jsf/composite/inward/bill/payment"
+      xmlns:prints="http://xmlns.jcp.org/jsf/composite/ezcomp/prints"
+      xmlns:bi="http://xmlns.jcp.org/jsf/composite/inward/bill">
+
+    <h:body>
+
+        <ui:composition template="/resources/template/template.xhtml">
+
+            <ui:define name="content">
+                <h:form>
+                    <p:panel>
+                        <f:facet name="header" >
+                            <div class=" d-flex justify-content-between ">
+                                <div><h:outputLabel value="Deposit Reprint" class="mt-2"></h:outputLabel></div>
+                                <div class="d-flex gap-2">
+
+                                    <p:commandButton
+                                        id="btnToCancel"
+                                        ajax="false" value="To Cancel"
+                                        class="ui-button-danger"
+                                        icon="fa fa-ban"
+                                        action="#{inwardSearch.navigateToDepositBillCancellation()}"
+                                        disabled="#{inwardSearch.bill.cancelled or inwardSearch.bill.refunded}"  >
+                                    </p:commandButton>
+
+                                    <p:commandButton
+                                        id="btnToRefund"
+                                        ajax="false" value="Refund"
+                                        class="ui-button-warning"
+                                        icon="fa fa-money-bill-transfer"
+                                        action="#{inwardRefundController.navigateToRefundFromDepositBill(inwardSearch.bill)}"
+                                        disabled="#{inwardSearch.bill.cancelled or inwardSearch.bill.refunded}"  >
+                                    </p:commandButton>
+
+                                    <p:commandButton
+                                        id="btnPrintBill"
+                                        value="Print"
+                                        ajax="false"
+                                        action="#"
+                                        class="ui-button-info"
+                                        icon="fas fa-print">
+                                        <p:printer target="gpBillPreview" ></p:printer>
+                                    </p:commandButton>
+
+                                    <p:commandButton
+                                        id="btnMarkAsChecked"
+                                        ajax="false"
+                                        value="Mark As Checked"
+                                        icon="fa fa-check-square"
+                                        class="ui-button-success"
+                                        action="#{inwardSearch.markAsChecked()}"
+                                        rendered="#{webUserController.hasPrivilege('InwardCheck')}"  >
+                                    </p:commandButton>
+
+                                    <p:commandButton
+                                        id="btnMarkAsUnChecked"
+                                        ajax="false"
+                                        value="Mark As Un Check"
+                                        icon="fa fa-square"
+                                        class="ui-button-warning"
+                                        action="#{inwardSearch.markAsUnChecked()}"
+                                        rendered="#{webUserController.hasPrivilege('InwardUnCheck')}"  >
+                                    </p:commandButton>
+
+                                    <p:commandButton
+                                        id="btnBackToInterim"
+                                        ajax="false"
+                                        value="Back To Interim"
+                                        icon="fa fa-backward"
+                                        action="/inward/inward_bill_intrim?faces-redirect=true"
+                                        actionListener="#{bhtSummeryController.createTables()}"
+                                        >
+                                    </p:commandButton>
+                                </div>
+                            </div>
+                        </f:facet>
+                        <div class="row">
+                            <div class="col-6">
+                                <h:panelGroup id="panSearch2" class="d-flex align-items-center justify-content-center p-1 w-100" >
+                                    <p:panel class="w-100">
+                                        <f:facet name="header">
+                                            <h:outputText styleClass="fas fa-id-card-alt"></h:outputText>
+                                            <h:outputLabel value="Patient Details" class="mx-2"></h:outputLabel>
+                                        </f:facet>
+                                        <in:bhtDetail admission="#{inwardSearch.bill.patientEncounter}"/>
+                                    </p:panel>
+
+                                </h:panelGroup>
+                            </div>
+                            <div class="col-6">
+                                <p:panel>
+                                    <f:facet name="header">
+                                        <h:outputText styleClass="fas fa-list-alt"></h:outputText>
+                                        <h:outputLabel value="Bill Item Detail" class="mx-2"></h:outputLabel>
+                                    </f:facet>
+                                    <p:dataTable rowIndexVar="rowIndex"
+                                                 value="#{inwardSearch.billItems}" var="bip" >
+                                        <p:column>
+                                            <f:facet name="header">No</f:facet>
+                                            <h:outputLabel value="#{rowIndex+1}"/>
+                                        </p:column>
+
+                                        <p:column>
+                                            <f:facet name="header">Fee</f:facet>
+                                            <h:outputLabel value="#{bip.netValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                        </p:column>
+
+                                    </p:dataTable>
+                                </p:panel>
+
+                                <p:panel class="mt-2">
+                                    <f:facet name="header">
+                                        <h:outputText styleClass="fas fa-comment-dots"></h:outputText>
+                                        <h:outputLabel value="Bill Comment" class="mx-2"></h:outputLabel>
+                                    </f:facet>
+
+                                    <div class="d-flex gap-2 justify-content-between">
+                                        <p:inputText
+                                            id="billComment"
+                                            class="w-100"
+                                            value="#{inwardSearch.bill.comments}">
+                                        </p:inputText>
+
+                                        <p:commandButton
+                                            id="saveBillComment"
+                                            value="Save Comment"
+                                            icon="fas fa-save"
+                                            class="ui-button-success"
+                                            style="width: 200px;"
+                                            action="#{inwardSearch.updateBillComments()}"
+                                            update="billComment gpBillPreview">
+                                        </p:commandButton>
+                                    </div>
+                                </p:panel>
+
+                            </div>
+                        </div>
+
+                        <p:panel >
+                            <f:facet name="header">
+                                <div class="d-flex justify-content-between">
+                                    <p:outputLabel value="Bill Preview" class="m-2"></p:outputLabel>
+                                    <div class="d-flex gap-3">
+                                        <p:commandButton
+                                            rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
+                                            value="Settings"
+                                            icon="fas fa-cog"
+                                            class="ui-button-secondary"
+                                            type="button"
+                                            onclick="PF('inwardPaymentConfigDialog').show();"/>
+                                    </div>
+                                </div>
+                            </f:facet>
+
+                            <div class="d-flex justify-content-center">
+                                <h:panelGroup id="gpBillPreview" >
+
+                                    <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Payment Bill A4 Paper', false)}" >
+                                        <bill:A4PaperPaymentBill bill="#{inwardSearch.bill}" duplicate="true"/>
+                                    </h:panelGroup>
+
+                                    <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Payment Bill Five Five Paper', false)}" >
+                                        <bill:FiveFivePaymentBill bill="#{inwardSearch.bill}" duplicate="true" />
+                                    </h:panelGroup>
+
+                                    <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Payment Bill POS Paper', true)}" style="align-items: center;">
+                                        <bill:posPaperPaymentBill bill="#{inwardSearch.bill}"/>
+                                    </h:panelGroup>
+
+                                    <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Payment Bill Five Five Custom 3 Paper', false)}" >
+                                        <prints:five_five_custom_3_inward_payments bill="#{inwardSearch.bill}" duplicate="true" />
+                                    </h:panelGroup>
+
+                                </h:panelGroup>
+                            </div>
+                        </p:panel>
+                    </p:panel>
+                </h:form>
+
+                <p:dialog id="inwardPaymentConfigDialog"
+                          header="Inward Payment Bill Printer Configuration"
+                          widgetVar="inwardPaymentConfigDialog"
+                          modal="true"
+                          width="560"
+                          resizable="false"
+                          closeOnEscape="true">
+                    <p:ajax event="open" listener="#{pharmacyConfigController.loadCurrentConfig}" update="inwardPaymentConfigForm"/>
+                    <h:form id="inwardPaymentConfigForm">
+                        <div class="card config-section">
+                            <div class="card-header">
+                                <i class="fas fa-file-alt me-2"/>
+                                <h:outputText value="Paper Format Settings"/>
+                            </div>
+                            <div class="card-body">
+                                <div class="mb-3">
+                                    <h:selectBooleanCheckbox id="inwardPaymentPOS" value="#{pharmacyConfigController.inwardPaymentPosPaper}"/>
+                                    <h:outputLabel for="inwardPaymentPOS" value="POS Paper" class="ms-2"/>
+                                </div>
+                                <div class="mb-3">
+                                    <h:selectBooleanCheckbox id="inwardPaymentFiveFive" value="#{pharmacyConfigController.inwardPaymentFiveFivePaper}"/>
+                                    <h:outputLabel for="inwardPaymentFiveFive" value="5×5 Paper" class="ms-2"/>
+                                </div>
+                                <div class="mb-3">
+                                    <h:selectBooleanCheckbox id="inwardPaymentFiveFiveCustom3" value="#{pharmacyConfigController.inwardPaymentFiveFiveCustom3Paper}"/>
+                                    <h:outputLabel for="inwardPaymentFiveFiveCustom3" value="5×5 Custom 3 Paper" class="ms-2"/>
+                                </div>
+                                <div class="mb-3">
+                                    <h:selectBooleanCheckbox id="inwardPaymentA4" value="#{pharmacyConfigController.inwardPaymentA4Paper}"/>
+                                    <h:outputLabel for="inwardPaymentA4" value="A4 Paper" class="ms-2"/>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="d-flex gap-2 mt-3">
+                            <p:commandButton value="Apply &amp; Close"
+                                             icon="fas fa-save"
+                                             class="ui-button-success"
+                                             ajax="false"
+                                             action="#{pharmacyConfigController.saveInwardPaymentConfig}"/>
+                            <p:commandButton value="Cancel"
+                                             icon="fas fa-times"
+                                             class="ui-button-secondary"
+                                             type="button"
+                                             onclick="PF('inwardPaymentConfigDialog').hide(); return false;"/>
+                        </div>
+                    </h:form>
+                </p:dialog>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/inward/inward_search_deposit.xhtml
+++ b/src/main/webapp/inward/inward_search_deposit.xhtml
@@ -1,0 +1,159 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:se="http://xmlns.jcp.org/jsf/composite/inward/search">
+
+    <h:body>
+        <ui:composition template="/resources/template/template.xhtml">
+            <ui:define name="content">
+                <h:form>
+                    <p:panel header="Search Deposit Bills" >
+
+                        <div class="row">
+                            <div class="col-2">
+                                <h:outputLabel value="From Date"/>
+                                <p:calendar
+                                    styleClass="dateTimePicker"
+                                    id="fromDate"
+                                    value="#{searchController.fromDate}"
+                                    navigator="false"
+                                    pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
+                                    class="w-100"
+                                    inputStyleClass="w-100">
+                                </p:calendar>
+                                <h:outputLabel value="To Date"/>
+                                <p:calendar
+                                    id="toDate"
+                                    value="#{searchController.toDate}"
+                                    navigator="false"
+                                    pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
+                                    class="w-100"
+                                    inputStyleClass="w-100">
+                                </p:calendar>
+
+                                <p:commandButton
+                                    ajax="false"
+                                    action="#{searchController.createInwardDepositBills()}"
+                                    value="Search"
+                                    class="ui-button-warning w-100 my-1"
+                                    icon="fas fa-search">
+                                </p:commandButton>
+
+                                <hr/>
+
+                                <h:outputLabel value="Bill No"/>
+                                <p:inputText autocomplete="off"  value="#{searchController.searchKeyword.billNo}" class="w-100"/>
+                                <h:outputLabel value="BHT No"/>
+                                <p:inputText autocomplete="off"  value="#{searchController.searchKeyword.bhtNo}" class="w-100"/>
+                                <h:outputLabel value="Patient Name"/>
+                                <p:inputText autocomplete="off" value="#{searchController.searchKeyword.patientName}" class="w-100"/>
+                                <h:outputLabel value="Patient Phone"/>
+                                <p:inputText autocomplete="off"  value="#{searchController.searchKeyword.patientPhone}" class="w-100"/>
+                                <h:outputLabel value="MRN / PHN No"/>
+                                <p:inputText autocomplete="off" value="#{searchController.searchKeyword.number}" class="w-100"/>
+                                <h:outputLabel value="Total"/>
+                                <p:inputText autocomplete="off"  value="#{searchController.searchKeyword.total}" class="w-100"/>
+                                <h:outputLabel value="Net Total"/>
+                                <p:inputText autocomplete="off" value="#{searchController.searchKeyword.netTotal}" class="w-100"/>
+                            </div>
+
+                            <div class="col-10">
+
+                                <p:dataTable
+                                    id="tblBills"
+                                    rowIndexVar="i"
+                                    paginator="true"
+                                     paginatorPosition="bottom"
+                                     rows="20"
+                                     paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                     rowsPerPageTemplate="20,50,100"
+                                    value="#{searchController.bills}"
+                                    var="bb">
+
+                                    <p:column headerText="#" width="20px;" style="padding: 12px;">
+                                        <h:outputLabel value="#{i+1}" ></h:outputLabel>
+                                    </p:column>
+
+                                    <p:column headerText="Bill No" width="10em;" style="padding: 12px;">
+                                        <p:commandLink
+                                            value="#{bb.deptId}"
+                                            ajax="false"
+                                            action="inward_reprint_bill_deposit?faces-redirect=true">
+                                            <f:setPropertyActionListener value="#{bb}" target="#{inwardSearch.bill}"/>
+                                        </p:commandLink>
+                                        <h:panelGroup rendered="#{bb.cancelled and bb.cancelledBill ne null}" layout="block" class="mt-1">
+                                            <h:outputLabel style="color: red;" value="Cancel Bill : "/>
+                                            <p:commandLink
+                                                style="color: red;"
+                                                value="#{bb.cancelledBill.deptId}"
+                                                ajax="false"
+                                                title="View cancellation bill preview"
+                                                action="#{inwardSearch.navigateToViewDepositBillCancellation(bb)}">
+                                            </p:commandLink>
+                                        </h:panelGroup>
+                                    </p:column>
+
+                                    <p:column headerText="BHT No" width="10em;" style="padding: 12px;">
+                                        <h:outputLabel value="#{bb.patientEncounter.bhtNo}" ></h:outputLabel>
+                                    </p:column>
+
+                                    <p:column headerText="Billed At" width="14em;" style="padding: 12px;">
+                                        <h:outputLabel value="#{bb.createdAt}" >
+                                            <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                        </h:outputLabel>
+                                        <br/>
+                                        <h:panelGroup rendered="#{bb.cancelled}" >
+                                            <h:outputLabel style="color: red;" value="Cancelled at " />
+                                            <h:outputLabel style="color: red;" rendered="#{bb.cancelled}" value="#{bb.cancelledBill.createdAt}" >
+                                                <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                            </h:outputLabel>
+                                        </h:panelGroup>
+                                    </p:column>
+
+                                    <p:column headerText="Billed By" width="12em;" style="padding: 12px;">
+                                        <h:outputLabel value="#{bb.creater.webUserPerson.name}" ></h:outputLabel>
+                                        <br/>
+                                        <h:panelGroup rendered="#{bb.cancelled}" >
+                                            <h:outputLabel style="color: red;" value="Cancelled By " />
+                                            <h:outputLabel style="color: red;" value="#{bb.cancelledBill.creater.webUserPerson.name}" ></h:outputLabel>
+                                        </h:panelGroup>
+                                    </p:column>
+
+                                    <p:column headerText="Patient" style="padding: 12px;">
+                                        <h:outputLabel value="#{bb.patientEncounter.patient.person.nameWithTitle}" ></h:outputLabel>
+                                    </p:column>
+
+                                    <p:column headerText="Payment Method" width="12em;" style="padding: 12px;">
+                                        <h:outputLabel value="#{bb.paymentMethod}" ></h:outputLabel>
+                                    </p:column>
+
+                                    <p:column headerText="Value" width="8em;" style="padding: 12px;" class="text-end">
+                                        <h:outputLabel value="#{bb.netTotal}" class="text-end" >
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </h:outputLabel>
+                                    </p:column>
+
+                                    <p:column headerText="Comments" width="16em;" style="padding: 12px;">
+                                        <h:outputLabel rendered="#{bb.refundedBill ne null}" value="#{bb.refundedBill.comments}" >
+                                        </h:outputLabel>
+                                        <h:outputLabel  rendered="#{bb.cancelledBill ne null}" value="#{bb.cancelledBill.comments}" >
+                                        </h:outputLabel>
+                                    </p:column>
+
+                                </p:dataTable>
+                            </div>
+                        </div>
+                    </p:panel>
+
+                </h:form>
+            </ui:define>
+
+
+        </ui:composition>
+
+    </h:body>
+</html>

--- a/src/main/webapp/payments/pay_index.xhtml
+++ b/src/main/webapp/payments/pay_index.xhtml
@@ -145,13 +145,18 @@
                                                 action="#{inwardPaymentController.navigateToInwardDepositPayment()}"
                                                 rendered="#{webUserController.hasPrivilege('InwardBilling')}">
                                             </p:commandButton>
-                                            <p:commandButton 
-                                                styleClass="w-100 ui-button-info ui-button-outlined" 
-                                                ajax="false" 
-                                                value="Payment Search" 
-                                                title="Payment Search" action="/inward/inward_search_payment?faces-redirect=true" 
-                                                actionListener="#{searchController.makeListNull}" 
+                                            <p:commandButton
+                                                styleClass="w-100 ui-button-info ui-button-outlined"
+                                                ajax="false"
+                                                value="Payment Search"
+                                                title="Payment Search" action="/inward/inward_search_payment?faces-redirect=true"
+                                                actionListener="#{searchController.makeListNull}"
                                                 rendered="#{webUserController.hasPrivilege('InwardBillSearch')}" >
+                                            </p:commandButton>
+                                            <p:commandButton styleClass="w-100 ui-button-info ui-button-outlined" ajax="false"
+                                                value="Deposit Search" title="Deposit Search" action="/inward/inward_search_deposit?faces-redirect=true"
+                                                actionListener="#{searchController.makeListNull}"
+                                                rendered="#{webUserController.hasPrivilege('InwardBillSearch')}">
                                             </p:commandButton>
                                             <p:commandButton
                                                 styleClass="w-100 ui-button-info ui-button-outlined"


### PR DESCRIPTION
## Summary

Closes #22826. Gives the Inward **Deposit** feature its own cancellation and
refund workflow, mirroring Payment's (#22820/#22824), with **independent
serial numbers** rather than sharing counters with Payment.

## What changed

### Deposit cancellation (new)
- `InwardSearch.navigateToDepositBillCancellation()` / `cancelInwardDepositBill()`
  / `createCancelInwardDepositBill()` — mirrors Payment's flow, applies the
  refunded-bill-cannot-be-cancelled guard from day one.
- New pages: `inward_reprint_bill_deposit.xhtml`, `inward_cancel_bill_deposit.xhtml`
  (retitled "Deposit", not "Payment" — deliberately avoids reintroducing the
  naming confusion #22804 fixed).
- "To Cancel" / "Refund" buttons added to `inward_bill_deposit.xhtml`'s
  post-pay confirmation panel.

### Deposit refund (new, reusing shared infra)
- `InwardRefundController.navigateToRefundFromDepositBill()` — new entry
  point, reuses the existing "Inward Refund Payment" picker
  (`inward_bill_refund.xhtml`) rather than building a second parallel page.
- Added a **Type** column to that picker so cashiers can tell Payment vs
  Deposit bills apart in the now-shared list.
- `saveBill()` derives the correct `BillTypeAtomic` from the bill being
  refunded (`INWARD_PAYMENT` → `INWARD_PAYMENT_REFUND`, `INWARD_DEPOSIT` →
  `INWARD_DEPOSIT_REFUND`) instead of hardcoding Payment's.

### Deposit refund-cancellation (reused, zero new pages)
`inward_reprint_bill_refund.xhtml` / `inward_cancel_bill_refund.xhtml` were
already generic (bound to the shared `inwardSearch.bill` field) — only
`InwardSearch.cancelBillRefund()` / `createRefundCancelBill()` needed to stop
hardcoding `INWARD_PAYMENT_REFUND_CANCELLATION` and derive the atomic
dynamically instead. Also added a double-cancel guard here that was missing.

### Serial numbering — the core ask
Both Payment's *and* Deposit's cancel/refund bills now go through the
`BillTypeAtomic`-keyed Yearly generator (`departmentBillNumberGeneratorYearly`
/`institutionBillNumberGeneratorYearly`), the same pattern already used for
the "pay" bills themselves — replacing the legacy `BillType`-keyed generator
that would have made Deposit-Cancel and Payment-Cancel silently share one
counter. This also closes the issue's own "side note": Payment's cancel/refund
bills were still on the old legacy format even after #22824.

### Correctness fixes found while implementing
- `SearchController.createInwardPaymentBills()` now filters by
  `BillTypeAtomic.INWARD_PAYMENT` — without this, once Deposit bills exist
  they'd leak into Payment's search results mislabeled as Payment bills.
  New `createInwardDepositBills()` + `inward_search_deposit.xhtml` for the
  Deposit-only equivalent.
- Interim Bill's Payments tab "View Bill" button now routes each row to the
  correct reprint page (Refund bills of either feature → the shared generic
  refund reprint; Deposit pay bills → the new Deposit reprint; Payment pay
  bills → unchanged) via a new `InwardSearch.navigateToPaymentOrDepositReprint(Bill)`
  method — the original inline EL ternary attempt failed at runtime
  ("Not a Valid Method Expression"), caught by local Playwright testing
  before it ever left this branch.
- Interim Bill rows now show a small **Deposit** badge so cashiers can tell
  which feature a merged row came from.

## Verification (Playwright + DB, local Payara, BHT/56755)

Full cycle exercised live: made a Deposit → cancelled it → made another
Deposit → refunded it → cancelled that refund. Also made a Payment →
cancelled it, to confirm the numbering migration.

**Independent serial counters confirmed via DB** (all four now on the Yearly
scheme, `BILLNUMBER` counters distinct from each other and from the pre-existing
Payment counters):

| Atomic | Bill No | Institution serial |
|---|---|---|
| `INWARD_DEPOSIT_CANCELLATION` | `Inward//26/038005` | `//26/000001` |
| `INWARD_DEPOSIT_REFUND` | `Inward//26/038007` | `//26/000001` |
| `INWARD_DEPOSIT_REFUND_CANCELLATION` | `Inward//26/038008` | `//26/000001` |
| `INWARD_PAYMENT_CANCELLATION` (migrated) | `Inward//26/038010` | `//26/000002` |

- Refunded-bill-cannot-be-cancelled / cancelled-bill-cannot-be-refunded
  guards confirmed working for Deposit.
- A double-cancel attempt (revisiting an already-cancelled bill via stale
  session state on the post-pay panel) was confirmed blocked server-side by
  the existing `check()` guard chain — no duplicate `CancelledBill` created.
  This is a pre-existing session-staleness UX gap (the "To Cancel" button
  isn't visually disabled on a stale re-visit) — data integrity is intact,
  but flagging as a possible small follow-up.
- Payment search page confirmed to no longer show Deposit bills after the
  `SearchController` fix; new Deposit search page confirmed to show only
  Deposit bills.

Screenshot evidence (redacted, no patient PII) on the
[issue comment](https://github.com/hmislk/hmis/issues/22826#issuecomment-5240705364):

![Interim Bill Payments tab](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/22826-interim-bill-deposit-rows.png)

## Known behavior change

Payment's cancel/refund bill number *format* changes from the old
`Inward/INWCAN/1` / `InwardINWREF/1` style to the Yearly
`Inward//26/0000xx` style (matching the pay bill's own format) — same
category of change as #22804's already-communicated pay-bill migration.
Worth the same client heads-up before deploying to production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added inward deposit bill search with filters for dates, patient details, bill numbers, and amounts.
  - Added deposit bill reprinting with multiple paper formats and printer settings.
  - Added workflows for deposit cancellation, refunds, previews, and related bill navigation.
  - Added deposit search access from the Inward Deposit section.
- **Bug Fixes**
  - Improved routing and labeling for payment, deposit, and refund bills.
  - Prevented cancellation or refund actions for bills already processed.
- **User Interface**
  - Added deposit type indicators and cancellation details throughout billing screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->