### PR TITLE
fix: sync Privileges tree + OPD billitem persistence guard (ruhunu-prod hotfix bundle)

### DIFF
--- a/src/main/java/com/divudi/bean/common/UserPrivilageController.java
+++ b/src/main/java/com/divudi/bean/common/UserPrivilageController.java
@@ -166,6 +166,9 @@ public class UserPrivilageController implements Serializable {
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardAdmissionsAdmission, "Admission"), admissionsNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardAdmissionsEditAdmission, "Edit Admission Details"), admissionsNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardAdmissionsInwardAppoinment, "Inward Appointment"), admissionsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardEditPatientDetailsFromAdmission, "Edit Patient Details From Admission"), admissionsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardEditPaymentDetails, "Edit Payment Details"), admissionsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardManageAllergies, "Manage Allergies"), admissionsNode);
 
         TreeNode appointmentNode = new DefaultTreeNode(new PrivilegeHolder(null, "Appointment"), inwardNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardAppointmentMenu, "Appointment Menu"), appointmentNode);
@@ -190,30 +193,98 @@ public class UserPrivilageController implements Serializable {
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardServicesAndItemsAddOutSideCharges, "Add Outside Charges"), servicesItemsNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardServicesAndItemsAddProfessionalFee, "Add Professional Fee"), servicesItemsNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardServicesAndItemsAddTimedServices, "Add Timed Services"), servicesItemsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardAddChargesAfterNursingDischarge, "Add Charges After Nursing Discharge"), servicesItemsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardHoldProfessionalPayments, "Hold Professional Payments"), servicesItemsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardPayProfessionalFeesWhileOnHold, "Pay Professional Fees While On Hold"), servicesItemsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardServiceItemRequestApproval, "Approve Service/Item Requests"), servicesItemsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardServiceItemRequestRejection, "Reject Service/Item Requests"), servicesItemsNode);
 
         TreeNode inwardBillingNode = new DefaultTreeNode(new PrivilegeHolder(null, "Billing"), inwardNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardBilling, "Billing Menu"), inwardBillingNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardBillingInterimBill, "Interim Bill"), inwardBillingNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardBillingInterimBillSearch, "Interim Bill Search"), inwardBillingNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardFinalBillReportEdit, "Edit Patient Name After Payment Finalized"), inwardBillingNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardDoctorPaymentAccess, "Doctor Payment Access"), inwardBillingNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardPostFinalPaymentAccess, "Post Final Payment Access"), inwardBillingNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardMakeDepositAccess, "Make Deposit Access"), inwardBillingNode);
+
+        TreeNode dashboardPanelsNode = new DefaultTreeNode(new PrivilegeHolder(null, "Inpatient Dashboard Panels"), inwardNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientDashboardPanelAdmission, "Admission Panel"), dashboardPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientDashboardPanelBilling, "Billing Panel"), dashboardPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientDashboardPanelServices, "Services Panel"), dashboardPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientDashboardPanelRoomManagement, "Room Management Panel"), dashboardPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientDashboardPanelOperationTheatre, "Operation Theatre Panel"), dashboardPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientDashboardPanelClinicalData, "Clinical Data Panel"), dashboardPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientDashboardPanelPharmaceuticals, "Pharmaceuticals Panel"), dashboardPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientDashboardPanelDocuments, "Documents Panel"), dashboardPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientDashboardPanelReports, "Reports Panel"), dashboardPanelsNode);
+
+        TreeNode inwardSurgeryNode = new DefaultTreeNode(new PrivilegeHolder(null, "Surgery"), inwardNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSurgeryAdd, "Add Surgery"), inwardSurgeryNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSurgeryManage, "Manage Surgery"), inwardSurgeryNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSurgeryValidate, "Validate Surgery"), inwardSurgeryNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSurgeryValidationRevert, "Revert Surgery Validation"), inwardSurgeryNode);
+
+        TreeNode clinicalDataViewNode = new DefaultTreeNode(new PrivilegeHolder(null, "Clinical Data Access"), inwardNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardPatientHistoryView, "Patient History View"), clinicalDataViewNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardClinicalNotesView, "Clinical Notes View"), clinicalDataViewNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardWardMedicationsView, "Ward Medications View"), clinicalDataViewNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardDischargeMedicationsView, "Discharge Medications View"), clinicalDataViewNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardInvestigationsView, "Investigations View"), clinicalDataViewNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardImagesView, "Images View"), clinicalDataViewNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardDiagnosisCardView, "Diagnosis Card View"), clinicalDataViewNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardEventHistoryView, "Event History View"), clinicalDataViewNode);
 
         TreeNode inwardPharmacyNode = new DefaultTreeNode(new PrivilegeHolder(null, "Pharmacy"), inwardNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardPharmacyMenu, "Pharmacy Menu"), inwardPharmacyNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardPharmacyIssueRequest, "Pharmacy Issue Request"), inwardPharmacyNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardPharmacyIssueRequestSearch, "Pharmacy Issue Request Search"), inwardPharmacyNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardPharmacyIssueRequestCancel, "Pharmacy Issue Request Cancel"), inwardPharmacyNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardPharmacyReturnCancel, "Pharmacy Return Cancel"), inwardPharmacyNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardPharmacyReturnSubmit, "Pharmacy Return Submit"), inwardPharmacyNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardPharmacyBhtReceive, "Pharmacy BHT Receive"), inwardPharmacyNode);
 
         TreeNode searchNode = new DefaultTreeNode(new PrivilegeHolder(null, "Search"), inwardNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSearch, "Search Menu"), searchNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSearchServiceBill, "Search Service Bill"), searchNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSearchAdmissionsGeneralSearch, "Search Admissions - General Search (Date Range)"), searchNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSearchProfessionalBill, "Search Professional Bill"), searchNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSearchFinalBill, "Search Final Bill"), searchNode);
 
+        TreeNode admissionSearchScopeNode = new DefaultTreeNode(new PrivilegeHolder(null, "Admission Search Scope"), searchNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSearchAdmissionsByAdmittedDepartmentAnyInstitute, "By Admitted Department - Any Institute"), admissionSearchScopeNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSearchAdmissionsByAdmittedDepartmentLoggedInstitute, "By Admitted Department - Logged Institute"), admissionSearchScopeNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSearchAdmissionsByAdmittedDepartmentLoggedDepartment, "By Admitted Department - Logged Department"), admissionSearchScopeNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSearchAdmissionsByCurrentDepartmentAnyInstitute, "By Current Department - Any Institute"), admissionSearchScopeNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSearchAdmissionsByCurrentDepartmentLoggedInstitute, "By Current Department - Logged Institute"), admissionSearchScopeNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSearchAdmissionsByCurrentDepartmentLoggedDepartment, "By Current Department - Logged Department"), admissionSearchScopeNode);
+
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardReport, "Inward Reports"), inwardNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardPostDischargeReports, "Inward Post-Discharge Reports"), inwardNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardAdministration, "Administration"), inwardNode);
+
+        TreeNode inwardLaboratoryNode = new DefaultTreeNode(new PrivilegeHolder(null, "Laboratory"), inwardNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardLaboratory, "Laboratory Dashboard Menu"), inwardLaboratoryNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardLaboratoryBarcodeGeneration, "Barcode Generation"), inwardLaboratoryNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardLaboratorySampleManagement, "Sample Management"), inwardLaboratoryNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardLaboratoryReportSearch, "Report Search"), inwardLaboratoryNode);
+
+        TreeNode inwardFormsNode = new DefaultTreeNode(new PrivilegeHolder(null, "Forms"), inwardNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardFormTemplateAdmin, "Form Template Admin"), inwardFormsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardFormFill, "Fill / Edit Forms"), inwardFormsNode);
 
         TreeNode inwardClinicalNode = new DefaultTreeNode(new PrivilegeHolder(null, "Clinical"), inwardNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientClinicalAssessment, "Clinical Notes / Assessments"), inwardClinicalNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientClinicalDischarge, "Clinical Discharge"), inwardClinicalNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardNursingDischarge, "Nursing Discharge"), inwardClinicalNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardPhysicalDischarge, "Physical Discharge"), inwardClinicalNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardDocumentUpload, "Document Upload"), inwardClinicalNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientLetter, "Generate Inpatient Letters"), inwardClinicalNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSendEmail, "Send Email"), inwardClinicalNode);
+
+        TreeNode inwardPackageNode = new DefaultTreeNode(new PrivilegeHolder(null, "Packages"), inwardNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardPackageAdministration, "Manage Inpatient Packages"), inwardPackageNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardPackageAdmission, "Package-Based Admission"), inwardPackageNode);
 
         TreeNode additionalPrivilegesNode = new DefaultTreeNode(new PrivilegeHolder(null, "Additional Privileges"), inwardNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardAdditionalPrivilages, "Additional Privilege Menu"), additionalPrivilegesNode);
