### PR TITLE
fix(opd): guard against silent BillItem persistence failure in OPD batch bill settlement (hotfix)

### DIFF
--- a/src/main/java/com/divudi/bean/opd/OpdBillController.java
+++ b/src/main/java/com/divudi/bean/opd/OpdBillController.java
@@ -2288,6 +2288,24 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
         return bi != null && bi.getId() != null;
     }
 
+    private void retirePartialBillOnSettlementFailure(Bill bill, List<BillItem> persistedItems) {
+        if (bill == null) {
+            return;
+        }
+        for (BillItem bi : persistedItems) {
+            if (isPersistedBillItem(bi) && !bi.isRetired()) {
+                bi.setRetired(true);
+                bi.setRetiredAt(new Date());
+                getBillItemFacade().edit(bi);
+            }
+        }
+        if (bill.getId() != null && !bill.isRetired()) {
+            bill.setRetired(true);
+            bill.setRetiredAt(new Date());
+            getBillFacade().edit(bill);
+        }
+    }
+
     private boolean processBillsByDepartment() {
         Set<Department> billDepts = new HashSet<>();
         for (BillEntry e : lstBillEntries) {
@@ -2306,6 +2324,7 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
                 if (Objects.equals(prformingDept.getId(), d.getId())) {
                     BillItem bi = getBillBean().saveBillItemForOpdBill(myBill, e, getSessionController().getLoggedUser(), getBillFeeBundleEntrys());
                     if (!isPersistedBillItem(bi)) {
+                        retirePartialBillOnSettlementFailure(myBill, myBill.getBillItems());
                         JsfUtil.addErrorMessage("Failed to save bill items for department " + d.getName() + ". Please retry the bill settlement.");
                         return false;
                     }
@@ -2314,6 +2333,7 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
                 }
             }
             if (tmp.isEmpty()) {
+                retirePartialBillOnSettlementFailure(myBill, myBill.getBillItems());
                 JsfUtil.addErrorMessage("No bill items were found for department " + d.getName() + ". Please retry the bill settlement.");
                 return false;
             }
@@ -2366,6 +2386,7 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
                             && Objects.equals(billEntry.getBillItem().getItem().getCategory().getId(), c.getId())) {
                         BillItem bi = getBillBean().saveBillItem(newlyCreatedIndividualBill, billEntry, getSessionController().getLoggedUser());
                         if (!isPersistedBillItem(bi)) {
+                            retirePartialBillOnSettlementFailure(newlyCreatedIndividualBill, newlyCreatedIndividualBill.getBillItems());
                             JsfUtil.addErrorMessage("Failed to save bill items for department " + d.getName() + " and category " + c.getName() + ". Please retry the bill settlement.");
                             return false;
                         }
@@ -2374,6 +2395,7 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
                     }
                 }
                 if (tmp.isEmpty()) {
+                    retirePartialBillOnSettlementFailure(newlyCreatedIndividualBill, newlyCreatedIndividualBill.getBillItems());
                     JsfUtil.addErrorMessage("No bill items were found for department " + d.getName() + " and category " + c.getName() + ". Please retry the bill settlement.");
                     return false;
                 }
@@ -2516,6 +2538,7 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
             for (BillEntry billEntry : getLstBillEntries()) {
                 BillItem bi = getBillBean().saveBillItem(newSingleBill, billEntry, getSessionController().getLoggedUser());
                 if (!isPersistedBillItem(bi)) {
+                    retirePartialBillOnSettlementFailure(newSingleBill, list);
                     JsfUtil.addErrorMessage("Failed to save bill items. Please retry the bill settlement.");
                     return false;
                 }

--- a/src/main/java/com/divudi/bean/opd/OpdBillController.java
+++ b/src/main/java/com/divudi/bean/opd/OpdBillController.java
@@ -2284,6 +2284,10 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
         return false; // Fallback case, should not reach here.
     }
 
