### PR TITLE
docs(skills): harden API-only bug replay safeguards in dev-issue workflow

### DIFF
--- a/.claude/skills/dev-issue/SKILL.md
+++ b/.claude/skills/dev-issue/SKILL.md
@@ -133,9 +133,13 @@ Run the `playwright-e2e` skill workflow:
   final result) — per playwright-e2e §0. These double as evidence for the
   issue/PR and wiki in step 10. For bug issues where step 2a ran, capture the
   same view/state it reproduced, so it pairs cleanly as the "after" half of
-  that before/after comparison. For API-only bugs, replay the same sanitized
-  request from step 2a instead, and save the response status/body (redacted,
-  same rule as step 2a) as the "after" evidence.
+  that before/after comparison. For API-only bugs, replay the original
+  request (the actual parameters, not the redacted evidence artifact)
+  against the same confirmed target instead. If that request mutates state,
+  reuse a resettable/disposable target or get the user's confirmation again
+  before replaying it — don't apply a write twice against real data just to
+  capture evidence. Save the response status/body (redacted, same rule as
+  step 2a) as the "after" evidence.
 - Verify the result in the local DB (credentials: see the
   `local_mysql_credentials.md` memory)
 


### PR DESCRIPTION
## Summary
- Step 7's API-only post-fix verification previously said to "replay the same sanitized request from step 2a" — ambiguous wording that could mean replaying the *redacted* evidence artifact (which may be missing the identifiers/parameters needed to actually run, or no longer targets the right record) instead of the real request.
- It also didn't guard against replaying a mutating request (`POST`/`PUT`/`PATCH`/`DELETE`) a second time against real data just to capture "after" evidence.
- Now explicit: replay the *original* request parameters (not the redacted artifact) against the same confirmed target, and for mutating requests, require a resettable/disposable target or fresh user confirmation before replaying — mirroring the same safety gate already added to step 2a in #22895.
- Step 10's redaction requirement (already merged in #22895) already covers "keep only redacted bodies in publishable evidence", so this PR only needed the step 7 fix — verified against all 4 acceptance criteria in #22897.

Closes #22897

## Test plan
- [x] Docs-only change (`.claude/skills/dev-issue/SKILL.md`) — no Java/build changes, no compilation or runtime testing required per CLAUDE.md.
- [x] Re-read step 7 + step 10 together to confirm the runnable-request vs. redacted-evidence distinction is consistent across both, and that all 4 acceptance criteria in #22897 are met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)