### PR TITLE
Add DTO-based drill-down for OP Drug Return report

### DIFF
--- a/src/main/java/com/divudi/bean/report/PharmacyReportController.java
+++ b/src/main/java/com/divudi/bean/report/PharmacyReportController.java
@@ -34,6 +34,7 @@ import com.divudi.core.data.dto.AmpDto;
 import com.divudi.core.data.dto.BillItemDTO;
 import com.divudi.core.data.dto.CostOfGoodSoldBillDTO;
 import com.divudi.core.data.dto.StockConsumptionItemDto;
+import com.divudi.core.data.dto.OpDrugReturnRowDto;
 import com.divudi.core.data.dto.ExpiryItemListDto;
 import com.divudi.core.data.dto.ExpiryItemStockListDto;
 import com.divudi.core.data.dto.StockLedgerDTO;
@@ -395,6 +396,12 @@ public class PharmacyReportController implements Serializable {
     private double dtoStockConsumptionPurchaseTotal;
     private double dtoStockConsumptionCostTotal;
     private double dtoStockConsumptionRetailTotal;
+
+    private List<OpDrugReturnRowDto> opDrugReturnRowDtos;
+    private double dtoOpDrugReturnPurchaseTotal;
+    private double dtoOpDrugReturnCostTotal;
+    private double dtoOpDrugReturnRetailTotal;
+    private double dtoOpDrugReturnTotal;
 
     // Maps to store remaining quantities and values for Good In Transit report
     private Map<Long, Double> billItemRemainingQuantities = new HashMap<>();
@@ -4915,6 +4922,94 @@ public class PharmacyReportController implements Serializable {
             billItems = new ArrayList<>();
             netTotal = 0.0;
             resetFinanceTotals();
+        }
+    }
+
+    /**
+     * DTO-based drill-down for the "Drug Return Op" COGS row (see
+     * calculateDrugReturnOp() / retrievePurchaseAndCostValues()). Unlike
+     * processOpDrugReturn() this populates every displayed field - including
+     * the cost/purchase/MRP values - directly in a single JPQL {@code SELECT
+     * NEW} constructor query, so there is exactly one place computing the
+     * valuation (qty * current ItemBatch rate), matching the COGS row instead
+     * of being re-derived separately for the table, the Excel export, and the
+     * PDF export. See #22919.
+     */
+    public void processOpDrugReturnDto() {
+        opDrugReturnRowDtos = new ArrayList<>();
+        dtoOpDrugReturnPurchaseTotal = 0.0;
+        dtoOpDrugReturnCostTotal = 0.0;
+        dtoOpDrugReturnRetailTotal = 0.0;
+        dtoOpDrugReturnTotal = 0.0;
+        try {
+            List<BillTypeAtomic> billTypes = Arrays.asList(
+                    BillTypeAtomic.PHARMACY_RETAIL_SALE_RETURN_ITEMS_AND_PAYMENTS,
+                    BillTypeAtomic.PHARMACY_RETAIL_SALE_RETURN_ITEMS_ONLY,
+                    BillTypeAtomic.PHARMACY_RETAIL_SALE_REFUND,
+                    BillTypeAtomic.PHARMACY_RETURN_ITEMS_AND_PAYMENTS_CANCELLATION
+            );
+
+            // rb1/rb2/rb3 replicate the legacy op_drug_return.xhtml's Ref Doc No
+            // lookup: a "return items and payments" bill's reference chain is
+            // three hops back to the original sale (return-items-and-payments ->
+            // return-items-only -> sale), while every other return type here
+            // points straight at its reference bill.
+            StringBuilder jpql = new StringBuilder();
+            jpql.append("SELECT NEW com.divudi.core.data.dto.OpDrugReturnRowDto(")
+                    .append("bi.id, b.id, b.deptId, b.billTypeAtomic, ")
+                    .append("CASE WHEN b.billTypeAtomic = :chainedReturnType THEN rb3.id ELSE rb1.id END, ")
+                    .append("CASE WHEN b.billTypeAtomic = :chainedReturnType THEN rb3.deptId ELSE rb1.deptId END, ")
+                    .append("bi.createdAt, batchItem.name, batchItem.code, pbi.qty, ")
+                    .append("ib.costRate, pbi.qty * COALESCE(ib.costRate, 0.0), ")
+                    .append("ib.purcahseRate, pbi.qty * ib.purcahseRate, ")
+                    .append("ib.retailsaleRate, pbi.qty * ib.retailsaleRate, ")
+                    .append("b.paymentMethod, bi.discount, bi.rate * bi.qty) ")
+                    .append("FROM BillItem bi ")
+                    .append("JOIN bi.bill b ")
+                    .append("JOIN bi.pharmaceuticalBillItem pbi ")
+                    .append("JOIN pbi.itemBatch ib ")
+                    .append("JOIN ib.item batchItem ")
+                    .append("LEFT JOIN b.referenceBill rb1 ")
+                    .append("LEFT JOIN rb1.referenceBill rb2 ")
+                    .append("LEFT JOIN rb2.referenceBill rb3 ")
+                    .append("WHERE bi.retired = false ")
+                    .append("AND b.billTypeAtomic IN :billTypes ")
+                    // Same GREATEST(createdAt, completedAt, checkeAt) stock-movement date
+                    // basis as retrievePurchaseAndCostValues() - see processOpDrugReturn().
+                    .append("AND FUNCTION('GREATEST', b.createdAt, COALESCE(b.completedAt, b.createdAt), COALESCE(b.checkeAt, b.createdAt)) BETWEEN :fromDate AND :toDate ");
+
+            Map<String, Object> params = new HashMap<>();
+            params.put("billTypes", billTypes);
+            params.put("chainedReturnType", BillTypeAtomic.PHARMACY_RETAIL_SALE_RETURN_ITEMS_AND_PAYMENTS);
+            params.put("fromDate", fromDate);
+            params.put("toDate", toDate);
+
+            addFilter(jpql, params, "b.institution", "ins", institution);
+            addFilter(jpql, params, "b.department.site", "sit", site);
+            addFilter(jpql, params, "b.department", "dep", department);
+            // Same item join path as the COGS row (pharmaceuticalBillItem.itemBatch.item),
+            // not bi.item/Amp - see processOpDrugReturn().
+            addFilter(jpql, params, "batchItem", "itm", item);
+
+            if (selectedDepartmentTypes != null && !selectedDepartmentTypes.isEmpty()) {
+                jpql.append("AND b.departmentType IN :departmentTypes ");
+                params.put("departmentTypes", selectedDepartmentTypes);
+            }
+
+            jpql.append("ORDER BY bi.createdAt");
+
+            opDrugReturnRowDtos = (List<OpDrugReturnRowDto>) billItemFacade.findLightsByJpql(jpql.toString(), params, TemporalType.TIMESTAMP);
+
+            for (OpDrugReturnRowDto dto : opDrugReturnRowDtos) {
+                dtoOpDrugReturnPurchaseTotal += dto.getPurchaseValue() != null ? dto.getPurchaseValue() : 0.0;
+                dtoOpDrugReturnCostTotal += dto.getCostValue() != null ? dto.getCostValue() : 0.0;
+                dtoOpDrugReturnRetailTotal += dto.getMrpValue() != null ? dto.getMrpValue() : 0.0;
+                dtoOpDrugReturnTotal += dto.getTotal() != null ? dto.getTotal() : 0.0;
+            }
+        } catch (Exception e) {
+            Logger.getLogger(PharmacyReportController.class.getName()).log(Level.SEVERE, "Error generating Op Drug Return DTO report", e);
+            JsfUtil.addErrorMessage(e, "Failed to generate Drug Return Op DTO report.");
+            opDrugReturnRowDtos = new ArrayList<>();
         }
     }
 
