### PR TITLE
Add Claude-in-Chrome device identification guide and skill

### DIFF
--- a/.claude/skills/identify-chrome-devices/SKILL.md
+++ b/.claude/skills/identify-chrome-devices/SKILL.md
@@ -32,11 +32,18 @@ visibility into paired Claude-in-Chrome devices).
 
 ## Step 0 — Precondition check
 
-Confirm `list_connected_browsers`, `select_browser` (or `switch_browser`),
-and `javascript_tool` are actually available in this session (check the
-active tool list / deferred-tool search). If they aren't, this session
-isn't connected to the Claude-in-Chrome extension — tell the user this
-skill must be run from a session that has it connected, and stop here.
+Confirm `list_connected_browsers`, `select_browser`, and `javascript_tool`
+are actually available in this session (check the active tool list /
+deferred-tool search). If they aren't, this session isn't connected to the
+Claude-in-Chrome extension — tell the user this skill must be run from a
+session that has it connected, and stop here.
+
+Use `select_browser`, not `switch_browser`, throughout this skill:
+`select_browser(deviceId)` targets a known device directly.
+`switch_browser` is a different tool — it broadcasts a pairing prompt to
+*every* connected device and waits for the user to manually click
+"Connect", and does not accept a `deviceId` to target one device. It has
+no role in this automated loop.
 
 ## Step 1 — Load the existing mapping
 
@@ -52,18 +59,21 @@ anywhere inside the project repo.
 
 Call `list_connected_browsers`. For each returned `deviceId`, check it
 against the loaded map:
-- Known (already has a `name` entry) → skip, no need to re-prompt.
-- Unknown → add to the work list for Step 3.
+- Known (already has a `name` entry) → skip by default, no need to
+  re-prompt. **Exception**: if the user asked to re-verify a specific
+  device, or to re-verify everything (e.g. "re-check my devices"), include
+  already-known devices in the work list too — that's the only path that
+  reaches the `lastConfirmed` update in Step 3.
+- Unknown → always add to the work list for Step 3.
 
 If the work list is empty, report the existing mapping to the user (Step 5)
-and stop — nothing new to identify.
+and stop — nothing new to identify or re-verify.
 
 ## Step 3 — Identify each unknown device
 
-For each unknown `deviceId`, in turn:
+For each `deviceId` in the work list, in turn:
 
-1. Call `select_browser` (or `switch_browser`) with that `deviceId` to make
-   it the active device.
+1. Call `select_browser` with that `deviceId` to make it the active device.
 2. Open a tab and use `javascript_tool` to inject a full-viewport banner
    showing the raw `deviceId` as large, plain text on the page — nothing
    else needed on the page for this to work.
@@ -71,26 +81,35 @@ For each unknown `deviceId`, in turn:
    screen and confirm: is this the device they expect, and what name
    should it be given (e.g. "Home laptop", "Office desktop", "DC server 2")?
    Let them decline/skip a device if they don't recognize it right now.
