### PR TITLE
fix(inward): stop Admit Room 500 error and dead Continue action

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -1730,6 +1730,49 @@ silently returns "No results found" with no error — this looks like a missing 
 an empty/mistyped query. Confirmed working seed name: "Appendicectomy". Verified while testing
 issue #20891.
 
+## 66. An earlier `p:ajax` event mutating the field a later button's enclosing `rendered` depends on silently skips that button's action — canary-test with a `throw` to prove it
+
+On `inward/admit_room.xhtml`, a `p:autoComplete`'s `itemSelect` ajax handler bound directly to
+`roomChangeController.current` set that field as soon as a patient was selected — *before* the
+"Continue" `p:commandButton` (bound to `roomChangeController.selectRoomForAdmit()`, `ajax="false"`)
+was ever clicked. The Continue button lived inside a panel gated
+`rendered="#{roomChangeController.current eq null}"`. By the time the Continue postback started,
+`current` was already non-null (set by that earlier ajax request, persisted in the
+`@SessionScoped` bean) — so JSF evaluated the *whole panel*, including the Continue button, as not
+rendered for this request and silently skipped decoding/invoking its action. The button's own
+network POST still looked completely normal (correct hidden field values, correct button
+parameter) — nothing in the request/response cycle hinted the action never ran.
+
+**How this was proven, not just suspected**: added `if (true) { throw new RuntimeException("canary"); }`
+as the literal first line of the suspected action method, rebuilt, redeployed, and repeated the
+click. No exception, no 500, no log line — page rendered its normal "success" output. That's the
+tell: if the action method actually executed, a first-line unconditional throw is unmissable
+(crashes the page). Silence under that canary means the method body never ran at all — reach for
+this test before trusting any subtler theory (stale ViewState, lazy-loading timing, EL caching)
+about a command button that "looks like" it does nothing.
+
+**Fix pattern**: don't bind the ajax-updated input directly to the field that gates the
+surrounding panel's `rendered`. Introduce a separate staging field (e.g. `selectedAdmission`) for
+the autocomplete's `value` and for anything displayed *before* the confirm button is clicked; only
+assign it into the gating field (`current`) inside the confirm button's own action method. That
+keeps the panel's `rendered` condition — and therefore whether the button inside it gets
+decoded/invoked at all — stable for the entire lifecycle of that button's own request. Verified
+against a real waiting-room patient (DB `ROOMADMITTED` flipped 0→1 after "Assign Room") while
+fixing issue #22911.
+
+Two other Payara/asadmin quirks hit while chasing this on the carecode dev machine, worth knowing
+before you spend time debugging "missing" log output:
+- **`java.util.logging` calls (even `.severe(...)`) can silently not reach `server.log`** despite
+  `logging.properties` listing `GFFileHandler` with `logStandardStreams=true` — don't trust
+  "no log line appeared" as proof a code path didn't run; use the canary-throw test above instead,
+  since an uncaught exception during `INVOKE_APPLICATION` reliably surfaces as a rendered error
+  page regardless of the logging pipeline's state.
+- **A `redeploy` that exceeds the foreward-call timeout can leave the domain's DAS memory-bloated
+  and totally unresponsive** (`curl` to the app hangs/times out, `asadmin` commands against the
+  same domain also hang) — matches the existing "Local DAS stalls when memory-bloated" pattern.
+  Recovery: `kill -9` the stuck DAS `java` process (find via `ps aux | grep domains/<name>`),
+  `asadmin start-domain <name>`, then a plain `deploy` (not `redeploy`).
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.

