### PR TITLE
fix(admin): self-service DDL load on DB migration/missing-fields pages

### DIFF
--- a/src/main/java/com/divudi/bean/common/DataAdministrationController.java
+++ b/src/main/java/com/divudi/bean/common/DataAdministrationController.java
@@ -349,6 +349,10 @@ public class DataAdministrationController implements Serializable {
     // never be rendered into a textarea that a full-form submit would echo back.
     private String wikiFetchedDdl;
     private String wikiFetchedDdlInfo;
+    // Table picked by the admin on the "Check Missing Fields and Add Fields"
+    // tab to extract that table's CREATE TABLE statement out of wikiFetchedDdl
+    // into createdSql, instead of requiring it to be hand-pasted.
+    private String selectedWikiTableName;
 
     Date fromDate;
     Date toDate;
@@ -2560,6 +2564,65 @@ public class DataAdministrationController implements Serializable {
         return wikiFetchedDdlInfo;
     }
 
+    /**
+     * Table names parsed out of {@link #wikiFetchedDdl} (populated by
+     * {@link #loadDdlFromWiki()}), for the "Check Missing Fields and Add
+     * Fields" tab's table picker. Uses the same split-by-"CREATE TABLE"
+     * approach as {@link #createTablesOnDatabase}, so the list always
+     * matches what that execution path would actually operate on.
+     */
+    public List<String> getWikiTableNames() {
+        List<String> tableNames = new ArrayList<>();
+        if (wikiFetchedDdl == null || wikiFetchedDdl.trim().isEmpty()) {
+            return tableNames;
+        }
+        String[] rawParts = wikiFetchedDdl.split("(?i)CREATE TABLE");
+        for (String part : rawParts) {
+            part = part.trim();
+            if (part.isEmpty()) {
+                continue;
+            }
+            String tableName = extractTableName("CREATE TABLE " + part);
+            if (tableName != null && !tableName.isEmpty()) {
+                tableNames.add(tableName);
+            }
+        }
+        Collections.sort(tableNames);
+        return tableNames;
+    }
+
+    /**
+     * Extracts the CREATE TABLE statement for {@link #selectedWikiTableName}
+     * out of {@link #wikiFetchedDdl} and places it in {@link #createdSql},
+     * so the admin doesn't need to already know and hand-paste it before
+     * clicking "Generate Alter Statements".
+     */
+    public void loadCreateStatementForSelectedTable() {
+        if (wikiFetchedDdl == null || wikiFetchedDdl.trim().isEmpty()) {
+            JsfUtil.addErrorMessage("Load the latest DDL from wiki first.");
+            return;
+        }
+        if (selectedWikiTableName == null || selectedWikiTableName.trim().isEmpty()) {
+            JsfUtil.addErrorMessage("Select a table first.");
+            return;
+        }
+        String[] rawParts = wikiFetchedDdl.split("(?i)CREATE TABLE");
+        for (String part : rawParts) {
+            part = part.trim();
+            if (part.isEmpty()) {
+                continue;
+            }
+            String createStatement = "CREATE TABLE " + part;
+            String tableName = extractTableName(createStatement);
+            if (selectedWikiTableName.equals(tableName)) {
+                createdSql = createStatement;
+                JsfUtil.addSuccessMessage("Loaded CREATE TABLE statement for '" + tableName + "'. Click 'Generate Alter Statements' to continue.");
+                return;
+            }
+        }
+        JsfUtil.addErrorMessage("Table '" + selectedWikiTableName + "' not found in the fetched DDL.");
+    }
+
     public void checkMissingFields() {
         // Clear all previous results
         suggestedSql = "";
@@ -4673,6 +4736,14 @@ public class DataAdministrationController implements Serializable {
 
     public void setCreatedSql(String createdSql) {
         this.createdSql = createdSql;
+    }
+
+    public String getSelectedWikiTableName() {
+        return selectedWikiTableName;
+    }
+
+    public void setSelectedWikiTableName(String selectedWikiTableName) {
+        this.selectedWikiTableName = selectedWikiTableName;
     }
 
     public String getAlterSql() {

--- a/src/main/webapp/mf.xhtml
+++ b/src/main/webapp/mf.xhtml
@@ -14,54 +14,38 @@
     </h:head>
     <h:body>
 
-        <!-- Migration pending: open to everyone. Reduced toolset only (fullAccess="false") —
-             this page is reachable pre-login, so it must never expose the full admin toolset
-             (Check Missing Fields, Run Custom SQL). Those remain available only through the
-             authenticated Admin Functions path (dataAdmin/missing_database_fields.xhtml). -->
-        <h:panelGroup rendered="#{applicationController.databaseMigrationPending}">
+        <!-- Available whenever canAccessMigrationPage() allows it: unauthenticated while a
+             migration is pending (as before), or to logged-in Admin-privilege users afterward,
+             so schema drift can always be fixed without requiring an admin to hand-run SQL.
+             Reduced toolset only (fullAccess="false") — this page is reachable pre-login, so it
+             must never expose the full admin toolset (Check Missing Fields, Run Custom SQL).
+             Those remain available only through the authenticated Admin Functions path
+             (dataAdmin/missing_database_fields.xhtml). -->
+        <h:panelGroup rendered="#{dataAdministrationController.canAccessMigrationPage()}" layout="block">
 
             <div class="container mt-3">
-                <div class="alert alert-warning" role="alert">
+                <h:panelGroup layout="block" styleClass="alert alert-warning" rendered="#{applicationController.databaseMigrationPending}">
                     <strong>Database Migration Pending</strong> —
                     Please check for missing fields and run the migration below, then mark it as complete.
-                </div>
+                </h:panelGroup>
+                <h:panelGroup layout="block" styleClass="alert alert-info" rendered="#{not applicationController.databaseMigrationPending}">
+                    No database migration is pending. Tools remain available below for administrators.
+                </h:panelGroup>
+
+                <p:button value="Back to Home" outcome="/index" icon="fa fa-home"
+                          styleClass="ui-button-info ui-button-outlined mb-3"/>
             </div>
 
             <ez:midding_data_fields fullAccess="false"/>
 
-            <div class="container mt-3 mb-5">
-                <h:form id="migrationControlForm">
-                    <p:commandButton value="Mark Migration as Complete"
-                                     action="#{dataAdministrationController.markMigrationComplete()}"
-                                     ajax="false"
-                                     styleClass="ui-button-success me-2"/>
-                    <p:commandButton value="Mark as Not Necessary"
-                                     action="#{dataAdministrationController.markMigrationNotNecessary()}"
-                                     ajax="false"
-                                     styleClass="ui-button-secondary"/>
-                </h:form>
-            </div>
-
         </h:panelGroup>
 
-        <!-- Not migration pending: this page is unauthenticated, so nothing is rendered here.
-             The full admin toolset is reached only via the authenticated Admin Functions path. -->
-        <h:panelGroup rendered="#{not applicationController.databaseMigrationPending}" layout="block">
-            <div class="container mt-3">
-                <div class="alert alert-info" role="alert">
-                    No database migration is pending.
+        <!-- Access denied: migration not pending and the current user is not an Admin. -->
+        <h:panelGroup rendered="#{dataAdministrationController.isMigrationPageAccessDenied()}" layout="block">
+            <div class="container mt-3 mb-5">
+                <div class="alert alert-danger" role="alert">
+                    No database migration is pending. This page is restricted to administrators.
                 </div>
-
-                <!-- Feedback from a migration action just run in this same request (e.g. the
-                     Update Database button, which marks the migration complete on success and
-                     therefore switches this page straight to the "not pending" branch above) —
-                     shown here so the result isn't lost, since the tool that produced it is
-                     no longer rendered once migration is no longer pending. -->
-                <h:panelGroup layout="block" styleClass="alert alert-secondary" style="white-space: pre-wrap;"
-                              rendered="#{not empty dataAdministrationController.executionFeedback}">
-                    #{dataAdministrationController.executionFeedback}
-                </h:panelGroup>
-
                 <p:button value="Back to Home" outcome="/index" icon="fa fa-home"
                           styleClass="ui-button-info ui-button-outlined"/>
             </div>

--- a/src/main/webapp/resources/ezcomp/midding_data_fields.xhtml
+++ b/src/main/webapp/resources/ezcomp/midding_data_fields.xhtml
@@ -131,6 +131,17 @@
                         <p:outputLabel value="Wiki DDL Version" />
                         <h:outputText value="#{dataAdministrationController.wikiDdlVersion != null ? dataAdministrationController.wikiDdlVersion : '(not yet fetched)'}" />
 
+                        <p:outputLabel value="Load from Wiki" />
+                        <h:panelGroup layout="block" class="d-flex align-items-center">
+                            <p:commandButton
+                                value="Load Latest DDL from Wiki"
+                                ajax="false"
+                                action="#{dataAdministrationController.loadDdlFromWiki}"
+                                styleClass="ui-button-success mr-3"
+                                title="Server downloads the full DDL script from the wiki, so the table below can be picked without hand-pasting its CREATE TABLE statement"/>
+                            <h:outputText value="#{dataAdministrationController.wikiFetchedDdlInfo}" />
+                        </h:panelGroup>
+
                         <p:outputLabel value="Stored DB Version" />
                         <h:panelGroup layout="block" class="d-flex align-items-center">
                             <h:outputText value="#{dataAdministrationController.storedDdlVersion != null ? dataAdministrationController.storedDdlVersion : '(not set)'}" styleClass="me-3"/>
@@ -165,8 +176,25 @@
                             class="w-100"
                             rendered="#{dataAdministrationController.runOnAuditDatabase and not empty dataAdministrationController.auditDatabaseErrors}"/>
 
+                        <p:outputLabel value="Table (from fetched DDL)" rendered="#{not empty dataAdministrationController.wikiFetchedDdlInfo}"/>
+                        <h:panelGroup layout="block" class="d-flex align-items-center" rendered="#{not empty dataAdministrationController.wikiFetchedDdlInfo}">
+                            <p:selectOneMenu id="wikiTableSelect" value="#{dataAdministrationController.selectedWikiTableName}" class="mr-2">
+                                <f:selectItem itemLabel="Select a table..." itemValue="" noSelectionOption="true"/>
+                                <f:selectItems value="#{dataAdministrationController.wikiTableNames}"/>
+                            </p:selectOneMenu>
+                            <p:commandButton
+                                value="Use Selected Table's DDL"
+                                ajax="true"
+                                process="@this wikiTableSelect"
+                                update="createdSqlArea growl"
+                                action="#{dataAdministrationController.loadCreateStatementForSelectedTable}"
+                                styleClass="ui-button-info"
+                                title="Fills 'Data table Create SQL statement' below with this table's CREATE TABLE statement from the fetched DDL"/>
+                        </h:panelGroup>
+
                         <p:outputLabel value="Data table Create SQL statement" ></p:outputLabel>
                         <p:inputTextarea
+                            id="createdSqlArea"
                             rows="6"
                             autoResize="false"
                             value="#{dataAdministrationController.createdSql}"
@@ -343,37 +371,51 @@
                 </h:panelGroup>
 
                 <p:outputLabel value="Actions" />
-                <h:panelGroup layout="block" class="d-flex flex-wrap">
+                <h:panelGroup layout="block" class="d-flex flex-wrap align-items-center">
                     <p:commandButton
                         value="Load Latest DDL from Wiki and Update Both Databases"
                         ajax="false"
                         action="#{dataAdministrationController.loadDdlFromWikiAndUpdateBothDatabases}"
-                        styleClass="ui-button-success me-2"
+                        styleClass="ui-button-success me-2 mb-2"
                         icon="fa fa-download"
                         title="Downloads the full DDL script from the wiki and applies it to the main (hmisPU) and audit (hmisAuditPU) databases"/>
                     <p:commandButton
                         value="Fix AUTO_INCREMENT"
                         ajax="false"
                         action="#{dataAdministrationController.fixMissingAutoIncrement()}"
-                        styleClass="ui-button-warning"
+                        styleClass="ui-button-warning me-2 mb-2"
                         icon="fa fa-wrench"
                         title="Scans every table for a BIGINT ID primary key missing AUTO_INCREMENT and re-adds it. Safe to run repeatedly — a no-op on a healthy database."/>
+                    <p:commandButton
+                        value="Mark Migration as Complete"
+                        ajax="false"
+                        action="#{dataAdministrationController.markMigrationComplete()}"
+                        styleClass="ui-button-info me-2 mb-2"
+                        icon="fa fa-check"
+                        title="Confirms the schema is up to date and clears the migration-pending banner"/>
+                    <p:commandButton
+                        value="Mark as Not Necessary"
+                        ajax="false"
+                        action="#{dataAdministrationController.markMigrationNotNecessary()}"
+                        styleClass="ui-button-secondary mb-2"
+                        icon="fa fa-times"
+                        title="Dismisses the migration-pending banner without applying any DDL"/>
                 </h:panelGroup>
 
                 <p:outputLabel value="Execution Feedback" rendered="#{not empty dataAdministrationController.executionFeedback}"/>
-                <h:panelGroup layout="block" styleClass="p-2 border rounded bg-light w-100" style="white-space: pre-wrap;"
+                <h:panelGroup layout="block" styleClass="p-2 border rounded bg-light w-100" style="white-space: pre-wrap; max-height: 400px; overflow-y: auto;"
                               rendered="#{not empty dataAdministrationController.executionFeedback}">
                     #{dataAdministrationController.executionFeedback}
                 </h:panelGroup>
 
                 <p:outputLabel value="Main Database Results" rendered="#{not empty dataAdministrationController.mainDatabaseExecutionFeedback}"/>
-                <h:panelGroup layout="block" styleClass="p-2 border rounded bg-light w-100" style="white-space: pre-wrap;"
+                <h:panelGroup layout="block" styleClass="p-2 border rounded bg-light w-100" style="white-space: pre-wrap; max-height: 400px; overflow-y: auto;"
                               rendered="#{not empty dataAdministrationController.mainDatabaseExecutionFeedback}">
                     #{dataAdministrationController.mainDatabaseExecutionFeedback}
                 </h:panelGroup>
 
                 <p:outputLabel value="Audit Database Results" rendered="#{not empty dataAdministrationController.auditDatabaseExecutionFeedback}"/>
-                <h:panelGroup layout="block" styleClass="p-2 border rounded bg-light w-100" style="white-space: pre-wrap;"
+                <h:panelGroup layout="block" styleClass="p-2 border rounded bg-light w-100" style="white-space: pre-wrap; max-height: 400px; overflow-y: auto;"
                               rendered="#{not empty dataAdministrationController.auditDatabaseExecutionFeedback}">
                     #{dataAdministrationController.auditDatabaseExecutionFeedback}
                 </h:panelGroup>

--- a/src/main/webapp/resources/ezcomp/midding_data_fields.xhtml
+++ b/src/main/webapp/resources/ezcomp/midding_data_fields.xhtml
@@ -186,7 +186,7 @@
                                 value="Use Selected Table's DDL"
                                 ajax="true"
                                 process="@this wikiTableSelect"
-                                update="createdSqlArea growl"
+                                update="createdSqlArea :growl"
                                 action="#{dataAdministrationController.loadCreateStatementForSelectedTable}"
                                 styleClass="ui-button-info"
                                 title="Fills 'Data table Create SQL statement' below with this table's CREATE TABLE statement from the fetched DDL"/>


### PR DESCRIPTION
## Summary

Closes #22869.

- **mf.xhtml**: the DB-mutating tool (Load Latest DDL, Fix AUTO_INCREMENT) was reachable pre-login with **no privilege check at all** once `databaseMigrationPending` flipped false — only the button's `rendered` condition hid it. Gated the page instead with the existing (previously unused) `DataAdministrationController.canAccessMigrationPage()`: available unauthenticated while migration is pending (unchanged), available to Admin-privilege users otherwise, explicit access-denied message for anyone else.
- Moved "Back to Home" above the execution-feedback block and capped that block's height (`max-height: 400px; overflow-y: auto`) so a long DDL execution log no longer pushes navigation several screens down.
- Merged "Mark Migration as Complete" / "Mark as Not Necessary" into the same action toolbar as "Load Latest DDL" / "Fix AUTO_INCREMENT" instead of a separate disconnected form.
- Added a "Load Latest DDL from Wiki" button + table picker to the authenticated "Check Missing Fields and Add Fields" tab (`dataAdmin/missing_database_fields.xhtml`), so admins no longer have to hand-paste a table's `CREATE TABLE` statement before generating `ALTER TABLE` statements. Reuses the existing `loadDdlFromWiki()` fetch and the same DDL-splitting approach already used by `createTablesOnDatabase`.

## Test plan (verified against local coop DB, Playwright)

- Unauthenticated + migration not pending → access-denied message, no tool exposed.
- Admin-authenticated + migration not pending → tool available, unified action bar, "Back to Home" visible without scrolling.
- Ran "Load Latest DDL from Wiki and Update Both Databases" for real — feedback panel scrolls within a fixed height instead of expanding the page.
- Tab 2: loaded DDL (672171 chars, 212 tables), selected `ITEM` from the new picker, clicked "Use Selected Table's DDL" — textarea auto-filled with the full `CREATE TABLE ITEM (...)` statement, then "Generate Alter Statements" produced real `ALTER TABLE` output — full downstream flow confirmed working.
- Caught and fixed a real bug during testing: the first version of "Use Selected Table's DDL" did a full-form AJAX submit and hit `GRIZZLY0205: Post too large`. Fixed by scoping `process`/`update` to just the dropdown + textarea.
- Did not execute "RUN SQL" against the database — verification stopped at confirming the generated ALTER statements render correctly.

Screenshots and full verification notes: https://github.com/hmislk/hmis/issues/22869#issuecomment-5261534671

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added table selection for downloaded Wiki DDL, including automatic loading of the selected table’s `CREATE TABLE` statement.
  * Added Wiki DDL download and table-selection tools to the missing-fields migration view.
  * Added options to mark migrations as complete or unnecessary.
  * Added migration status messaging and access controls for authorized administrators.

* **Bug Fixes**
  * Added validation and feedback for missing DDL, missing selections, successful extraction, and unavailable tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->