### PR TITLE
fix(pharmacy): correct net value adjustment sign handling in GRN/purchase returns

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/DirectPurchaseReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/DirectPurchaseReturnWorkflowController.java
@@ -2403,8 +2403,12 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
 
     /**
      * Calculates the net value adjustment based on actual net value entered by
-     * user Adjustment = Net Total (calculated) - Actual Net Value Positive
-     * adjustment means calculated is higher than actual Negative adjustment
+     * user Adjustment = |Net Total (calculated)| - |Actual Net Value|
+     * netTotal follows the return sign convention (negative = value returning to
+     * supplier); actualNetValue is entered by staff as the physical counted amount,
+     * always a positive magnitude. Comparing absolute values keeps the result
+     * correct regardless of netTotal's sign, so equal amounts net to zero.
+     * Positive adjustment means calculated is higher than actual Negative adjustment
      * means calculated is lower than actual
      */
     public void calculateNetValueAdjustment() {
@@ -2418,7 +2422,7 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
         BigDecimal netTotal = bfd.getNetTotal();
 
         if (actualNetValue != null && netTotal != null) {
-            BigDecimal adjustment = netTotal.subtract(actualNetValue);
+            BigDecimal adjustment = netTotal.abs().subtract(actualNetValue.abs());
             bfd.setNetValueAdjustment(adjustment);
         } else {
             bfd.setNetValueAdjustment(null);

--- a/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
@@ -2778,7 +2778,11 @@ public class GrnReturnWorkflowController implements Serializable {
 
     /**
      * Calculates the net value adjustment based on actual net value entered by user
-     * Adjustment = Net Total (calculated) - Actual Net Value
+     * Adjustment = |Net Total (calculated)| - |Actual Net Value|
+     * netTotal follows the GRN-return sign convention (negative = value returning to
+     * supplier); actualNetValue is entered by staff as the physical counted amount,
+     * always a positive magnitude. Comparing absolute values keeps the result correct
+     * regardless of netTotal's sign, so equal amounts net to zero.
      * Positive adjustment means calculated is higher than actual
      * Negative adjustment means calculated is lower than actual
      */
@@ -2793,7 +2797,7 @@ public class GrnReturnWorkflowController implements Serializable {
         BigDecimal netTotal = bfd.getNetTotal();
 
         if (actualNetValue != null && netTotal != null) {
-            BigDecimal adjustment = netTotal.subtract(actualNetValue);
+            BigDecimal adjustment = netTotal.abs().subtract(actualNetValue.abs());
             bfd.setNetValueAdjustment(adjustment);
         } else {
             bfd.setNetValueAdjustment(null);

--- a/src/main/java/com/divudi/core/entity/BillFinanceDetails.java
+++ b/src/main/java/com/divudi/core/entity/BillFinanceDetails.java
@@ -184,7 +184,10 @@ public class BillFinanceDetails implements Serializable {
     private BigDecimal actualNetValue;
 
     // Adjustment between calculated net total and actual physical net value
-    // netValueAdjustment = actualNetValue - netTotal
+    // netValueAdjustment = |netTotal| - |actualNetValue|
+    // netTotal follows the return sign convention (negative for GRN/purchase
+    // returns); actualNetValue is always entered as a positive physical
+    // magnitude, so the comparison must use absolute values.
     @Column(precision = 18, scale = 4, nullable = true)
     private BigDecimal netValueAdjustment;
 


### PR DESCRIPTION
## What

Fixes incorrect **Net Value Adjustment** on the GRN Return and Direct Purchase Return forms when the calculated return amount and the staff-entered actual net value represent the same physical value.

## Root cause

`calculateNetValueAdjustment()` computed `netTotal.subtract(actualNetValue)` directly. `netTotal` ("Return Amount") follows the negative sign convention established for GRN/purchase returns, while `actualNetValue` is always entered by staff as a plain positive magnitude. Subtracting a positive value from its negative counterpart **doubles** the discrepancy instead of canceling it to zero (e.g. `-10 - 10 = -20`) — exactly matching the value shown in the screenshot attached to #19202.

The identical bug (same fields, same formula) existed verbatim in `DirectPurchaseReturnWorkflowController` and is fixed the same way.

## Fix

Compare magnitudes instead of raw signed values:

```java
BigDecimal adjustment = netTotal.abs().subtract(actualNetValue.abs());
```

This preserves the existing javadoc semantics ("positive = calculated higher than actual, negative = calculated lower than actual") and the existing red/green UI class on the adjustment label, regardless of `netTotal`'s sign.

Also corrected the stale doc comment on `BillFinanceDetails.netValueAdjustment`, which documented the formula in the wrong order and didn't account for the sign convention either.

## Files changed

- `src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java`
- `src/main/java/com/divudi/bean/pharmacy/DirectPurchaseReturnWorkflowController.java`
- `src/main/java/com/divudi/core/entity/BillFinanceDetails.java` (doc comment only)

No schema/entity field changes.

## Testing performed

Verified locally end-to-end against a real GRN return (Playwright + local Payara + DB):

1. **Reproduced the bug** with a real GRN return: Return Amount `-2,250.00`, entered Actual Net Value `2250` → adjustment showed a doubled negative value before the fix.
2. **After the fix**: same inputs → Net Value Adjustment `0.00`.
3. **Mismatch case**: Actual Net Value `2000` vs Return Amount `2,250.00` → adjustment correctly shows `250.00` (positive, "calculated higher than actual"), confirming the sign semantics still hold.
4. **Saved and DB-verified** (cold read against MySQL, not the cached entity):
   ```
   NETTOTAL: 2250.0000  ACTUALNETVALUE: 2250.0000  NETVALUEADJUSTMENT: 0.0000
   ```

Screenshots and full verification detail posted to the issue: https://github.com/hmislk/hmis/issues/19202#issuecomment-5248851664

Direct Purchase Return path received the identical code fix but could not be live-clicked-through locally (no Direct Purchase transaction data existed in the local dev DB, and creating one requires a separate create→finalize→approve cycle outside this bug's scope); it was verified by code identity with the GRN Return path above, which shares the exact same fields, formula, and entity.

Fixes #19202

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved net value adjustments for pharmacy and GRN returns by comparing transaction amounts based on their absolute values.
  * Return calculations now correctly handle negative totals while preserving the intended adjustment magnitude.

* **Documentation**
  * Clarified how net value adjustments are calculated for return transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->