--- a/src/main/java/com/divudi/bean/inward/RoomChangeController.java
+++ b/src/main/java/com/divudi/bean/inward/RoomChangeController.java
@@ -91,6 +91,19 @@ public class RoomChangeController implements Serializable {
     private PatientRoom roomForReceipt;
     List<Admission> selectedItems;
     private Admission current;
+    /**
+     * Staging field for the Admit Room "Patient Selection" step
+     * (admit_room.xhtml). The autocomplete there binds to this field, not
+     * {@link #current} directly, so that selecting a patient does not flip
+     * {@code current} — and therefore does not flip the {@code rendered}
+     * condition on the surrounding panel — mid-lifecycle. If it bound to
+     * {@code current} directly, an earlier ajax event (itemSelect) would
+     * already leave {@code current} non-null by the time the "Continue"
+     * button's own full postback runs, so JSF would evaluate the panel
+     * (and the Continue button inside it) as not rendered for that
+     * request and silently skip invoking its action. See #22911.
+     */
+    private Admission selectedAdmission;
     private List<Admission> items = null;
     private Institution institution;
     private List<Patient> patientList;
@@ -209,18 +222,19 @@ public class RoomChangeController implements Serializable {
 
     public String navigateToAdmitRoomFromMenu() {
         setCurrent(null);
+        setSelectedAdmission(null);
         setCurrentPatientRoom(null);
         institution = sessionController.getInstitution();
         return "/inward/admit_room?faces-redirect=true";
     }
 
     public void selectRoomForAdmit() {
-        if (current == null) {
+        if (selectedAdmission == null) {
             JsfUtil.addErrorMessage("No Patient Room Detected");
             return;
         }
+        current = selectedAdmission;
         if (current.getCurrentPatientRoom() == null) {
-            JsfUtil.addErrorMessage("No Patient Room Detected");
             return;
         }
         setCurrentPatientRoom(current.getCurrentPatientRoom());
@@ -486,6 +500,7 @@ public class RoomChangeController implements Serializable {
         patientRoom = null;
         selectedItems = null;
         current = null;
+        selectedAdmission = null;
         items = null;
         patientList = null;
         changeAt = null;
@@ -737,6 +752,14 @@ public class RoomChangeController implements Serializable {
 
     public void setCurrent(Admission current) {
         this.current = current;
+    }
+
+    public Admission getSelectedAdmission() {
+        return selectedAdmission;
+    }
+
+    public void setSelectedAdmission(Admission selectedAdmission) {
+        this.selectedAdmission = selectedAdmission;
     }
 
     public void createPatientRoom() {

--- a/src/main/webapp/inward/admit_room.xhtml
+++ b/src/main/webapp/inward/admit_room.xhtml
@@ -83,7 +83,7 @@
                                                 widgetVar="aPtAdmit"
                                                 id="acPtAdmit"
                                                 forceSelection="true"
-                                                value="#{roomChangeController.current}"
+                                                value="#{roomChangeController.selectedAdmission}"
                                                 completeMethod="#{roomChangeController.completePatientFromWaitingRoomByInstitution}"
                                                 var="myItem"
                                                 itemLabel="#{myItem.bhtNo}"
@@ -133,7 +133,7 @@
                                     </div>
 
                                     <h:panelGroup id="pnlPatientPreviewAdmit">
-                                        <h:panelGroup rendered="#{roomChangeController.current ne null}" layout="block">
+                                        <h:panelGroup rendered="#{roomChangeController.selectedAdmission ne null}" layout="block">
                                             <div class="card border-primary mt-3 mb-3">
                                                 <div class="card-header bg-primary text-white py-2">
                                                     <div class="d-flex align-items-center">
@@ -145,29 +145,29 @@
                                                     <div class="row">
                                                         <div class="col-md-3 mb-2">
                                                             <small class="text-muted d-block">Patient Name</small>
-                                                            <strong>#{roomChangeController.current.patient.person.nameWithTitle}</strong>
+                                                            <strong>#{roomChangeController.selectedAdmission.patient.person.nameWithTitle}</strong>
                                                         </div>
                                                         <div class="col-md-2 mb-2">
                                                             <small class="text-muted d-block">BHT No</small>
-                                                            <strong class="text-primary">#{roomChangeController.current.bhtNo}</strong>
+                                                            <strong class="text-primary">#{roomChangeController.selectedAdmission.bhtNo}</strong>
                                                         </div>
                                                         <div class="col-md-2 mb-2">
                                                             <small class="text-muted d-block">PHN</small>
-                                                            <strong>#{roomChangeController.current.patient.phn}</strong>
+                                                            <strong>#{roomChangeController.selectedAdmission.patient.phn}</strong>
                                                         </div>
                                                         <div class="col-md-2 mb-2">
                                                             <small class="text-muted d-block">Room</small>
-                                                            <h:panelGroup rendered="#{roomChangeController.current.currentPatientRoom ne null}">
-                                                                <strong>#{roomChangeController.current.currentPatientRoom.roomFacilityCharge.name}</strong>
+                                                            <h:panelGroup rendered="#{roomChangeController.selectedAdmission.currentPatientRoom ne null}">
+                                                                <strong>#{roomChangeController.selectedAdmission.currentPatientRoom.roomFacilityCharge.name}</strong>
                                                             </h:panelGroup>
-                                                            <h:panelGroup rendered="#{roomChangeController.current.currentPatientRoom eq null}">
+                                                            <h:panelGroup rendered="#{roomChangeController.selectedAdmission.currentPatientRoom eq null}">
                                                                 <span class="text-muted">Not assigned</span>
                                                             </h:panelGroup>
                                                         </div>
                                                         <div class="col-md-3 mb-2">
                                                             <small class="text-muted d-block">Status</small>
-                                                            <p:badge value="Discharged" styleClass="ui-badge-danger" rendered="#{roomChangeController.current.discharged}" />
-                                                            <p:badge value="Active" styleClass="ui-badge-success" rendered="#{!roomChangeController.current.discharged}" />
+                                                            <p:badge value="Discharged" styleClass="ui-badge-danger" rendered="#{roomChangeController.selectedAdmission.discharged}" />
+                                                            <p:badge value="Active" styleClass="ui-badge-success" rendered="#{!roomChangeController.selectedAdmission.discharged}" />
                                                         </div>
                                                     </div>
                                                 </div>
@@ -288,48 +288,61 @@
                                         <h:outputText styleClass="fas fa-door-open" />
                                         <h:outputLabel value="Assign Room" class="mx-4"></h:outputLabel>
                                     </f:facet>
-                                    <div class="d-grid gap-3">
-                                        <div class="row">
-                                            <div class="col-2">Room</div>
-                                            <div class="col-7">
-                                                <h:outputLabel value="#{roomChangeController.current.currentPatientRoom.roomFacilityCharge.name}"  />
+                                    <h:panelGroup rendered="#{roomChangeController.currentPatientRoom ne null}" layout="block">
+                                        <div class="d-grid gap-3">
+                                            <div class="row">
+                                                <div class="col-2">Room</div>
+                                                <div class="col-7">
+                                                    <h:outputLabel value="#{roomChangeController.currentPatientRoom.roomFacilityCharge.name}"  />
+                                                </div>
+                                            </div>
+
+                                            <div class="row">
+                                                <div class="col-2">Admitted At</div>
+                                                <div class="col-7">
+                                                    <p:calendar
+                                                        navigator="true"
+                                                        value="#{roomChangeController.currentPatientRoom.admittedAt}"
+                                                        pattern="dd MMM yyyy HH:mm:ss"
+
+                                                        class="w-100" >
+                                                    </p:calendar>
+
+                                                    <p:commandButton
+                                                        class="ui-button-warning mx-1"
+                                                        ajax="false"
+                                                        icon="fa fa-clock"
+                                                        title="Assign Current Time"
+                                                        action="#{roomChangeController.getCurrentTime()}">
+                                                    </p:commandButton>
+
+                                                </div>
+                                            </div>
+                                            <div class="row">
+                                                <div class="col-2"></div>
+                                                <div class="col-4">
+                                                    <p:commandButton
+                                                        class="ui-button-info"
+                                                        ajax="false"
+                                                        icon="fas fa-edit"
+                                                        value="Assign Room"
+                                                        action="#{roomChangeController.admitRoom()}">
+                                                    </p:commandButton>
+                                                </div>
                                             </div>
                                         </div>
-
-                                        <div class="row">
-                                            <div class="col-2">Admitted At</div>
-                                            <div class="col-7">
-                                                <p:calendar 
-                                                    navigator="true"
-                                                    value="#{roomChangeController.currentPatientRoom.admittedAt}" 
-                                                    pattern="dd MMM yyyy HH:mm:ss" 
-
-                                                    class="w-100" > 
-                                                </p:calendar>
-
-                                                <p:commandButton 
-                                                    class="ui-button-warning mx-1" 
-                                                    ajax="false" 
-                                                    icon="fa fa-clock" 
-                                                    title="Assign Current Time" 
-                                                    action="#{roomChangeController.getCurrentTime()}">
-                                                </p:commandButton>
-
-                                            </div>
+                                    </h:panelGroup>
+                                    <h:panelGroup rendered="#{roomChangeController.currentPatientRoom eq null}" layout="block">
+                                        <div class="alert alert-info d-flex align-items-center">
+                                            <i class="fa-solid fa-circle-info me-2"></i>
+                                            <h:panelGroup rendered="#{roomChangeController.current.parentEncounter ne null}">
+                                                This is a baby admission. Babies share the mother's room, so no separate room needs to be assigned here.
+                                            </h:panelGroup>
+                                            <h:panelGroup rendered="#{roomChangeController.current.parentEncounter eq null}">
+                                                No room is currently assigned to this patient yet.
+                                            </h:panelGroup>
                                         </div>
-                                        <div class="row">
-                                            <div class="col-2"></div>
-                                            <div class="col-4">
-                                                <p:commandButton 
-                                                    class="ui-button-info" 
-                                                    ajax="false" 
-                                                    icon="fas fa-edit"  
-                                                    value="Assign Room"  
-                                                    action="#{roomChangeController.admitRoom()}">
-                                                </p:commandButton>
-                                            </div>
-                                        </div>
-                                    </div>
+                                    </h:panelGroup>
                                 </p:panel>
                             </div>
                         </div>


### PR DESCRIPTION
## Summary

Fixes #22911 — the Admit Room page (`inward/admit_room.xhtml`) threw a `PropertyNotFoundException` 500 error when a baby admission (no `PatientRoom` yet, by design — babies share the mother's room) was selected and "Continue" clicked.

### Root cause 1 (the reported crash)
`RoomChangeController.selectRoomForAdmit()` bailed out with a growl message when `current.getCurrentPatientRoom() == null`, but left `current` set — so the "Admit to Room" panel rendered anyway. Its calendar was bound to `roomChangeController.currentPatientRoom.admittedAt`, and reading a property off the still-null `currentPatientRoom` during render threw the exception.

### Root cause 2 (found during regression testing, also fixed here)
While verifying the fix against a *real* waiting-room patient who already has a `PatientRoom`, found that the "Continue" button's action never fires **for any patient**. The button lives inside a panel gated `rendered="#{roomChangeController.current eq null}"`, but `current` is already set to non-null by the search autocomplete's earlier `itemSelect` ajax event — so by the time the Continue postback reaches the server, JSF evaluates that whole panel (including the button) as "not rendered" and silently skips invoking its action. Confirmed with a canary `throw` placed as the first line of the method (rebuilt/redeployed — the exception never fired).

## Fix

1. **`RoomChangeController.java`**: `selectRoomForAdmit()` no longer emits a growl for the "no room yet" case (replaced by an inline message in the XHTML — see below). Introduced a `selectedAdmission` staging field that the autocomplete's `value` binds to instead of `current`; `current` is now only assigned inside `selectRoomForAdmit()` itself, so the panel's `rendered` condition stays stable for the Continue button's own request lifecycle.
2. **`admit_room.xhtml`**: room-assignment fields (room name, "Admitted At" calendar, action buttons) are now guarded on `currentPatientRoom ne null`; a sibling panel shows an informational message when null — baby-specific wording when `current.parentEncounter ne null` ("Babies share the mother's room..."), generic wording otherwise. The "Patient Selection" step's fields (autocomplete, preview card) now bind to the new `selectedAdmission` staging field.
3. Documented the underlying JSF gotcha (ajax mutating a field that gates a later button's `rendered`, plus the canary-throw debugging technique) in `developer_docs/testing/playwright-e2e-workflow.md` §66.

## Verification (local Payara, `carecode` dev machine)

- **Baby admission with no room** (BHT/56752 — same pattern as the original report): Admit Room page now loads cleanly, showing "This is a baby admission. Babies share the mother's room, so no separate room needs to be assigned here." instead of a 500.
- **Real waiting-room patient with an existing unadmitted `PatientRoom`** (OPDCARD/42965): full Continue → Assign Room flow now works end-to-end — room name, "Admitted At" calendar, and buttons render correctly; clicking "Assign Room" succeeded ("Room admitted successfully") and the DB confirms `Admission.ROOMADMITTED` flipped `0 → 1` with `PatientRoom.admittedAt` correctly persisted.

Screenshot + full verification notes posted on the issue: https://github.com/hmislk/hmis/issues/22911#issuecomment-5279408483

🤖 Generated with [Claude Code](https://claude.com/claude-code)