@@ -232,12 +303,22 @@ public class UserPrivilageController implements Serializable {
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardBillSettleWithoutCheck, "Inward Bill Settle Without Check"), additionalPrivilegesNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSearchServiceBillUnrestrictedAccess, "Inward Bill Search Without Restriction"), additionalPrivilegesNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSettleFinalBillUnrestricted, "Inward Final Bill Settle Without Restriction"), additionalPrivilegesNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSettleFinalBill, "Inward Settle Final Bill"), additionalPrivilegesNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardFinalBillCreateVersion, "Inward Final Bill Create New Version"), additionalPrivilegesNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardFinalBillSetConfirmed, "Inward Final Bill Set As Confirmed"), additionalPrivilegesNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardFinalBillRetire, "Inward Final Bill Retire"), additionalPrivilegesNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardFinalBillEmail, "Inward Final Bill Email"), additionalPrivilegesNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSaveProvisionalFinalBill, "Inward Save Provisional Final Bill"), additionalPrivilegesNode);
 
         // Theatre Privileges
         TreeNode theatreNode = new DefaultTreeNode(new PrivilegeHolder(null, "Theatre"), allNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.Theatre, "Theatre Menu"), theatreNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.TheatreAddSurgery, "Add Surgery"), theatreNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.TheatreBilling, "Theatre Billing"), theatreNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.TheatreSendPatient, "Send Patient to Theatre"), theatreNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.TheatreAcceptPatient, "Accept Patient in Theatre"), theatreNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.TheatreReturnPatient, "Return Patient to Ward"), theatreNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.WardAcceptTheatreReturn, "Accept Patient Returning from Theatre"), theatreNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.TheaterTransfer, "Theatre Transfer Menu Item"), theatreNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.TheaterTransferRequest, "Theatre Transfer Request"), theatreNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.TheaterTransferIssue, "Theatre Transfer Issue"), theatreNode);
@@ -356,6 +437,7 @@ public class UserPrivilageController implements Serializable {
         TreeNode pharmacyNode = new DefaultTreeNode(new PrivilegeHolder(null, "Pharmacy"), allNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.Pharmacy, "Pharmacy Menu"), pharmacyNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyAdministration, "Pharmacy Administration"), pharmacyNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyItemNameEdit, "Pharmacy Item Name Edit"), pharmacyNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDonation, "Pharmacy Donation"), pharmacyNode);
 
         // Channelling Privileges
@@ -497,6 +579,8 @@ public class UserPrivilageController implements Serializable {
         new DefaultTreeNode(new PrivilegeHolder(Privileges.ClinicalPatientEdit, "Edit Patient"), clinicalsNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.ClinicalPatientNameChange, "Change Patient Name"), clinicalsNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.ClinicalPatientPhoneNumberEdit, "Edit Patient Phone Number"), clinicalsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.ClinicalPatientBlacklist, "Blacklist / Unblacklist Patient"), clinicalsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.ClinicalPatientPseudonymise, "Pseudonymise Patient"), clinicalsNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.ClinicalPatientCommentsView, "View Patient Comments"), clinicalsNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.ClinicalPatientCommentsEdit, "Edit Patient Comments"), clinicalsNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.ClinicalMembershipAdd, "Add Membership"), clinicalsNode);
@@ -511,6 +595,10 @@ public class UserPrivilageController implements Serializable {
         new DefaultTreeNode(new PrivilegeHolder(Privileges.AdminStaff, "Manage Staff"), adminNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.AdminItems, "Manage Items/Services"), adminNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.AdminPrices, "Manage Fees/Prices/Packages"), adminNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.AdminPatientRelationships, "Manage Patient Relationships"), adminNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.AdminInactivePatients, "Manage Inactive Patients"), adminNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.MergePatients, "Merge Patients"), adminNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.ClientPortalCreateAccount, "Create Client Portal Account"), adminNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.ManageCreditCompany, "Manage Credit Companies"), adminNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.AdminFilterWithoutDepartment, "Filter Without Department"), adminNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.SearchAll, "Search All"), adminNode);
@@ -664,12 +752,16 @@ public class UserPrivilageController implements Serializable {
 
         TreeNode handoverAcceptAsCashier = new DefaultTreeNode(new PrivilegeHolder(Privileges.ShiftHandoverAcceptAsCashier, "Shift Handover Accept As A Cashier"), cashTransactionNode);
         TreeNode handoverAcceptAsMainCashier = new DefaultTreeNode(new PrivilegeHolder(Privileges.ShiftHandoverAcceptAsMainCashier, "Shift Handover Accept As Main Cashier"), cashTransactionNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.SettleHandoverProofMissing, "Settle Handover Proof Missing"), cashTransactionNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.SettleNonCashPayments, "Settle Non-Cash Payments"), cashTransactionNode);
 
         TreeNode listToCashReceiveNode = new DefaultTreeNode(new PrivilegeHolder(Privileges.CashTransactionListToCashRecieve, "List To Cash Receive"), cashTransactionNode);
 
         TreeNode PettyCashBillApprove = new DefaultTreeNode(new PrivilegeHolder(Privileges.PettyCashBillApprove, "Petty Cash Bill Approval"), cashTransactionNode);
         TreeNode PettyCashBillCancellationApprove = new DefaultTreeNode(new PrivilegeHolder(Privileges.PettyCashBillCancellationApprove, "Petty Cash Bill Cancellation Approval"), cashTransactionNode);
+        TreeNode PettyCashEditFinancialYear = new DefaultTreeNode(new PrivilegeHolder(Privileges.PettyCashEditFinancialYear, "Petty Cash Edit Financial Year"), cashTransactionNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.AllCashierSummery, "All Cashier Summary"), cashTransactionNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.CashierHandoverStatusReport, "Cashier Handover Status Report"), cashTransactionNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.IncomeReport, "Income Report"), cashTransactionNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.DuesAndAccess, "Dues and Access"), cashTransactionNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.CheckEnteredData, "Check Entered Data"), cashTransactionNode);
@@ -712,8 +804,16 @@ public class UserPrivilageController implements Serializable {
         TreeNode disbursementFinalizeRequest = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDisbursementFinalizeRequest, "Finalize Transfer Request"), disbursementNode);
         TreeNode PharmacyDisbursementApproval = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDisbursementRequestApproval, "Pharmacy Disbursement Request Approval"), disbursementNode);
         TreeNode disbursementIssueForRequest = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDisbursementIssurForRequest, "Issue for Request"), disbursementNode);
+        TreeNode issueForRequestSave = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyIssueForRequestSave, "Issue for Request Save"), disbursementNode);
+        TreeNode issueForRequestFinalize = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyIssueForRequestFinalize, "Issue for Request Finalize"), disbursementNode);
+        TreeNode issueForRequestApprove = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyIssueForRequestApprove, "Issue for Request Approve"), disbursementNode);
         TreeNode disbursementDirectIssue = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDisbursementDirectIssue, "Direct Issue"), disbursementNode);
         TreeNode disbursementRecieve = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDisbursementRecieve, "Recieve"), disbursementNode);
+        TreeNode receiveSave = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyReceiveSave, "Receive Save"), disbursementNode);
+        TreeNode receiveFinalize = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyReceiveFinalize, "Receive Finalize"), disbursementNode);
+        TreeNode receiveApprove = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyReceiveApprove, "Receive Approve"), disbursementNode);
+        TreeNode transferIssueCancel = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyTransferIssueCancel, "Transfer Issue Cancel"), disbursementNode);
+        TreeNode transferReceiveCancel = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyTransferReceiveCancel, "Transfer Receive Cancel"), disbursementNode);
         TreeNode TransferReciveApproval = new DefaultTreeNode(new PrivilegeHolder(Privileges.TransferReciveApproval, "Recieve Approval"), disbursementNode);
         TreeNode PharmacyDisbursementReports = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDisbursementReports, "Pharmacy Disbursement Reports"), disbursementNode);
         TreeNode PharmacyTransferViewRates = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyTransferViewRates, "Pharmacy Transfer View Rates"), disbursementNode);
@@ -725,8 +825,11 @@ public class UserPrivilageController implements Serializable {
         TreeNode InpatientMedicationManagementNode = new DefaultTreeNode("Inpatient medication Management", pharmacyNode);
         TreeNode InpatientMedicationManagementMenue = new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientMedicationManagementMenue, "Procurement Menu"), InpatientMedicationManagementNode);
         TreeNode PharmacyDirectIssueToBht = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDirectIssueToBht, "Pharmacy Direct Issue To Bht"), InpatientMedicationManagementNode);
+        TreeNode PharmacyDischargeMedicineIssue = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDischargeMedicineIssue, "Pharmacy Discharge Medicine Issue"), InpatientMedicationManagementNode);
         TreeNode PharmacyDirectIssueToTheaterCases = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDirectIssueToTheaterCases, "Pharmacy Direct Issue To Theater Cases"), InpatientMedicationManagementNode);
         TreeNode PharmacyBhtIssueRequest = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyBhtIssueRequest, "Pharmacy Bht Issue Request"), InpatientMedicationManagementNode);
