### PR TITLE
fix(cashier): update Drawer and Cash Book on Fund Withdrawal Bill

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -1606,6 +1606,26 @@ easy to mistake for the click not registering at all. Always fill the comment fi
 "Cancel" (or similarly `ajax="false"`) button appears to no-op, check for this pattern before
 assuming a click/ref problem.
 
+## 60. Direct `browser_navigate` to a fund-bill page (deposit/withdrawal/etc.) leaves `currentBill` null — the "+Add" button then silently no-ops with zero visible feedback
+
+On `cashier/fund_withdrawal_bill.xhtml` (and the same pattern likely applies
+to `deposit_funds.xhtml` and other `FinancialTransactionController` fund-bill
+pages), navigating straight to the page URL skips the menu action method
+(`navigateToCreateNewFundWithdrawalBill()` → `prepareToAddNewWithdrawalProcessingBill()`)
+that initializes the `@SessionScoped` bean's `currentBill`/`currentBillPayments`.
+The page still renders fully — Payment Method dropdown, Value field, "+Add"
+button all present and clickable — but `addPaymentToWithdrawalFundBill()`
+starts with `if (currentBill == null) { JsfUtil.addErrorMessage("Error"); return; }`,
+and the page has no `<p:messages>`/`<h:messages>` bound, so the growl error
+never renders. Clicking "+Add" just re-shows the same empty payment fields
+with **no error, no added row, no total change** — indistinguishable from a
+Playwright click/ref problem unless you check the "Withdrawal List" /
+"Deposits to Submit" table state after the click. Fix: always reach these
+pages via **Drawer tab → Withdrawals/Deposit to Safe/Bank button**, not
+`browser_navigate` to the URL directly — same root cause as §57, but here the
+consequence is a silent no-op rather than an empty page. Found while
+verifying issue #22870.
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.

--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -3741,6 +3741,15 @@ public class FinancialTransactionController implements Serializable {
             JsfUtil.addErrorMessage("Error");
             return "";
         }
+        if (withdrawalCashBook == null) {
+            JsfUtil.addErrorMessage("Please select a cashbook for this withdrawal");
+            return "";
+        }
+        if (getCurrentBillPayments() == null || getCurrentBillPayments().isEmpty()) {
+            JsfUtil.addErrorMessage("At least one withdrawal payment must be added before settlement");
+            return "";
+        }
+
         currentBill.setDepartment(sessionController.getDepartment());
         currentBill.setInstitution(sessionController.getInstitution());
         currentBill.setStaff(sessionController.getLoggedUser().getStaff());