@@ -18947,5 +19042,45 @@ public class PharmacyReportController implements Serializable {
 
     public void setDtoStockConsumptionRetailTotal(double dtoStockConsumptionRetailTotal) {
         this.dtoStockConsumptionRetailTotal = dtoStockConsumptionRetailTotal;
+    }
+
+    public List<OpDrugReturnRowDto> getOpDrugReturnRowDtos() {
+        return opDrugReturnRowDtos;
+    }
+
+    public void setOpDrugReturnRowDtos(List<OpDrugReturnRowDto> opDrugReturnRowDtos) {
+        this.opDrugReturnRowDtos = opDrugReturnRowDtos;
+    }
+
+    public double getDtoOpDrugReturnPurchaseTotal() {
+        return dtoOpDrugReturnPurchaseTotal;
+    }
+
+    public void setDtoOpDrugReturnPurchaseTotal(double dtoOpDrugReturnPurchaseTotal) {
+        this.dtoOpDrugReturnPurchaseTotal = dtoOpDrugReturnPurchaseTotal;
+    }
+
+    public double getDtoOpDrugReturnCostTotal() {
+        return dtoOpDrugReturnCostTotal;
+    }
+
+    public void setDtoOpDrugReturnCostTotal(double dtoOpDrugReturnCostTotal) {
+        this.dtoOpDrugReturnCostTotal = dtoOpDrugReturnCostTotal;
+    }
+
+    public double getDtoOpDrugReturnRetailTotal() {
+        return dtoOpDrugReturnRetailTotal;
+    }
+
+    public void setDtoOpDrugReturnRetailTotal(double dtoOpDrugReturnRetailTotal) {
+        this.dtoOpDrugReturnRetailTotal = dtoOpDrugReturnRetailTotal;
+    }
+
+    public double getDtoOpDrugReturnTotal() {
+        return dtoOpDrugReturnTotal;
+    }
+
+    public void setDtoOpDrugReturnTotal(double dtoOpDrugReturnTotal) {
+        this.dtoOpDrugReturnTotal = dtoOpDrugReturnTotal;
     }
 }

