### PR TITLE
Fix: guard Nursing WorkBench surgery buttons against unselected admission (#20893)

### DIFF
--- a/src/main/webapp/nurse/index.xhtml
+++ b/src/main/webapp/nurse/index.xhtml
@@ -484,7 +484,7 @@
                                                             value="Add Surgeries"
                                                             icon="fa fa-clock"
                                                             ajax="false"
-                                                            rendered="#{admissionController.current ne null and not admissionController.current.paymentFinalized and webUserController.hasPrivilege('InwardSurgeryAdd')}"
+                                                            rendered="#{admissionController.current ne null and admissionController.current.id ne null and not admissionController.current.paymentFinalized and webUserController.hasPrivilege('InwardSurgeryAdd')}"
                                                             action="#{surgeryBillController.navigateToAddSurgeriesFromAdmissionProfile}"
                                                             class="w-100">
                                                             <f:setPropertyActionListener
@@ -497,7 +497,7 @@
                                                             value="Manage Surgeries"
                                                             icon="fa fa-list"
                                                             ajax="false"
-                                                            rendered="#{webUserController.hasPrivilege('InwardSurgeryManage')}"
+                                                            rendered="#{admissionController.current ne null and admissionController.current.id ne null and webUserController.hasPrivilege('InwardSurgeryManage')}"
                                                             action="#{surgeryBillController.navigateToSurgeryListFromAdmissionProfile()}"
                                                             class="w-100">
                                                             <f:setPropertyActionListener


### PR DESCRIPTION
## Summary

Fixes #20893 — "no place to add surgery service and investigation" (reported by @Irani96 after the original display-loading fix in #22773 was merged).

## Root cause

`AdmissionController.getCurrent()` auto-vivifies a blank `Admission` (with `dateOfAdmission = now()`) whenever it's referenced and `current` is null:

```java
public Admission getCurrent() {
    if (current == null) {
        current = new Admission();
        current.setDateOfAdmission(new Date());
        ...
    }
    return current;
}
```

This means `#{admissionController.current ne null}` in EL never actually detects "no admission selected" — it's always true once anything evaluates the getter.

`nurse/index.xhtml`'s Operation Theatre panel had two buttons relying on this broken check:
- **"Add Surgeries"** — guarded by `admissionController.current ne null` (ineffective per above)
- **"Manage Surgeries"** — had no guard on `admissionController.current` at all

Both push `admissionController.current` into `surgeryBillController.surgeryBill.patientEncounter` via `f:setPropertyActionListener` regardless. With no BHT selected in the Nursing WorkBench, clicking either button carries the blank auto-vivified encounter into `inward_bill_surgery_list.xhtml`, whose own patient-search panel only renders when `patientEncounter eq null` — so the page shows blank patient details and **no way to search for a patient**. This is a separate defect from the already-fixed `lstBillEntries` display bug on the same issue (#22773).

## Fix

Guard both buttons with `admissionController.current.id ne null`, the pattern already used elsewhere in the codebase (`opd/patient.xhtml`, `inward_patient_accept_single.xhtml`, `ward/ward_pharmacy_bht_issue_request_list_for_issue.xhtml`) to distinguish a real persisted admission from the getter's auto-vivified placeholder.

## Testing

Verified via Playwright against local Payara + `coop` DB:
- **Before fix**: with no BHT selected in Nursing WorkBench (Inward department), "Manage Surgeries" was visible and clicking it landed on `inward_bill_surgery_list.xhtml` showing blank patient fields, a fabricated "today" admission date, and no search panel — reproducing the exact symptom reported.
- **After fix**: with no BHT selected, both "Add Surgeries" and "Manage Surgeries" are correctly hidden from the Operation Theatre panel.
- **After fix, positive path**: selected BHT/56977 (Mrs. M.N.KAWSHALYA) via the BHT tab — both buttons appear; "Manage Surgeries" → surgery list correctly shows her real admission details and existing surgery "Inguinal Hernia Repair" (Inward/SURG/2) → "Surgery Dashboard" → "Add Services & Investigations" correctly lands on the item-request page with real patient/admission/surgery context and a working item search box.

This is a JSF-only (XHTML) change — no Java modified, no migration needed.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Surgery management actions are now shown only when the current admission has been saved successfully.
  * Prevented users from attempting to add or manage surgeries for admissions without a persisted record.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->