### PR TITLE
fix(pharmacy): make GRN "already approved" guard read fresh from DB

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/GrnCostingNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnCostingNativeSqlController.java
@@ -618,9 +618,24 @@ public class GrnCostingNativeSqlController implements Serializable {
         if (!isAuthorized("APPROVE_GRN_WITH_SAVE_APPROVE", "PharmacyGrnApprove")) {
             return;
         }
-        if (getCurrentGrnBillPre().getBillTypeAtomic() == BillTypeAtomic.PHARMACY_GRN) {
-            JsfUtil.addErrorMessage("This GRN is already approved");
-            return;
+        // A fresh DB read, not the in-memory currentGrnBillPre.getBillTypeAtomic()
+        // (#22894): this bean is @SessionScoped, and approveGrn() below sets
+        // billTypeAtomic=PHARMACY_GRN on the in-memory entity for immediate UI
+        // feedback (see the end of this method). If that mutated reference --
+        // or any other staleness in this session across two sequential GRN
+        // approvals -- ever leaked into a later read, the in-memory check could
+        // false-positive on a bill the DB still has as PHARMACY_GRN_PRE, blocking
+        // a genuinely first-time approval. The DB is the only source of truth
+        // this guard should trust; a real double-approve is still correctly
+        // blocked since a truly-approved bill reads back PHARMACY_GRN here too.
+        // Skipped for a bill with no id yet -- it cannot possibly be already
+        // approved if it has never been persisted.
+        if (getCurrentGrnBillPre().getId() != null) {
+            Bill freshBillState = billFacade.findWithoutCache(getCurrentGrnBillPre().getId());
+            if (freshBillState != null && freshBillState.getBillTypeAtomic() == BillTypeAtomic.PHARMACY_GRN) {
+                JsfUtil.addErrorMessage("This GRN is already approved");
+                return;
+            }
         }
         if (getCurrentGrnBillPre().getInvoiceNumber() == null || getCurrentGrnBillPre().getInvoiceNumber().trim().isEmpty()) {
             JsfUtil.addErrorMessage("Please fill invoice number");


### PR DESCRIPTION
## Summary
`approveGrnWithSaveApprove()` checked `getCurrentGrnBillPre().getBillTypeAtomic() == PHARMACY_GRN` against the in-memory bean field, not a fresh DB read. `GrnCostingNativeSqlController` is `@SessionScoped` and reused across sequential GRN approvals within the same HTTP session; this same method sets `billTypeAtomic=PHARMACY_GRN` on the in-memory entity right after a successful approve, for immediate UI feedback. The QA session that found this could not pin down exactly how that mutated/stale state leaked into a later read for a second GRN — it wasn't reliably reproducible — but confirmed via DB that the blocked bill was genuinely still `PHARMACY_GRN_PRE` at the moment of the false block.

Rather than chase a non-deterministic staleness source further, this guard should not trust in-memory session-scoped state for a decision this consequential in the first place. Changed it to a fresh, uncached DB read (`billFacade.findWithoutCache(id)`) immediately before the check. This closes off the entire class of staleness this bug belongs to, not just the one hypothesized cause, while a genuinely already-approved bill still correctly blocks (it reads back `PHARMACY_GRN` from the DB too).

## Verification
Verified via Playwright + DB against local `coop` DB: created 3 GRNs against the same PO in a single browser session, Finalized and Approved each one immediately after the last, back to back. All 3 succeeded on the first attempt with no false "already approved" error (previously non-deterministic even for a single repeat).

Fixes #22894

🤖 Generated with [Claude Code](https://claude.com/claude-code)