### PR TITLE
fix(pharmacy): stop retired GRN line items resurrecting on reload

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/GrnCostingNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnCostingNativeSqlController.java
@@ -329,7 +329,14 @@ public class GrnCostingNativeSqlController implements Serializable {
         setCurrentExpense(null);
 
         if (getCurrentGrnBillPre().getId() != null) {
-            String jpql = "SELECT bi FROM BillItem bi WHERE bi.bill.id = :billId ORDER BY bi.searialNo";
+            // bi.retired = false is required here (#22891): without it, a
+            // line removed during an earlier Save (soft-retired via
+            // "Remove Selected") reappears as an active, editable row on
+            // every fresh reload -- reached from both the "To Finalize
+            // GRNs" and "To Approve GRNs" lists, which both route through
+            // this same method. Matches the pattern already used by
+            // reloadCurrentGrnBillPreAfterApprove()'s query below.
+            String jpql = "SELECT bi FROM BillItem bi WHERE bi.bill.id = :billId AND bi.retired = false ORDER BY bi.searialNo";
             Map<String, Object> params = new HashMap<>();
             params.put("billId", getCurrentGrnBillPre().getId());
             List<BillItem> loadedItems = billItemFacade.findByJpql(jpql, params);


### PR DESCRIPTION
## Summary
`navigateToEditGrnCosting()` in `GrnCostingNativeSqlController` reloaded a GRN's `billItems` via a JPQL query with no retired-filter, so any line removed during an earlier Save (soft-retired, `RETIRED=1`) came back as an active, editable row on the next fresh page load — inflating Gross/Net Total and risking re-approval of a phantom line.

Both the **"To Finalize GRNs"** and **"To Approve GRNs"** lists route through this same method (`PharmacyBillSearch.navigateToEditSavedGrnCostingNative()` / `...ByBillId()`), so this was a single root cause affecting both entry points, not two separate reload paths as originally suspected. Added `AND bi.retired = false` to the query, matching the pattern already used elsewhere in this same controller (`reloadCurrentGrnBillPreAfterApprove()`).

## Verification
Verified via Playwright + DB against local `coop` DB:
1. Created a GRN, added a duplicate line, soft-retired it via "Remove Selected" + Save (confirmed `RETIRED=1` in DB).
2. Reloaded via the **Finalize list** → only the active line shown, Gross Total correct (43.35, not 57.80).
3. Reloaded via the **Approve list** → same result, confirming the fix covers both entry points from a single code change.
4. Finalized and Approved the GRN normally afterward — the retired row stayed `RETIRED=1`, and `STOCKHISTORY` confirms only the active line's 15 units were added to stock (not 20), so the retired line was never reprocessed into stock.

Fixes #22891

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Editing saved GRNs now excludes retired line items.
  * Prevents soft-deleted items from reappearing during GRN costing edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->