### PR TITLE
fix(opd): NPE when settling Staff Payment Bill via due-payment search

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -1687,8 +1687,7 @@ subsequent GET showed stale/empty state instead). Instead, once the click has al
 stay on the page and retry `browser_snapshot` after a real wait (`sleep 20` via Bash, not a tool
 `time` argument — those get capped short); the page does eventually render with results. Narrowing
 the date range and adding a name filter before clicking Search avoids the slow path entirely and
-should be preferred when the target staff/date are already known. Found while verifying issue
-#22860.
+should be preferred when the target staff/date are already known. Found while verifying issue #22860.
 
 ## Quick checklist
 

--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -1658,6 +1658,38 @@ pages via **Drawer tab → Withdrawals/Deposit to Safe/Bank button**, not
 consequence is a silent no-op rather than an empty page. Found while
 verifying issue #22870.
 
+## 63. `STAFF.ID` is not `PERSON.ID` — joining `billfee.staff_id` straight to `PERSON.ID` silently returns the wrong person's name
+
+When hand-writing a verification/candidate-finding query against `billfee.staff_id`, do **not**
+join it directly to `PERSON.ID` — `Staff` is its own entity with its own `ID`, related to `Person`
+via `STAFF.PERSON_ID`. `billfee.staff_id JOIN person ON billfee.staff_id = person.id` silently
+returns a row (some unrelated person whose `ID` happens to equal the staff's `ID`) instead of an
+empty result, so the query looks correct but reports the wrong doctor's name for the due-payment
+total. Always go through the extra hop: `JOIN staff s ON bf.staff_id = s.id JOIN person p ON
+s.person_id = p.id`. Found while picking Playwright test data for issue #22860 — the initial
+candidate list mislabeled staff ID 11865 as "N H W Mahinda" when the correct name (still under the
+same ID, same due-fee totals) was "A K Liyanage"; the ID itself was fine to test with, only the
+display name was wrong.
+
+## 64. A slow, unfiltered `p:dataTable` search can make *every* subsequent Playwright tool call time out — don't `browser_navigate` away to "recover", just wait longer
+
+On `opd_search_professional_payment_due.xhtml` ("OPD Payments Due Search"), the `ajax="false"`
+Search button runs an unindexed JPQL join across `BILLFEE`/`BILL`/`STAFF`/`PERSON` with no
+department scoping. A wide date range with no name filter can run long enough that
+`browser_click`'s "waiting for scheduled navigations to finish" times out (5s), and every
+following `browser_snapshot`/`browser_wait_for` also times out (30s) because the page is still
+mid-navigation — this looks identical to a wedged browser session. **Do not `browser_navigate` away
+to recover in this situation**: a plain GET reload creates a fresh request and abandons whatever
+the slow POST was about to render, so the search results are lost even though the query eventually
+would have completed server-side (confirmed via `mysql.general_log` — the correct query, with the
+correct bind parameters, executed and matched rows, but the client never saw the response and a
+subsequent GET showed stale/empty state instead). Instead, once the click has already timed out,
+stay on the page and retry `browser_snapshot` after a real wait (`sleep 20` via Bash, not a tool
+`time` argument — those get capped short); the page does eventually render with results. Narrowing
+the date range and adding a name filter before clicking Search avoids the slow path entirely and
+should be preferred when the target staff/date are already known. Found while verifying issue
+#22860.
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.

--- a/src/main/java/com/divudi/bean/common/StaffPaymentBillController.java
+++ b/src/main/java/com/divudi/bean/common/StaffPaymentBillController.java
@@ -548,7 +548,8 @@ public class StaffPaymentBillController implements Serializable {
         calculateTotalDue();
         calculatePaymentsSelected();
 
-        switch (withholdingTaxCalculationStatus) {
+        String status = withholdingTaxCalculationStatus != null ? withholdingTaxCalculationStatus : "Depending On Payments";
+        switch (status) {
             case "Depending On Payments":
                 calculateWithholdingTaxDependingOnPayments();
                 break;
@@ -695,12 +696,21 @@ public class StaffPaymentBillController implements Serializable {
         currentStaff = s;
         speciality = s.getSpeciality();
         calculateDueFeesOpdForSelectedPeriod();
+        initializeWithholdingTaxOptions();
         return "/opd/professional_payments/payment_staff_bill?faces-redirect=true";
     }
 
     public String navigateToViewOpdPayProfessionalPayments() {
         recreateModel();
+        initializeWithholdingTaxOptions();
+        return "/opd/professional_payments/payment_staff_bill?faces-redirect=true";
+    }
 
+    // Shared by both navigation entry points into payment_staff_bill.xhtml (this bean is
+    // @SessionScoped, so withholdingTaxCalculationStatus must be set here, not left to
+    // navigateToViewOpdPayProfessionalPayments alone, or performCalculations() NPEs on a
+    // session that only ever reached the page via navigateToStaffPaymentFromDuePayment).
+    private void initializeWithholdingTaxOptions() {
         allowUserToSelectPayWithholdingTaxDuringProfessionalPayments
                 = configOptionApplicationController.getBooleanValueByKey(
                         "Allow User To Select Whether To Pay Withholding Tax During Professional Payments", true);
@@ -724,8 +734,6 @@ public class StaffPaymentBillController implements Serializable {
         } else {
             withholdingTaxCalculationStatus = "Depending On Payments";  // Default to "Depending On Payments"
         }
-
-        return "/opd/professional_payments/payment_staff_bill?faces-redirect=true";
     }
 
     private boolean errorCheck() {

--- a/src/main/java/com/divudi/bean/common/StaffPaymentBillController.java
+++ b/src/main/java/com/divudi/bean/common/StaffPaymentBillController.java
@@ -707,9 +707,10 @@ public class StaffPaymentBillController implements Serializable {
     }
 
     // Shared by both navigation entry points into payment_staff_bill.xhtml (this bean is
-    // @SessionScoped, so withholdingTaxCalculationStatus must be set here, not left to
-    // navigateToViewOpdPayProfessionalPayments alone, or performCalculations() NPEs on a
-    // session that only ever reached the page via navigateToStaffPaymentFromDuePayment).
+    // @SessionScoped, so withholdingTaxCalculationStatus must be set here for either path
+    // to get a config-driven default; performCalculations() falls back to "Depending On
+    // Payments" if this was ever skipped, but that fallback ignores this installation's
+    // configured WHT default).
     private void initializeWithholdingTaxOptions() {
         allowUserToSelectPayWithholdingTaxDuringProfessionalPayments
                 = configOptionApplicationController.getBooleanValueByKey(


### PR DESCRIPTION
## Summary
- Fixes #22860: settling a Staff Payment Bill threw a 500 (`NullPointerException`) in `StaffPaymentBillController.performCalculations()` when reached via **OPD Payments Due Search → click doctor name**.
- Root cause: `performCalculations()` switches on `withholdingTaxCalculationStatus` (a `String` field with no default). That field was only initialized by `navigateToViewOpdPayProfessionalPayments()`, not by the separate `navigateToStaffPaymentFromDuePayment(Staff s)` entry point used by the due-payment search page. Since the controller is `@SessionScoped`, a session that only ever went through the second path had a `null` status, and `switch (null)` throws regardless of the `default` case.
- Fix: extracted the WHT-status init logic into a shared `initializeWithholdingTaxOptions()` and call it from both navigation entry points, plus a null-guard in `performCalculations()` as defense-in-depth (falls back to "Depending On Payments" instead of throwing).
- Also appended two Playwright/testing gotchas discovered while verifying this fix to `developer_docs/testing/playwright-e2e-workflow.md` (§63: `STAFF.ID` vs `PERSON.ID` join trap; §64: recovering from a slow non-AJAX search without navigating away and losing session state).

## Test plan
- [x] Built locally (`mvn clean package`) — 197 tests pass.
- [x] Redeployed to local Payara, verified via Playwright against the local `coop` DB:
  - Logged in, selected department **OPD - Diagnostic Centre**.
  - Reproduced the exact broken flow: **OPD Payments Due Search** → clicked a doctor's name link (`navigateToStaffPaymentFromDuePayment`) → landed on Staff Payment Bill page with WHT dropdown correctly pre-populated ("Include Withholding Tax") instead of crashing.
  - Selected a due fee, Payment Method "Cash", clicked **Settle Professional Payment**, confirmed the dialog — bill settled successfully (Payment Voucher rendered, no 500).
  - Verified in DB: new `bill` row with `BILLTYPEATOMIC = PROFESSIONAL_PAYMENT_FOR_STAFF_FOR_OPD_SERVICES`; original due `BILLFEE.PAIDVALUE`/`SETTLEVALUE` updated from 0 to 150.
  - Regression-checked the already-working entry point (**Initiate Professional Payments** → `navigateToViewOpdPayProfessionalPayments`) — WHT dropdown still initializes correctly, unchanged.
- [x] Verification details also posted as a comment on #22860.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved withholding-tax handling when no payment status is selected.
  * Ensured withholding-tax options remain available across staff-payment navigation and refreshed views.

* **Documentation**
  * Added Playwright testing guidance for accurate staff-payment verification queries.
  * Documented how to handle slow professional-payment searches by waiting for results or applying filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->