### PR TITLE
docs(skills): add bug reproduction and before/after evidence to dev-issue workflow

### DIFF
--- a/.claude/skills/dev-issue/SKILL.md
+++ b/.claude/skills/dev-issue/SKILL.md
@@ -43,17 +43,26 @@ Skip this step for feature/enhancement issues, and for bug issues where step
 Run it when the issue is a bug and step 2 left the cause unconfirmed or
 unfound:
 
+- Prefer reproducing against existing data first (read-only navigation or
+  API `GET`s). If reproduction requires creating or modifying a record,
+  confirm the target department/record with the user first
+  (`AskUserQuestion`, same pattern as step 4) rather than picking one
+  unilaterally.
 - Reproduce live against local Payara — the `playwright-e2e` skill for
   UI-facing bugs, or direct REST calls (per `api-development`) for API-only
   ones.
 - Save "before" evidence into the project `tmp/` folder: screenshots for UI
-  bugs, request/response bodies for API bugs.
+  bugs, request/response bodies for API bugs. Redact patient identifiers,
+  credentials, tokens, cookies, and other sensitive fields from any saved
+  API body before it leaves `tmp/`.
   - If it reproduces, this evidence proves the bug and becomes the "before"
     half of the before/after comparison published in step 10.
-  - If it does **not** reproduce, this evidence proves that instead — stop
-    here, post the finding to the issue, and confirm with the user whether to
-    still proceed (per CLAUDE.md "discuss uncertainties") rather than
-    guessing at a fix for a bug you couldn't observe.
+  - If it does **not** reproduce, record that — under the tested
+    environment, data, and inputs — the bug did not reproduce; that is not
+    proof the bug is absent. Stop here, post the finding to the issue, and
+    confirm with the user whether to still proceed (per CLAUDE.md "discuss
+    uncertainties") rather than guessing at a fix for a bug you couldn't
+    observe.
 
 ## 3. Discuss the approach (Plan Mode)
 
@@ -122,9 +131,11 @@ Run the `playwright-e2e` skill workflow:
 - **Take screenshots** (`browser_take_screenshot`) into the project `tmp/`
   folder at each meaningful stage (before/after states, confirmation dialogs,
   final result) — per playwright-e2e §0. These double as evidence for the
-  issue/PR and wiki in step 10. For bug issues, capture the same view/state
-  that step 2a reproduced, so it pairs cleanly as the "after" half of that
-  before/after comparison.
+  issue/PR and wiki in step 10. For bug issues where step 2a ran, capture the
+  same view/state it reproduced, so it pairs cleanly as the "after" half of
+  that before/after comparison. For API-only bugs, replay the same sanitized
+  request from step 2a instead, and save the response status/body (redacted,
+  same rule as step 2a) as the "after" evidence.
 - Verify the result in the local DB (credentials: see the
   `local_mysql_credentials.md` memory)
 
@@ -148,16 +159,24 @@ Follow playwright-e2e
 [§8a Before/after pairing](../../../developer_docs/testing/playwright-e2e-workflow.md#8a-bug-fixes-pair-before-and-after-evidence)):
 
 1. Review the screenshots from steps 2a and 7 and discard/crop any that
-   expose patient data, credentials, or other sensitive information.
+   expose patient data, credentials, or other sensitive information. For API
+   evidence, redact patient identifiers, credentials, tokens, cookies, and
+   other sensitive fields from the request/response bodies before they leave
+   `tmp/`.
 2. Copy the durable, non-sensitive screenshots into `../hmis.wiki/images/`,
-   then commit and push the wiki from `../hmis.wiki`.
+   then commit and push the wiki from `../hmis.wiki`. Redacted API
+   request/response snippets aren't images — post them as fenced code blocks
+   directly in the issue comment/PR instead of adding them to the wiki.
 3. Add a comment (or update the description) on issue `$0`, embedding the
    wiki images via their raw URLs
-   (`https://raw.githubusercontent.com/wiki/hmislk/hmis/images/<name>.png`).
-   For bug issues, label and pair the step 2a "before" evidence with the
-   step 7 "after" evidence so the fix is visible as a comparison, not just a
-   final-state screenshot.
-4. Remove the temporary screenshots from the project `tmp/` folder.
+   (`https://raw.githubusercontent.com/wiki/hmislk/hmis/images/<name>.png`)
+   or the redacted API snippets as code blocks. For bug issues where step 2a
+   ran, label and pair the step 2a "before" evidence with the step 7 "after"
+   evidence so the fix is visible as a comparison. For bug issues where step
+   2a was skipped (root cause already confirmed by reading code), there is
+   no "before" evidence — publish only the step 7 confirmation, with no
+   comparison implied.
+4. Remove the temporary screenshots/evidence from the project `tmp/` folder.
 
 These wiki image URLs are reused in the PR description in step 13.
 

--- a/.claude/skills/dev-issue/SKILL.md
+++ b/.claude/skills/dev-issue/SKILL.md
@@ -14,8 +14,8 @@ argument-hint: "<issue-number>"
 # Full Issue Lifecycle (HMIS)
 
 Invoking this skill is the explicit authorization for every commit/push/PR
-step below — do not re-ask before each one. Discussion gates (steps 3, 4, 14)
-are the points where you pause for the user.
+step below — do not re-ask before each one. Discussion gates (steps 2a
+non-repro case, 3, 4, 14) are the points where you pause for the user.
 
 ## 1. Setup
 
@@ -31,11 +31,34 @@ issue, sets the project board status to In Progress.
 - Identify: which entities/services/JSF pages are involved, which existing
   patterns to follow (DTOs, privileges, AJAX), and what's actually broken or
   missing.
+- **If the issue is a bug report**, try to pin down the root cause by reading
+  code first. Note explicitly whether this succeeded — that decides whether
+  step 2a runs.
+
+## 2a. Reproduce the bug (bug issues only)
+
+Skip this step for feature/enhancement issues, and for bug issues where step
+2's code reading already found a clear, confirmed root cause.
+
+Run it when the issue is a bug and step 2 left the cause unconfirmed or
+unfound:
+
+- Reproduce live against local Payara — the `playwright-e2e` skill for
+  UI-facing bugs, or direct REST calls (per `api-development`) for API-only
+  ones.
+- Save "before" evidence into the project `tmp/` folder: screenshots for UI
+  bugs, request/response bodies for API bugs.
+  - If it reproduces, this evidence proves the bug and becomes the "before"
+    half of the before/after comparison published in step 10.
+  - If it does **not** reproduce, this evidence proves that instead — stop
+    here, post the finding to the issue, and confirm with the user whether to
+    still proceed (per CLAUDE.md "discuss uncertainties") rather than
+    guessing at a fix for a bug you couldn't observe.
 
 ## 3. Discuss the approach (Plan Mode)
 
 Enter Plan Mode. Present:
-- What you found in step 2
+- What you found in step 2 (and step 2a's reproduction evidence, for bugs)
 - The proposed change (files to touch, approach)
 - Anything uncertain (per CLAUDE.md rule "discuss uncertainties")
 
@@ -99,7 +122,9 @@ Run the `playwright-e2e` skill workflow:
 - **Take screenshots** (`browser_take_screenshot`) into the project `tmp/`
   folder at each meaningful stage (before/after states, confirmation dialogs,
   final result) — per playwright-e2e §0. These double as evidence for the
-  issue/PR and wiki in step 10.
+  issue/PR and wiki in step 10. For bug issues, capture the same view/state
+  that step 2a reproduced, so it pairs cleanly as the "after" half of that
+  before/after comparison.
 - Verify the result in the local DB (credentials: see the
   `local_mysql_credentials.md` memory)
 
@@ -118,15 +143,20 @@ quirk, a new accessibility gap, a new verification pattern), append it to
 ## 10. Publish evidence (wiki, issue, PR)
 
 Follow playwright-e2e
-[§8 Publishing screenshot evidence](../../../developer_docs/testing/playwright-e2e-workflow.md#8-publishing-screenshot-evidence):
+[§8 Publishing screenshot evidence](../../../developer_docs/testing/playwright-e2e-workflow.md#8-publishing-screenshot-evidence)
+(and, for bug issues,
+[§8a Before/after pairing](../../../developer_docs/testing/playwright-e2e-workflow.md#8a-bug-fixes-pair-before-and-after-evidence)):
 
-1. Review the screenshots from step 7 and discard/crop any that expose
-   patient data, credentials, or other sensitive information.
+1. Review the screenshots from steps 2a and 7 and discard/crop any that
+   expose patient data, credentials, or other sensitive information.
 2. Copy the durable, non-sensitive screenshots into `../hmis.wiki/images/`,
    then commit and push the wiki from `../hmis.wiki`.
-3. Add a comment (or update the description) on issue `$0` showing the
-   verified before/after flow, embedding the wiki images via their raw URLs
+3. Add a comment (or update the description) on issue `$0`, embedding the
+   wiki images via their raw URLs
    (`https://raw.githubusercontent.com/wiki/hmislk/hmis/images/<name>.png`).
+   For bug issues, label and pair the step 2a "before" evidence with the
+   step 7 "after" evidence so the fix is visible as a comparison, not just a
+   final-state screenshot.
 4. Remove the temporary screenshots from the project `tmp/` folder.
 
 These wiki image URLs are reused in the PR description in step 13.

--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -328,20 +328,30 @@ ones into the wiki so they are not accidentally committed with application code.
 
 ### 8a. Bug fixes: pair "before" and "after" evidence
 
-When the underlying issue is a bug report, capture evidence at **two** points
-instead of one, and publish them together as a comparison rather than as a
-single final-state screenshot:
+When the underlying issue is a bug report **and reproducing it required a
+live check** (the root cause wasn't already confirmed by reading code),
+capture evidence at **two** points instead of one, and publish them together
+as a comparison rather than as a single final-state screenshot:
 
 1. **Before** — during reproduction (before any fix is written), capture the
    broken state: a screenshot for UI bugs, or the raw request/response for
    API-only bugs. This is also the evidence that the bug is real if the
    report turns out to be stale — save it even when the answer turns out to
-   be "does not reproduce".
+   be "does not reproduce" (record that it didn't reproduce under the tested
+   environment/data/inputs — that is not proof the bug is absent).
 2. **After** — once the fix is deployed, capture the same view/state again
-   showing correct behavior.
-3. Place both images (or both response snippets) in the same issue comment /
-   PR description, labeled "Before" and "After", so a reviewer can see the
-   fix without redeploying locally.
+   (or replay the same request, for API-only bugs) showing correct behavior.
+3. Redact patient identifiers, credentials, tokens, cookies, and other
+   sensitive fields from any API request/response snippet before it leaves
+   `tmp/` or is published — the same sanitization rule §8 applies to
+   screenshots.
+4. Place both images (or both sanitized response snippets) in the same issue
+   comment / PR description, labeled "Before" and "After", so a reviewer can
+   see the fix without redeploying locally.
+
+If the root cause was already confirmed by reading code (no live
+reproduction needed), there is no "before" evidence — publish only the
+post-fix confirmation, without implying a comparison.
 
 ---
 

--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -326,6 +326,23 @@ gh issue comment 21364 --repo hmislk/hmis --body "Verified with Playwright.
 Remove temporary screenshots from the main repository after copying the durable
 ones into the wiki so they are not accidentally committed with application code.
 
+### 8a. Bug fixes: pair "before" and "after" evidence
+
+When the underlying issue is a bug report, capture evidence at **two** points
+instead of one, and publish them together as a comparison rather than as a
+single final-state screenshot:
+
+1. **Before** — during reproduction (before any fix is written), capture the
+   broken state: a screenshot for UI bugs, or the raw request/response for
+   API-only bugs. This is also the evidence that the bug is real if the
+   report turns out to be stale — save it even when the answer turns out to
+   be "does not reproduce".
+2. **After** — once the fix is deployed, capture the same view/state again
+   showing correct behavior.
+3. Place both images (or both response snippets) in the same issue comment /
+   PR description, labeled "Before" and "After", so a reviewer can see the
+   fix without redeploying locally.
+
 ---
 
 ## 9. Interacting with non-accessible canvas widgets (e.g. `p:timeline` / vis-timeline)


### PR DESCRIPTION
## Summary
- For bug issues, `dev-issue` now tries to pin the root cause by reading code first (step 2), and only falls back to live reproduction via Playwright/API (new step 2a) when code investigation alone doesn't confirm it.
- Step 2a captures "before" evidence (screenshots for UI bugs, request/response bodies for API bugs) that either proves the bug or proves it doesn't reproduce — the latter is a discussion gate with the user rather than guessing at a fix.
- Post-fix verification (step 7) and evidence publishing (step 10) now pair that "before" evidence with "after" evidence into a before/after comparison in the issue comment, PR description, and wiki, instead of only publishing a final-state screenshot.
- Documented the general before/after evidence pattern in `developer_docs/testing/playwright-e2e-workflow.md` §8a so it's reusable outside the dev-issue skill too.

## Test plan
- [x] JSF/docs-only change (`.claude/skills/dev-issue/SKILL.md`, `developer_docs/testing/playwright-e2e-workflow.md`) — no Java/build changes, no compilation or runtime testing required per CLAUDE.md.
- [x] Read through the full updated `SKILL.md` end-to-end to confirm step numbering/cross-references stay consistent (2 → 2a → 3 → 7 → 10 → 13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for verifying bug fixes with paired “Before” and “After” evidence.
  * Documented reproduction evidence requirements before applying a fix.
  * Updated the development workflow to stop and request input when an issue cannot be reproduced.
  * Clarified how reproduction and post-fix evidence should be presented for UI and API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->