+        TreeNode PharmacyBhtRequestForceComplete = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyBhtRequestForceComplete, "Pharmacy Bht Request Force Complete"), InpatientMedicationManagementNode);
+        TreeNode PharmacyReturnFromWardForceComplete = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyReturnFromWardForceComplete, "Pharmacy Return From Ward Force Complete"), InpatientMedicationManagementNode);
         TreeNode PharmacySearchInpatientDirectIssuesbyBill = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacySearchInpatientDirectIssuesbyBill, "Pharmacy Search Inpatient Direct Issues by Bill"), InpatientMedicationManagementNode);
         TreeNode PharmacySearchInpatientDirectIssuesbyItem = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacySearchInpatientDirectIssuesbyItem, "Pharmacy Search Inpatient Direct Issues by Item"), InpatientMedicationManagementNode);
         TreeNode PharmacySearchInpatientDirectIssueReturnsbyBill = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacySearchInpatientDirectIssueReturnsbyBill, "Pharmacy Search Inpatient Direct Issue Returns by Bill"), InpatientMedicationManagementNode);
@@ -740,11 +843,18 @@ public class UserPrivilageController implements Serializable {
         TreeNode pharmacyAutoOrderPModel = new DefaultTreeNode(new PrivilegeHolder(Privileges.AutoOrderPModel, "Auto Order (P Model)"), ProcumentNode);
         TreeNode pharmacyAutoOrderQModel = new DefaultTreeNode(new PrivilegeHolder(Privileges.AutoOrderQModal, "Auto Order (Q Model)"), ProcumentNode);
         TreeNode pharmacyDirectPurchase = new DefaultTreeNode(new PrivilegeHolder(Privileges.DirectPurchase, "Direct Purchase"), ProcumentNode);
+        TreeNode pharmacyDirectPurchaseSave = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDirectPurchaseSave, "Pharmacy Direct Purchase Save"), ProcumentNode);
+        TreeNode pharmacyDirectPurchaseFinalize = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDirectPurchaseFinalize, "Pharmacy Direct Purchase Finalize"), ProcumentNode);
+        TreeNode pharmacyDirectPurchaseApprove = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDirectPurchaseApprove, "Pharmacy Direct Purchase Approve"), ProcumentNode);
         TreeNode pharmacyPurchaseOrderApprovel = new DefaultTreeNode(new PrivilegeHolder(Privileges.PurchaseOrdersApprovel, "Purchase Orders Approvel"), ProcumentNode);
+        TreeNode pharmacyPurchaseOrderSave = new DefaultTreeNode(new PrivilegeHolder(Privileges.PurchaseOrderSave, "Purchase Order Save"), ProcumentNode);
+        TreeNode pharmacyPurchaseOrderFinalize = new DefaultTreeNode(new PrivilegeHolder(Privileges.PurchaseOrderFinalize, "Purchase Order Finalize"), ProcumentNode);
         TreeNode pharmacyGoodRecipt = new DefaultTreeNode(new PrivilegeHolder(Privileges.GoodsRecipt, "Pharmacy Good Recipt"), ProcumentNode);
         TreeNode pharmacyGrnSave = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyGrnSave, "Pharmacy GRN Save"), ProcumentNode);
         TreeNode pharmacyGrnFinalize = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyGrnFinalize, "Pharmacy GRN Finalize"), ProcumentNode);
         TreeNode pharmacyGrnApprove = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyGrnApprove, "Pharmacy GRN Approve"), ProcumentNode);
+        TreeNode pharmacyGrnCancel = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyGrnCancel, "Pharmacy GRN Cancel"), ProcumentNode);
+        TreeNode pharmacyGrnReturnCancel = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyGrnReturnCancel, "Pharmacy GRN Return Cancel"), ProcumentNode);
         TreeNode pharmacyReturnReceviedGoods = new DefaultTreeNode(new PrivilegeHolder(Privileges.ReturnReceviedGoods, "Pharmacy Return Recevied Goods"), ProcumentNode);
         TreeNode pharmacyCreateGrnReturn = new DefaultTreeNode(new PrivilegeHolder(Privileges.CreateGrnReturn, "Create GRN Return"), ProcumentNode);
         TreeNode pharmacyFinalizeGrnReturn = new DefaultTreeNode(new PrivilegeHolder(Privileges.FinalizeGrnReturn, "Finalize GRN Return"), ProcumentNode);
@@ -786,10 +896,18 @@ public class UserPrivilageController implements Serializable {
         TreeNode PharmacyStockTakeApprove = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyStockTakeApprove, "Pharmacy Stock Take Approve"), PharmacyAdjustment);
         // Create New Batch privilege
         new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyAdjustmentCreateBatch, "Pharmacy Adjustment Create Batch"), PharmacyAdjustment);
+        // Archive Old StockHistory Records (issue #20726)
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.ArchiveOldStockHistory, "Archive Old StockHistory Records"), PharmacyAdjustment);
+        // Archive Old ItemBatch Records (issue #20724)
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.ArchiveOldItemBatch, "Archive Old ItemBatch Records"), PharmacyAdjustment);
 
         TreeNode pharmacyDisposalNode = new DefaultTreeNode(new PrivilegeHolder(null, "Pharmacy Disposal"), pharmacyNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDisposalMenue, "Pharmacy Disposal Menu"), pharmacyDisposalNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDisposalIssue, "Pharmacy Disposal Issue"), pharmacyDisposalNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDisposalIssueFinalize, "Pharmacy Disposal Issue Finalize"), pharmacyDisposalNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDisposalIssueApprove, "Pharmacy Disposal Issue Approve"), pharmacyDisposalNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDisposalIssueCancel, "Pharmacy Disposal Issue Cancel"), pharmacyDisposalNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDiscardCategoryManage, "Pharmacy Issue Category Manage"), pharmacyDisposalNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDisposalSearchIssueBill, "Pharmacy Disposal Search Issue Bill"), pharmacyDisposalNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDisposalSearchIssueBillItems, "Pharmacy Disposal Search Issue Bill Items"), pharmacyDisposalNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDisposalSearchIssueReturnBill, "Pharmacy Disposal Search Issue Return Bill"), pharmacyDisposalNode);
@@ -861,15 +979,42 @@ public class UserPrivilageController implements Serializable {
 
         // Request Privileges
         TreeNode requestNode = new DefaultTreeNode(new PrivilegeHolder(null, "Request Manage"), allNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.RequestManager, "Request Manager"), requestNode);
         TreeNode billCancelRequestApproval = new DefaultTreeNode(new PrivilegeHolder(Privileges.BillCancelRequestApproval, "Bill Cancel Approval"), requestNode);
         TreeNode itemRefundRequestApproval = new DefaultTreeNode(new PrivilegeHolder(Privileges.ItemRefundRequestApproval, "Item Refund Approval"), requestNode);
         TreeNode drawerAdjustmentRequestApproval = new DefaultTreeNode(new PrivilegeHolder(Privileges.DrawerAdjustmentRequestApproval, "Drawer Adjustment Approval"), requestNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.DrawerAdjustmentDirect, "Drawer Adjustment Direct (No Approval)"), requestNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.PettyCashCancellationApproval, "Petty-Cash Cancellation Approval"), requestNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyRetailSaleReturnApproval, "Pharmacy Retail Sale Return Approval"), requestNode);
+
+        // Float Transfer Privileges
+        TreeNode floatTransferNode = new DefaultTreeNode(new PrivilegeHolder(null, "Float Transfer"), allNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.IssueFundTransfer, "Issue Float Transfer"), floatTransferNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.ReceiveFundTransfer, "Receive Float Transfer"), floatTransferNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.DeclineFundTransfer, "Decline Float Transfer"), floatTransferNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.RequestFundTransfer, "Request Float Transfer"), floatTransferNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.ProcessFundTransferRequest, "Process Float Transfer Request"), floatTransferNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.CancelOwnFundTransfer, "Cancel Own Float Transfer"), floatTransferNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.CancelOthersFundTransfer, "Cancel Others Float Transfer"), floatTransferNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.ViewFundTransferReports, "View Float Transfer Reports"), floatTransferNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.ViewAllShiftShortageBills, "View All Shift Shortage Bills"), floatTransferNode);
 
         // Request Privileges
         TreeNode nurseNode = new DefaultTreeNode(new PrivilegeHolder(null, "Nursing Work Bench"), allNode);
         TreeNode nursingWorkBench = new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingWorkBench, "Nursing Work Bench"), nurseNode);
         TreeNode showDrugCharges = new DefaultTreeNode(new PrivilegeHolder(Privileges.ShowDrugCharges, "Show Drug Charges"), nurseNode);
