### PR TITLE
22857 add route name and agent commission columns to lab income report

### DIFF
--- a/src/main/java/com/divudi/core/data/IncomeBundle.java
+++ b/src/main/java/com/divudi/core/data/IncomeBundle.java
@@ -135,6 +135,7 @@ public class IncomeBundle implements Serializable {
         double sumOfVoucherValues = 0.0;
         double sumOfIouValues = 0.0;
         double sumOfAgentValues = 0.0;
+        double sumOfCcValues = 0.0;
         double sumOfChequeValues = 0.0;
         double sumOfSlipValues = 0.0;
         double sumOfEWalletValues = 0.0;
@@ -173,6 +174,7 @@ public class IncomeBundle implements Serializable {
             sumOfNoneValues += r.getNoneValue();
             sumOfOpdCreditValues += r.getOpdCreditValue();
             sumOfInpatientCreditValues += r.getInpatientCreditValue();
+            sumOfCcValues += r.getBill().getTotalCenterFee();
 
             sumOfGrossTotal += r.getGrossTotal();
             sumOfDiscount += r.getDiscount();
@@ -202,6 +204,7 @@ public class IncomeBundle implements Serializable {
         getSummaryRow().setNoneValue(sumOfNoneValues);
         getSummaryRow().setOpdCreditValue(sumOfOpdCreditValues);
         getSummaryRow().setInpatientCreditValue(sumOfInpatientCreditValues);
+        getSummaryRow().setCcTotal(sumOfCcValues);
 
         getSummaryRow().setGrossTotal(sumOfGrossTotal);
         getSummaryRow().setDiscount(sumOfDiscount);

--- a/src/main/webapp/reportLab/laboratary_income_report.xhtml
+++ b/src/main/webapp/reportLab/laboratary_income_report.xhtml
@@ -355,15 +355,20 @@
                                 <h:outputText value="#{row.bill.deptId}"  style="padding: 2px!important; margin: 0px!important;" />
                             </p:column>
 
-                            <p:column headerText="Patient"  style="padding: 2px!important; margin: 0px!important;" >
+                            <p:column headerText="Patient" width="20em" style="padding: 2px!important; margin: 0px!important;" >
                                 <h:outputText value="#{row.bill.patient.person.nameWithTitle}"  style="padding: 2px!important; margin: 0px!important;" />
                             </p:column>
                             
                             <p:column headerText="BHT No" width="6em" style="padding: 2px!important; margin: 0px!important;">
                                 <h:outputText value="#{row.bhtNo}"  style="padding: 2px!important; margin: 0px!important;" ></h:outputText>
                             </p:column>
+                            
+                            <p:column headerText="Route Name" width="10em" style="padding: 2px!important; margin: 0px!important;"
+                                rendered="#{configOptionApplicationController.getBooleanValueByKey('Laboratory Income Report - Show Route Name Column',false)}">
+                                <h:outputText value="#{row.bill.collectingCentre.route.name}"  style="padding: 2px!important; margin: 0px!important;" />
+                            </p:column>
 
-                            <p:column headerText="Collecting Centre"  style="padding: 2px!important; margin: 0px!important;"
+                            <p:column headerText="Collecting Centre" width="20em" style="padding: 2px!important; margin: 0px!important;"
                                 rendered="#{configOptionApplicationController.getBooleanValueByKey('Laboratory Income Report - Show Collecting Centre Column',false)}">
                                 <h:outputText value="#{row.bill.collectingCentre.name}"  style="padding: 2px!important; margin: 0px!important;" />
                             </p:column>
@@ -446,6 +451,18 @@
                                 </h:outputText>
                                 <f:facet name="footer" >
                                     <h:outputText value="#{laborataryReportController.bundle.summaryRow.agentValue}" style="padding: 2px!important; margin: 0px!important;" >
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputText>
+                                </f:facet>
+                            </p:column>
+                            
+                            <p:column headerText="Agent Commission"   width="9em"  class="text-end light-grey-background"  style="padding: 2px!important; margin: 0px!important;"
+                                      rendered="#{configOptionApplicationController.getBooleanValueByKey('Laboratory Income Report - Show Agent Commission Column',false)}">
+                                <h:outputText value="#{row.bill.totalCenterFee}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputText>
+                                <f:facet name="footer" >
+                                    <h:outputText value="#{laborataryReportController.bundle.summaryRow.ccTotal}" style="padding: 2px!important; margin: 0px!important;" >
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputText>
                                 </f:facet>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Laboratory income reports now support optional Route Name and Agent Commission columns, controlled through report configuration.
  * Patient column sizing has been standardized for improved readability.
  * Agent Commission values now display bill center fees and a corresponding total in the report summary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->