### PR TITLE
fix(pharmacy): update GRN/Direct Purchase refundAmount on return approval

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -1606,6 +1606,38 @@ easy to mistake for the click not registering at all. Always fill the comment fi
 "Cancel" (or similarly `ajax="false"`) button appears to no-op, check for this pattern before
 assuming a click/ref problem.
 
+## 60. GRN receive/approve `Invoice Total` resets to 0.00 on every page (re)load and needs a *real* blur, not just `fill()`, to pass the "invoice does not match" check
+
+On `pharmacy_grn_costing_with_save_approve.xhtml` (both the initial Finalize and the separate
+Approve page load), `Invoice Total` starts blank/0.00 every time the page is (re)rendered —
+including the second time you land on the same GRN for the Approve step, even though you already
+filled it once during Finalize. Two gotchas stack here:
+
+1. **It must be re-filled at every stage** (Finalize *and* Approve) — don't assume a value entered
+   once persists across the finalize→approve navigation.
+2. **A plain `browser_type`/`.fill()` + `Tab` does not reliably commit it** — the page kept
+   re-showing `Difference: -<amount>` (computed server-side from the *old* 0.00) and Finalize
+   failed with "The invoice does not match..! Check again" even though the input visibly showed
+   the typed value. The fix: `browser_click` into the field, `Control+a`, `browser_type` with
+   `slowly: true`, then an explicit `browser_click` on an unrelated static element (e.g. the page
+   heading) to force a real blur — only then does `Difference` recompute to `0.00` and
+   Finalize/Approve succeed. Verify via `browser_find` on "Difference" before clicking
+   Finalize/Approve, not just by eyeballing the Invoice Total box.
+
+Found while verifying issue #18280 (GRN Return refundAmount fix).
+
+## 61. "Generate Supplier Payments" only lists Credit-payment-method GRNs — a Cash GRN's return never shows up there, by design
+
+`SupplierPaymentController.fillUnsettledCreditPharmacyBills()` (and the sibling return-bills
+method) hard-filter on `PaymentMethod.Credit`. A GRN received with Payment Method = **Cash** will
+never appear on `list_bills_to_generate_supplier_payments.xhtml` or `list_all_grns.xhtml`'s
+"Prepare Payment" flow, no matter its return/refund state — there's nothing owed to the supplier
+for a bill already settled in cash at receipt, so this is correct behavior, not a bug. If a test
+needs to reach the actual Supplier Payment screen (`generate_supplier_payment.xhtml`), the GRN
+**must** be created with Payment Method = **Credit** at receive time; a Cash-paid test GRN is only
+verifiable at the DB level (`BILL.REFUNDAMOUNT`/`PAIDAMOUNT`/`NETTOTAL`), not through this UI path.
+Found while verifying issue #18280.
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.

--- a/src/main/java/com/divudi/bean/pharmacy/DirectPurchaseReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/DirectPurchaseReturnWorkflowController.java
@@ -594,14 +594,22 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
             }
         }
 
-        // Check if the original Direct Purchase is fully returned and mark it as fullReturned
+        // Update the original Direct Purchase's refundAmount so Supplier Payment
+        // screens (SupplierPaymentController) settle on the net-of-return amount
+        // instead of the full original Direct Purchase amount (hmislk/hmis#18280).
+        // Also check if the original Direct Purchase is now fully returned.
         Bill originalDirectPurchaseBill = currentBill.getReferenceBill();
-        if (originalDirectPurchaseBill != null && isDirectPurchaseFullyReturned(originalDirectPurchaseBill)) {
-            originalDirectPurchaseBill.setFullReturned(true);
-            originalDirectPurchaseBill.setFullReturnedBy(sessionController.getLoggedUser());
-            originalDirectPurchaseBill.setFullReturnedAt(new Date());
+        if (originalDirectPurchaseBill != null) {
+            originalDirectPurchaseBill.setRefundAmount(Math.abs(originalDirectPurchaseBill.getRefundAmount()) + Math.abs(currentBill.getNetTotal()));
+            if (isDirectPurchaseFullyReturned(originalDirectPurchaseBill)) {
+                originalDirectPurchaseBill.setFullReturned(true);
+                originalDirectPurchaseBill.setFullReturnedBy(sessionController.getLoggedUser());
+                originalDirectPurchaseBill.setFullReturnedAt(new Date());
+            }
             billFacade.edit(originalDirectPurchaseBill);
-            JsfUtil.addSuccessMessage("Original Direct Purchase has been fully returned and marked as complete.");
+            if (originalDirectPurchaseBill.isFullReturned()) {
+                JsfUtil.addSuccessMessage("Original Direct Purchase has been fully returned and marked as complete.");
+            }
         }
 
         // Reload via billService to show items in print preview without

--- a/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
@@ -876,14 +876,22 @@ public class GrnReturnWorkflowController implements Serializable {
             }
         }
 
-        // Check if the original GRN is fully returned and mark it as fullReturned
+        // Update the original GRN's refundAmount so Supplier Payment screens
+        // (SupplierPaymentController) settle on the net-of-return amount
+        // instead of the full original GRN amount (hmislk/hmis#18280).
+        // Also check if the original GRN is now fully returned.
         Bill originalGrnBill = currentBill.getReferenceBill();