+        TreeNode ShowServiceCharges = new DefaultTreeNode(new PrivilegeHolder(Privileges.ShowServiceCharges, "Show Service Charges"), nurseNode);
+        TreeNode ShowTimeServiceCharges = new DefaultTreeNode(new PrivilegeHolder(Privileges.ShowTimeServiceCharges, "Show Time Service Charges"), nurseNode);
+
+        TreeNode nursingWorkBenchPanelsNode = new DefaultTreeNode(new PrivilegeHolder(null, "Nursing Workbench Panels"), nurseNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingWorkBenchPanelEdit, "Edit Panel"), nursingWorkBenchPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingWorkBenchPanelClinicalData, "Clinical Data Panel"), nursingWorkBenchPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingWorkBenchPanelRoomManagement, "Room Management Panel"), nursingWorkBenchPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingWorkBenchPanelService, "Service Panel"), nursingWorkBenchPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingWorkBenchPanelOperationTheatre, "Operation Theatre Panel"), nursingWorkBenchPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingWorkBenchPanelPharmaceuticals, "Pharmaceuticals Panel"), nursingWorkBenchPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingWorkBenchPanelReports, "Reports Panel"), nursingWorkBenchPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingWorkBenchPanelPayments, "Payments Panel"), nursingWorkBenchPanelsNode);
 
         // Admin Privileges
         TreeNode superAdminNode = new DefaultTreeNode(new PrivilegeHolder(Privileges.SuperAdmin, "Super Admin"), allNode);
