### PR TITLE
Register page metadata for pharmacy purchase order native page

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestNativeSqlController.java
@@ -8,12 +8,17 @@ import com.divudi.bean.common.ConfigOptionApplicationController;
 import com.divudi.bean.common.ConfigOptionController;
 import com.divudi.bean.common.EnumController;
 import com.divudi.bean.common.ItemController;
+import com.divudi.bean.common.PageMetadataRegistry;
 import com.divudi.bean.common.SessionController;
 import com.divudi.bean.common.WebUserController;
 import com.divudi.core.data.BillType;
 import com.divudi.core.data.BillTypeAtomic;
 import com.divudi.core.data.DepartmentType;
+import com.divudi.core.data.OptionScope;
 import com.divudi.core.data.PaymentMethod;
+import com.divudi.core.data.admin.ConfigOptionInfo;
+import com.divudi.core.data.admin.PageMetadata;
+import com.divudi.core.data.admin.PrivilegeInfo;
 import com.divudi.core.data.dto.PharmacyPurchaseOrderRateDTO;
 import com.divudi.core.data.dto.pharmacy.PurchaseOrderRequestLineData;
 import com.divudi.core.entity.AppEmail;
@@ -45,6 +50,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.PostConstruct;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Inject;
@@ -84,6 +90,8 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
     private PharmacyController pharmacyController;
     @Inject
     private PharmacyCalculation pharmacyBillBean;
+    @Inject
+    private PageMetadataRegistry pageMetadataRegistry;
 
     @EJB
     private PurchaseOrderRequestNativeSqlService purchaseOrderRequestNativeSqlService;
