### PR TITLE
fix(cashier): stop duplicate Cash Book entries on fund deposit and handover

### DIFF
--- a/src/main/java/com/divudi/bean/cashTransaction/CashBookEntryController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/CashBookEntryController.java
@@ -1796,11 +1796,13 @@ public class CashBookEntryController implements Serializable {
         newCbEntry.setCashBook(cb);
         updateBalances(p.getPaymentMethod(), p.getPaidValue(), newCbEntry);
 
+        // Persist before merging the Payment - see writeCashBookEntryAtBankDeposit
+        // for why merging a Payment whose cashbookEntry is still transient causes
+        // EclipseLink to implicitly cascade-insert a duplicate row (issue #20963).
+        cashbookEntryFacade.create(newCbEntry);
         p.setCashbook(cb);
         p.setCashbookEntry(newCbEntry);
         paymentFacade.edit(p);
-        cashbookEntryFacade.create(newCbEntry);
-
     }
 
     public void writeCashBookEntryAtBankDeposit(Payment p, CashBook cb, Bill depositBill) {
@@ -1824,10 +1826,19 @@ public class CashBookEntryController implements Serializable {
         newCbEntry.setBill(depositBill);
         newCbEntry.setCashBook(cb);
         updateBalances(p.getPaymentMethod(), p.getPaidValue(), newCbEntry);
+        // Persist the CashBookEntry BEFORE merging the Payment that references it.
+        // Payment.cashbookEntry has no cascade, but handing em.merge() a Payment
+        // whose cashbookEntry is still transient makes EclipseLink implicitly
+        // cascade-insert an orphaned copy of it (no cascade needed to trigger this -
+        // it's merge's default handling of a new related entity), so the explicit
+        // create() below used to insert a SECOND row for the same entry - the
+        // duplicate Cash Book entry reported in issue #20963. Persisting first means
+        // paymentFacade.edit(p) merges a Payment pointing at an already-managed,
+        // real CashBookEntry row instead of a transient one.
+        cashbookEntryFacade.create(newCbEntry);
         p.setCashbook(cb);
         p.setCashbookEntry(newCbEntry);
         paymentFacade.edit(p);
-        cashbookEntryFacade.create(newCbEntry);
     }
 
     public void updateBalances(PaymentMethod pm, Double Value, CashBookEntry cbe) {


### PR DESCRIPTION
## Summary

- Fixes #20963 — Deposit Fund Amount Duplicated in Cash Book Entries.
- Root cause: `CashBookEntryController.writeCashBookEntryAtBankDeposit()` set `Payment.cashbookEntry` to a still-transient (unsaved) `CashBookEntry` and merged the Payment (`paymentFacade.edit(p)`) **before** persisting that `CashBookEntry` (`cashbookEntryFacade.create(newCbEntry)`). `Payment.cashbookEntry` is a plain `@ManyToOne` with no cascade, but EclipseLink implicitly cascade-inserts a still-transient related entity during merge anyway — so the merge silently created an orphaned `CashBookEntry` row, and the method's own subsequent `create()` call inserted a **second** row for the same entry. Confirmed via instrumented logging and the MySQL general query log: both `INSERT INTO CASHBOOKENTRY` statements came from the same request/thread, so this is not a double-submit race — it reproduces on a single, normal click.
- Fix: reorder both methods to persist the `CashBookEntry` first, then set it on the `Payment` and merge, so the merge always references an already-managed row.
- Applied the identical fix to the sibling `writeCashBookEntryAtHandover()` in the same file/class, which had the exact same ordering bug and would have caused the same duplication on Handover Accept.

## Test plan

- [x] Rebuilt and redeployed locally; reproduced the bug pre-fix with a **single** normal click on the Deposit button (Cashier → Drawer → Deposit to Safe/Bank): 1 `Bill`, 1 `Payment`, but **2** `CashBookEntry` rows for the same payment.
- [x] Confirmed via `mysql.general_log` (microsecond timestamps, same `thread_id`) that both `CashBookEntry` inserts came from a single request — ruling out the original double-submit theory.
- [x] Applied the fix, rebuilt/redeployed, repeated the same single-click deposit flow → exactly **1** `CashBookEntry` row, with `payment.CASHBOOKENTRY_ID` correctly pointing at it.
- [x] Verified visually on `cashier/cash_book_entry.xhtml`: every pre-fix test deposit shows twice in the list; the post-fix deposit shows exactly once.
- [x] `writeCashBookEntryAtHandover()` fix verified by code review only (identical 3-line reorder, same mechanism proven on the Deposit flow) — a full Handover Accept E2E pass would need a second shift/handover cycle to set up and was out of scope for this pass.

Screenshots (from issue comment): https://github.com/hmislk/hmis/issues/20963#issuecomment-5250536199

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cash book entries for handovers and bank deposits being inserted more than once.
  * Ensured associated payments correctly reference the persisted cash book entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->