### PR TITLE
fix: Enter key on BHT search now triggers Continue, not Nursing WorkBench (RMH prod hotfix)

### DIFF
--- a/src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml
+++ b/src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml
@@ -77,7 +77,8 @@
                                                     placeholder="Type patient name, BHT number, or PHN..."
                                                     minQueryLength="2"
                                                     style="width: 100%;"
-                                                    inputStyleClass="form-control form-control-lg">
+                                                    inputStyleClass="form-control form-control-lg"
+                                                    onkeydown="if(event.which===13){var w=PF('aPt2');if(!w.panel||!w.panel.is(':visible')){event.preventDefault();document.getElementById('bill:btnSelect').click();}}">
                                                     <p:column headerText="PHN" style="padding: 8px; min-width: 100px;">
                                                         <div class="d-flex align-items-center">
                                                             <i class="fa-solid fa-id-card me-2 text-info"></i>


### PR DESCRIPTION
## Summary
Hotfix for RMH production: pressing Enter in the patient search box on the pharmacy bill issue BHT page submitted the form via the first submit button in the DOM (the "Nursing WorkBench" button), incorrectly navigating to the Nursing WorkBench/Dashboard instead of proceeding with the selected BHT. Enter now clicks the "Continue" button directly once the autocomplete suggestions panel is closed, while still letting the suggestions panel handle Enter normally when it's open (to pick a highlighted match).

## Issue Details
References #22852 (same root cause as the `development` fix in #22853, ported here because `rmh-prod`'s `pharmacy_bill_issue_bht.xhtml` is the older entity-based version, not the native-SQL rewrite on `development`).

### Actual Behavior (before fix)
Pressing Enter in the BHT search field submitted the form via the first submit button found in the DOM (the "Nursing WorkBench" button that sits above the search box in the same `h:form`), incorrectly navigating the user to the Nursing WorkBench/Dashboard page instead of continuing with the selected patient.

### Expected Behavior (after fix)
Pressing Enter after selecting/typing a valid BHT triggers the "Continue" button and proceeds to the bill entry screen, not navigate away to the Nursing WorkBench.

## Affected File
- `src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml`

## Test plan
- [ ] Go to Inward > Pharmacy Bill Issue (BHT) page on RMH
- [ ] Type a BHT number in the patient search box, press Enter while suggestions are open -> highlighted suggestion is selected (no navigation)
- [ ] Press Enter again with a valid BHT selected -> proceeds to bill entry screen (Continue action), not Nursing WorkBench