### PR TITLE
fix(pharmacy): persist GRN Batch No / Date of Expiry / Invoice Date at Save

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/GrnCostingNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnCostingNativeSqlController.java
@@ -519,6 +519,7 @@ public class GrnCostingNativeSqlController implements Serializable {
         grnCostingNativeSqlService.updateDraftBillHeader(
                 billId,
                 getCurrentGrnBillPre().getInvoiceNumber(),
+                getCurrentGrnBillPre().getInvoiceDate(),
                 getCurrentGrnBillPre().getPaymentMethod() != null ? getCurrentGrnBillPre().getPaymentMethod().name() : null,
                 getCurrentGrnBillPre().getCreditDuration(),
                 null,
@@ -848,6 +849,18 @@ public class GrnCostingNativeSqlController implements Serializable {
     private GrnLineData toLineData(BillItem bi) {
         GrnLineData line = new GrnLineData();
         populateLineData(line, bi);
+
+        // Batch No / Date of Expiry, entered on this page pre-Finalize --
+        // read here (Save-stage) so GrnCostingNativeSqlService.saveLine()
+        // can persist them to pharmaceuticalbillitem.doe/stringValue. Without
+        // this, they only ever existed in-memory and were silently dropped
+        // on any fresh page reload before Finalize/Approve (#22892).
+        PharmaceuticalBillItem pbi = bi.getPharmaceuticalBillItem();
+        if (pbi != null) {
+            line.setDoe(pbi.getDoe());
+            line.setBatchNumber(pbi.getStringValue());
+        }
+
         return line;
     }
 

--- a/src/main/java/com/divudi/core/data/dto/pharmacy/GrnLineData.java
+++ b/src/main/java/com/divudi/core/data/dto/pharmacy/GrnLineData.java
@@ -1,5 +1,7 @@
 package com.divudi.core.data.dto.pharmacy;
 
+import java.util.Date;
+
 /**
  * Carries one GRN (Goods Received Note, "Manage Costing = true" flow) line's
  * already-computed values from the controller to
@@ -56,6 +58,17 @@ public class GrnLineData {
     private double lineCostRate;
     private double valueAtCostRate;
     private double totalCostRate;
+
+    // Date of Expiry / Batch No, entered at Save time -- carried through to
+    // pharmaceuticalbillitem.doe/stringValue so they survive a reload before
+    // Finalize/Approve. Missing from this DTO was the root cause of #22892
+    // (Save-stage native SQL silently dropped these two fields, unlike the
+    // Approve-stage GrnApproveLineData which already carried its own
+    // expiryDate/batchNo pair). Named batchNumber, not batchNo, to avoid
+    // field-hiding/method-overriding GrnApproveLineData's distinct batchNo
+    // field of the same name.
+    private Date doe;
+    private String batchNumber;
 
     // Used only by expense lines (GrnCostingNativeSqlService.saveExpenseLine) --
     // mirrors BillItem.consideredForCosting, whether this expense feeds the
@@ -284,6 +297,22 @@ public class GrnLineData {
 
     public void setLineCostRate(double lineCostRate) {
         this.lineCostRate = lineCostRate;
+    }
+
+    public Date getDoe() {
+        return doe;
+    }
+
+    public void setDoe(Date doe) {
+        this.doe = doe;
+    }
+
+    public String getBatchNumber() {
+        return batchNumber;
+    }
+
+    public void setBatchNumber(String batchNumber) {
+        this.batchNumber = batchNumber;
     }
 
     public double getValueAtCostRate() {

--- a/src/main/java/com/divudi/service/pharmacy/GrnCostingNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/GrnCostingNativeSqlService.java
@@ -96,23 +96,31 @@ public class GrnCostingNativeSqlService {
      * which only ever calls getChequeRefNo()/setChequeRefNo()). bankRefNo is
      * accepted here to satisfy the intended controller call shape but is not
      * written to any column; only chequeRefNo is persisted.
+     * <p>
+     * invoiceDate added for #22892: this method previously never wrote it at
+     * all (Bill.invoiceDate is a real column; it was simply missing from
+     * this UPDATE), so it reverted to blank on every reload -- same root
+     * cause shape as the Batch No/Date of Expiry fix in saveLine() above.
+     * This method has exactly one caller (GrnCostingNativeSqlController),
+     * so extending the signature directly is safe.
      */
-    public void updateDraftBillHeader(long billId, String invoiceNumber, String paymentMethod, Integer creditDuration,
+    public void updateDraftBillHeader(long billId, String invoiceNumber, Date invoiceDate, String paymentMethod, Integer creditDuration,
                                        String bankRefNo, String chequeRefNo, String comments, String departmentType,
                                        double discount, long editorId) {
         em.createNativeQuery(
             "UPDATE " + billTable()
-            + " SET invoiceNumber=?, paymentMethod=?, creditDuration=?, chequeRefNo=?,"
+            + " SET invoiceNumber=?, invoiceDate=?, paymentMethod=?, creditDuration=?, chequeRefNo=?,"
             + " comments=?, departmentType=?, discount=?, editor_ID=?, editedAt=NOW() WHERE ID=?")
             .setParameter(1, invoiceNumber)
-            .setParameter(2, paymentMethod)
-            .setParameter(3, creditDuration != null ? creditDuration : 0)
-            .setParameter(4, chequeRefNo)
-            .setParameter(5, comments)
-            .setParameter(6, departmentType)
-            .setParameter(7, discount)
-            .setParameter(8, editorId)
-            .setParameter(9, billId)
+            .setParameter(2, invoiceDate)
+            .setParameter(3, paymentMethod)
+            .setParameter(4, creditDuration != null ? creditDuration : 0)
+            .setParameter(5, chequeRefNo)
+            .setParameter(6, comments)
+            .setParameter(7, departmentType)
+            .setParameter(8, discount)
+            .setParameter(9, editorId)
+            .setParameter(10, billId)
             .executeUpdate();
         evictCache();
     }
@@ -215,7 +223,12 @@ public class GrnCostingNativeSqlService {
         int updated = em.createNativeQuery(
                 "UPDATE " + pharmBillItemTable()
                 + " SET qty=?, freeQty=?, purchaseRate=?, purchaseRatePack=?, purchaseValue=?,"
-                + " retailRate=?, retailRatePack=?, retailValue=?, wholesaleRate=?, wholesaleRatePack=?"
+                + " retailRate=?, retailRatePack=?, retailValue=?, wholesaleRate=?, wholesaleRatePack=?,"
+                // doe/stringValue (Batch No / Date of Expiry) were the missing
+                // columns behind #22892 -- entered here at Save time but never
+                // written, so they silently reverted to blank on any reload
+                // before Finalize/Approve.
+                + " doe=?, stringValue=?"
                 + " WHERE billItem_ID=?")
                 .setParameter(1, line.getQuantityByUnits())
                 .setParameter(2, line.getFreeQuantityByUnits())
@@ -227,7 +240,9 @@ public class GrnCostingNativeSqlService {
                 .setParameter(8, line.getValueAtRetailRate())
                 .setParameter(9, line.isAmpp() ? divide(line.getWholesaleRate(), line.getUnitsPerPack()) : line.getWholesaleRate())
                 .setParameter(10, line.getWholesaleRate())
-                .setParameter(11, billItemId)
+                .setParameter(11, line.getDoe())
+                .setParameter(12, line.getBatchNumber())
+                .setParameter(13, billItemId)
                 .executeUpdate();
 
         long pharmaceuticalBillItemId;
@@ -236,8 +251,9 @@ public class GrnCostingNativeSqlService {
                 "INSERT INTO " + pharmBillItemTable()
                 + " (billItem_ID, qty, freeQty, purchaseRate, purchaseRatePack, purchaseValue,"
                 + " retailRate, retailRatePack, retailValue, wholesaleRate, wholesaleRatePack,"
+                + " doe, stringValue,"
                 + " costRate, costRatePack, costValue, createdAt, creater_ID)"
-                + " VALUES (?,?,?,?,?,?,?,?,?,?,?,0,0,0,?,?)")
+                + " VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,0,0,0,?,?)")
                 .setParameter(1, billItemId)
                 .setParameter(2, line.getQuantityByUnits())
                 .setParameter(3, line.getFreeQuantityByUnits())
@@ -249,8 +265,10 @@ public class GrnCostingNativeSqlService {
                 .setParameter(9, line.getValueAtRetailRate())
                 .setParameter(10, line.isAmpp() ? divide(line.getWholesaleRate(), line.getUnitsPerPack()) : line.getWholesaleRate())
                 .setParameter(11, line.getWholesaleRate())
-                .setParameter(12, new Timestamp(new Date().getTime()))
-                .setParameter(13, line.getCreaterId())
+                .setParameter(12, line.getDoe())
+                .setParameter(13, line.getBatchNumber())
+                .setParameter(14, new Timestamp(new Date().getTime()))
+                .setParameter(15, line.getCreaterId())
                 .executeUpdate();
             pharmaceuticalBillItemId = ((Number) em.createNativeQuery("SELECT LAST_INSERT_ID()").getSingleResult()).longValue();
         } else {


### PR DESCRIPTION
## Summary
`GrnCostingNativeSqlService.saveLine()` never wrote `pharmaceuticalbillitem.doe`/`stringValue` (Date of Expiry / Batch No) at all — `GrnLineData`, the DTO carrying Save-stage data from the controller, simply had no fields for them (unlike the Approve-stage `GrnApproveLineData`, which already carried its own `expiryDate`/`batchNo` pair). So a value entered and Saved was held only in the browser form / in-memory bean, and reverted to blank on any fresh page reload (via either the "To Finalize GRNs" or "To Approve GRNs" list) — Finalize would then fail with "Please Fill Batch deatail and Sale Price to All Item" until the operator re-typed values they had already entered once.

**Fix**: added `doe`/`batchNumber` fields to `GrnLineData` (named `batchNumber`, not `batchNo`, to avoid colliding with `GrnApproveLineData`'s distinct same-named field — `GrnApproveLineData extends GrnLineData`), populated in `toLineData()` from the in-memory `PharmaceuticalBillItem`, and added the two columns to both the INSERT and UPDATE branches of `saveLine()`.

While investigating (the master plan flagged this as worth checking, not fixing the two reported fields in isolation), found the exact same root-cause shape on **Invoice Date**: `Bill.invoiceDate` is a real column, but `updateDraftBillHeader()`'s native UPDATE never included it either. Fixed the same way — added an `invoiceDate` parameter (this method has exactly one caller, so extending its signature is safe) and passed it from the controller.

**Invoice Total** is architecturally different (no DB column exists for it at all — purely a transient session field used to compute "Difference" against Gross Total) and was left untouched; that reset is a separate, already-documented gotcha (see `developer_docs/testing/playwright-e2e-workflow.md` §29), explicitly out of scope per the issue body.

## Verification
Verified via Playwright + DB against local `coop` DB:
- Saved a GRN with Batch No, Date of Expiry, Invoice No, Invoice Date, and Invoice Total filled; reloaded via **both** the Finalize list and the Approve list — all fields (except the known Invoice Total gotcha) correctly populated.
- Finalized and Approved on the **first attempt**, no "Please Fill Batch deatail..." error.
- Regression-checked Retail Rate / Purchase Rate still persist correctly.
- Confirmed end-to-end that the resulting `ItemBatch` row got the correct `BATCHNO`/`DATEOFEXPIRE`.

Fixes #22892

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GRN costing now records invoice dates when saving draft bills.
  * Pharmaceutical GRN lines now retain batch numbers and expiry dates through the costing process.

* **Bug Fixes**
  * Improved persistence of batch and expiry details for pharmaceutical bill items during draft saving and finalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->