### PR TITLE
fix(pharmacy): refresh stale stock-take session state after settling/navigating

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyStockTakeController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyStockTakeController.java
@@ -117,6 +117,7 @@ public class PharmacyStockTakeController implements Serializable {
     private Long viewBillId; // bound to f:viewParam on print page for state recovery
     /** Holds snapshot items as plain DTOs — no JPA entities, no EclipseLink EAGER triggers */
     private List<com.divudi.core.data.dto.SnapshotBillItemDTO> snapshotItems;
+    private Long snapshotItemsLoadedForBillId;
     private Bill physicalCountBill;
     private UploadedFile file;
     private Institution institution;
@@ -2883,6 +2884,7 @@ public class PharmacyStockTakeController implements Serializable {
             }
 
             snapshotItems = dtos;
+            snapshotItemsLoadedForBillId = snapshotBill.getId();
             System.out.println("[LoadLazy] DONE. items=" + dtos.size()
                     + " ms=" + (System.currentTimeMillis() - t0));
 
@@ -2912,7 +2914,9 @@ public class PharmacyStockTakeController implements Serializable {
      */
     public List<com.divudi.core.data.dto.SnapshotBillItemDTO> getSnapshotItems() {
         // Fast path — already loaded as plain DTOs, no EclipseLink involved
-        if (snapshotItems != null && !snapshotItems.isEmpty()) {
+        if (snapshotItems != null && !snapshotItems.isEmpty()
+                && snapshotBillDisplay != null
+                && Objects.equals(snapshotItemsLoadedForBillId, snapshotBillDisplay.getId())) {
             System.out.println("[GetLazy] CACHE HIT items=" + snapshotItems.size());
             return snapshotItems;
         }

--- a/src/main/webapp/pharmacy/pharmacy_stock_take_list.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_stock_take_list.xhtml
@@ -20,6 +20,7 @@
                         </div>
                         <div class="card-body">
                             <h:form id="frmFilters">
+                                <f:event type="preRenderView" listener="#{pharmacyStockTakeController.listSnapshotBillRows}"/>
                                 <p:panel header="Filters" styleClass="mb-3">
                                     <p:panelGrid columns="6" styleClass="w-100" layout="tabular">
                                         <h:outputLabel for="ins" value="Institution"/>


### PR DESCRIPTION
## What

Fixes two symptoms of the same root cause reported in #22844: `PharmacyStockTakeController` is `@SessionScoped`, and two of its cached fields weren't invalidated when the user moved between stock-take bills within a session.

1. **Wrong "previous stock-taking" values on the Stock Count Bill / Excel export.** `getSnapshotItems()` had a cache-hit fast path that returned the cached DTO list without checking it belonged to the bill currently displayed. Settling a second stock take in the same session (the QA workflow reported: two stock counts a day) left the print page and Guided/Blind Excel export for the *new* bill showing the *previous* bill's items/totals.
2. **Newly recorded stock take missing from "Manage Stock Takings".** The list page's data was only refreshed by clicking the "List" filter button — navigating to the page from the menu, or from "Pending Physical Count Approvals → Back to List", showed whatever was cached earlier in the session, so the just-recorded stock take was invisible until "List" was clicked again — causing QA to mistakenly check the older bill.

## Fix

- `PharmacyStockTakeController.getSnapshotItems()`: added `snapshotItemsLoadedForBillId`, tracked whenever items are (re)loaded in `loadSnapshotBillItemsLazily()`. The cache-hit path now also requires this to match `snapshotBillDisplay.getId()`; on a mismatch it falls through to the existing reload logic instead of serving stale rows.
- `pharmacy_stock_take_list.xhtml`: added `<f:event type="preRenderView" listener="#{pharmacyStockTakeController.listSnapshotBillRows}"/>`, mirroring the same pattern already used on `pharmacy_stock_take_print.xhtml` and `pharmacy_physical_count_pending.xhtml` in this codebase — refreshes the list on every render, covering all navigation paths into the page.

## Verification (local Payara, Main Pharmacy department)

Settled two stock takes back-to-back in one session: bill A (**MP//6**, id `13988651`) then bill B (**MP//7**, id `13988652`).

**Print page / Excel** — bill B's page shows bill B's own items, confirmed against the DB (`BILLITEM.BILL_ID = 13988652` for the exact BillItem IDs rendered), not bill A's (whose IDs are a disjoint earlier range). Server log shows the cache-miss/reload firing correctly right after settling:
```
[GetLazy] CACHE MISS — will load. snapshotBillDisplay=13988652
[LoadLazy] START billId=13988652
[LoadLazy] JPQL done. rows=2161 ms=36
```
![Bill B print page](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/22844-02-billB-print.png)

**Manage Stock Takings list** — both bills appear immediately after navigating from the menu, without a manual "List" click:
![Manage Stock Takings list showing both bills](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/22844-03-manage-list-both-bills.png)

Also re-verified via the second navigation path (Pending Physical Count Approvals → Back to List) — same result.

Closes #22844

🤖 Generated with [Claude Code](https://claude.com/claude-code)