@@ -1499,5 +1507,126 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
 
     public void setEmailRecipient(String emailRecipient) {
         this.emailRecipient = emailRecipient;
+    }
+
+    @PostConstruct
+    public void init() {
+        registerPageMetadata();
+    }
+
+    /**
+     * Register page metadata for the admin configuration interface
+     */
+    private void registerPageMetadata() {
+        if (pageMetadataRegistry == null) {
+            return;
+        }
+
+        PageMetadata metadata = new PageMetadata(
+                "pharmacy/pharmacy_purhcase_order_request_native",
+                "Pharmacy Purchase Order Request (Native)",
+                "Create and manage pharmacy purchase order requests to suppliers",
+                "PurchaseOrderRequestNativeSqlController"
+        );
+
+        // Configuration Options - APPLICATION scope
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "Pharmacy PO - Show Item History Above Items",
+                "Controls whether item history panel appears above or below the items datatable",
+                OptionScope.APPLICATION
+        ));
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "Enable Consignment in Pharmacy Purchasing",
+                "Shows or hides the consignment checkbox option in the purchase order panel",
+                OptionScope.APPLICATION
+        ));
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "Minimum Number of Characters to Search for Item",
+                "Minimum characters required before item autocomplete search triggers",
+                OptionScope.APPLICATION
+        ));
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "Prevent Duplicate Items in Purchase Orders",
+                "When enabled, prevents adding duplicate items to a purchase order",
+                OptionScope.APPLICATION
+        ));
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "Consignment Option is checked in new Pharmacy Purchasing Bills",
+                "Sets the default checked state of the consignment checkbox when creating a new purchase order",
+                OptionScope.APPLICATION
+        ));
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "Pharmacy Purchase Order Default Payment Method",
+                "Sets the default payment method when creating a new purchase order",
+                OptionScope.APPLICATION
+        ));
+
+        // Bill Number Generation Strategies
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "Bill Number Suffix for PHARMACY_ORDER_PRE",
+                "Custom suffix for purchase order request bill numbers (default: POR)",
+                OptionScope.APPLICATION
+        ));
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "Bill Number Generation Strategy for Purchase Order Requests - Prefix + Department Code + Institution Code + Year + Yearly Number and Yearly Number",
+                "Bill numbering format: Prefix-DeptCode-InstCode-Year-Number",
+                OptionScope.APPLICATION
+        ));
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "Bill Number Generation Strategy for Purchase Order Requests - Prefix + Institution Code + Department Code + Year + Yearly Number and Yearly Number",
+                "Bill numbering format: Prefix-InstCode-DeptCode-Year-Number",
+                OptionScope.APPLICATION
+        ));
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "Bill Number Generation Strategy for Purchase Order Requests - Prefix + Institution Code + Year + Yearly Number and Yearly Number",
+                "Bill numbering format: Prefix-InstCode-Year-Number (institution-wide)",
+                OptionScope.APPLICATION
+        ));
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "Institution Number Generation Strategy for Purchase Order Requests - Prefix + Institution Code + Year + Yearly Number and Yearly Number",
+                "Controls separate institution-wide number generation for the insId field",
+                OptionScope.APPLICATION
+        ));
+
+        // Configuration Options - INSTITUTION scope
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "Pharmacy Purchase Order Request Print - A4 Paper Custom 1",
+                "Uses A4 Paper Custom Format 1 for purchase order request printing",
+                OptionScope.INSTITUTION
+        ));
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "Pharmacy Purchase Order Request Print - A4 Paper Custom 2",
+                "Uses A4 Paper Custom Format 2 for purchase order request printing",
+                OptionScope.INSTITUTION
+        ));
+        metadata.addConfigOption(new ConfigOptionInfo(
+                "Pharmacy Purchase - Quantity Must Be Integer",
+                "Validates that quantity and free quantity values are whole numbers (no decimals)",
+                OptionScope.INSTITUTION
+        ));
+
+        // Privileges
+        metadata.addPrivilege(new PrivilegeInfo(
+                "Admin",
+                "Administrative access to configuration interface",
+                "Controls visibility of the Config button"
+        ));
+        metadata.addPrivilege(new PrivilegeInfo(
+                "CreatePurchaseOrder",
+                "Permission to create and manage purchase orders",
+                "Controls access to the entire purchase order request page"
+        ));
+        metadata.addPrivilege(new PrivilegeInfo(
+                "Developers",
+                "Developer-only features",
+                "Controls visibility of item ID column in autocomplete"
+        ));
+        metadata.addPrivilege(new PrivilegeInfo(
+                "ChangeReceiptPrintingPaperTypes",
+                "Access to receipt printing configuration settings",
+                "Controls visibility of the Settings button in print preview"
+        ));
+
+        pageMetadataRegistry.registerPage(metadata);
     }
 }

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestNativeSqlController.java
@@ -1617,6 +1617,16 @@ public class PurchaseOrderRequestNativeSqlController implements Serializable {
                 "Controls access to the entire purchase order request page"
         ));
         metadata.addPrivilege(new PrivilegeInfo(
+                "PurchaseOrderSave",
+                "Permission to save purchase order requests",
+                "Controls the Save button and Remove Selected action"
+        ));
+        metadata.addPrivilege(new PrivilegeInfo(
+                "PurchaseOrderFinalize",
+                "Permission to finalize purchase order requests",
+                "Controls the Finalize button"
+        ));
+        metadata.addPrivilege(new PrivilegeInfo(
                 "Developers",
                 "Developer-only features",
                 "Controls visibility of item ID column in autocomplete"

--- a/src/main/webapp/pharmacy/pharmacy_purhcase_order_request_native.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purhcase_order_request_native.xhtml
@@ -14,17 +14,6 @@
                 You are NOT authorized
             </h:panelGroup>
             <h:panelGroup id="gpOrder" rendered="#{webUserController.hasPrivilege('CreatePurchaseOrder')}" >
-                <div class="d-flex justify-content-end">
-                    <!-- Small non-prominent fallback to legacy entity-based page -->
-                    <p:commandButton
-                        ajax="false"
-                        value="Legacy View"
-                        title="Open original entity-based Purchase Order Request page"
-                        action="pharmacy_purhcase_order_request?faces-redirect=true"
-                        class="ui-button-secondary ms-3"
-                        icon="fas fa-history"
-                        style="font-size: 0.75rem; padding: 0.2rem 0.5rem;"/>
-                </div>
                 <p:defaultCommand target="btnSave" ></p:defaultCommand>
                 <p:messages id="pageMessages" ></p:messages>
                 <h:panelGroup id="notPrintPreview"  rendered="#{not purchaseOrderRequestNativeSqlController.printPreview}" class="w-100 p-0 m-0">
@@ -62,10 +51,19 @@
                                                         value="Config"
                                                         icon="fa fa-cog"
                                                         title="Page Configuration Management"
-                                                        action="#{pageAdminController.navigateToPageAdmin('pharmacy/pharmacy_purhcase_order_request')}"
+                                                        action="#{pageAdminController.navigateToPageAdmin('pharmacy/pharmacy_purhcase_order_request_native')}"
                                                         ajax="false"
                                                         styleClass="ui-button-secondary"/>
                                                 </h:panelGroup>
+                                                <!-- Small non-prominent fallback to legacy entity-based page -->
+                                                <p:commandButton
+                                                    ajax="false"
+                                                    value="Legacy View"
+                                                    title="Open original entity-based Purchase Order Request page"
+                                                    action="pharmacy_purhcase_order_request?faces-redirect=true"
+                                                    class="ui-button-secondary"
+                                                    icon="fas fa-history"
+                                                    style="font-size: 0.75rem; padding: 0.2rem 0.5rem;"/>
                                                 <p:commandButton ajax="false" class="ui-button-danger" value="Remove Selected"
                                                                  disabled="#{not webUserController.hasPrivilege('PurchaseOrderSave')}"
                                                                  action="#{purchaseOrderRequestNativeSqlController.removeSelected()}"/>


### PR DESCRIPTION
## Summary
Adds page metadata registration for the pharmacy purchase order request native SQL page to enable admin configuration interface integration. This allows administrators to manage configuration options and privileges for this page through the centralized page admin controller.

## Key Changes
- **Added `PageMetadataRegistry` injection** to `PurchaseOrderRequestNativeSqlController` for registering page metadata
- **Implemented `@PostConstruct init()` method** that calls `registerPageMetadata()` during bean initialization
- **Registered comprehensive page metadata** including:
  - Page identification and description
  - 11 APPLICATION-scoped configuration options (UI layout, consignment settings, item search, bill numbering strategies)
  - 3 INSTITUTION-scoped configuration options (print formats, quantity validation)
  - 4 privilege definitions (Admin, CreatePurchaseOrder, Developers, ChangeReceiptPrintingPaperTypes)
- **Updated page navigation** in XHTML:
  - Fixed Config button to navigate to correct page path (`pharmacy_purhcase_order_request_native`)
  - Relocated "Legacy View" button from top toolbar into the settings toolbar for better UX organization

## Implementation Details
- Page metadata registration follows the established pattern using `PageMetadata`, `ConfigOptionInfo`, and `PrivilegeInfo` classes
- Configuration options cover existing functionality: item history panel positioning, consignment checkbox defaults, item search thresholds, duplicate prevention, payment method defaults, and bill number generation strategies
- Privilege registration documents the access control requirements already enforced in the XHTML template
- No functional changes to purchase order logic; this is purely administrative metadata registration

https://claude.ai/code/session_0173dtmmYwGQXDhpz2QXeQv5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added page configuration and privilege support for the pharmacy purchase order request page.
  - Added administrator access to configuration options from the native purchase-order request view.
  - Added support for application- and institution-level page settings.

- **UI Updates**
  - Repositioned the legacy-view option alongside item-list controls.
  - Removed the legacy-view button from the page header.
  - Updated configuration navigation to open the native purchase-order request view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->