+    static boolean isPersistedBillItem(BillItem bi) {
+        return bi != null && bi.getId() != null;
+    }
+
     private boolean processBillsByDepartment() {
         Set<Department> billDepts = new HashSet<>();
         for (BillEntry e : lstBillEntries) {
@@ -2301,9 +2305,17 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
                 Department prformingDept = departmentResolver.resolvePerformingDepartment(sessionController.getDepartment(), e.getBillItem().getItem());
                 if (Objects.equals(prformingDept.getId(), d.getId())) {
                     BillItem bi = getBillBean().saveBillItemForOpdBill(myBill, e, getSessionController().getLoggedUser(), getBillFeeBundleEntrys());
+                    if (!isPersistedBillItem(bi)) {
+                        JsfUtil.addErrorMessage("Failed to save bill items for department " + d.getName() + ". Please retry the bill settlement.");
+                        return false;
+                    }
                     myBill.getBillItems().add(bi);
                     tmp.add(e);
                 }
+            }
+            if (tmp.isEmpty()) {
+                JsfUtil.addErrorMessage("No bill items were found for department " + d.getName() + ". Please retry the bill settlement.");
+                return false;
             }
             if (getSessionController().getApplicationPreference().isPartialPaymentOfOpdBillsAllowed()) {
                 myBill.setCashPaid(cashPaid);
@@ -2353,9 +2365,17 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
                     if (Objects.equals(dept.getId(), d.getId())
                             && Objects.equals(billEntry.getBillItem().getItem().getCategory().getId(), c.getId())) {
                         BillItem bi = getBillBean().saveBillItem(newlyCreatedIndividualBill, billEntry, getSessionController().getLoggedUser());
+                        if (!isPersistedBillItem(bi)) {
+                            JsfUtil.addErrorMessage("Failed to save bill items for department " + d.getName() + " and category " + c.getName() + ". Please retry the bill settlement.");
+                            return false;
+                        }
                         newlyCreatedIndividualBill.getBillItems().add(bi);
                         tmp.add(billEntry);
                     }
+                }
+                if (tmp.isEmpty()) {
+                    JsfUtil.addErrorMessage("No bill items were found for department " + d.getName() + " and category " + c.getName() + ". Please retry the bill settlement.");
+                    return false;
                 }
 
                 Priority highestPriority = Optional
@@ -2494,7 +2514,12 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
             }
             List<BillItem> list = new ArrayList<>();
             for (BillEntry billEntry : getLstBillEntries()) {
-                list.add(getBillBean().saveBillItem(newSingleBill, billEntry, getSessionController().getLoggedUser()));
+                BillItem bi = getBillBean().saveBillItem(newSingleBill, billEntry, getSessionController().getLoggedUser());
+                if (!isPersistedBillItem(bi)) {
+                    JsfUtil.addErrorMessage("Failed to save bill items. Please retry the bill settlement.");
+                    return false;
+                }
+                list.add(bi);
             }
             newSingleBill.setBillItems(list);
 
@@ -2535,9 +2560,13 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
             getBillBean().checkBillItemFeesInitiated(newSingleBill);
             getBills().add(newSingleBill);
         } else if (oneOpdBillForEachDepartmentAndCategoryCombination) {
-            processBillsByDepartmentAndCategory();
+            if (!processBillsByDepartmentAndCategory()) {
+                return false;
+            }
         } else if (oneOpdBillForEachDepartment) {
-            processBillsByDepartment();
+            if (!processBillsByDepartment()) {
+                return false;
+            }
         } else if (oneOpdBillForEachCategory) {
             JsfUtil.addErrorMessage("Still Under Development");
             return false;

--- a/src/test/java/com/divudi/bean/opd/OpdBillControllerTest.java
+++ b/src/test/java/com/divudi/bean/opd/OpdBillControllerTest.java
@@ -1,0 +1,27 @@
+package com.divudi.bean.opd;
+
+import com.divudi.core.entity.BillItem;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OpdBillControllerTest {
+
+    @Test
+    void isPersistedBillItem_returnsFalse_whenNull() {
+        assertFalse(OpdBillController.isPersistedBillItem(null));
+    }
+
+    @Test
+    void isPersistedBillItem_returnsFalse_whenIdIsNull() {
+        assertFalse(OpdBillController.isPersistedBillItem(new BillItem()));
+    }
+
+    @Test
+    void isPersistedBillItem_returnsTrue_whenIdIsSet() {
+        BillItem bi = new BillItem();
+        bi.setId(1L);
+        assertTrue(OpdBillController.isPersistedBillItem(bi));
+    }
+}


### PR DESCRIPTION
## Summary

Port of #22411 (merged to `development` 2026-07-25) to `ruhunu-prod`.

At Ruhunu Hospital, an OPD batch-bill settle could produce a sub-bill with a correct `NETTOTAL` and a correct payment, but **zero `BillItem` rows** — because the sub-bill's total is computed from an in-memory list, completely independent of whether the item rows actually got persisted. This caused a Rs 2,420 gap between the Daily Return report (counts `BillItem`s) and the All Cashier Summary report (counts `Payment`s) for 27.05.2026, RHD-OPD Matara. Root cause confirmed and reported to Dushan Maduranga (Ruhunu Hospital) on 2026-07-24; data backfilled for the affected bills on 2026-08-13. This PR is the promised permanent safeguard.

Full investigation: #22399. Original fix: #22411.

## Changes

Cherry-picked cleanly from `development` (`b2ff223c`, `e38db79e`), no conflicts:

- `src/main/java/com/divudi/bean/opd/OpdBillController.java`:
  - New `static boolean isPersistedBillItem(BillItem bi)` helper.
  - Guard added after each `saveBillItemForOpdBill`/`saveBillItem` call in all three settle-flow branches (`processBillsByDepartment`, `processBillsByDepartmentAndCategory`, default `oneOpdBillForAllDepartments`), plus an empty-matched-entries guard.
  - `executeSettleBillActions()` now aborts (`return false`) if the delegate methods report failure.
  - Partial `Bill`/`BillItem`s are retired when settlement aborts on a persistence failure, instead of being left as orphaned rows.
- `src/test/java/com/divudi/bean/opd/OpdBillControllerTest.java` (new): unit tests for `isPersistedBillItem`.

Root-cause internals (`BillBeanController.saveBillItemForOpdBill`/`saveBillItem`) are intentionally left untouched — shared with `OpdOrderController`, underlying stale-ID mechanism needs its own follow-up investigation.

## Test plan

- `mvn clean test -Dtest=OpdBillControllerTest` — 3/3 pass on this branch.
- `mvn clean compile` — clean build on this branch.
- Original PR #22411 test plan (Playwright regression, local MySQL verification) applies unchanged since the diff is an unmodified cherry-pick.

Closes #22399