-        if (originalGrnBill != null && isGrnFullyReturned(originalGrnBill)) {
-            originalGrnBill.setFullReturned(true);
-            originalGrnBill.setFullReturnedBy(sessionController.getLoggedUser());
-            originalGrnBill.setFullReturnedAt(new Date());
+        if (originalGrnBill != null) {
+            originalGrnBill.setRefundAmount(Math.abs(originalGrnBill.getRefundAmount()) + Math.abs(currentBill.getNetTotal()));
+            if (isGrnFullyReturned(originalGrnBill)) {
+                originalGrnBill.setFullReturned(true);
+                originalGrnBill.setFullReturnedBy(sessionController.getLoggedUser());
+                originalGrnBill.setFullReturnedAt(new Date());
+            }
             billFacade.edit(originalGrnBill);
-            JsfUtil.addSuccessMessage("Original GRN has been fully returned and marked as complete.");
+            if (originalGrnBill.isFullReturned()) {
+                JsfUtil.addSuccessMessage("Original GRN has been fully returned and marked as complete.");
+            }
         }
 
         // Reload via billService to show items in print preview without


### PR DESCRIPTION
## What

Fixes #18280 — Supplier Payment amount was still calculated on the full original GRN amount after a GRN return had been approved, instead of net of the returned quantity/value.

## Root cause

`SupplierPaymentController` computes the amount payable to a supplier for a GRN as:

```
payable = |GRN netTotal| − (|GRN refundAmount| + |GRN paidAmount|)
```

`Bill.refundAmount` is a plain persisted field. The only code path that ever incremented it was the legacy `GoodsReturnController`, which is **not wired into the current UI** (the live entry point `pharmacy/returns_and_cancellations_index.xhtml` only calls `grnReturnWorkflowController.*` / `directPurchaseReturnWorkflowController.*`).

The actual, currently-used GRN Return approval path — `GrnReturnWorkflowController.completeApproval()` (called from both `approve()` and the auto-approve branch of `finalizeRequest()`) — deducts stock, creates the return payment, and flags `fullReturned` on 100% return, but never touched `refundAmount`. So after an approved partial (or full) return, `refundAmount` stayed `0`, and Supplier Payment screens kept charging the full original GRN amount.

The identical gap existed in the sibling `DirectPurchaseReturnWorkflowController.completeApproval()` for Direct Purchase bills, which feed the same Supplier Payment screens — fixed there too for consistency.

## Fix

In both `completeApproval()` methods, alongside the existing "is this now fully returned" check, increment the original bill's `refundAmount` by the absolute net total of the just-approved return bill (same sign convention `GoodsReturnController` already uses), then persist unconditionally (previously the `billFacade.edit()` call only ran on full return).

## Out of scope (discussed with the user)

- No backfill of `refundAmount` for GRNs/Direct Purchases whose returns were already approved before this fix — code fix only, going forward.
- Legacy `GoodsReturnController` / `GrnReturnApprovalController` (not reachable from the current UI) — left untouched.
- Noticed the "Recievable Amount"/"Balance" column on `list_bills_to_generate_supplier_payments.xhtml` reads a separate, similarly-stale `Bill.balance` field that this fix does not touch — the actual **Paying Amount** used to generate the payment is correct (verified below); the display column is a candidate for a follow-up issue.

## Verification (local dev, synthetic test data only)

1. Created a Credit-payment GRN (`MP/GRN/26/038017`) for 10 units of a test item @ Rs 10.75 → net total **Rs 107.50**.
2. Created and approved a partial GRN Return for 4 of those units (**Rs 43.00**).
3. DB: `BILL.REFUNDAMOUNT` on the original GRN is now **43.00** (previously always `0`, regardless of return state).
4. **Generate Supplier Payment** screen: GRN Amount 107.50, GRN Return Amount **43.00**, Paying Amount now correctly **64.50** — net of the return.
5. Repeated the same flow for a Cash-payment GRN and confirmed `refundAmount` updates identically at the DB level (Cash GRNs never reach the Supplier Payment screens by design — `PaymentMethod.Credit` filter — so only DB-level verification applies there).

**GRN approved (Credit, 10 units):**
![GRN approved](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/issue-18280-grn-approved.png)

**GRN Return note (4 units returned):**
![GRN Return note](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/issue-18280-grn-return-note.png)

**Generate Supplier Payment — net of the return (Rs 64.50, not Rs 107.50):**
![Supplier payment net of return](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/issue-18280-supplier-payment-net-of-return.png)

Also documented two new Playwright E2E testing gotchas hit during verification (`developer_docs/testing/playwright-e2e-workflow.md` §60-61): the GRN Invoice Total field's blur-commit requirement, and the Credit-only filter on the Supplier Payment generation list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved purchase return processing by accurately accumulating refund amounts and identifying when purchases are fully returned.
  - Improved GRN return approvals by correctly tracking approved refund amounts and updating fully returned status.
  - Completion notifications now appear only when the original GRN is fully returned.

- **Documentation**
  - Added Playwright workflow guidance for re-entering invoice totals during finalization and approval.
  - Documented how to verify supplier payments for credit-based and cash-based GRNs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->