### PR TITLE
Fix Op Drug Return drill-down not reconciling with COGS row total

### DIFF
--- a/src/main/java/com/divudi/bean/report/PharmacyReportController.java
+++ b/src/main/java/com/divudi/bean/report/PharmacyReportController.java
@@ -4829,7 +4829,8 @@ public class PharmacyReportController implements Serializable {
         List<BillTypeAtomic> billTypes = Arrays.asList(
                 BillTypeAtomic.PHARMACY_RETAIL_SALE_RETURN_ITEMS_AND_PAYMENTS,
                 BillTypeAtomic.PHARMACY_RETAIL_SALE_RETURN_ITEMS_ONLY,
-                BillTypeAtomic.PHARMACY_RETAIL_SALE_REFUND
+                BillTypeAtomic.PHARMACY_RETAIL_SALE_REFUND,
+                BillTypeAtomic.PHARMACY_RETURN_ITEMS_AND_PAYMENTS_CANCELLATION
         );
         retrieveBillItems("b.billTypeAtomic", billTypes);
     }


### PR DESCRIPTION
## Summary
- `processOpDrugReturn()` (drill-down behind the COGS "Drug Return Op" link) was missing `BillTypeAtomic.PHARMACY_RETURN_ITEMS_AND_PAYMENTS_CANCELLATION`, which PR #22896 added to `calculateDrugReturnOp()` (the row total itself) to net out cancelled returns.
- Result: the drill-down showed gross returns (27,100.35) while the COGS row showed the netted figure (18,318.65) for Matara Pharmacy, July 2026 — an 8,781.70 mismatch, reproduced live via Playwright against the home server.
- Fix adds the same atomic to the drill-down's bill types list so both reconcile, same pattern as the earlier BHT Issue drill-down fix (issue #22011).

Closes #22910

## Test plan
- [x] `mvn compile` succeeds (JDK 11)
- [ ] User to verify in browser: Cost Of Goods Sold report → Matara Pharmacy → 01 Jul 2026–31 Jul 2026 → click "Drug Return Op" link → Process → total should now read 18,318.65, matching the COGS row

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pharmacy reports now include cancelled pharmacy return items and payments when using the bill-type filter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->