@@ -3752,12 +3761,6 @@ public class FinancialTransactionController implements Serializable {
         currentBill.setDeptId(deptId);
 
         Double netTotal = currentBill.getNetTotal();
-
-        if (withdrawalCashBook == null) {
-            JsfUtil.addErrorMessage("Please select a cashbook for this withdrawal");
-            return "";
-        }
-
         currentBill.setNetTotal(Math.abs(netTotal));
         currentBill.setTotal(Math.abs(netTotal));
         billController.save(currentBill);

--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -287,6 +287,7 @@ public class FinancialTransactionController implements Serializable {
     private List<Payment> fundTransferAvailablePayments;
     private List<Payment> depositableNonCashPayments;
     private CashBook depositCashBook;
+    private CashBook withdrawalCashBook;
 
     // Shortage Bill Cancellation Properties
     private String shortageCancellationComment;
@@ -3301,6 +3302,14 @@ public class FinancialTransactionController implements Serializable {
         this.depositCashBook = depositCashBook;
     }
 
+    public CashBook getWithdrawalCashBook() {
+        return withdrawalCashBook;
+    }
+
+    public void setWithdrawalCashBook(CashBook withdrawalCashBook) {
+        this.withdrawalCashBook = withdrawalCashBook;
+    }
+
     public void addPaymentToShiftEndFundBill() {
         if (currentBill == null) {
             JsfUtil.addErrorMessage("Error");
@@ -3735,16 +3744,31 @@ public class FinancialTransactionController implements Serializable {
         currentBill.setDepartment(sessionController.getDepartment());
         currentBill.setInstitution(sessionController.getInstitution());
         currentBill.setStaff(sessionController.getLoggedUser().getStaff());
-
+        String deptId = billNumberGenerator.departmentBillNumberGeneratorYearly(sessionController.getDepartment(), BillTypeAtomic.FUND_WITHDRAWAL_BILL);
+        currentBill.setBillTypeAtomic(BillTypeAtomic.FUND_WITHDRAWAL_BILL);
         currentBill.setBillDate(new Date());
         currentBill.setBillTime(new Date());
+        currentBill.setInsId(deptId);
+        currentBill.setDeptId(deptId);
 
+        Double netTotal = currentBill.getNetTotal();
+
+        if (withdrawalCashBook == null) {
+            JsfUtil.addErrorMessage("Please select a cashbook for this withdrawal");
+            return "";
+        }
+
+        currentBill.setNetTotal(Math.abs(netTotal));
+        currentBill.setTotal(Math.abs(netTotal));
         billController.save(currentBill);
         for (Payment p : getCurrentBillPayments()) {
             p.setBill(currentBill);
             p.setDepartment(sessionController.getDepartment());
             p.setInstitution(sessionController.getInstitution());
+            p.setPaidValue(Math.abs(p.getPaidValue()));
             paymentController.save(p);
+            drawerController.updateDrawerForIns(p);
+            cashBookEntryController.writeCashBookEntryAtBankDeposit(p, withdrawalCashBook, currentBill);
         }
         return "/cashier/fund_withdrawal_bill_print?faces-redirect=true";
     }
@@ -9078,6 +9102,7 @@ public class FinancialTransactionController implements Serializable {
         currentBill.setBillType(BillType.WithdrawalFundBill);
         currentBill.setBillTypeAtomic(BillTypeAtomic.FUND_WITHDRAWAL_BILL);
         currentBill.setBillClassType(BillClassType.Bill);
+        withdrawalCashBook = null;
     }
 
     //Damith

--- a/src/main/webapp/cashier/fund_withdrawal_bill.xhtml
+++ b/src/main/webapp/cashier/fund_withdrawal_bill.xhtml
@@ -107,7 +107,7 @@
                                         icon="fa fa-plus"
                                         class="ui-button-success"
                                         process="btnAdd cmdPayment paymentDetails"
-                                        update="tblPayments totals cmdPayment paymentDetails"
+                                        update="tblPayments totals cmdPayment paymentDetails txtTotalWithdrawalValue"
                                         action="#{financialTransactionController.addPaymentToWithdrawalFundBill()}" >
                                     </p:commandButton>
                                 </div>
@@ -149,7 +149,7 @@
                                         value="Remove" 
                                         action="#{financialTransactionController.removePayment}" 
                                         process="btnRemove tblPayments"
-                                        update=":#{p:resolveFirstComponentWithId('tblPayments',view).clientId} :#{p:resolveFirstComponentWithId('totals',view).clientId}"
+                                        update=":#{p:resolveFirstComponentWithId('tblPayments',view).clientId} :#{p:resolveFirstComponentWithId('totals',view).clientId} :#{p:resolveFirstComponentWithId('txtTotalWithdrawalValue',view).clientId}"
                                         >
                                         <f:setPropertyActionListener value="#{bp}" target="#{financialTransactionController.removingPayment}" ></f:setPropertyActionListener>
                                     </p:commandButton>

--- a/src/main/webapp/cashier/fund_withdrawal_bill.xhtml
+++ b/src/main/webapp/cashier/fund_withdrawal_bill.xhtml
@@ -17,15 +17,10 @@
                         <f:facet name="header">
                             <i class="fa fa-money-bill-wave mt-2"/>
                             <p:outputLabel value="Fund Withdrawal Bill" class="mx-2 mt-2"></p:outputLabel>
-                            <p:commandButton 
-                                icon="fa-solid fa-check"
-                                class="ui-button-success"
-                                style="float: right;"
-                                value="Withdraw" 
-                                ajax="false" 
-                                action="#{financialTransactionController.settleWithdrawalFundBill()}" >
-                            </p:commandButton>
                         </f:facet>
+
+                        <div class="row">
+                        <div class="col-8">
                         <p:panel header="Add Withdrawal" >
 
                             <div class="row">
@@ -162,6 +157,66 @@
                             </p:dataTable>
 
                         </p:panel>
+                        </div>
+
+                        <div class="col-4">
+                            <p:panelGrid
+                                columns="2"
+                                class="w-100 m-1"
+                                layout="tabular"
+                                columnClasses="custom-col-28, custom-col-68">
+                                <f:facet name="header">
+                                    <h:outputLabel value="Withdraw From"/>
+                                    <p:commandButton
+                                        icon="fa-solid fa-check"
+                                        class="ui-button-success float-end"
+                                        style="float: right;"
+                                        value="Withdraw"
+                                        ajax="false"
+                                        action="#{financialTransactionController.settleWithdrawalFundBill()}">
+                                    </p:commandButton>
+                                </f:facet>
+
+                                <p:outputLabel value="Cashbook"/>
+                                <p:autoComplete
+                                    class="w-100"
+                                    inputStyleClass="w-100"
+                                    completeMethod="#{cashBookController.completeCashBook}"
+                                    value="#{financialTransactionController.withdrawalCashBook}"
+                                    var="cb"
+                                    forceSelection="true"
+                                    itemLabel="#{cashBookController.getCashBookLabel(cb)}"
+                                    itemValue="#{cb}"
+                                    required="true"
+                                    requiredMessage="Please select a cashbook"/>
+
+                                <p:outputLabel value="Bank/Safe"/>
+                                <p:autoComplete
+                                    class="w-100"
+                                    inputStyleClass="w-100"
+                                    completeMethod="#{bankAccountController.completeBankAccount}"
+                                    value="#{financialTransactionController.currentBill.bankAccount}"
+                                    var="account"
+                                    forceSelection="true"
+                                    itemLabel="#{account.accountName}"
+                                    itemValue="#{account}"/>
+
+                                <p:outputLabel value="Comments"/>
+                                <p:inputTextarea
+                                    class="w-100"
+                                    rows="3"
+                                    value="#{financialTransactionController.currentBill.comments}"/>
+
+                                <p:outputLabel value="Total Withdrawal Value"/>
+                                <p:inputText
+                                    id="txtTotalWithdrawalValue"
+                                    class="w-100 text-end"
+                                    readonly="true"
+                                    value="#{financialTransactionController.currentBill.netTotal}"/>
+                            </p:panelGrid>
+                        </div>
+
+                        </div>
                     </p:panel>
                     </h:form>
                 </ui:define>


### PR DESCRIPTION
## Summary
- `settleWithdrawalFundBill()` saved the bill/payments but never generated a bill number, updated the cashier's Drawer, or wrote a Cash Book entry — submitting a Fund Withdrawal Bill (Cashier → Drawer → Withdrawals) was effectively a no-op from the user's point of view.
- The withdrawal page also had no Cashbook or source Bank/Safe selector at all, unlike the working "Deposit to Safe/Bank" page.
- Fixes this by mirroring the working `settleFundDepositBill()` pattern, adapted for the reverse direction: withdrawal pulls cash **from** a bank/safe **into** the drawer (`BillTypeAtomic.FUND_WITHDRAWAL_BILL` = `BillFinanceType.BANK_IN`, vs deposit's `BANK_OUT`), so it generates a real bill number, keeps `paidValue` positive, calls `drawerController.updateDrawerForIns(p)`, and writes a Cash Book entry via the same `writeCashBookEntryAtBankDeposit(...)` helper deposit already uses (previously hardened against duplicate rows by #20963).
- Added a required `withdrawalCashBook` field + a "Withdraw From" panel (Cashbook, Bank/Safe, Comments, Total) on `fund_withdrawal_bill.xhtml`, mirroring the deposit page's panel.

Closes #22870

## Test plan
Verified end-to-end against local Payara (Galle Co-op DB), department Main Pharmacy, via Playwright + direct DB queries — full evidence and screenshots posted on [issue #22870](https://github.com/hmislk/hmis/issues/22870#issuecomment-5259798186):

- [x] Added a Cash payment (500), selected a Cashbook, submitted via "Withdraw"
- [x] Print receipt now shows a real bill number (`MP//26/020294`) instead of blank
- [x] Drawer cash-in-hand increased by exactly the withdrawn amount: `20256.98` → `20756.98`
- [x] Exactly one `cashbookentry` row created for the bill (no duplicate), correct `entry_value` and cashbook link
- [x] Entry visible in both "My Drawer History" and "Cash Book → Cash Book Entries" in the UI

![before](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/22870-withdrawal-before-submit.png)
![receipt](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/22870-withdrawal-print-receipt.png)
![drawer history](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/22870-drawer-history-after.png)
![cash book](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/22870-cashbook-entries-after.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added withdrawal-source cashbook selection to fund withdrawal forms.
  - Added fields for withdrawal comments and a read-only total.
  - Withdrawal settlements now record the selected cashbook and update related cashbook balances.
- **Improvements**
  - Withdrawal now requires a cashbook and at least one payment.
  - Withdrawal amounts and payment totals are consistently handled as positive values.
  - Updated the withdrawal form with a clearer two-column layout and improved action placement.
- **Documentation**
  - Added guidance for navigating to fund-bill pages through the Drawer to ensure all actions work correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->