### PR TITLE
fix(pharmacy): block GRN over-receipt instead of allowing silent negative remainingQty

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/GrnCostingNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnCostingNativeSqlController.java
@@ -2413,6 +2413,18 @@ public class GrnCostingNativeSqlController implements Serializable {
             return "";
         }
 
+        // Aggregate THIS GRN's own lines by PO item first. A single PO line can
+        // be split/duplicated across multiple GRN lines for the same item, and
+        // each line individually staying under the remaining qty does not
+        // guarantee their SUM does -- checking line-by-line against
+        // "previously received (other GRNs) + this one line" let an aggregate
+        // over-receipt slip through silently (#22893: 20 received against 15
+        // ordered, split across 2 duplicate lines, no validation error).
+        Map<Long, Double> currentGrnQtyByPoItem = new HashMap<>();
+        Map<Long, Double> currentGrnFreeQtyByPoItem = new HashMap<>();
+        Map<Long, PharmaceuticalBillItem> poItemById = new HashMap<>();
+        Map<Long, String> itemNameByPoItem = new HashMap<>();
+
         for (BillItem grnItem : billItems) {
             if (grnItem.getReferanceBillItem() == null || grnItem.getPharmaceuticalBillItem() == null) {
                 continue;
@@ -2421,32 +2433,41 @@ public class GrnCostingNativeSqlController implements Serializable {
             BillItem purchaseOrderItem = grnItem.getReferanceBillItem();
             PharmaceuticalBillItem poItem = purchaseOrderItem.getPharmaceuticalBillItem();
 
-            if (poItem == null) {
+            if (poItem == null || poItem.getId() == null) {
                 continue;
             }
 
             PharmaceuticalBillItem currentGrnPbi = grnItem.getPharmaceuticalBillItem();
 
+            Long poItemId = poItem.getId();
+            currentGrnQtyByPoItem.merge(poItemId, currentGrnPbi.getQty(), Double::sum);
+            currentGrnFreeQtyByPoItem.merge(poItemId, currentGrnPbi.getFreeQty(), Double::sum);
+            poItemById.putIfAbsent(poItemId, poItem);
+            itemNameByPoItem.putIfAbsent(poItemId, grnItem.getItem() != null ? grnItem.getItem().getName() : "Unknown Item");
+        }
+
+        boolean enableFreeQtyValidation = configOptionApplicationController.getBooleanValueByKey("Enable Free Quantity Validation in GRN", false);
+
+        for (Map.Entry<Long, PharmaceuticalBillItem> e : poItemById.entrySet()) {
+            Long poItemId = e.getKey();
+            PharmaceuticalBillItem poItem = e.getValue();
+
             double orderedQty = poItem.getQty();
             double orderedFreeQty = poItem.getFreeQty();
-            double currentGrnQty = currentGrnPbi.getQty();
-            double currentGrnFreeQty = currentGrnPbi.getFreeQty();
+            double currentGrnQty = currentGrnQtyByPoItem.getOrDefault(poItemId, 0.0);
+            double currentGrnFreeQty = currentGrnFreeQtyByPoItem.getOrDefault(poItemId, 0.0);
 
-            double totalReceivedFromAllGrns = calculateRemainigQtyFromOrder(poItem);
-            double totalFreeReceivedFromAllGrns = calculateRemainingFreeQtyFromOrder(poItem);
-
-            double previouslyReceivedQty = totalReceivedFromAllGrns;
-            double previouslyReceivedFreeQty = totalFreeReceivedFromAllGrns;
+            double previouslyReceivedQty = calculateRemainigQtyFromOrder(poItem);
+            double previouslyReceivedFreeQty = calculateRemainingFreeQtyFromOrder(poItem);
 
             if (orderedQty < previouslyReceivedQty + currentGrnQty) {
-                return "Item " + grnItem.getItem().getName() + " cannot receive " + currentGrnQty
+                return "Item " + itemNameByPoItem.get(poItemId) + " cannot receive " + currentGrnQty
                         + " as it exceeds ordered quantity. Ordered: " + orderedQty + ", Already received: " + previouslyReceivedQty
                         + ", Remaining: " + (orderedQty - previouslyReceivedQty);
             }
 
-            boolean enableFreeQtyValidation = configOptionApplicationController.getBooleanValueByKey("Enable Free Quantity Validation in GRN", false);
             if (enableFreeQtyValidation && orderedFreeQty < previouslyReceivedFreeQty + currentGrnFreeQty) {
-                return "Item " + grnItem.getItem().getName() + " cannot receive " + currentGrnFreeQty
+                return "Item " + itemNameByPoItem.get(poItemId) + " cannot receive " + currentGrnFreeQty
                         + " free quantity as it exceeds ordered free quantity. Ordered free: " + orderedFreeQty
                         + ", Already received free: " + previouslyReceivedFreeQty
                         + ", Remaining free: " + (orderedFreeQty - previouslyReceivedFreeQty);

--- a/src/main/java/com/divudi/service/pharmacy/GrnApprovingNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/GrnApprovingNativeSqlService.java
@@ -580,13 +580,27 @@ public class GrnApprovingNativeSqlService {
     // pharmaceuticalbillitem row -- the PO's own line, not this GRN's)
     // -----------------------------------------------------------------------
 
+    /**
+     * Two bugs fixed here (#22893):
+     * - {@code ABS(completedQty) + ABS(?)}: MySQL {@code ABS(NULL)} is
+     *   {@code NULL} and {@code NULL + x} is {@code NULL}, so with the column
+     *   starting {@code NULL} it never became non-null, on any GRN.
+     *   {@code COALESCE(...,0)} fixes that.
+     * - No floor at 0 on {@code remainingQty}/{@code remainingFreeQty} --
+     *   {@code GREATEST(...,0)} is a defense-in-depth floor; the primary
+     *   guard against over-receipt driving this negative is now the
+     *   pre-approve validation in
+     *   {@code GrnCostingNativeSqlController.validateGrnQuantities()}, which
+     *   blocks Finalize/Approve with an error before this UPDATE ever runs
+     *   (product decision: block, not silently clamp -- see #22893).
+     */
     private void decrementPoRemainingQty(long poBillItemId, double qty, double freeQty) {
         em.createNativeQuery(
                 "UPDATE " + pharmBillItemTable()
-                + " SET remainingQty = ABS(remainingQty) - ABS(?),"
-                + " remainingFreeQty = ABS(remainingFreeQty) - ABS(?),"
-                + " completedQty = ABS(completedQty) + ABS(?),"
-                + " completedFreeQty = ABS(completedFreeQty) + ABS(?)"
+                + " SET remainingQty = GREATEST(ABS(COALESCE(remainingQty,0)) - ABS(?), 0),"
+                + " remainingFreeQty = GREATEST(ABS(COALESCE(remainingFreeQty,0)) - ABS(?), 0),"
+                + " completedQty = ABS(COALESCE(completedQty,0)) + ABS(?),"
+                + " completedFreeQty = ABS(COALESCE(completedFreeQty,0)) + ABS(?)"
                 + " WHERE billItem_ID=?")
                 .setParameter(1, qty)
                 .setParameter(2, freeQty)


### PR DESCRIPTION
## Summary
Fixes two related bugs in the native-SQL GRN flow found during #22874 QA:

- **Over-receipt validation gap**: `validateGrnQuantities()` checked each GRN line's received qty against the PO's remaining qty in isolation, never summing sibling lines within the same GRN batch that reference the same PO item. Two duplicate lines (e.g. 10+10) could each individually pass the check even though their sum exceeded the ordered quantity, letting over-receipt through Finalize/Approve with no error. Now aggregates received qty per PO item across the whole batch before validating.
- **`completedQty` always NULL**: `decrementPoRemainingQty()`'s native UPDATE used `ABS(completedQty) + ABS(?)`, and MySQL's `ABS(NULL)` is `NULL`, so `completedQty` (which starts `NULL`) never became non-null on any GRN, over-receipt or not. Fixed with `COALESCE(...,0)`.

**Product decision**: over-receipt is now **blocked with a validation error** at Finalize/Approve, not silently clamped. `GREATEST(...,0)` floors on `remainingQty`/`remainingFreeQty` were still added as defense-in-depth, since the validation above is now the primary guard.

## Verification
Verified via Playwright + DB against local `coop` DB:
- **Over-receipt blocked**: PO ordering 15 units, GRN with 2 duplicate lines totaling 20 → Finalize blocked with "Item ... cannot receive 20.0 as it exceeds ordered quantity. Ordered: 15.0, Already received: 0.0, Remaining: 15.0". Zero DB side effects (no GRN row created).
- **Normal receipt regression-checked**: PO ordering 500 units, GRN receiving 100 → Finalize + Approve both succeeded. DB: `REMAININGQTY=400` (correct), `COMPLETEDQTY=100` (previously always NULL, now correctly populated).
- Confirmed `PharmacyController.java`'s `completedQty` report queries (~10334, ~10400) are plain pass-through JPQL projections with no NULL-handling that would break with real data.

Incidentally reproduced two pre-existing, separately-tracked bugs while testing (worked around, not fixed here): #22892 (Batch/Expiry blank on Approve-page reload) and a documented Invoice Total reset gotcha on the same navigation.

Fixes #22893

🤖 Generated with [Claude Code](https://claude.com/claude-code)