--- a/src/main/java/com/divudi/bean/report/PharmacyReportController.java
+++ b/src/main/java/com/divudi/bean/report/PharmacyReportController.java
@@ -402,6 +402,10 @@ public class PharmacyReportController implements Serializable {
     private double dtoOpDrugReturnCostTotal;
     private double dtoOpDrugReturnRetailTotal;
     private double dtoOpDrugReturnTotal;
+    // Toggled around printing so the paginated tblDto table renders every row into the
+    // DOM before p:printer clones it - p:printer only captures whatever is currently
+    // rendered, so a paginated table would otherwise print just the current page.
+    private boolean opDrugReturnPrintAll;
 
     // Maps to store remaining quantities and values for Good In Transit report
     private Map<Long, Double> billItemRemainingQuantities = new HashMap<>();
@@ -4963,7 +4967,7 @@ public class PharmacyReportController implements Serializable {
                     .append("ib.costRate, pbi.qty * COALESCE(ib.costRate, 0.0), ")
                     .append("ib.purcahseRate, pbi.qty * ib.purcahseRate, ")
                     .append("ib.retailsaleRate, pbi.qty * ib.retailsaleRate, ")
-                    .append("b.paymentMethod, bi.discount, bi.rate * bi.qty) ")
+                    .append("b.paymentMethod, bi.discount, bi.Rate * bi.qty) ")
                     .append("FROM BillItem bi ")
                     .append("JOIN bi.bill b ")
                     .append("JOIN bi.pharmaceuticalBillItem pbi ")
@@ -19082,5 +19086,21 @@ public class PharmacyReportController implements Serializable {
 
     public void setDtoOpDrugReturnTotal(double dtoOpDrugReturnTotal) {
         this.dtoOpDrugReturnTotal = dtoOpDrugReturnTotal;
+    }
+
+    public boolean isOpDrugReturnPrintAll() {
+        return opDrugReturnPrintAll;
+    }
+
+    public void setOpDrugReturnPrintAll(boolean opDrugReturnPrintAll) {
+        this.opDrugReturnPrintAll = opDrugReturnPrintAll;
+    }
+
+    public void enableOpDrugReturnPrintAll() {
+        opDrugReturnPrintAll = true;
+    }
+
+    public void disableOpDrugReturnPrintAll() {
+        opDrugReturnPrintAll = false;
     }
 }

--- a/src/main/java/com/divudi/bean/report/ReportController.java
+++ b/src/main/java/com/divudi/bean/report/ReportController.java
@@ -6675,7 +6675,7 @@ public class ReportController implements Serializable, ControllerWithReportFilte
             case "Drug Return IP":
                 return "/reports/inventoryReports/ip_drug_return?faces-redirect=true";
             case "Drug Return Op":
-                return "/reports/inventoryReports/op_drug_return?faces-redirect=true";
+                return "/reports/inventoryReports/op_drug_return_dto?faces-redirect=true";
             case "Stock Consumption":
                 return "/reports/inventoryReports/stock_consumption_dto?faces-redirect=true";
             case "Purchase Return":

--- a/src/main/java/com/divudi/core/data/dto/OpDrugReturnRowDto.java
+++ b/src/main/java/com/divudi/core/data/dto/OpDrugReturnRowDto.java
@@ -1,0 +1,236 @@
+package com.divudi.core.data.dto;
+
+import com.divudi.core.data.BillTypeAtomic;
+import com.divudi.core.data.PaymentMethod;
+
+import java.io.Serializable;
+import java.util.Date;
+
+/**
+ * Drill-down row for the "Drug Return Op" COGS row (see
+ * PharmacyReportController.calculateDrugReturnOp() /
+ * processOpDrugReturnDto()). Populated directly by a single JPQL
+ * {@code SELECT NEW} constructor query so the date basis, item join path,
+ * and valuation formula live in exactly one place, matching the COGS row's
+ * retrievePurchaseAndCostValues() rather than being re-derived independently
+ * across the XHTML table, the Excel export, and the PDF export (see #22919).
+ */
+public class OpDrugReturnRowDto implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Long billItemId;
+    private Long billId;
+    private String deptId;
+    private BillTypeAtomic billTypeAtomic;
+    private Long referenceBillId;
+    private String referenceBillDeptId;
+    private Date createdAt;
+    private String itemName;
+    private String itemCode;
+    private Double qty;
+    private Double costRate;
+    private Double costValue;
+    private Double purchaseRate;
+    private Double purchaseValue;
+    private Double mrpRate;
+    private Double mrpValue;
+    private PaymentMethod paymentMethod;
+    private Double discount;
+    private Double total;
+
+    public OpDrugReturnRowDto() {
+    }
+
+    public OpDrugReturnRowDto(Long billItemId,
+                               Long billId,
+                               String deptId,
+                               BillTypeAtomic billTypeAtomic,
+                               Long referenceBillId,
+                               String referenceBillDeptId,
+                               Date createdAt,
+                               String itemName,
+                               String itemCode,
+                               Double qty,
+                               Double costRate,
+                               Double costValue,
+                               Double purchaseRate,
+                               Double purchaseValue,
+                               Double mrpRate,
+                               Double mrpValue,
+                               PaymentMethod paymentMethod,
+                               Double discount,
+                               Double total) {
+        this.billItemId = billItemId;
+        this.billId = billId;
+        this.deptId = deptId;
+        this.billTypeAtomic = billTypeAtomic;
+        this.referenceBillId = referenceBillId;
+        this.referenceBillDeptId = referenceBillDeptId;
+        this.createdAt = createdAt;
+        this.itemName = itemName;
+        this.itemCode = itemCode;
+        this.qty = qty;
+        this.costRate = costRate != null ? costRate : 0.0;
+        this.costValue = costValue != null ? costValue : 0.0;
+        this.purchaseRate = purchaseRate;
+        this.purchaseValue = purchaseValue;
+        this.mrpRate = mrpRate;
+        this.mrpValue = mrpValue;
+        this.paymentMethod = paymentMethod;
+        this.discount = discount != null ? discount : 0.0;
+        this.total = total != null ? total : 0.0;
+    }
+
+    public Long getBillItemId() {
+        return billItemId;
+    }
+
+    public void setBillItemId(Long billItemId) {
+        this.billItemId = billItemId;
+    }
+
+    public Long getBillId() {
+        return billId;
+    }
+
+    public void setBillId(Long billId) {
+        this.billId = billId;
+    }
+
+    public String getDeptId() {
+        return deptId;
+    }
+
+    public void setDeptId(String deptId) {
+        this.deptId = deptId;
+    }
+
+    public BillTypeAtomic getBillTypeAtomic() {
+        return billTypeAtomic;
+    }
+
+    public void setBillTypeAtomic(BillTypeAtomic billTypeAtomic) {
+        this.billTypeAtomic = billTypeAtomic;
+    }
+
+    public Long getReferenceBillId() {
+        return referenceBillId;
+    }
+
+    public void setReferenceBillId(Long referenceBillId) {
+        this.referenceBillId = referenceBillId;
+    }
+
+    public String getReferenceBillDeptId() {
+        return referenceBillDeptId;
+    }
+
+    public void setReferenceBillDeptId(String referenceBillDeptId) {
+        this.referenceBillDeptId = referenceBillDeptId;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public String getItemName() {
+        return itemName;
+    }
+
+    public void setItemName(String itemName) {
+        this.itemName = itemName;
+    }
+
+    public String getItemCode() {
+        return itemCode;
+    }
+
+    public void setItemCode(String itemCode) {
+        this.itemCode = itemCode;
+    }
+
+    public Double getQty() {
+        return qty;
+    }
+
+    public void setQty(Double qty) {
+        this.qty = qty;
+    }
+
+    public Double getCostRate() {
+        return costRate;
+    }
+
+    public void setCostRate(Double costRate) {
+        this.costRate = costRate;
+    }
+
+    public Double getCostValue() {
+        return costValue;
+    }
+
+    public void setCostValue(Double costValue) {
+        this.costValue = costValue;
+    }
+
+    public Double getPurchaseRate() {
+        return purchaseRate;
+    }
+
+    public void setPurchaseRate(Double purchaseRate) {
+        this.purchaseRate = purchaseRate;
+    }
+
+    public Double getPurchaseValue() {
+        return purchaseValue;
+    }
+
+    public void setPurchaseValue(Double purchaseValue) {
+        this.purchaseValue = purchaseValue;
+    }
+
+    public Double getMrpRate() {
+        return mrpRate;
+    }
+
+    public void setMrpRate(Double mrpRate) {
+        this.mrpRate = mrpRate;
+    }
+
+    public Double getMrpValue() {
+        return mrpValue;
+    }
+
+    public void setMrpValue(Double mrpValue) {
+        this.mrpValue = mrpValue;
+    }
+
+    public PaymentMethod getPaymentMethod() {
+        return paymentMethod;
+    }
+
+    public void setPaymentMethod(PaymentMethod paymentMethod) {
+        this.paymentMethod = paymentMethod;
+    }
+
+    public Double getDiscount() {
+        return discount;
+    }
+
+    public void setDiscount(Double discount) {
+        this.discount = discount;
+    }
+
+    public Double getTotal() {
+        return total;
+    }
+
+    public void setTotal(Double total) {
+        this.total = total;
+    }
+}

--- a/src/main/webapp/reports/inventoryReports/op_drug_return_dto.xhtml
+++ b/src/main/webapp/reports/inventoryReports/op_drug_return_dto.xhtml
@@ -6,6 +6,7 @@
       xmlns:p="http://primefaces.org/ui"
       xmlns:f="http://xmlns.jcp.org/jsf/core">
     <h:head>
+        <h:outputScript library="primefaces" name="printer/printer.js" target="head"/>
         <style type="text/css">
             .op-drug-return-cancellation-row td {
                 background-color: #fdecea;
@@ -21,12 +22,12 @@
 
                         <h:panelGrid columns="8" class="w-100">
 
-                            <h:panelGroup layout="block" styleClass="form-group">
-                                <h:outputText value="&#xf073;" styleClass="fa mr-2"/>
+                            <h:panelGroup layout="block" class="form-group">
+                                <h:outputText value="&#xf073;" class="fa mr-2"/>
                                 <p:outputLabel value="From Date" for="fromDate" class="m-3"/>
                             </h:panelGroup>
                             <p:calendar
-                                styleClass="w-100"
+                                class="w-100"
                                 inputStyleClass="w-100 form-control"
                                 id="fromDate"
                                 value="#{pharmacyReportController.fromDate}"
@@ -35,12 +36,12 @@
 
                             <p:spacer width="20"/>
 
-                            <h:panelGroup layout="block" styleClass="form-group">
-                                <h:outputText value="&#xf073;" styleClass="fa mr-2"/>
+                            <h:panelGroup layout="block" class="form-group">
+                                <h:outputText value="&#xf073;" class="fa mr-2"/>
                                 <p:outputLabel value="To Date" for="toDate" class="m-3"/>
                             </h:panelGroup>
                             <p:calendar
-                                styleClass="w-100"
+                                class="w-100"
                                 inputStyleClass="w-100 form-control"
                                 id="toDate"
                                 value="#{pharmacyReportController.toDate}"
@@ -49,11 +50,11 @@
 
                             <p:spacer width="20"/>
 
-                            <h:panelGroup layout="block" styleClass="form-group">
-                                <h:outputText styleClass="fa fa-building mr-2"/>
+                            <h:panelGroup layout="block" class="form-group">
+                                <h:outputText class="fa fa-building mr-2"/>
                                 <p:outputLabel value="Department Type" for="departmentTypeFilter" class="m-3"/>
                             </h:panelGroup>
-                            <h:panelGroup layout="block" styleClass="form-group">
+                            <h:panelGroup layout="block" class="form-group">
                                 <p:selectCheckboxMenu
                                     id="departmentTypeFilter"
                                     value="#{pharmacyReportController.selectedDepartmentTypes}"
@@ -74,8 +75,8 @@
                                 <p:tooltip for="departmentTypeFilter" value="Select one or more department types to filter results. Leave empty to include all departments." position="top"/>
                             </h:panelGroup>
 
-                            <h:panelGroup layout="block" styleClass="form-group">
-                                <h:outputText styleClass="fa fa-university mr-2"/>
+                            <h:panelGroup layout="block" class="form-group">
+                                <h:outputText class="fa fa-university mr-2"/>
                                 <p:outputLabel value="Institution" for="phmIns" class="m-3"/>
                             </h:panelGroup>
                             <p:selectOneMenu
@@ -90,8 +91,8 @@
 
                             <p:spacer width="20"/>
 
-                            <h:panelGroup layout="block" styleClass="form-group">
-                                <h:outputText styleClass="fa fa-map-marker-alt mr-2"/>
+                            <h:panelGroup layout="block" class="form-group">
+                                <h:outputText class="fa fa-map-marker-alt mr-2"/>
                                 <p:outputLabel value="Site" for="phmSite" class="m-3"/>
                             </h:panelGroup>
                             <p:selectOneMenu
@@ -106,8 +107,8 @@
 
                             <p:spacer width="20"/>
 
-                            <h:panelGroup layout="block" styleClass="form-group">
-                                <h:outputText styleClass="fa fa-building mr-2"/>
+                            <h:panelGroup layout="block" class="form-group">
+                                <h:outputText class="fa fa-building mr-2"/>
                                 <p:outputLabel value="Department" for="phmDept" class="m-3"/>
                             </h:panelGroup>
                             <h:panelGroup id="phmDept">
@@ -115,7 +116,7 @@
                                 <!-- Component 1: Without Institution and Site -->
                                 <p:selectOneMenu
                                     rendered="#{pharmacyReportController.institution eq null and pharmacyReportController.site eq null}"
-                                    styleClass="w-100 form-control"
+                                    class="w-100 form-control"
                                     value="#{pharmacyReportController.department}"
                                     filterMatchMode="contains"
                                     filter="true">
@@ -130,7 +131,7 @@
                                 <!-- Component 2: With Site Only -->
                                 <p:selectOneMenu
                                     rendered="#{pharmacyReportController.institution eq null and pharmacyReportController.site ne null}"
-                                    styleClass="w-100 form-control"
+                                    class="w-100 form-control"
                                     value="#{pharmacyReportController.department}"
                                     filterMatchMode="contains"
                                     filter="true">
@@ -145,7 +146,7 @@
                                 <!-- Component 3: With Institution Only -->
                                 <p:selectOneMenu
                                     rendered="#{pharmacyReportController.institution ne null and pharmacyReportController.site eq null}"
-                                    styleClass="w-100 form-control"
+                                    class="w-100 form-control"
                                     value="#{pharmacyReportController.department}"
                                     filterMatchMode="contains"
                                     filter="true">
@@ -160,7 +161,7 @@
                                 <!-- Component 4: With Both Institution and Site -->
                                 <p:selectOneMenu
                                     rendered="#{pharmacyReportController.institution ne null and pharmacyReportController.site ne null}"
-                                    styleClass="w-100 form-control"
+                                    class="w-100 form-control"
                                     value="#{pharmacyReportController.department}"
                                     filterMatchMode="contains"
                                     filter="true">
@@ -190,14 +191,21 @@
                                 value="Process"
                                 action="#{pharmacyReportController.processOpDrugReturnDto()}"/>
 
+                            <p:remoteCommand name="rcExpandOpDrugReturnForPrint"
+                                             update="tblDto"
+                                             actionListener="#{pharmacyReportController.enableOpDrugReturnPrintAll()}"
+                                             oncomplete="printOpDrugReturnAfterExpand()"/>
+
+                            <p:remoteCommand name="rcRestoreOpDrugReturnPaging"
+                                             update="tblDto"
+                                             actionListener="#{pharmacyReportController.disableOpDrugReturnPrintAll()}"/>
+
                             <p:commandButton
-                                class="ui-button- mx-1"
+                                class="ui-button-secondary mx-1"
                                 icon="fas fa-print"
-                                ajax="false"
+                                type="button"
                                 value="Print"
-                                onclick="hidePaginatorBeforePrint()">
-                                <p:printer target="tblDto" oncomplete="restorePaginatorAfterPrint()"/>
-                            </p:commandButton>
+                                onclick="preparePrintOpDrugReturn()"/>
 
                             <p:commandButton
                                 class="ui-button-success mx-1"
@@ -236,6 +244,21 @@
                                 paginators.forEach(el => el.style.display = '');
                             }
                             window.onafterprint = function () { restorePaginatorAfterPrint(); };
+
+                            // tblDto is paginated, so p:printer (which just clones the current
+                            // DOM) would only capture the visible page. rcExpandOpDrugReturnForPrint
+                            // re-renders the table with every row before we clone it for print.
+                            function preparePrintOpDrugReturn() {
+                                hidePaginatorBeforePrint();
+                                rcExpandOpDrugReturnForPrint();
+                            }
+                            function printOpDrugReturnAfterExpand() {
+                                PrimeFaces.expressions.SearchExpressionFacade
+                                    .resolveComponentsAsSelector(document.body, 'tblDto')
+                                    .print({globalStyles: true});
+                                restorePaginatorAfterPrint();
+                                rcRestoreOpDrugReturnPaging();
+                            }
                         </h:outputScript>
 
                         <p:dataTable id="tblDto"
@@ -243,9 +266,9 @@
                                      var="f"
                                      rowIndexVar="n"
                                      rowKey="#{f.billItemId}"
-                                     paginator="true"
+                                     paginator="#{!pharmacyReportController.opDrugReturnPrintAll}"
                                      paginatorPosition="bottom"
-                                     rows="10"
+                                     rows="#{pharmacyReportController.opDrugReturnPrintAll ? (empty pharmacyReportController.opDrugReturnRowDtos ? 1 : pharmacyReportController.opDrugReturnRowDtos.size()) : 10}"
                                      paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
                                      currentPageReportTemplate="Showing {startRecord} to {endRecord} of {totalRecords}"
                                      rowsPerPageTemplate="5,10,15,25,50,100,500,1000"

--- a/src/main/webapp/reports/inventoryReports/op_drug_return_dto.xhtml
+++ b/src/main/webapp/reports/inventoryReports/op_drug_return_dto.xhtml
@@ -1,0 +1,385 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+    <h:head>
+        <style type="text/css">
+            .op-drug-return-cancellation-row td {
+                background-color: #fdecea;
+                color: #b71c1c;
+            }
+        </style>
+    </h:head>
+    <h:body>
+        <ui:composition template="/reports/index.xhtml">
+            <ui:define name="subcontent">
+                <h:form>
+                    <p:panel header="OP Drug Return (DTO)">
+
+                        <h:panelGrid columns="8" class="w-100">
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf073;" styleClass="fa mr-2"/>
+                                <p:outputLabel value="From Date" for="fromDate" class="m-3"/>
+                            </h:panelGroup>
+                            <p:calendar
+                                styleClass="w-100"
+                                inputStyleClass="w-100 form-control"
+                                id="fromDate"
+                                value="#{pharmacyReportController.fromDate}"
+                                navigator="false"
+                                pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+
+                            <p:spacer width="20"/>
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf073;" styleClass="fa mr-2"/>
+                                <p:outputLabel value="To Date" for="toDate" class="m-3"/>
+                            </h:panelGroup>
+                            <p:calendar
+                                styleClass="w-100"
+                                inputStyleClass="w-100 form-control"
+                                id="toDate"
+                                value="#{pharmacyReportController.toDate}"
+                                navigator="false"
+                                pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+
+                            <p:spacer width="20"/>
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText styleClass="fa fa-building mr-2"/>
+                                <p:outputLabel value="Department Type" for="departmentTypeFilter" class="m-3"/>
+                            </h:panelGroup>
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <p:selectCheckboxMenu
+                                    id="departmentTypeFilter"
+                                    value="#{pharmacyReportController.selectedDepartmentTypes}"
+                                    label="Select Department Types"
+                                    updateLabel="true"
+                                    class="w-100"
+                                    filter="true"
+                                    filterMatchMode="contains"
+                                    showHeader="true"
+                                    scrollHeight="200"
+                                    title="Select one or more department types to filter results. Leave empty to include all departments.">
+                                    <f:selectItems
+                                        value="#{pharmacyReportController.availableDepartmentTypes}"
+                                        var="depType"
+                                        itemLabel="#{depType.label}"
+                                        itemValue="#{depType}"/>
+                                </p:selectCheckboxMenu>
+                                <p:tooltip for="departmentTypeFilter" value="Select one or more department types to filter results. Leave empty to include all departments." position="top"/>
+                            </h:panelGroup>
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText styleClass="fa fa-university mr-2"/>
+                                <p:outputLabel value="Institution" for="phmIns" class="m-3"/>
+                            </h:panelGroup>
+                            <p:selectOneMenu
+                                id="phmIns"
+                                class="w-100"
+                                value="#{pharmacyReportController.institution}"
+                                filter="true">
+                                <f:selectItem itemLabel="All Institutions"/>
+                                <f:selectItems value="#{institutionController.companies}" var="ins" itemLabel="#{ins.name}" itemValue="#{ins}"/>
+                                <p:ajax process="phmIns" update="phmDept"/>
+                            </p:selectOneMenu>
+
+                            <p:spacer width="20"/>
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText styleClass="fa fa-map-marker-alt mr-2"/>
+                                <p:outputLabel value="Site" for="phmSite" class="m-3"/>
+                            </h:panelGroup>
+                            <p:selectOneMenu
+                                id="phmSite"
+                                class="w-100"
+                                value="#{pharmacyReportController.site}"
+                                filter="true">
+                                <f:selectItem itemLabel="All Sites"/>
+                                <f:selectItems value="#{institutionController.sites}" var="site" itemLabel="#{site.name}" itemValue="#{site}"/>
+                                <p:ajax process="phmSite" update="phmDept"/>
+                            </p:selectOneMenu>
+
+                            <p:spacer width="20"/>
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText styleClass="fa fa-building mr-2"/>
+                                <p:outputLabel value="Department" for="phmDept" class="m-3"/>
+                            </h:panelGroup>
+                            <h:panelGroup id="phmDept">
+
+                                <!-- Component 1: Without Institution and Site -->
+                                <p:selectOneMenu
+                                    rendered="#{pharmacyReportController.institution eq null and pharmacyReportController.site eq null}"
+                                    styleClass="w-100 form-control"
+                                    value="#{pharmacyReportController.department}"
+                                    filterMatchMode="contains"
+                                    filter="true">
+                                    <f:selectItem itemLabel="All Departments"/>
+                                    <f:selectItems
+                                        value="#{departmentController.getDepartmentsOfInstitutionAndSite()}"
+                                        var="dept"
+                                        itemLabel="#{dept.name}"
+                                        itemValue="#{dept}"/>
+                                </p:selectOneMenu>
+
+                                <!-- Component 2: With Site Only -->
+                                <p:selectOneMenu
+                                    rendered="#{pharmacyReportController.institution eq null and pharmacyReportController.site ne null}"
+                                    styleClass="w-100 form-control"
+                                    value="#{pharmacyReportController.department}"
+                                    filterMatchMode="contains"
+                                    filter="true">
+                                    <f:selectItem itemLabel="All Departments"/>
+                                    <f:selectItems
+                                        value="#{departmentController.getDepartmentsOfInstitutionAndSite(pharmacyReportController.site)}"
+                                        var="dept"
+                                        itemLabel="#{dept.name}"
+                                        itemValue="#{dept}"/>
+                                </p:selectOneMenu>
+
+                                <!-- Component 3: With Institution Only -->
+                                <p:selectOneMenu
+                                    rendered="#{pharmacyReportController.institution ne null and pharmacyReportController.site eq null}"
+                                    styleClass="w-100 form-control"
+                                    value="#{pharmacyReportController.department}"
+                                    filterMatchMode="contains"
+                                    filter="true">
+                                    <f:selectItem itemLabel="All Departments"/>
+                                    <f:selectItems
+                                        value="#{departmentController.getDepartmentsOfInstitutionAndSite(pharmacyReportController.institution)}"
+                                        var="dept"
+                                        itemLabel="#{dept.name}"
+                                        itemValue="#{dept}"/>
+                                </p:selectOneMenu>
+
+                                <!-- Component 4: With Both Institution and Site -->
+                                <p:selectOneMenu
+                                    rendered="#{pharmacyReportController.institution ne null and pharmacyReportController.site ne null}"
+                                    styleClass="w-100 form-control"
+                                    value="#{pharmacyReportController.department}"
+                                    filterMatchMode="contains"
+                                    filter="true">
+                                    <f:selectItem itemLabel="All Departments"/>
+                                    <f:selectItems
+                                        value="#{departmentController.getDepartmentsOfInstitutionAndSite(pharmacyReportController.institution, pharmacyReportController.site)}"
+                                        var="dept"
+                                        itemLabel="#{dept.name}"
+                                        itemValue="#{dept}"/>
+                                </p:selectOneMenu>
+                            </h:panelGroup>
+
+                        </h:panelGrid>
+
+                        <div class="d-flex align-items-center mt-5">
+                            <p:commandButton
+                                class="ui-button-secondary mx-1"
+                                icon="fas fa-arrow-left"
+                                ajax="false"
+                                value="Back"
+                                action="#{reportController.navigateToCostOfGoodsSold()}"/>
+
+                            <p:commandButton
+                                class="ui-button-warning mx-1"
+                                icon="fas fa-cogs"
+                                ajax="false"
+                                value="Process"
+                                action="#{pharmacyReportController.processOpDrugReturnDto()}"/>
+
+                            <p:commandButton
+                                class="ui-button- mx-1"
+                                icon="fas fa-print"
+                                ajax="false"
+                                value="Print"
+                                onclick="hidePaginatorBeforePrint()">
+                                <p:printer target="tblDto" oncomplete="restorePaginatorAfterPrint()"/>
+                            </p:commandButton>
+
+                            <p:commandButton
+                                class="ui-button-success mx-1"
+                                icon="fas fa-file-excel"
+                                ajax="false"
+                                value="Download">
+                                <p:dataExporter type="xlsx" target="tblDto"
+                                                fileName="Op_Drug_Return_Report"/>
+                            </p:commandButton>
+
+                            <p:commandButton
+                                class="ui-button-danger mx-1"
+                                icon="fas fa-file-pdf"
+                                ajax="false"
+                                value="PDF">
+                                <p:dataExporter type="pdf" target="tblDto"
+                                                fileName="Op_Drug_Return_Report"/>
+                            </p:commandButton>
+
+                            <p:commandButton
+                                class="ui-button-secondary mx-1"
+                                icon="fas fa-exchange-alt"
+                                ajax="false"
+                                value="View Legacy Report"
+                                title="Switch to the entity-based report for cross-checking"
+                                action="op_drug_return?faces-redirect=true"/>
+                        </div>
+
+                        <h:outputScript>
+                            function hidePaginatorBeforePrint() {
+                                let paginators = document.querySelectorAll('.ui-paginator');
+                                paginators.forEach(el => el.style.display = 'none');
+                            }
+                            function restorePaginatorAfterPrint() {
+                                let paginators = document.querySelectorAll('.ui-paginator');
+                                paginators.forEach(el => el.style.display = '');
+                            }
+                            window.onafterprint = function () { restorePaginatorAfterPrint(); };
+                        </h:outputScript>
+
+                        <p:dataTable id="tblDto"
+                                     value="#{pharmacyReportController.opDrugReturnRowDtos}"
+                                     var="f"
+                                     rowIndexVar="n"
+                                     rowKey="#{f.billItemId}"
+                                     paginator="true"
+                                     paginatorPosition="bottom"
+                                     rows="10"
+                                     paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                     currentPageReportTemplate="Showing {startRecord} to {endRecord} of {totalRecords}"
+                                     rowsPerPageTemplate="5,10,15,25,50,100,500,1000"
+                                     rowStyleClass="#{f.billTypeAtomic eq 'PHARMACY_RETURN_ITEMS_AND_PAYMENTS_CANCELLATION' ? 'op-drug-return-cancellation-row' : null}">
+
+                            <p:column headerText="Date">
+                                <h:outputText value="#{f.createdAt}">
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Bill Type">
+                                <h:outputText value="#{f.billTypeAtomic.label}"/>
+                            </p:column>
+
+                            <p:column headerText="Item Name">
+                                <h:outputText value="#{f.itemName}"/>
+                            </p:column>
+
+                            <p:column headerText="Code">
+                                <h:outputText value="#{f.itemCode}"/>
+                            </p:column>
+
+                            <p:column headerText="Doc No" filterMatchMode="contains" filterBy="#{f.deptId}">
+                                <h:outputText value="#{f.deptId}"/>
+                            </p:column>
+
+                            <p:column headerText="Ref Doc No" filterMatchMode="contains" filterBy="#{f.referenceBillDeptId}">
+                                <h:outputText value="#{f.referenceBillDeptId}"/>
+                            </p:column>
+
+                            <p:column headerText="QTY" style="text-align: right;">
+                                <h:outputText value="#{f.qty}">
+                                    <f:convertNumber pattern="#,##0"/>
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Cost Rate" width="5em" style="text-align: right;">
+                                <h:outputText value="#{f.costRate}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Cost Value" width="5em" style="text-align: right;">
+                                <h:outputText value="#{f.costValue}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputText>
+                                <f:facet name="footer">
+                                    <h:outputText value="#{pharmacyReportController.dtoOpDrugReturnCostTotal}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </h:outputText>
+                                </f:facet>
+                            </p:column>
+
+                            <p:column headerText="Purchase Rate" width="5em" style="text-align: right;">
+                                <h:outputText value="#{f.purchaseRate}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Purchase Value" width="5em" style="text-align: right;">
+                                <h:outputText value="#{f.purchaseValue}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputText>
+                                <f:facet name="footer">
+                                    <h:outputText value="#{pharmacyReportController.dtoOpDrugReturnPurchaseTotal}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </h:outputText>
+                                </f:facet>
+                            </p:column>
+
+                            <p:column headerText="MRP" width="5em" style="text-align: right;">
+                                <h:outputText value="#{f.mrpRate}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="MRP Value" width="5em" style="text-align: right;">
+                                <h:outputText value="#{f.mrpValue}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputText>
+                                <f:facet name="footer">
+                                    <h:outputText value="#{pharmacyReportController.dtoOpDrugReturnRetailTotal}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </h:outputText>
+                                </f:facet>
+                            </p:column>
+
+                            <p:column headerText="Payment Mode" width="5em">
+                                <h:outputText value="#{f.paymentMethod}"/>
+                            </p:column>
+
+                            <p:column headerText="Discount" width="5em" style="text-align: right;">
+                                <h:outputText value="#{f.discount}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Total" width="5em" style="text-align: right;">
+                                <h:outputText value="#{f.total}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputText>
+                                <f:facet name="footer">
+                                    <h:outputText value="#{pharmacyReportController.dtoOpDrugReturnTotal}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </h:outputText>
+                                </f:facet>
+                            </p:column>
+
+                            <p:column
+                                exportable="false"
+                                headerText="Actions"
+                                width="5em">
+                                <p:commandButton
+                                    value="View Bill"
+                                    class="m-1 ui-button-info"
+                                    style="width: 100px;"
+                                    action="#{billSearch.navigateToViewBillByAtomicBillTypeByBillId(f.billId)}"
+                                    ajax="false"/>
+
+                                <p:commandButton
+                                    value="View Ref Bill"
+                                    rendered="#{f.referenceBillId != null}"
+                                    class="m-1 ui-button-info"
+                                    style="width: 100px;"
+                                    action="#{billSearch.navigateToViewBillByAtomicBillTypeByBillId(f.referenceBillId)}"
+                                    ajax="false"/>
+                            </p:column>
+
+                        </p:dataTable>
+
+                    </p:panel>
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>


### PR DESCRIPTION
## Summary
Adds a new DTO-based drill-down report for the "Drug Return Op" Cost of Goods Sold (COGS) row, providing detailed line-item visibility with consistent valuation across table, Excel, and PDF exports.

## Changes

### New Files
- **`OpDrugReturnRowDto.java`**: Data transfer object for drill-down rows, populated directly by a single JPQL `SELECT NEW` constructor query. Includes all displayed fields (item details, quantities, cost/purchase/MRP rates and values, payment method, discount, total) to ensure valuation is computed in exactly one place, matching the COGS row's `retrievePurchaseAndCostValues()` logic.

- **`op_drug_return_dto.xhtml`**: New report UI with:
  - Date range, department type, institution, site, and department filters
  - Data table with 15 columns (date, bill type, item details, quantities, rates, values, payment mode, discount, total)
  - Footer totals for cost value, purchase value, MRP value, and total
  - Visual highlighting (red background) for cancellation rows
  - Action buttons: View Bill, View Reference Bill, Print, Excel/PDF export, and link to legacy entity-based report

### Modified Files
- **`PharmacyReportController.java`**:
  - Added `processOpDrugReturnDto()` method that queries bill items for return types (retail sale returns, refunds, cancellations) using a single JPQL query with `SELECT NEW OpDrugReturnRowDto(...)` constructor
  - Implements same date basis (`GREATEST(createdAt, completedAt, checkeAt)`) and item join path (`pharmaceuticalBillItem.itemBatch.item`) as the legacy `processOpDrugReturn()` to ensure consistency
  - Handles chained reference lookups: "return items and payments" bills trace three hops back to original sale; other return types point directly to reference bill
  - Added properties: `opDrugReturnRowDtos`, `dtoOpDrugReturnPurchaseTotal`, `dtoOpDrugReturnCostTotal`, `dtoOpDrugReturnRetailTotal`, `dtoOpDrugReturnTotal` with getters/setters
  - Supports filtering by institution, site, department, item, and department type

## Implementation Details
- **Single source of truth**: All valuation formulas (qty × current ItemBatch rate) live in the JPQL query, eliminating discrepancies between table display, Excel export, and PDF export (addresses issue #22919)
- **Reference chain handling**: Uses conditional `CASE WHEN` in JPQL to correctly resolve reference bill IDs and department IDs based on bill type
- **Consistent with COGS row**: Replicates the same stock-movement date basis and item join path as the existing COGS calculation to ensure drill-down values match the summary row
- **Backward compatibility**: Preserves intentional typo `purcahseRate` in ItemBatch entity for database compatibility

https://claude.ai/code/session_01RwzbyviBFiL2xhz9nBKWCL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a detailed OP Drug Return report with date, department, institution, site, and department filters.
  * Added paginated return-item details with quantities, costs, purchase values, retail values, discounts, and totals.
  * Added report totals, cancellation highlighting, reference-bill navigation, and bill-view access.
  * Added printing and Excel/PDF export options.
  * Updated Drug Return navigation to open the new report.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->