@@ -896,7 +1041,7 @@ public class UserPrivilageController implements Serializable {
 
     public void saveUserRolePrivileges() {
         if (webUserRole == null) {
-            JsfUtil.addErrorMessage("Please select a user");
+            JsfUtil.addErrorMessage("Please select a User Role");
             return;
         }
         saveWebUserRolePrivileges();
@@ -1147,7 +1292,7 @@ public class UserPrivilageController implements Serializable {
         fillUserRolePrivileges();
         JsfUtil.addSuccessMessage("Updated");
     }
-
+    
     private static void checkNodes(TreeNode root, List<PrivilegeHolder> privilegesToCheck) {
         if (root == null || privilegesToCheck == null || privilegesToCheck.isEmpty()) {
             return;
@@ -1405,6 +1550,7 @@ public class UserPrivilageController implements Serializable {
         currentUserPrivilegeHolders = createRolePrivilegeHolders(currentWebUserRolePrivileges);
         unselectTreeNodes(rootTreeNode);
         checkNodes(rootTreeNode, currentUserPrivilegeHolders);
+        privilegesLoaded = true;
     }
 
     public List<WebUserRolePrivilege> fetchUserPrivileges(WebUserRole role) {

--- a/src/main/java/com/divudi/bean/opd/OpdBillController.java
+++ b/src/main/java/com/divudi/bean/opd/OpdBillController.java
@@ -2288,6 +2288,24 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
         return bi != null && bi.getId() != null;
     }
 
+    private void retirePartialBillOnSettlementFailure(Bill bill, List<BillItem> persistedItems) {
+        if (bill == null) {
+            return;
+        }
+        for (BillItem bi : persistedItems) {
+            if (isPersistedBillItem(bi) && !bi.isRetired()) {
+                bi.setRetired(true);
+                bi.setRetiredAt(new Date());
+                getBillItemFacade().edit(bi);
+            }
+        }
+        if (bill.getId() != null && !bill.isRetired()) {
+            bill.setRetired(true);
+            bill.setRetiredAt(new Date());
+            getBillFacade().edit(bill);
+        }
+    }
+
     private boolean processBillsByDepartment() {
         Set<Department> billDepts = new HashSet<>();
         for (BillEntry e : lstBillEntries) {
@@ -2306,6 +2324,7 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
                 if (Objects.equals(prformingDept.getId(), d.getId())) {
                     BillItem bi = getBillBean().saveBillItemForOpdBill(myBill, e, getSessionController().getLoggedUser(), getBillFeeBundleEntrys());
                     if (!isPersistedBillItem(bi)) {
+                        retirePartialBillOnSettlementFailure(myBill, myBill.getBillItems());
                         JsfUtil.addErrorMessage("Failed to save bill items for department " + d.getName() + ". Please retry the bill settlement.");
                         return false;
                     }
@@ -2314,6 +2333,7 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
                 }
             }
             if (tmp.isEmpty()) {
+                retirePartialBillOnSettlementFailure(myBill, myBill.getBillItems());
                 JsfUtil.addErrorMessage("No bill items were found for department " + d.getName() + ". Please retry the bill settlement.");
                 return false;
             }
@@ -2366,6 +2386,7 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
                             && Objects.equals(billEntry.getBillItem().getItem().getCategory().getId(), c.getId())) {
                         BillItem bi = getBillBean().saveBillItem(newlyCreatedIndividualBill, billEntry, getSessionController().getLoggedUser());
                         if (!isPersistedBillItem(bi)) {
+                            retirePartialBillOnSettlementFailure(newlyCreatedIndividualBill, newlyCreatedIndividualBill.getBillItems());
                             JsfUtil.addErrorMessage("Failed to save bill items for department " + d.getName() + " and category " + c.getName() + ". Please retry the bill settlement.");
                             return false;
                         }
@@ -2374,6 +2395,7 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
                     }
                 }
                 if (tmp.isEmpty()) {
+                    retirePartialBillOnSettlementFailure(newlyCreatedIndividualBill, newlyCreatedIndividualBill.getBillItems());
                     JsfUtil.addErrorMessage("No bill items were found for department " + d.getName() + " and category " + c.getName() + ". Please retry the bill settlement.");
                     return false;
                 }
@@ -2516,6 +2538,7 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
             for (BillEntry billEntry : getLstBillEntries()) {
                 BillItem bi = getBillBean().saveBillItem(newSingleBill, billEntry, getSessionController().getLoggedUser());
                 if (!isPersistedBillItem(bi)) {
+                    retirePartialBillOnSettlementFailure(newSingleBill, list);
                     JsfUtil.addErrorMessage("Failed to save bill items. Please retry the bill settlement.");
                     return false;
                 }

--- a/src/main/java/com/divudi/bean/opd/OpdBillController.java
+++ b/src/main/java/com/divudi/bean/opd/OpdBillController.java
@@ -2284,6 +2284,10 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
         return false; // Fallback case, should not reach here.
     }
 
+    static boolean isPersistedBillItem(BillItem bi) {
+        return bi != null && bi.getId() != null;
+    }
+
     private boolean processBillsByDepartment() {
         Set<Department> billDepts = new HashSet<>();
         for (BillEntry e : lstBillEntries) {
@@ -2301,9 +2305,17 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
                 Department prformingDept = departmentResolver.resolvePerformingDepartment(sessionController.getDepartment(), e.getBillItem().getItem());
                 if (Objects.equals(prformingDept.getId(), d.getId())) {
                     BillItem bi = getBillBean().saveBillItemForOpdBill(myBill, e, getSessionController().getLoggedUser(), getBillFeeBundleEntrys());
+                    if (!isPersistedBillItem(bi)) {
+                        JsfUtil.addErrorMessage("Failed to save bill items for department " + d.getName() + ". Please retry the bill settlement.");
+                        return false;
+                    }
                     myBill.getBillItems().add(bi);
                     tmp.add(e);
                 }
+            }
+            if (tmp.isEmpty()) {
+                JsfUtil.addErrorMessage("No bill items were found for department " + d.getName() + ". Please retry the bill settlement.");
+                return false;
             }
             if (getSessionController().getApplicationPreference().isPartialPaymentOfOpdBillsAllowed()) {
                 myBill.setCashPaid(cashPaid);
@@ -2353,9 +2365,17 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
                     if (Objects.equals(dept.getId(), d.getId())
                             && Objects.equals(billEntry.getBillItem().getItem().getCategory().getId(), c.getId())) {
                         BillItem bi = getBillBean().saveBillItem(newlyCreatedIndividualBill, billEntry, getSessionController().getLoggedUser());
+                        if (!isPersistedBillItem(bi)) {
+                            JsfUtil.addErrorMessage("Failed to save bill items for department " + d.getName() + " and category " + c.getName() + ". Please retry the bill settlement.");
+                            return false;
+                        }
                         newlyCreatedIndividualBill.getBillItems().add(bi);
                         tmp.add(billEntry);
                     }
+                }
+                if (tmp.isEmpty()) {
+                    JsfUtil.addErrorMessage("No bill items were found for department " + d.getName() + " and category " + c.getName() + ". Please retry the bill settlement.");
+                    return false;
                 }
 
                 Priority highestPriority = Optional
@@ -2494,7 +2514,12 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
             }
             List<BillItem> list = new ArrayList<>();
             for (BillEntry billEntry : getLstBillEntries()) {
-                list.add(getBillBean().saveBillItem(newSingleBill, billEntry, getSessionController().getLoggedUser()));
+                BillItem bi = getBillBean().saveBillItem(newSingleBill, billEntry, getSessionController().getLoggedUser());
+                if (!isPersistedBillItem(bi)) {
+                    JsfUtil.addErrorMessage("Failed to save bill items. Please retry the bill settlement.");
+                    return false;
+                }
+                list.add(bi);
             }
             newSingleBill.setBillItems(list);
 
@@ -2535,9 +2560,13 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
             getBillBean().checkBillItemFeesInitiated(newSingleBill);
             getBills().add(newSingleBill);
         } else if (oneOpdBillForEachDepartmentAndCategoryCombination) {
-            processBillsByDepartmentAndCategory();
+            if (!processBillsByDepartmentAndCategory()) {
+                return false;
+            }
         } else if (oneOpdBillForEachDepartment) {
-            processBillsByDepartment();
+            if (!processBillsByDepartment()) {
+                return false;
+            }
         } else if (oneOpdBillForEachCategory) {
             JsfUtil.addErrorMessage("Still Under Development");
             return false;

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -87,6 +87,11 @@ public enum Privileges {
     InwardServicesAndItemsAddOutSideCharges("Inward Add Outside Charges"),
     InwardServicesAndItemsAddProfessionalFee("Inward Add Professional Fee"),
     InwardServicesAndItemsAddTimedServices("Inward Add Timed Services"),
+    InwardServiceItemRequestApproval("Inward Service/Item Request Approval"),
+    InwardServiceItemRequestRejection("Inward Service/Item Request Rejection"),
+    InwardAddChargesAfterNursingDischarge("Inward Add Charges After Nursing Discharge"),
+    InwardHoldProfessionalPayments("Hold Professional Payments"),
+    InwardPayProfessionalFeesWhileOnHold("Pay Professional Fees While On Hold"),
     InwardBilling("Inward Billing"),
     InwardBillingInterimBill("Inward Interim Bill"),
     InwardBillingInterimBillSearch("Inward Interim Bill Search"),
@@ -95,10 +100,31 @@ public enum Privileges {
     InwardSearchServiceBillUnrestrictedAccess("Inward Search Service Bill Without Restricted"),
     InwardSearchProfessionalBill("Inward Search Professional Bill"),
     InwardSearchFinalBill("Inward Search Final Bill"),
+    // Admission search scope buttons (issue #22382)
+    InwardSearchAdmissionsByAdmittedDepartmentAnyInstitute("Inward Search Admissions By Admitted Department - Any Institute"),
+    InwardSearchAdmissionsByAdmittedDepartmentLoggedInstitute("Inward Search Admissions By Admitted Department - Logged Institute"),
+    InwardSearchAdmissionsByAdmittedDepartmentLoggedDepartment("Inward Search Admissions By Admitted Department - Logged Department"),
+    InwardSearchAdmissionsByCurrentDepartmentAnyInstitute("Inward Search Admissions By Current Department - Any Institute"),
+    InwardSearchAdmissionsByCurrentDepartmentLoggedInstitute("Inward Search Admissions By Current Department - Logged Institute"),
+    InwardSearchAdmissionsByCurrentDepartmentLoggedDepartment("Inward Search Admissions By Current Department - Logged Department"),
+    InwardSearchAdmissionsGeneralSearch("Inward Search Admissions - General Search (Date Range)"),
     InwardSettleFinalBillUnrestricted("Inward Settle Final Bill Without Restricted"),
+    InwardSettleFinalBill("Inward Settle Final Bill"),
+    InwardFinalBillCreateVersion("Inward Final Bill Create New Version"),
+    InwardFinalBillSetConfirmed("Inward Final Bill Set As Confirmed"),
+    InwardFinalBillRetire("Inward Final Bill Retire"),
+    InwardFinalBillEmail("Inward Final Bill Email"),
+    InwardSaveProvisionalFinalBill("Inward Save Provisional Final Bill"),
     InwardReport("Inward Report"),
+    InwardPostDischargeReports("Inward Post-Discharge Reports"),
+    InwardLaboratory("Inward Laboratory"),
+    InwardLaboratoryBarcodeGeneration("Inward Laboratory Barcode Generation"),
+    InwardLaboratorySampleManagement("Inward Laboratory Sample Management"),
+    InwardLaboratoryReportSearch("Inward Laboratory Report Search"),
     InwardFinalBillReportEdit("Inward Final Bill Report Edit"),
     InwardAdministration("Inward Administration"),
+    InwardFormTemplateAdmin("Inward Form Template Admin"),
+    InwardFormFill("Inward Form Fill"),
     InwardAdditionalPrivilages("Inward Additional Privileges"),
     InwardBillSearch("Inward Bill Search"),
     InwardBillItemSearch("Inward Bill Item Search"),
@@ -116,25 +142,83 @@ public enum Privileges {
     InwardPharmacyIssueRequest("Inward Pharmacy Issue Request"),
     InwardPharmacyIssueRequestCancel("Inward Pharmacy Issue Request Cancel"),
     InwardPharmacyIssueRequestSearch("Inward Pharmacy Issue Request Search"),
+    InwardPharmacyReturnCancel("Inward Pharmacy Return Cancel"),
+    InwardPharmacyReturnSubmit("Inward Pharmacy Return Submit"),
+    InwardPharmacyBhtReceive("Inward Pharmacy BHT Receive"),
     InwardBillSettleWithoutCheck("Inward Bill Settle Without Check"),
     TheaterIssueBHT("Theater Issue BHT"),
     InpatientClinicalAssessment("Inpatient Clinical Assessment"),
+    InpatientClinicalDischarge("Inpatient Clinical Discharge"),
+    InwardNursingDischarge("Inward Nursing Discharge"),
+    InwardPhysicalDischarge("Inward Physical Discharge"),
+    InwardDocumentUpload("Inward Document Upload"),
+    InpatientLetter("Inpatient Letter"),
+    InwardSendEmail("Inward Send Email"),
+    InwardPackageAdministration("Inward Package Administration"),
+    InwardPackageAdmission("Inward Package Admission"),
+    InwardEditPatientDetailsFromAdmission("Inward Edit Patient Details From Admission"),
+    InwardEditPaymentDetails("Inward Edit Payment Details"),
+    InwardManageAllergies("Inward Manage Allergies"),
+    InwardDoctorPaymentAccess("Inward Doctor Payment Access"),
+    InwardMakeDepositAccess("Inward Make Deposit Access"),
+    InwardPostFinalPaymentAccess("Inward Post Final Payment Access"),
+    InwardSurgeryAdd("Inward Surgery Add"),
+    InwardSurgeryManage("Inward Surgery Manage"),
+    InwardSurgeryValidate("Inward Surgery Validate"),
+    InwardSurgeryValidationRevert("Inward Surgery Validation Revert"),
+    InwardPatientHistoryView("Inward Patient History View"),
+    InwardClinicalNotesView("Inward Clinical Notes View"),
+    InwardWardMedicationsView("Inward Ward Medications View"),
+    InwardDischargeMedicationsView("Inward Discharge Medications View"),
+    InwardInvestigationsView("Inward Investigations View"),
+    InwardImagesView("Inward Images View"),
+    InwardDiagnosisCardView("Inward Diagnosis Card View"),
+    InwardEventHistoryView("Inward Event History View"),
     //</editor-fold>
-    
+
+    //<editor-fold defaultstate="collapsed" desc="Inpatient Dashboard Panels">
+    InpatientDashboardPanelAdmission("Inpatient Dashboard - Admission Panel"),
+    InpatientDashboardPanelBilling("Inpatient Dashboard - Billing Panel"),
+    InpatientDashboardPanelServices("Inpatient Dashboard - Services Panel"),
+    InpatientDashboardPanelRoomManagement("Inpatient Dashboard - Room Management Panel"),
+    InpatientDashboardPanelOperationTheatre("Inpatient Dashboard - Operation Theatre Panel"),
+    InpatientDashboardPanelClinicalData("Inpatient Dashboard - Clinical Data Panel"),
+    InpatientDashboardPanelPharmaceuticals("Inpatient Dashboard - Pharmaceuticals Panel"),
+    InpatientDashboardPanelDocuments("Inpatient Dashboard - Documents Panel"),
+    InpatientDashboardPanelReports("Inpatient Dashboard - Reports Panel"),
+    //</editor-fold>
+
     //<editor-fold defaultstate="collapsed" desc="Nurse">
     NursingWorkBench("Nursing Work Bench"),
     ShowDrugCharges("Show Drug Charges"),
+    ShowServiceCharges("Show Service Charges"),
+    ShowTimeServiceCharges("Show Time Service Charges"),
+    //</editor-fold>
+
+    //<editor-fold defaultstate="collapsed" desc="Nursing Workbench Panels">
+    NursingWorkBenchPanelEdit("Nursing Workbench - Edit Panel"),
+    NursingWorkBenchPanelClinicalData("Nursing Workbench - Clinical Data Panel"),
+    NursingWorkBenchPanelRoomManagement("Nursing Workbench - Room Management Panel"),
+    NursingWorkBenchPanelService("Nursing Workbench - Service Panel"),
+    NursingWorkBenchPanelOperationTheatre("Nursing Workbench - Operation Theatre Panel"),
+    NursingWorkBenchPanelPharmaceuticals("Nursing Workbench - Pharmaceuticals Panel"),
+    NursingWorkBenchPanelReports("Nursing Workbench - Reports Panel"),
+    NursingWorkBenchPanelPayments("Nursing Workbench - Payments Panel"),
     //</editor-fold>
 
     //<editor-fold defaultstate="collapsed" desc="Finance">
     PettyCashBillCancellationApprove("Petty Cash Bill Cancellation Approval"),
     PettyCashBillApprove("Petty Cash Bill Approval"),
+    PettyCashEditFinancialYear("Petty Cash Edit Financial Year"),
     AllCashierSummery("All Cashier Summary"),
     CashTransactionCashIn("Cash Transaction Cash In"),
     CashTransactionCashOut("Cash Transaction Cash Out"),
     CashTransactionListToCashRecieve("Cash Transaction List to Cash Receive"),
     ShiftHandoverAcceptAsCashier("Shift Handover Accept As Cashier"),
     ShiftHandoverAcceptAsMainCashier("Shift Handover Accept As Main Cashier"),
+    CashierHandoverStatusReport("Cashier Handover Status Report"),
+    SettleHandoverProofMissing("Settle Handover Proof Missing"),
+    SettleNonCashPayments("Settle Non-Cash Payments"),
     //</editor-fold>
 
     //<editor-fold defaultstate="collapsed" desc="Lab">
@@ -269,6 +353,10 @@ public enum Privileges {
     Theatre("Theater"),
     TheatreAddSurgery("Theater Add Surgery"),
     TheatreBilling("Theater Billing"),
+    TheatreSendPatient("Theatre Send Patient"),
+    TheatreAcceptPatient("Theatre Accept Patient"),
+    TheatreReturnPatient("Theatre Return Patient"),
+    WardAcceptTheatreReturn("Ward Accept Theatre Return"),
     TheaterTransfer("Theater Transfer"),
     TheaterTransferRequest("Theater Transfer Request"),
     TheaterTransferIssue("Theater Transfer Issue"),
@@ -323,6 +411,7 @@ public enum Privileges {
     StoreReports("Store Reports"),
     StoreSummery("Store Summary"),
     StoreAdministration("Store Administration"),
+    PharmacyItemNameEdit("Pharmacy Item Name Edit"),
     //</editor-fold>
 
     //<editor-fold defaultstate="collapsed" desc="Channel">
@@ -481,6 +570,8 @@ public enum Privileges {
     ClinicalMembershipAdd("Clinical Membership Add"),
     ClinicalMembershipEdit("Clinical Membership Edit"),
     ClinicalPatientPhoneNumberEdit("Clinical Patient Phone Number Edit"),
+    ClinicalPatientBlacklist("Clinical Patient Blacklist"),
+    ClinicalPatientPseudonymise("Clinical Patient Pseudonymise"),
     //</editor-fold>
 
     //<editor-fold defaultstate="collapsed" desc="Pharmacy">
@@ -493,11 +584,22 @@ public enum Privileges {
     PharmacyDisbursementRecieve("Pharmacy Disbursement Receive"),
     PharmacyDisbursementReports("Pharmacy Disbursement Reports"),
     PharmacyDisbursementRequestApproval("Pharmacy Disbursement Request Approval"),
+    PharmacyIssueForRequestSave("Pharmacy Issue For Request Save"),
+    PharmacyIssueForRequestFinalize("Pharmacy Issue For Request Finalize"),
+    PharmacyIssueForRequestApprove("Pharmacy Issue For Request Approve"),
+    PharmacyReceiveSave("Pharmacy Receive Save"),
+    PharmacyReceiveFinalize("Pharmacy Receive Finalize"),
+    PharmacyReceiveApprove("Pharmacy Receive Approve"),
+    PharmacyTransferIssueCancel("Pharmacy Transfer Issue Cancel"),
+    PharmacyTransferReceiveCancel("Pharmacy Transfer Receive Cancel"),
     // Pharmacy Inpatient medication management
     InpatientMedicationManagementMenue("Inpatient Medication Management Menu"),
     PharmacyDirectIssueToBht("Pharmacy Direct Issue to BHT"),
+    PharmacyDischargeMedicineIssue("Pharmacy Discharge Medicine Issue"),
     PharmacyDirectIssueToTheaterCases("Pharmacy Direct Issue to Theater Cases"),
     PharmacyBhtIssueRequest("Pharmacy BHT Issue Request"),
+    PharmacyBhtRequestForceComplete("Pharmacy BHT Request Force Complete"),
+    PharmacyReturnFromWardForceComplete("Pharmacy Return From Ward Force Complete"),
     PharmacySearchInpatientDirectIssuesbyBill("Pharmacy Search Inpatient Direct Issues by Bill"),
     PharmacySearchInpatientDirectIssuesbyItem("Pharmacy Search Inpatient Direct Issues by Item"),
     PharmacySearchInpatientDirectIssueReturnsbyBill("Pharmacy Search Inpatient Direct Issue Returns by Bill"),
@@ -532,6 +634,10 @@ public enum Privileges {
     // Pharmacy Disposal
     PharmacyDisposalMenue("Pharmacy Disposal Menu"),
     PharmacyDisposalIssue("Pharmacy Disposal Issue"),
+    PharmacyDisposalIssueFinalize("Pharmacy Disposal Issue Finalize"),
+    PharmacyDisposalIssueApprove("Pharmacy Disposal Issue Approve"),
+    PharmacyDisposalIssueCancel("Pharmacy Disposal Issue Cancel"),
+    PharmacyDiscardCategoryManage("Pharmacy Issue Category Manage"),
     PharmacyDisposalSearchIssueBill("Pharmacy Disposal Search Issue Bill"),
     PharmacyDisposalSearchIssueBillItems("Pharmacy Disposal Search Issue Bill Items"),
     PharmacyDisposalSearchIssueReturnBill("Pharmacy Disposal Search Issue Return Bill"),
@@ -551,6 +657,8 @@ public enum Privileges {
     PharmacyAdjustmentCreateBatch("Pharmacy Adjustment Create Batch"),
     PharmacyPhysicalCountApprove("Pharmacy Physical Count Approve"),
     PharmacyStockTakeApprove("Pharmacy Stock Take Approve"),
+    ArchiveOldStockHistory("Archive Old StockHistory Records"),
+    ArchiveOldItemBatch("Archive Old ItemBatch Records"),
     // Pharmacy Dealer Payments
     PharmacyDealerPaymentMenue("Pharmacy Dealer Payment Menu"),
     PharmacyDealerDueSearch("Pharmacy Dealer Due Search"),
@@ -590,7 +698,12 @@ public enum Privileges {
     AutoOrderPModel("Auto Order P Model"),
     AutoOrderQModal("Auto Order Q Model"),
     DirectPurchase("Direct Purchase"),
+    PharmacyDirectPurchaseSave("Pharmacy Direct Purchase Save"),
+    PharmacyDirectPurchaseFinalize("Pharmacy Direct Purchase Finalize"),
+    PharmacyDirectPurchaseApprove("Pharmacy Direct Purchase Approve"),
     PurchaseOrdersApprovel("Purchase Orders Approval"),
+    PurchaseOrderSave("Purchase Order Save"),
+    PurchaseOrderFinalize("Purchase Order Finalize"),
     TransferReciveApproval("Transfer Receive Approval"),
     GoodsRecipt("Goods Receipt"),
     ReturnReceviedGoods("Return Received Goods"),
@@ -609,6 +722,8 @@ public enum Privileges {
     PharmacyGrnSave("Pharmacy GRN Save"),
     PharmacyGrnFinalize("Pharmacy GRN Finalize"),
     PharmacyGrnApprove("Pharmacy GRN Approve"),
+    PharmacyGrnCancel("Pharmacy GRN Cancel"),
+    PharmacyGrnReturnCancel("Pharmacy GRN Return Cancel"),
     PharmacyItemSearch("Pharmacy Item Search"),
     PharmacyGenarateReports("Pharmacy Generate Reports"),
     PharmacySummaryViews("Pharmacy Summary Views"),
@@ -685,15 +800,33 @@ public enum Privileges {
     AdminStaff("Admin Staff"),
     AdminItems("Admin Items"),
     AdminPrices("Admin Prices"),
+    AdminPatientRelationships("Manage Patient Relationships"),
+    AdminInactivePatients("Manage Inactive Patients"),
+    MergePatients("Merge Patients"),
     ManageCreditCompany("Manage Credit Company"),
     AdminFilterWithoutDepartment("Admin Filter Without Department"),
     //</editor-fold>
     
     //<editor-fold defaultstate="collapsed" desc="Approval">
+    RequestManager("Request Manager"),
     BillCancelRequestApproval("Bill Cancel Request Approval"),
     ItemRefundRequestApproval("Item Refund Request Approval"),
     DrawerAdjustmentRequestApproval("Drawer Adjustment Request Approval"),
     DrawerAdjustmentDirect("Drawer Adjustment Direct (No Approval)"),
+    PettyCashCancellationApproval("Petty-Cash Cancellation Approval"),
+    PharmacyRetailSaleReturnApproval("Pharmacy Retail Sale Return Approval"),
+    //</editor-fold>
+
+    //<editor-fold defaultstate="collapsed" desc="Float Transfer">
+    IssueFundTransfer("Issue Float Transfer"),
+    ReceiveFundTransfer("Receive Float Transfer"),
+    DeclineFundTransfer("Decline Float Transfer"),
+    RequestFundTransfer("Request Float Transfer"),
+    ProcessFundTransferRequest("Process Float Transfer Request"),
+    CancelOwnFundTransfer("Cancel Own Float Transfer"),
+    CancelOthersFundTransfer("Cancel Others Float Transfer"),
+    ViewFundTransferReports("View Float Transfer Reports"),
+    ViewAllShiftShortageBills("View All Shift Shortage Bills"),
     //</editor-fold>
 
     //<editor-fold defaultstate="collapsed" desc="Developers">
@@ -708,48 +841,7 @@ public enum Privileges {
     BillCancel("Bill Cancel"),
     BillRefund("Bill Refund"), //</editor-fold>
     AiChat("AI Chat"),
-    // Inward
-    InwardFormTemplateAdmin("Inward Form Template Admin"),
-    InwardFormFill("Inward Form Fill"),
-    InwardDocumentUpload("Inward Document Upload"),
-    InpatientClinicalDischarge("Inpatient Clinical Discharge"),
-    // Pharmacy workflow
-    PharmacyDischargeMedicineIssue("Pharmacy Discharge Medicine Issue"),
-    PharmacyIssueForRequestSave("Pharmacy Issue For Request Save"),
-    PharmacyIssueForRequestFinalize("Pharmacy Issue For Request Finalize"),
-    PharmacyIssueForRequestApprove("Pharmacy Issue For Request Approve"),
-    PharmacyReceiveFinalize("Pharmacy Receive Finalize"),
-    PharmacyReceiveApprove("Pharmacy Receive Approve"),
-    PharmacyDisposalIssueFinalize("Pharmacy Disposal Issue Finalize"),
-    PharmacyDisposalIssueApprove("Pharmacy Disposal Issue Approve"),
-    PharmacyDirectPurchaseSave("Pharmacy Direct Purchase Save"),
-    PharmacyDirectPurchaseFinalize("Pharmacy Direct Purchase Finalize"),
-    PharmacyDirectPurchaseApprove("Pharmacy Direct Purchase Approve"),
-    ArchiveOldStockHistory("Archive Old StockHistory Records"),
-    ArchiveOldItemBatch("Archive Old ItemBatch Records"),
-    // Cashier / petty cash
-    PettyCashEditFinancialYear("Petty Cash Edit Financial Year"),
-    PettyCashCancellationApproval("Petty-Cash Cancellation Approval"),
-    CashierHandoverStatusReport("Cashier Handover Status Report"),
-    SettleHandoverProofMissing("Settle Handover Proof Missing"),
-    SettleNonCashPayments("Settle Non-Cash Payments"),
-    ViewAllShiftShortageBills("View All Shift Shortage Bills"),
-    // Clinical
-    ClinicalPatientBlacklist("Clinical Patient Blacklist"),
-    ClinicalPatientPseudonymise("Clinical Patient Pseudonymise"),
-    // Admin
-    AdminPatientRelationships("Manage Patient Relationships"),
-    AdminInactivePatients("Manage Inactive Patients"),
-    MergePatients("Merge Patients"),
-    // Fund transfer
-    RequestFundTransfer("Request Float Transfer"),
-    IssueFundTransfer("Issue Float Transfer"),
-    ReceiveFundTransfer("Receive Float Transfer"),
-    DeclineFundTransfer("Decline Float Transfer"),
-    ProcessFundTransferRequest("Process Float Transfer Request"),
-    CancelOwnFundTransfer("Cancel Own Float Transfer"),
-    CancelOthersFundTransfer("Cancel Others Float Transfer"),
-    ViewFundTransferReports("View Float Transfer Reports")
+    ClientPortalCreateAccount("Create Client Portal Account")
     ;
 
     private final String label;
@@ -909,8 +1001,14 @@ public enum Privileges {
             // Inpatient medication management
             case InpatientMedicationManagementMenue:
             case PharmacyDirectIssueToBht:
+            case PharmacyDischargeMedicineIssue:
             case PharmacyDirectIssueToTheaterCases:
             case PharmacyBhtIssueRequest:
+            case PharmacyBhtRequestForceComplete:
+            case PharmacyReturnFromWardForceComplete:
+            case InwardPharmacyReturnCancel:
+            case InwardPharmacyReturnSubmit:
+            case InwardPharmacyBhtReceive:
             case PharmacySearchInpatientDirectIssuesbyBill:
             case PharmacySearchInpatientDirectIssuesbyItem:
             case PharmacySearchInpatientDirectIssueReturnsbyBill:
@@ -921,7 +1019,12 @@ public enum Privileges {
             case AutoOrderPModel:
             case AutoOrderQModal:
             case DirectPurchase:
+            case PharmacyDirectPurchaseSave:
+            case PharmacyDirectPurchaseFinalize:
+            case PharmacyDirectPurchaseApprove:
             case PurchaseOrdersApprovel:
+            case PurchaseOrderSave:
+            case PurchaseOrderFinalize:
             case GoodsRecipt:
             case ReturnReceviedGoods:
             case CreateGrnReturn:
@@ -943,6 +1046,14 @@ public enum Privileges {
             case PharmacyDisbursementDirectIssue:
             case PharmacyDisbursementRecieve:
             case PharmacyDisbursementReports:
+            case PharmacyIssueForRequestSave:
+            case PharmacyIssueForRequestFinalize:
+            case PharmacyIssueForRequestApprove:
+            case PharmacyReceiveSave:
+            case PharmacyReceiveFinalize:
+            case PharmacyReceiveApprove:
+            case PharmacyTransferIssueCancel:
+            case PharmacyTransferReceiveCancel:
 
             // Retail Transactions
             case PharmacyRetailTransaction:
@@ -973,6 +1084,10 @@ public enum Privileges {
 
             // Disposal
             case PharmacyDisposalIssue:
+            case PharmacyDisposalIssueFinalize:
+            case PharmacyDisposalIssueApprove:
+            case PharmacyDisposalIssueCancel:
+            case PharmacyDiscardCategoryManage:
             case PharmacyDisposalSearchIssueBill:
             case PharmacyDisposalSearchIssueBillItems:
             case PharmacyDisposalSearchIssueReturnBill:
@@ -992,6 +1107,8 @@ public enum Privileges {
             case PharmacyAdjustmentCreateBatch:
             case PharmacyPhysicalCountApprove:
             case PharmacyStockTakeApprove:
+            case ArchiveOldStockHistory:
+            case ArchiveOldItemBatch:
 
             // Pharmacy Dealer Payments
             case PharmacyDealerDueSearch:
@@ -1007,10 +1124,48 @@ public enum Privileges {
             case PharmacyGrnSave:
             case PharmacyGrnFinalize:
             case PharmacyGrnApprove:
+            case PharmacyGrnCancel:
+            case PharmacyGrnReturnCancel:
             case PrintOriginalPoBillFromReprint:
-            case PrintOriginalGrnBillFromReprint:    
+            case PrintOriginalGrnBillFromReprint:
+            case PharmacyItemNameEdit:
 
                 return "Pharmacy";
+
+            case Store:
+            case StoreIssue:
+            case StoreIssueInwardBilling:
+            case StoreIssueSearchBill:
+            case StoreIssueBillItems:
+            case StorePurchase:
+            case StorePurchaseOrder:
+            case StorePurchaseOrderApprove:
+            case StorePurchaseOrderApproveSearch:
+            case StorePurchaseGRNRecive:
+            case StorePurchaseGRNReturn:
+            case StorePurchasePurchase:
+            case StoreTransfer:
+            case StoreTransferRequest:
+            case StoreTransferIssue:
+            case StoreTransferRecive:
+            case StoreTransferReport:
+            case StoreAdjustment:
+            case StoreAdjustmentDepartmentStock:
+            case StoreAdjustmentStaffStock:
+            case StoreAdjustmentPurchaseRate:
+            case StoreAdjustmentSaleRate:
+            case StoreDealorPayment:
+            case StoreDealorPaymentDueSearch:
+            case StoreDealorPaymentDueByAge:
+            case StoreDealorPaymentPayment:
+            case StoreDealorPaymentPaymentGRN:
+            case StoreDealorPaymentPaymentGRNSelect:
+            case StoreDealorPaymentGRNDoneSearch:
+            case StoreSearch:
+            case StoreReports:
+            case StoreSummery:
+            case StoreAdministration:
+                return "Store";
 
             case Clinic:
             case ClinicCalendar:
@@ -1038,16 +1193,45 @@ public enum Privileges {
                 return "Collecting Centre";
             
             // Approval Privileges
+            case RequestManager:
             case BillCancelRequestApproval:
             case ItemRefundRequestApproval:
             case DrawerAdjustmentRequestApproval:
             case DrawerAdjustmentDirect:
+            case PettyCashCancellationApproval:
+            case PharmacyRetailSaleReturnApproval:
                 return "Approval";
-            
+
+            case CashierHandoverStatusReport:
+            case SettleHandoverProofMissing:
+            case SettleNonCashPayments:
+                return "Finance";
+
+            case IssueFundTransfer:
+            case ReceiveFundTransfer:
+            case DeclineFundTransfer:
+            case RequestFundTransfer:
+            case ProcessFundTransferRequest:
+            case CancelOwnFundTransfer:
+            case CancelOthersFundTransfer:
+            case ViewFundTransferReports:
+            case ViewAllShiftShortageBills:
+                return "Float Transfer";
+
             case NursingWorkBench:
             case ShowDrugCharges:
+            case ShowServiceCharges:
+            case ShowTimeServiceCharges:
+            case NursingWorkBenchPanelEdit:
+            case NursingWorkBenchPanelClinicalData:
+            case NursingWorkBenchPanelRoomManagement:
+            case NursingWorkBenchPanelService:
+            case NursingWorkBenchPanelOperationTheatre:
+            case NursingWorkBenchPanelPharmaceuticals:
+            case NursingWorkBenchPanelReports:
+            case NursingWorkBenchPanelPayments:
                 return "Nursing Work Bench";
-                
+
             case WatingRoomAdmitPatient:
             case InwardAppointmentMenu:
             case AddInwardAppointment:
@@ -1056,10 +1240,67 @@ public enum Privileges {
             case InwardAppointmentCancel:
             case InpatientClinicalAssessment:
             case InpatientClinicalDischarge:
+            case InwardNursingDischarge:
+            case InwardPhysicalDischarge:
+            case InwardAddChargesAfterNursingDischarge:
+            case InwardHoldProfessionalPayments:
+            case InwardPayProfessionalFeesWhileOnHold:
+            case InwardDocumentUpload:
+            case InpatientLetter:
+            case InwardSendEmail:
+            case InwardPackageAdministration:
+            case InwardPackageAdmission:
             case InwardFormTemplateAdmin:
             case InwardFormFill:
-            case InwardDocumentUpload:
+            case InwardSettleFinalBill:
+            case InwardFinalBillCreateVersion:
+            case InwardFinalBillSetConfirmed:
+            case InwardFinalBillRetire:
+            case InwardFinalBillEmail:
+            case InwardSaveProvisionalFinalBill:
+            case InwardLaboratory:
+            case InwardLaboratoryBarcodeGeneration:
+            case InwardLaboratorySampleManagement:
+            case InwardLaboratoryReportSearch:
+            case TheatreSendPatient:
+            case TheatreAcceptPatient:
+            case TheatreReturnPatient:
+            case WardAcceptTheatreReturn:
+            case InwardServiceItemRequestApproval:
+            case InwardServiceItemRequestRejection:
+            case InpatientDashboardPanelAdmission:
+            case InpatientDashboardPanelBilling:
+            case InpatientDashboardPanelServices:
+            case InpatientDashboardPanelRoomManagement:
+            case InpatientDashboardPanelOperationTheatre:
+            case InpatientDashboardPanelClinicalData:
+            case InpatientDashboardPanelPharmaceuticals:
+            case InpatientDashboardPanelDocuments:
+            case InpatientDashboardPanelReports:
+            case InwardEditPatientDetailsFromAdmission:
+            case InwardEditPaymentDetails:
+            case InwardManageAllergies:
+            case InwardDoctorPaymentAccess:
+            case InwardMakeDepositAccess:
+            case InwardPostFinalPaymentAccess:
+            case InwardSurgeryAdd:
+            case InwardSurgeryManage:
+            case InwardSurgeryValidate:
+            case InwardSurgeryValidationRevert:
+            case InwardPatientHistoryView:
+            case InwardClinicalNotesView:
+            case InwardWardMedicationsView:
+            case InwardDischargeMedicationsView:
+            case InwardInvestigationsView:
+            case InwardImagesView:
+            case InwardDiagnosisCardView:
+            case InwardEventHistoryView:
+            case InwardPostDischargeReports:
                 return "Inward";
+
+            case AdminInactivePatients:
+            case MergePatients:
+                return "Admin";
 
             default:
                 return this.toString();

--- a/src/main/webapp/admin/users/user_privileges.xhtml
+++ b/src/main/webapp/admin/users/user_privileges.xhtml
@@ -108,7 +108,7 @@
                                 autocomplete="off">
                                 <p:ajax
                                     event="keyup"
-                                    process="@this"
+                                    process="@this tree"
                                     listener="#{userPrivilageController.filterPrivileges}"
                                     update="tree"
                                     oncomplete="PF('privTree').filter()" />

--- a/src/test/java/com/divudi/bean/opd/OpdBillControllerTest.java
+++ b/src/test/java/com/divudi/bean/opd/OpdBillControllerTest.java
@@ -1,0 +1,27 @@
+package com.divudi.bean.opd;
+
+import com.divudi.core.entity.BillItem;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OpdBillControllerTest {
+
+    @Test
+    void isPersistedBillItem_returnsFalse_whenNull() {
+        assertFalse(OpdBillController.isPersistedBillItem(null));
+    }
+
+    @Test
+    void isPersistedBillItem_returnsFalse_whenIdIsNull() {
+        assertFalse(OpdBillController.isPersistedBillItem(new BillItem()));
+    }
+
+    @Test
+    void isPersistedBillItem_returnsTrue_whenIdIsSet() {
+        BillItem bi = new BillItem();
+        bi.setId(1L);
+        assertTrue(OpdBillController.isPersistedBillItem(bi));
+    }
+}


### PR DESCRIPTION
## Summary

Combined hotfix bundle for the next `ruhunu-prod` downtime merge window, to minimize the number of separate merges (and conflict risk) during the limited downtime available. Originally two separate PRs (#22924 privileges sync, #22914 OPD billitem guard) with no file overlap — merged into one branch per request so there's a single merge to click during downtime instead of two.

---

### 1. Privileges enum + tree sync with `development`

`ruhunu-prod`'s `Privileges.java` had fallen far behind `development` (635 vs 723 enum constants). The `rh` (development) app and `rh-production` share the same MySQL database, so privileges saved from the `rh` app write enum names into `WEBUSERPRIVILEGE` that `ruhunu-prod`'s older enum doesn't recognize. EclipseLink throws `EnumConstantNotPresentException` deserializing those rows, which `AbstractFacade.findByJpql` silently swallows — returning an empty privilege list and hiding menu items after login for affected users/departments.

This is the same root cause as 523bfe33c7 ("fix(privileges): add 36 missing Privileges enum constants that broke General Stores login"), which patched 36 constants directly on `ruhunu-prod`. All 36 of those already exist in `development`'s superset, so this PR fully absorbs that hotfix rather than conflicting with it.

**Verification before taking files wholesale:**
- Confirmed `development`'s `Privileges.java` name-set is a strict superset of `ruhunu-prod`'s: all 635 existing constant names present, 88 additional, zero names unique to `ruhunu-prod`.
- Confirmed `UserPrivilageController.java` and `user_privileges.xhtml` have **no `ruhunu-prod`-only commits** since the branches diverged (only `Privileges.java` had one: 523bfe33c7, already covered above).
- Given no divergence to reconcile, all three files were taken wholesale from `development` (`git checkout origin/development -- <files>`) instead of hand-merged.

**Changes:**
- `src/main/java/com/divudi/core/data/Privileges.java` — full enum + `getCategory()` sync from development
- `src/main/java/com/divudi/bean/common/UserPrivilageController.java` — privilege-tree node wiring for the new privileges
- `src/main/webapp/admin/users/user_privileges.xhtml` — filter AJAX `process` list fix carried with the sync

### 2. OPD batch-bill settle: guard against silent BillItem persistence failure

Port of #22411 (merged to `development` 2026-07-25), originally opened as #22914.

At Ruhunu Hospital, an OPD batch-bill settle could produce a sub-bill with a correct `NETTOTAL` and a correct payment, but **zero `BillItem` rows** — because the sub-bill's total is computed from an in-memory list, independent of whether the item rows actually got persisted. This caused a Rs 2,420 gap between the Daily Return report and the All Cashier Summary report for 27.05.2026, RHD-OPD Matara. Root cause reported to Dushan Maduranga (Ruhunu Hospital) 2026-07-24; data backfilled 2026-08-13. This is the promised permanent safeguard.

Full investigation: #22399. Original fix: #22411.

**Changes (cherry-picked cleanly from `development`, `b2ff223c`/`e38db79e`):**
- `src/main/java/com/divudi/bean/opd/OpdBillController.java`: new `static boolean isPersistedBillItem(BillItem bi)` helper; guard added after each `saveBillItemForOpdBill`/`saveBillItem` call in all three settle-flow branches, plus an empty-matched-entries guard. `executeSettleBillActions()` now aborts if the delegate methods report failure. Partial `Bill`/`BillItem`s are retired when settlement aborts, instead of left orphaned.
- `src/test/java/com/divudi/bean/opd/OpdBillControllerTest.java` (new): unit tests for `isPersistedBillItem`.

Closes #22399

## Test plan

- `mvn clean compile` — clean build on this branch.
- `mvn test -Dtest=OpdBillControllerTest` — 3/3 pass.
- Recommend: after deploy, verify privilege tree renders in Admin → User Privileges and a previously-broken login (e.g. General Stores) shows full menu; spot-check an OPD batch-bill settle produces matching BillItem rows.