### PR TITLE
fix(pharmacy): allow item filter on Stock Transfer Summary and By Bill reports

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
@@ -6401,22 +6401,10 @@ public class PharmacyController implements Serializable {
         return data;
     }
 
-    public boolean isInvalidFilter() {
-        if (item != null && (reportType.equals("summeryReport") || reportType.equals("byBill"))) {
-            return true;
-        }
-        return false;
-    }
-
     public void createStockTransferReport() {
         reportTimerController.trackReportExecution(() -> {
             resetFields();
 //            BillType bt;
-
-            if (isInvalidFilter()) {
-                JsfUtil.addErrorMessage("Item filter cannot be applied for 'Summary' or 'Bill' report types. Please remove the item filter or choose a 'Detail' Report.");
-                return;
-            }
 
             List<BillTypeAtomic> billTypeAtomics = new ArrayList<>();
             if ("issue".equals(transferType)) {
@@ -6937,6 +6925,10 @@ public class PharmacyController implements Serializable {
         if (dosageForm != null) {
             sql.append(" AND EXISTS (SELECT bi FROM BillItem bi WHERE bi.bill = b AND bi.item.dosageForm = :df) ");
             parameters.put("df", dosageForm);
+        }
+        if (item != null) {
+            sql.append(" AND EXISTS (SELECT bi FROM BillItem bi WHERE bi.bill = b AND bi.item = :item) ");
+            parameters.put("item", item);
         }
         if (selectedDepartmentTypes != null && !selectedDepartmentTypes.isEmpty()) {
             sql.append(" AND b.departmentType IN :departmentTypes ");


### PR DESCRIPTION
## What changed

Fixes the two Item Name/Code filter checklist items from #22850 on the Stock Transfer Report (`reports/inventoryReports/stock_transfer_report.xhtml`).

`PharmacyController.createStockTransferReport()` hard-blocked the Item filter for the **Summary** and **By Bill** report types with:
> "Item filter cannot be applied for 'Summary' or 'Bill' report types. Please remove the item filter or choose a 'Detail' Report."

Root cause: those two report types aggregate at the `Bill` level (`SELECT b.department.name, ..., SUM(...) FROM Bill b ...`) and had no item-level filter wired into the shared `additionalCommonFilltersForBillEntity` helper — `category` and `dosageForm` already solved the identical problem via an `EXISTS (SELECT bi FROM BillItem bi WHERE bi.bill = b AND ...)` subquery, so item filtering now uses the same pattern. The blocking validation (`isInvalidFilter()`) is removed since it's no longer needed.

## Also investigated (no code change): Department Type filter — Transfer Receive

Traced the third checklist item end-to-end. The filter query (`b.departmentType IN :departmentTypes`) and the bill-stamping logic are identical and correct for both Transfer Issue and Transfer Receive (already fixed by #22056/PR #22060). Verified it returns correct results once `departmentType` is populated (56/56 matching bills, totals match the DB exactly — see issue comment). The "not working" symptom traces to historical bills (both Issue and Receive, not Receive-specific) still having a NULL `departmentType`, which the filter correctly excludes — a data-only gap tracked separately at #22057 (still open, Ruhunu production backfill). No code change needed for this item.

## Verification

Playwright E2E pass against local `coop` DB (department: Pharmacy), cross-checked against direct SQL queries:

- **Summary** report, Transfer = Receive, Item filter applied over March 2026 → runs successfully (previously blocked), returns 3 store rows, totals verified.
- **By Bill** report, same item filter → runs successfully, returns exactly 2 bills — matches `SELECT COUNT(DISTINCT b.ID) ... = 2` in the DB.
- **Detail** report, same item filter → regression check, still works as before.
- **Department Type** filter, Transfer = Receive, Department Type = Pharmacy, March 2026 → returns all 56 matching bills with totals matching the DB exactly (Purchase 8,068,282.6431 / Cost 7,877,880.36 / Retail 9,356,867.76).

Full verification writeup with screenshots posted on the issue: https://github.com/hmislk/hmis/issues/22850#issuecomment-5266689081

## Related

- Refs #22850
- Related: #22056 (closed), #22057 (open — Ruhunu prod backfill, resolves the Department Type data gap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stock-transfer reports by allowing item filters for summary and bill report types.
  * Ensured bill reports correctly include results matching the selected item filter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->