### PR TITLE
Highlight cancellation rows and add Bill Type column to Op Drug Return drill-down

### DIFF
--- a/src/main/java/com/divudi/bean/report/PharmacyReportController.java
+++ b/src/main/java/com/divudi/bean/report/PharmacyReportController.java
@@ -13224,7 +13224,7 @@ public class PharmacyReportController implements Serializable {
             XSSFSheet sheet = workbook.createSheet("OP Drug Return");
 
             int rowIndex = 0;
-            int totalColumns = 15;
+            int totalColumns = 16;
 
             // =========================
             // STYLES
@@ -13328,6 +13328,7 @@ public class PharmacyReportController implements Serializable {
 
             String[] headers = {
                 "Date",
+                "Bill Type",
                 "Item Name",
                 "Code",
                 "Doc No",
@@ -13362,63 +13363,67 @@ public class PharmacyReportController implements Serializable {
                         sdf.format(bi.getCreatedAt()));
                 d0.setCellStyle(dataStyle);
 
-                Cell d1 = row.createCell(1);
+                Cell billType = row.createCell(1);
+                billType.setCellValue(bi.getBill().getBillTypeAtomic().getLabel());
+                billType.setCellStyle(dataStyle);
+
+                Cell d1 = row.createCell(2);
                 d1.setCellValue(bi.getItem().getName());
                 d1.setCellStyle(dataStyle);
 
-                Cell d2 = row.createCell(2);
+                Cell d2 = row.createCell(3);
                 d2.setCellValue(bi.getItem().getCode());
                 d2.setCellStyle(dataStyle);
 
-                Cell d3 = row.createCell(3);
+                Cell d3 = row.createCell(4);
                 d3.setCellValue(bi.getBill().getDeptId());
                 d3.setCellStyle(dataStyle);
 
-                Cell d4 = row.createCell(4);
+                Cell d4 = row.createCell(5);
                 d4.setCellValue(bi.getBill().getBillTypeAtomic() == BillTypeAtomic.PHARMACY_RETAIL_SALE_RETURN_ITEMS_AND_PAYMENTS
                         ? bi.getBill().getReferenceBill().getReferenceBill().getReferenceBill().getDeptId()
                         : bi.getBill().getReferenceBill().getDeptId());
                 d4.setCellStyle(dataStyle);
 
-                Cell d5 = row.createCell(5);
+                Cell d5 = row.createCell(6);
                 d5.setCellValue(
                         bi.getQty());
                 d5.setCellStyle(dataStyle);
 
-                Cell costRate = row.createCell(6);
+                Cell costRate = row.createCell(7);
                 costRate.setCellValue(
                         bi.getPharmaceuticalBillItem().getItemBatch().getCostRate());
                 costRate.setCellStyle(numberStyle);
 
-                Cell costValue = row.createCell(7);
+                Cell costValue = row.createCell(8);
                 costValue.setCellValue(bi.getPharmaceuticalBillItem().getItemBatch().getCostRate() * bi.getQty());
                 costValue.setCellStyle(numberStyle);
 
-                Cell purchaseRate = row.createCell(8);
+                Cell purchaseRate = row.createCell(9);
                 purchaseRate.setCellValue(bi.getPharmaceuticalBillItem().getItemBatch().getPurcahseRate());
                 purchaseRate.setCellStyle(numberStyle);
 
-                Cell purchaseValue = row.createCell(9);
+                Cell purchaseValue = row.createCell(10);
                 purchaseValue.setCellValue(bi.getPharmaceuticalBillItem().getItemBatch().getPurcahseRate() * bi.getQty());
                 purchaseValue.setCellStyle(numberStyle);
 
-                Cell mrp = row.createCell(10);
+                Cell mrp = row.createCell(11);
                 mrp.setCellValue(bi.getPharmaceuticalBillItem().getRetailRate());
                 mrp.setCellStyle(numberStyle);
 
-                Cell mrpValue = row.createCell(11);
+                Cell mrpValue = row.createCell(12);
                 mrpValue.setCellValue(bi.getPharmaceuticalBillItem().getRetailRate() * bi.getQty());
                 mrpValue.setCellStyle(numberStyle);
 
-                Cell paymentM = row.createCell(12);
+                Cell paymentM = row.createCell(13);
                 paymentM.setCellValue(bi.getBill().getPaymentMethod().getLabel());
                 paymentM.setCellStyle(dataStyle);
 
-                Cell disc = row.createCell(13);
+                Cell disc = row.createCell(14);
                 disc.setCellValue(bi.getDiscount());
                 disc.setCellStyle(numberStyle);
 
-                Cell netT = row.createCell(14);
+                Cell netT = row.createCell(15);
                 netT.setCellValue(bi.getRate() * bi.getQty());
                 netT.setCellStyle(numberStyle);
 
@@ -13433,19 +13438,19 @@ public class PharmacyReportController implements Serializable {
             totalLabel.setCellValue("Net Amount");
             totalLabel.setCellStyle(headerStyle);
 
-            Cell totalCValue = totalRow.createCell(7);
+            Cell totalCValue = totalRow.createCell(8);
             totalCValue.setCellValue(totalCostValue);
             totalCValue.setCellStyle(numberStyle);
 
-            Cell totalPValue = totalRow.createCell(9);
+            Cell totalPValue = totalRow.createCell(10);
             totalPValue.setCellValue(totalPurchaseValue);
             totalPValue.setCellStyle(numberStyle);
 
-            Cell totalNetValue = totalRow.createCell(11);
+            Cell totalNetValue = totalRow.createCell(12);
             totalNetValue.setCellValue(totalRetailValue);
             totalNetValue.setCellStyle(numberStyle);
 
-            Cell totalRValue = totalRow.createCell(14);
+            Cell totalRValue = totalRow.createCell(15);
             totalRValue.setCellValue(netTotal);
             totalRValue.setCellStyle(numberStyle);
 

--- a/src/main/webapp/reports/inventoryReports/op_drug_return.xhtml
+++ b/src/main/webapp/reports/inventoryReports/op_drug_return.xhtml
@@ -5,6 +5,14 @@
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:p="http://primefaces.org/ui"
       xmlns:f="http://xmlns.jcp.org/jsf/core">
+    <h:head>
+        <style type="text/css">
+            .op-drug-return-cancellation-row td {
+                background-color: #fdecea;
+                color: #b71c1c;
+            }
+        </style>
+    </h:head>
     <h:body>
         <ui:composition template="/reports/index.xhtml">
             <ui:define name="subcontent">
@@ -224,21 +232,26 @@
                         </div>
 
 
-                        <p:dataTable id="tbl" 
-                                     value="#{pharmacyReportController.billItems}" 
-                                     var="row" 
-                                     rowIndexVar="n" 
-                                     paginator="true" 
+                        <p:dataTable id="tbl"
+                                     value="#{pharmacyReportController.billItems}"
+                                     var="row"
+                                     rowIndexVar="n"
+                                     paginator="true"
                                      paginatorPosition="bottom"
-                                     rows="10" 
+                                     rows="10"
                                      paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
-                                     currentPageReportTemplate="Showing {startRecord} to {endRecord} of {totalRecords}" 
-                                     rowsPerPageTemplate="5,10,15,25,50,100,500,1000">
+                                     currentPageReportTemplate="Showing {startRecord} to {endRecord} of {totalRecords}"
+                                     rowsPerPageTemplate="5,10,15,25,50,100,500,1000"
+                                     rowStyleClass="#{row.bill.billTypeAtomic eq 'PHARMACY_RETURN_ITEMS_AND_PAYMENTS_CANCELLATION' ? 'op-drug-return-cancellation-row' : null}">
 
                             <p:column headerText="Date">
                                 <h:outputText value="#{row.createdAt}">
                                     <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
                                 </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Bill Type">
+                                <h:outputText value="#{row.bill.billTypeAtomic.label}" />
                             </p:column>
 
                             <p:column headerText="Item Name">


### PR DESCRIPTION
## Summary
- Follow-up to #22912 (merged), which fixed the Op Drug Return drill-down total to reconcile with the COGS "Drug Return Op" row.
- Reported issue: even after the totals matched, cancellation-reversal rows (`PHARMACY_RETURN_ITEMS_AND_PAYMENTS_CANCELLATION`) were visually indistinguishable from normal return rows — same row styling, no bill-type label, and the negative value easy to miss in a dense numeric table. Users manually summing the exported data in Excel had no visual cue to net these out, producing a total that "felt wrong" even though the underlying figures were already signed correctly.
- Changes (on-screen table + Excel export, PDF export left out of scope for now):
  - Added a "Bill Type" column showing the friendly `BillTypeAtomic` label.
  - Highlighted cancellation rows with a red background/text via `rowStyleClass`.

Related to #22910

## Test plan
- [x] `mvn compile` succeeds (JDK 11)
- [ ] User to verify in browser: Cost Of Goods Sold → Matara Pharmacy → Drug Return Op drill-down → cancellation rows show in red with "Bill Type" = Pharmacy Return Items And Payments Cancellation; Excel download matches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visible **Bill Type** column to OP drug return reports and Excel exports.
  * Exported reports now include 16 columns while preserving existing values and formatting.

* **Style**
  * Cancelled OP drug return entries are now visually highlighted in the results table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->