-4. If the user provided a name, record an entry:
-   ```json
-   {
-     "deviceId": "<the deviceId>",
-     "name": "<user-supplied name>",
-     "osPlatform": "<from list_connected_browsers>",
-     "isLocal": <from list_connected_browsers>,
-     "firstIdentified": "<today's date>",
-     "lastConfirmed": "<today's date>"
-   }
-   ```
-   For a device that was already in the map and the user just re-confirmed
-   it, update `lastConfirmed` instead of creating a duplicate entry.
+4. If the user provided a name:
+   - **New device** (wasn't in the loaded map): add an entry:
+     ```json
+     {
+       "deviceId": "<the deviceId>",
+       "name": "<user-supplied name>",
+       "osPlatform": "<from list_connected_browsers>",
+       "isLocal": <from list_connected_browsers>,
+       "identifiedUnderAccount": "<current Claude account, e.g. email>",
+       "firstIdentified": "<today's date>",
+       "lastConfirmed": "<today's date>"
+     }
+     ```
+   - **Already-known device being re-verified**: update that entry's
+     `lastConfirmed` (and `name`, if the user gave a different one) in
+     place — never create a duplicate entry for a `deviceId` already in
+     the map.
 
 ## Step 4 — Persist the mapping
 
-Write the full updated `{"devices": [...]}` array back to the local file
-from Step 1, creating the parent directory first if it doesn't exist.
-Overwrite the whole file — the in-memory map from Step 1 plus this
-session's updates is always the full, current source of truth.
+Before writing, re-read the local file — if it changed since Step 1 (e.g.
+another session identified devices in the meantime), merge those entries
+into the in-memory map first rather than silently discarding them.
+
+Write the full updated `{"devices": [...]}` map as JSON to a temporary file
+in the same directory (creating the directory first if it doesn't exist),
+confirm it parses back as valid JSON, then rename it over the target file.
+This avoids leaving an unreadable half-written file if the write is
+interrupted.
 
 ## Step 5 — Summarize
 
@@ -104,5 +123,8 @@ above, outside the repo, and is never committed.
 `list_connected_browsers` only sees devices connected under the Claude
 account driving the current session. If the user has devices under more
 than one account, this skill needs to be run once per account — the same
-local mapping file accumulates entries across runs regardless of which
-account identified them.
+local mapping file accumulates entries across runs, with each entry's
+`identifiedUnderAccount` recording which account identified it. Anthropic's
+docs don't confirm `deviceId` is globally unique across accounts, so if the
+same `deviceId` shows up under two accounts with different names, flag it
+to the user rather than silently overwriting one with the other.

--- a/.claude/skills/identify-chrome-devices/SKILL.md
+++ b/.claude/skills/identify-chrome-devices/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: identify-chrome-devices
+description: >
+  Identify and name Chrome instances connected to the Claude-in-Chrome
+  extension under the current Claude account, and persist a stable
+  deviceId -> name mapping to a local file outside the repo. Use when the
+  user asks to "identify my chrome devices", "name my browsers", wants to
+  disambiguate list_connected_browsers output, or invokes
+  /identify-chrome-devices. Requires a session with the Claude-in-Chrome
+  extension actually connected — see
+  developer_docs/tools/claude-in-chrome-device-identification.md for
+  background and the policy on preferring Playwright for ordinary browser
+  automation.
+user-invocable: true
+---
+
+# Identify Chrome Devices
+
+Automates the manual workaround from
+[developer_docs/tools/claude-in-chrome-device-identification.md](../../../developer_docs/tools/claude-in-chrome-device-identification.md):
+loop through every `deviceId` the current Claude account can see, help the
+user confirm which physical device each one is, and record the result to a
+local mapping file — so this doesn't have to be done by hand in-chat every
+time a new device connects.
+
+**Before running this**: confirm the task genuinely needs Claude-in-Chrome.
+For ordinary browser automation/testing, use Playwright (`playwright-e2e`
+skill) instead — it's cheaper and more flexible. This skill exists only
+because identifying a user's *already-paired* physical devices is something
+Playwright cannot do (it launches its own separate browser, with no
+visibility into paired Claude-in-Chrome devices).
+
+## Step 0 — Precondition check
+
+Confirm `list_connected_browsers`, `select_browser` (or `switch_browser`),
+and `javascript_tool` are actually available in this session (check the
+active tool list / deferred-tool search). If they aren't, this session
+isn't connected to the Claude-in-Chrome extension — tell the user this
+skill must be run from a session that has it connected, and stop here.
+
+## Step 1 — Load the existing mapping
+
+Determine the local mapping file path for the current OS:
+- Windows: `C:\Credentials\claude-chrome-devices.json`
+- Linux/Mac: `~/.config/hmis/claude-chrome-devices.json`
+
+If it exists, read and parse it. If it doesn't exist yet, treat the map as
+empty — it will be created in Step 4. Never look for or write this file
+anywhere inside the project repo.
+
+## Step 2 — Enumerate connected devices
+
+Call `list_connected_browsers`. For each returned `deviceId`, check it
+against the loaded map:
+- Known (already has a `name` entry) → skip, no need to re-prompt.
+- Unknown → add to the work list for Step 3.
+
+If the work list is empty, report the existing mapping to the user (Step 5)
+and stop — nothing new to identify.
+
+## Step 3 — Identify each unknown device
+
+For each unknown `deviceId`, in turn:
+
+1. Call `select_browser` (or `switch_browser`) with that `deviceId` to make
+   it the active device.
+2. Open a tab and use `javascript_tool` to inject a full-viewport banner
+   showing the raw `deviceId` as large, plain text on the page — nothing
+   else needed on the page for this to work.
+3. Use `AskUserQuestion` to ask the user to physically check that device's
+   screen and confirm: is this the device they expect, and what name
+   should it be given (e.g. "Home laptop", "Office desktop", "DC server 2")?
+   Let them decline/skip a device if they don't recognize it right now.
+4. If the user provided a name, record an entry:
+   ```json
+   {
+     "deviceId": "<the deviceId>",
+     "name": "<user-supplied name>",
+     "osPlatform": "<from list_connected_browsers>",
+     "isLocal": <from list_connected_browsers>,
+     "firstIdentified": "<today's date>",
+     "lastConfirmed": "<today's date>"
+   }
+   ```
+   For a device that was already in the map and the user just re-confirmed
+   it, update `lastConfirmed` instead of creating a duplicate entry.
+
+## Step 4 — Persist the mapping
+
+Write the full updated `{"devices": [...]}` array back to the local file
+from Step 1, creating the parent directory first if it doesn't exist.
+Overwrite the whole file — the in-memory map from Step 1 plus this
+session's updates is always the full, current source of truth.
+
+## Step 5 — Summarize
+
+Print a `deviceId -> name` table for every device now in the mapping
+(known + newly identified this run) so the user has a single confirmation
+of the current state. Remind them the file lives at the OS-specific path
+above, outside the repo, and is never committed.
+
+## Note on multiple Claude accounts
+
+`list_connected_browsers` only sees devices connected under the Claude
+account driving the current session. If the user has devices under more
+than one account, this skill needs to be run once per account — the same
+local mapping file accumulates entries across runs regardless of which
+account identified them.

--- a/developer_docs/tools/claude-in-chrome-device-identification.md
+++ b/developer_docs/tools/claude-in-chrome-device-identification.md
@@ -1,0 +1,117 @@
+# Claude-in-Chrome: Identifying Connected Devices
+
+## Problem
+
+When multiple Chrome instances (laptops, desktops, remote servers) are
+connected to the Claude-in-Chrome extension under one Claude account,
+there's no reliable built-in way to tell them apart:
+
+- `list_connected_browsers` returns only generic placeholder names
+  ("Browser 1", "Browser 2", ...) for every connected device, and the
+  label/order is not stable across calls — the same physical device can
+  show up differently on a later call.
+- `switch_browser` broadcasts a pairing/confirmation prompt to *every*
+  connected extension and resolves on whichever device the user clicks
+  "Connect" on first, returning a user-supplied name at that point. That
+  name is **not** reflected back into subsequent `list_connected_browsers`
+  calls, which keep returning the same static generic list. The two tools
+  cannot currently be cross-referenced to build a stable `deviceId -> name`
+  map.
+- Neither tool alone gives enough signal (`deviceId` is an opaque GUID;
+  `osPlatform`/`isLocal` aren't enough) to let a user confidently say
+  "yes, that's my laptop."
+- `list_connected_browsers` is scoped to whichever Claude account is
+  currently driving the session — devices connected under a different
+  Claude account, on the same or a different machine, are invisible to it.
+  Anyone with multiple Claude accounts needs a separate identification
+  pass per account.
+
+See [issue #22925](https://github.com/hmislk/hmis/issues/22925).
+
+## Why this can't be fixed in this repo
+
+`list_connected_browsers` and `switch_browser` are implemented inside the
+Claude-in-Chrome browser extension itself, not in this codebase. Persisting
+a `switch_browser`-assigned name and surfacing it back through
+`list_connected_browsers` would require a change to that extension. If you
+want this pursued, file feedback with Anthropic directly (e.g. through the
+extension's own feedback channel) — it isn't something a change here can
+resolve.
+
+What *is* fixable from this repo is automating the manual disambiguation
+workaround below, and standardizing where the resulting map is stored. That
+is what the `identify-chrome-devices` skill does.
+
+## Policy: prefer Playwright
+
+For ordinary browser automation and UI testing (exercising HMIS pages,
+verifying a fix, taking screenshots), always default to **Playwright** —
+see the `playwright-e2e` skill. Playwright is cheaper on tokens, fully
+scriptable, and doesn't depend on any particular device being connected.
+
+Claude-in-Chrome tools (`list_connected_browsers`, `select_browser` /
+`switch_browser`, `javascript_tool` against a live tab) should only be used
+when the task specifically requires interacting with the user's own
+already-open, already-paired physical browser session. Device
+identification is that exception by nature: Playwright launches its own
+separate, throwaway browser instance — it has no visibility into, and
+cannot select among, a user's existing Claude-in-Chrome-paired devices.
+Outside of that kind of case, reach for Claude-in-Chrome only when the user
+explicitly asks for it.
+
+## Workflow
+
+Run the `identify-chrome-devices` skill (`.claude/skills/identify-chrome-devices/`)
+from a session that has the Claude-in-Chrome extension connected. It
+automates the loop that used to be done by hand:
+
+1. Load the existing local mapping file, if one exists, so already-named
+   devices aren't re-prompted.
+2. Call `list_connected_browsers` and diff against the known map to find
+   new/unidentified `deviceId`s.
+3. For each unidentified device:
+   a. `select_browser` (or `switch_browser`) to make it active.
+   b. Open a tab and inject a full-width banner via `javascript_tool`
+      showing the raw `deviceId` as plain text on the page.
+   c. Ask the user to physically check that screen and confirm which real
+      device it is and what name to give it.
+   d. Record `{deviceId, name, osPlatform, isLocal, firstIdentified,
+      lastConfirmed}` into the mapping.
+4. Write the updated mapping back to the local file (see below).
+5. Print a summary table of `deviceId -> name` to the user.
+
+Repeat the whole pass once per Claude account — `list_connected_browsers`
+only sees devices connected under the account driving the current session.
+
+## Storage format
+
+The resulting `deviceId -> name` map is written to a **single local JSON
+file outside this repository** — never commit it, and never paste real
+`deviceId`s, device names, or hostnames into any file inside this project
+(per CLAUDE.md's credentials rule). This mirrors the existing convention
+used for MySQL credentials in the `database-guide` skill.
+
+**Path:**
+- Windows: `C:\Credentials\claude-chrome-devices.json`
+- Linux/Mac: `~/.config/hmis/claude-chrome-devices.json`
+
+**Schema** (example uses placeholder values only):
+
+```json
+{
+  "devices": [
+    {
+      "deviceId": "abc-123-placeholder",
+      "name": "Example Laptop",
+      "osPlatform": "windows",
+      "isLocal": true,
+      "firstIdentified": "2026-08-13",
+      "lastConfirmed": "2026-08-13"
+    }
+  ]
+}
+```
+
+No Google Doc mirror or auto-memory pointer entry is required — the single
+file is the source of truth. If a developer wants a personal backup copy
+elsewhere, that's their own choice and stays outside the repo either way.

--- a/developer_docs/tools/claude-in-chrome-device-identification.md
+++ b/developer_docs/tools/claude-in-chrome-device-identification.md
@@ -49,8 +49,8 @@ verifying a fix, taking screenshots), always default to **Playwright** —
 see the `playwright-e2e` skill. Playwright is cheaper on tokens, fully
 scriptable, and doesn't depend on any particular device being connected.
 
-Claude-in-Chrome tools (`list_connected_browsers`, `select_browser` /
-`switch_browser`, `javascript_tool` against a live tab) should only be used
+Claude-in-Chrome tools (`list_connected_browsers`, `select_browser`,
+`javascript_tool` against a live tab) should only be used
 when the task specifically requires interacting with the user's own
 already-open, already-paired physical browser session. Device
 identification is that exception by nature: Playwright launches its own
@@ -75,15 +75,22 @@ automates the loop that used to be done by hand:
 2. Call `list_connected_browsers` and diff against the known map to find
    new/unidentified `deviceId`s.
 3. For each unidentified device:
-   a. `select_browser` (or `switch_browser`) to make it active.
+   a. `select_browser` to make it active — not `switch_browser`, which
+      broadcasts a pairing prompt to every connected device instead of
+      targeting one by `deviceId`.
    b. Open a tab and inject a full-width banner via `javascript_tool`
       showing the raw `deviceId` as plain text on the page.
    c. Ask the user to physically check that screen and confirm which real
       device it is and what name to give it.
-   d. Record `{deviceId, name, osPlatform, isLocal, firstIdentified,
-      lastConfirmed}` into the mapping.
-4. Write the updated mapping back to the local file (see below).
+   d. Record `{deviceId, name, osPlatform, isLocal, identifiedUnderAccount,
+      firstIdentified, lastConfirmed}` into the mapping.
+4. Write the updated mapping back to the local file via a temp file +
+   atomic rename (see below), re-reading first in case another run added
+   entries since step 1.
 5. Print a summary table of `deviceId -> name` to the user.
+
+Already-identified devices are skipped by default on later runs; the user
+can ask to re-verify a device (or all of them) to refresh `lastConfirmed`.
 
 Repeat the whole pass once per Claude account — `list_connected_browsers`
 only sees devices connected under the account driving the current session.
@@ -110,12 +117,21 @@ used for MySQL credentials in the `database-guide` skill.
       "name": "Example Laptop",
       "osPlatform": "windows",
       "isLocal": true,
+      "identifiedUnderAccount": "you@example.com",
       "firstIdentified": "2026-08-13",
       "lastConfirmed": "2026-08-13"
     }
   ]
 }
 ```
+
+`identifiedUnderAccount` records which Claude account was active when the
+device was identified. Anthropic's docs don't state whether `deviceId` is
+guaranteed globally unique across different Claude accounts (only that
+`list_connected_browsers` visibility is account-scoped) — if the same
+`deviceId` ever turns up under two accounts with different names, treat
+that as a signal to double-check before trusting the entry, rather than
+assuming it's a safe collision-free key.
 
 No Google Doc mirror or auto-memory pointer entry is required — the single
 file is the source of truth. If a developer wants a personal backup copy

--- a/developer_docs/tools/claude-in-chrome-device-identification.md
+++ b/developer_docs/tools/claude-in-chrome-device-identification.md
@@ -59,6 +59,11 @@ cannot select among, a user's existing Claude-in-Chrome-paired devices.
 Outside of that kind of case, reach for Claude-in-Chrome only when the user
 explicitly asks for it.
 
+For the full pros/cons comparison, safety notes (including why Claude in
+Chrome must never be pointed at real patient data), and how-to guidance for
+both tools, see
+[claude-in-chrome-vs-playwright.md](claude-in-chrome-vs-playwright.md).
+
 ## Workflow
 
 Run the `identify-chrome-devices` skill (`.claude/skills/identify-chrome-devices/`)

--- a/developer_docs/tools/claude-in-chrome-vs-playwright.md
+++ b/developer_docs/tools/claude-in-chrome-vs-playwright.md
@@ -1,0 +1,105 @@
+# Browser Automation: Playwright vs Claude in Chrome
+
+This project's default for browser automation and UI testing is **Playwright**
+(see the `playwright-e2e` skill and
+[`developer_docs/tools/playwright-mcp-guide.md`](playwright-mcp-guide.md) for
+setup and tool patterns). **Claude in Chrome** is a separate, narrower tool —
+this doc explains what it actually is, how it compares to Playwright, and the
+small set of cases where it's the right choice instead.
+
+## What each tool is
+
+- **Playwright (MCP)** — Claude Code drives a browser it launches itself
+  (Chromium, Firefox, or WebKit) through the Playwright API: navigate, click,
+  fill forms, read the accessibility tree, take screenshots. It's a clean,
+  disposable browser instance every time.
+- **Claude in Chrome** — a Chrome/Edge browser extension that lets Claude act
+  inside your **actual, already-open browser** — your real tabs, logins,
+  cookies, and session state — via `claude --chrome` or the VS Code
+  extension. See Anthropic's own docs:
+  [Use Claude Code with Chrome](https://code.claude.com/docs/en/chrome) and
+  [Use Claude in Chrome safely](https://support.claude.com/en/articles/12902428-use-claude-in-chrome-safely).
+
+## Pros and cons
+
+| | Playwright | Claude in Chrome |
+|---|---|---|
+| **Browser state** | Fresh, clean instance every run | Your real browser: existing logins, cookies, open tabs |
+| **Reproducibility** | Same result on repeat runs | Ephemeral — state changes as you use your browser day to day |
+| **CI/CD** | Runs in pipelines, on schedules, in parallel | Not usable in CI — needs a real, visible browser window with you present |
+| **Setup for logged-in flows** | Needs explicit auth (cookies/storage state, or a login step in the script) | Inherits whatever you're already signed into — no setup |
+| **Token/context cost** | Lower — structured DOM/accessibility-tree access (`browser_snapshot`) rather than raw screenshots | Higher — more screenshot- and page-content-heavy per step |
+| **Browser coverage** | Chromium, Firefox, WebKit | Chrome, Edge, and other Chromium-based browsers (Brave, Arc, Vivaldi, Opera) only |
+| **Cost** | Free, open source | Requires a paid Claude plan; not available via third-party providers (Bedrock, Vertex, Foundry) |
+| **Failure mode when blocked** | Script just fails/retries | Pauses and asks you to handle logins/CAPTCHAs manually |
+
+This lines up with independent comparisons too — Playwright MCP is generally
+described as faster and more reliable for scripted, repeatable automation via
+structured DOM access, while Claude in Chrome's value is being inside your
+real, authenticated session ("tasks you would do yourself, with your own eyes
+on it"). See sources at the bottom.
+
+## When to use which (in this project)
+
+**Default to Playwright** for anything that fits its model — which is nearly
+everything HMIS-related:
+- Testing a feature end-to-end (`playwright-e2e` skill) against local Payara
+  with local/test data.
+- Any repeatable verification you might want to run again, or that a
+  reviewer should be able to reproduce.
+- Anything that could plausibly run unattended or in CI later.
+
+**Reach for Claude in Chrome only when:**
+- The task genuinely needs your own already-open, already-authenticated
+  browser session and reproducing that login/state in Playwright isn't
+  practical (e.g. an SSO-gated internal tool, your personal Google Docs,
+  your Claude-in-Chrome device list itself).
+- The task is inherently about your real paired devices, like identifying
+  which physical machine a `deviceId` belongs to — see the
+  `identify-chrome-devices` skill and
+  [claude-in-chrome-device-identification.md](claude-in-chrome-device-identification.md).
+  Playwright cannot do this: it always launches its own separate browser, so
+  it has no visibility into your existing paired Claude-in-Chrome devices.
+- You explicitly ask for Claude in Chrome by name.
+
+### 🚨 Do not use Claude in Chrome on real patient data
+
+Per Anthropic's own guidance, **Claude in Chrome is unavailable for
+HIPAA-covered organizations and should not be used on pages containing
+regulated health data** — it screenshots the visible tab into the
+conversation and has no way to filter out sensitive content. HMIS pages
+routinely display real patient records. If Claude in Chrome is ever used
+against this application, it must only be pointed at local/test instances
+with synthetic data — never a production system or any page showing a real
+patient's information. Playwright, run against local/test data, is the safe
+default for exactly this reason.
+
+## How to use each
+
+**Playwright** — see the `playwright-e2e` skill for the project's standard
+workflow, and
+[`playwright-mcp-guide.md`](playwright-mcp-guide.md) for tool-by-tool
+patterns (snapshots vs screenshots, dropdowns, file upload, common errors).
+
+**Claude in Chrome** — from the CLI, `claude --chrome` (or enable it by
+default via `/chrome` → "Enabled by default"); it's available automatically
+in the VS Code extension once the extension is installed. Use `/chrome` at
+any time to check connection status, manage site permissions, reconnect, or
+pick which connected browser to use. A few practical points:
+- The extension asks permission per site — start with a restrictive
+  allowlist and only grant access to sites you actually need.
+- Prefer **Manually Approve** permission mode over the default
+  auto-approve when doing anything beyond trivial, read-only browsing.
+- Consider a separate Chrome profile with no sensitive-account logins for
+  any exploratory or first-time use.
+- In plan mode, read-only browser calls (reading the page, screenshots) run
+  without a prompt; state-changing calls (clicks, typing, navigation) still
+  ask for approval.
+
+## Sources
+
+- [Use Claude Code with Chrome — Claude Code Docs](https://code.claude.com/docs/en/chrome)
+- [Use Claude in Chrome safely — Claude Help Center](https://support.claude.com/en/articles/12902428-use-claude-in-chrome-safely)
+- [Chrome MCP vs Playwright MCP: Which to Use (2026) — test-lab.ai](https://www.test-lab.ai/blog/chrome-mcp-vs-playwright-mcp)
+- [Runtime Tools Compared: Playwright MCP, Chrome DevTools MCP, and Claude in Chrome — Steve Kinney](https://stevekinney.com/courses/self-testing-ai-agents/runtime-tools-compared)
+- [Playwright CLI vs agent-browser vs Claude in Chrome — AI browser automation token benchmark (2026) — ytyng.com](https://www.ytyng.com/en/blog/ai-browser-automation-tools-comparison-2026)


### PR DESCRIPTION
## Summary

Adds documentation and a new user-invocable skill to help developers identify and persistently map Chrome instances connected to the Claude-in-Chrome extension. This addresses the limitation that `list_connected_browsers` returns only generic placeholder names that cannot be reliably cross-referenced with user-supplied names from `switch_browser`.

## Changes

- **`developer_docs/tools/claude-in-chrome-device-identification.md`** — Comprehensive guide explaining:
  - The problem: generic browser names, unstable ordering, and account-scoped visibility
  - Why the root issue cannot be fixed in this repo (requires extension changes)
  - Policy to prefer Playwright for ordinary browser automation
  - The manual workaround workflow that the skill automates
  - Storage format and path for the persistent `deviceId → name` mapping (outside the repo, per credentials rule)

- **`.claude/skills/identify-chrome-devices/SKILL.md`** — User-invocable skill that automates the identification workflow:
  - Precondition check for Claude-in-Chrome tool availability
  - Load existing local mapping to avoid re-prompting known devices
  - Enumerate connected devices via `list_connected_browsers`
  - For each unknown device: activate it, inject a banner showing its `deviceId`, ask the user to confirm and name it
  - Persist the updated mapping to the local file
  - Summarize the current device map
  - Note on handling multiple Claude accounts

## Implementation Details

- The mapping file is stored **outside the repository** (Windows: `C:\Credentials\claude-chrome-devices.json`; Linux/Mac: `~/.config/hmis/claude-chrome-devices.json`) to comply with the credentials rule in CLAUDE.md — never committed, never containing real device names or hostnames in the repo.
- The skill is only invoked when the user explicitly asks to identify devices or when a task genuinely requires interacting with already-paired physical browser sessions (not for ordinary browser automation, which should use Playwright).
- The mapping includes `deviceId`, `name`, `osPlatform`, `isLocal`, `firstIdentified`, and `lastConfirmed` to support stable device identification across sessions and accounts.

Relates to [issue #22925](https://github.com/hmislk/hmis/issues/22925).

https://claude.ai/code/session_01APKXa1M4eMSMna9NCLSNix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a workflow for identifying and naming multiple connected Chrome devices.
  * Device names and metadata can be saved locally for future reference.
  * Displays the current device-to-name mapping after identification.

* **Documentation**
  * Added guidance on Chrome device identification, account behavior, tool limitations, and when to use Playwright.
  * Documented Playwright as the default for repeatable automation and Chrome interaction guidance for authenticated browser sessions.
  * Added privacy and permission guidance, including restrictions on real patient data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->