### PR TITLE
fix(theater): show direct-issue medicines on Surgery Workbench

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -1716,6 +1716,20 @@ stay on the page and retry `browser_snapshot` after a real wait (`sleep 20` via 
 the date range and adding a name filter before clicking Search avoids the slow path entirely and
 should be preferred when the target staff/date are already known. Found while verifying issue #22860.
 
+## 65. Theatre "Add New Surgery" — the Surgery Name autocomplete is `Item` rows (`DTYPE='ClinicalEntity'`), not a dedicated table
+
+On `theater/patient_surgery.xhtml`'s "Add Surgery" panel, the "Surgery Name" `p:autoComplete`
+(`ProcedureController.completeProcedures`) queries `ClinicalEntity` — which is a
+`SINGLE_TABLE`-inheritance subclass of `Item` (discriminator `DTYPE='ClinicalEntity'`), not its
+own table. There is no `CLINICALENTITY` table to query directly; look up seed rows with:
+```sql
+SELECT ID, NAME FROM ITEM WHERE DTYPE='ClinicalEntity' AND SYMANTICTYPE='Therapeutic_Procedure' AND RETIRED=0;
+```
+A query for an item name absent from that set (e.g. "Appendec" typo, or a name that isn't seeded)
+silently returns "No results found" with no error — this looks like a missing feature but is just
+an empty/mistyped query. Confirmed working seed name: "Appendicectomy". Verified while testing
+issue #20891.
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.

--- a/src/main/java/com/divudi/bean/inward/SurgeryBillController.java
+++ b/src/main/java/com/divudi/bean/inward/SurgeryBillController.java
@@ -1474,11 +1474,27 @@ public class SurgeryBillController implements Serializable {
     }
 
     public List<BillItem> getPharmacyIssues() {
+        if (pharmacyIssues == null && getSurgeryBill().getId() != null) {
+            createIssueTable();
+        }
         return pharmacyIssues;
     }
 
     public void setPharmacyIssues(List<BillItem> pharmacyIssues) {
         this.pharmacyIssues = pharmacyIssues;
+    }
+
+    /**
+     * Invalidates the cached Pharmacy/Store issue tables so the next
+     * getPharmacyIssues() call re-fetches from the DB. Wired to the
+     * "Back to Surgery Workbench" buttons on inward_bill_surgery_issue.xhtml
+     * so a freshly issued direct-issue medicine shows up on return (see
+     * issue #20891 — this @SessionScoped bean would otherwise keep serving
+     * the stale/empty list for the rest of the session).
+     */
+    public void refreshPharmacyIssues() {
+        pharmacyIssues = null;
+        storeIssues = null;
     }
 
     public void setSurgeryBill(Bill surgeryBill) {

--- a/src/main/webapp/theater/inward_bill_surgery_issue.xhtml
+++ b/src/main/webapp/theater/inward_bill_surgery_issue.xhtml
@@ -139,6 +139,7 @@
                                                          ajax="false" immediate="true"
                                                          title="Return to surgery dashboard"
                                                          action="/theater/patient_surgery?faces-redirect=true"
+                                                         actionListener="#{surgeryBillController.refreshPharmacyIssues()}"
                                                          styleClass="ui-button-info ui-button-outlined">
                                             <f:setPropertyActionListener value="#{pharmacySaleBhtController.batchBill}" target="#{surgeryBillController.surgeryBill}"/>
                                         </p:commandButton>
@@ -395,6 +396,7 @@
                                                      ajax="false" immediate="true"
                                                      title="Return to surgery dashboard"
                                                      action="/theater/patient_surgery?faces-redirect=true"
+                                                     actionListener="#{surgeryBillController.refreshPharmacyIssues()}"
                                                      styleClass="ui-button-info ui-button-outlined">
                                         <f:setPropertyActionListener value="#{pharmacySaleBhtController.batchBill}" target="#{surgeryBillController.surgeryBill}"/>
                                     </p:commandButton>


### PR DESCRIPTION
## What

The **Pharmacy Issues** tab on the Surgery Workbench (`theater/patient_surgery.xhtml`) never showed direct-issue medicines, even after issuing them via `theater/inward_bill_surgery_issue.xhtml`.

## Root cause

`SurgeryBillController.getPharmacyIssues()` was a plain getter that returned the `pharmacyIssues` field directly — it never fetched from the DB. The only method that populated it, `createIssueTable()`, was never called from any reachable code path (only referenced inside a commented-out block). So the tab was **permanently empty**, not just stale after one issue.

Confirmed by reading code — no live reproduction was needed to establish this.

## Fix

- `getPharmacyIssues()` now lazy-loads via `createIssueTable()` when null, matching the existing `getSurgeryMedicineIssues()` pattern.
- Added `refreshPharmacyIssues()` and wired it (as `actionListener`) onto both "Back to Surgery Workbench" buttons in `inward_bill_surgery_issue.xhtml`, so a freshly issued medicine is picked up on return — `SurgeryBillController` is `@SessionScoped` and would otherwise keep serving a stale/empty list for the rest of the session.
- Documented a Playwright testing gotcha found while verifying this fix (the Surgery Name autocomplete on `patient_surgery.xhtml` queries `Item` rows with `DTYPE='ClinicalEntity'`, not a dedicated table) in `developer_docs/testing/playwright-e2e-workflow.md`.

## Verification

Tested end-to-end against local Payara + DB (department: THEATRE, synthetic demo patient/BHT):

1. Created a new test surgery ("Appendicectomy") on an active admission.
2. Confirmed the Pharmacy Issues tab showed "No pharmacy issues recorded." (empty state).
3. Used **Direct Issue Medicines** to issue "Paracetamol 125mg Suppo" x2, settled the bill (`theatre//26/038037`).
4. Navigated back to the Surgery Workbench — the Pharmacy Issues tab now shows the issued item (Bill No, Item Name, Qty 2.0, Billed At, Billed By).
5. Cross-checked in the DB: the settled bill (`BILLTYPE='PharmacyBhtPre'`) has `FORWARDREFERENCEBILL_ID` pointing at the surgery bill, with a matching `BILLITEM` row for the issued item — exactly what the fixed query now surfaces.

**Before:**
![Before](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/20891-before-pharmacy-issues-empty.png)

**After:**
![After](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/20891-after-pharmacy-issues-populated.png)

Closes #20891

🤖 Generated with [Claude Code](https://claude.com/claude-code)