### PR TITLE
Add Excel export for Collecting Centre Payment Bill Search

### DIFF
--- a/src/main/java/com/divudi/bean/common/CollectingCentrePaymentController.java
+++ b/src/main/java/com/divudi/bean/common/CollectingCentrePaymentController.java
@@ -765,6 +765,95 @@ public class CollectingCentrePaymentController implements Serializable {
         return (value == null || value.trim().isEmpty()) ? defaultValue : value;
     }
 
+    public void exportPaymentBillsToExcel() throws IOException {
+        if (paymentBills == null || paymentBills.isEmpty()) {
+            JsfUtil.addErrorMessage("No Bills to Export");
+            return;
+        }
+
+        FacesContext context = FacesContext.getCurrentInstance();
+        HttpServletResponse response = (HttpServletResponse) context.getExternalContext().getResponse();
+
+        response.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+        response.setHeader("Content-Disposition", "attachment; filename=CC_Payment_Bills.xlsx");
+
+        try (XSSFWorkbook workbook = new XSSFWorkbook(); OutputStream out = response.getOutputStream()) {
+
+            XSSFSheet sheet = workbook.createSheet("CC Payment Bills");
+            int rowIndex = 0;
+
+            XSSFFont boldFont = workbook.createFont();
+            boldFont.setBold(true);
+
+            SimpleDateFormat sdf = new SimpleDateFormat("dd-MM-yyyy hh:mm a");
+
+            XSSFCellStyle boldStyle = workbook.createCellStyle();
+            boldStyle.setFont(boldFont);
+
+            XSSFCellStyle amountStyle = workbook.createCellStyle();
+
+            Row headerRow = sheet.createRow(rowIndex++);
+            String[] headers = {"No", "Bill No", "Bill At", "Billed By", "CC Code", "CC Name", "Status", "Cancelled At", "Cancelled By", "Net Total"};
+
+            for (int i = 0; i < headers.length; i++) {
+                Cell cell = headerRow.createCell(i);
+                cell.setCellValue(headers[i]);
+                cell.setCellStyle(boldStyle);
+            }
+
+            int no = 1;
+            for (Bill bill : paymentBills) {
+                Row row = sheet.createRow(rowIndex++);
+
+                row.createCell(0).setCellValue(no++);
+                row.createCell(1).setCellValue(defaultIfNullOrEmpty(bill.getDeptId(), ""));
+
+                Cell billAtCell = row.createCell(2);
+                if (bill.getCreatedAt() != null) {
+                    billAtCell.setCellValue(sdf.format(bill.getCreatedAt()));
+                }
+
+                row.createCell(3).setCellValue(defaultIfNullOrEmpty(getUserNameWithTitle(bill.getCreater()), ""));
+
+                row.createCell(4).setCellValue(bill.getToInstitution() != null ? defaultIfNullOrEmpty(bill.getToInstitution().getInstitutionCode(), "") : "");
+                row.createCell(5).setCellValue(bill.getToInstitution() != null ? defaultIfNullOrEmpty(bill.getToInstitution().getName(), "") : "");
+
+                row.createCell(6).setCellValue(bill.isCancelled() ? "Cancelled" : "");
+
+                Cell cancelAtCell = row.createCell(7);
+                Cell cancelByCell = row.createCell(8);
+                if (bill.isCancelled() && bill.getCancelledBill() != null) {
+                    if (bill.getCancelledBill().getCreatedAt() != null) {
+                        cancelAtCell.setCellValue(sdf.format(bill.getCancelledBill().getCreatedAt()));
+                    }
+                    cancelByCell.setCellValue(defaultIfNullOrEmpty(getUserNameWithTitle(bill.getCancelledBill().getCreater()), ""));
+                }
+
+                Cell netTotalCell = row.createCell(9);
+                netTotalCell.setCellValue(bill.getNetTotal());
+                netTotalCell.setCellStyle(amountStyle);
+            }
+
+            for (int i = 0; i < headers.length; i++) {
+                sheet.autoSizeColumn(i);
+            }
+
+            workbook.write(out);
+            out.flush();
+
+            context.responseComplete();
+
+        } catch (Exception e) {
+        }
+    }
+
+    private String getUserNameWithTitle(com.divudi.core.entity.WebUser user) {
+        if (user == null || user.getWebUserPerson() == null) {
+            return "";
+        }
+        return user.getWebUserPerson().getNameWithTitle();
+    }
+
     public void cancelPaymentBill() {
         if (ccPaymentSettlingStarted) {
             JsfUtil.addErrorMessage("Already Started Process");

--- a/src/main/webapp/collecting_centre/collecting_centre_repayment_bill_search.xhtml
+++ b/src/main/webapp/collecting_centre/collecting_centre_repayment_bill_search.xhtml
@@ -55,7 +55,18 @@
                                             value="Search" 
                                             icon="fa fa-search"
                                             class="ui-button-success mt-2"
-                                            action="#{collectingCentrePaymentController.findCollectingCentrePaymentBills()}" />
+                                            action="#{collectingCentrePaymentController.findCollectingCentrePaymentBills()}" >
+                                        </p:commandButton>
+                                        
+                                        <p:commandButton
+                                            id="btnExcel"
+                                            icon="fa-solid fa-file-excel"
+                                            ajax="false"
+                                            value="Download"
+                                            class="w-100 mt-1"
+                                            action="#{collectingCentrePaymentController.exportPaymentBillsToExcel()}">
+                                        </p:commandButton>
+                                        
                                         <hr/>
 
                                         <p:inputText 


### PR DESCRIPTION
## Summary
- Add `exportPaymentBillsToExcel()` to `CollectingCentrePaymentController` to build a POI-based `.xlsx` export of the payment bills table, replacing the generic `p:dataExporter` which couldn't separate cancellation details into their own columns.
- Wire the existing Download button on the Collecting Centre Payment Bill Search page to the new method.

Columns exported: No, Bill No, Bill At, Billed By (name with title), CC Code, CC Name, Status (Cancelled/blank), Cancelled At, Cancelled By, Net Total.

Closes #22866

## Test plan
- [ ] Search CC payment bills on `collecting_centre_repayment_bill_search.xhtml`
- [ ] Click Download and confirm the `.xlsx` file downloads with all 10 columns populated correctly
- [ ] Verify a cancelled bill shows Status = Cancelled with Cancelled At / Cancelled By populated
- [ ] Verify a non-cancelled bill leaves Status/Cancelled At/Cancelled By blank