### PR TITLE
fix(cashier): extend shift-end override to bypass all pending handover/float-transfer guards

### DIFF
--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -3811,20 +3811,30 @@ public class FinancialTransactionController implements Serializable {
             return null; // Early exit if no shift to end
         }
 
-        // Guard: outgoing pending floats — block until recipient accepts or sender cancels
-        if (hasAtLeastOneFundTransferBillToReceive(sessionController.getLoggedUser(), null, null, null)) {
+        // Read once — bypasses every pending-handover / pending-float-transfer guard below
+        // when a hospital does not practice handover/float-transfer acceptance systematically (#22931).
+        boolean allowShiftEndWithoutHandoverAcceptance = configOptionApplicationController
+                .getBooleanValueByKey("Allow Shift End Without Handover Acceptance", false);
+
+        // Guard: outgoing pending floats — bypassed when 'Allow Shift End Without Handover Acceptance' is true
+        if (!allowShiftEndWithoutHandoverAcceptance
+                && hasAtLeastOneFundTransferBillToReceive(sessionController.getLoggedUser(), null, null, null)) {
             JsfUtil.addErrorMessage("You have pending float transfers not yet accepted. Please cancel them or wait for the recipient to accept before closing your shift.");
             return null;
         }
 
-        // Guard: incoming pending floats — block until this user accepts or declines
-        if (hasAtLeastOneFundTransferBillToReceive(null, null, sessionController.getLoggedUser(), null)) {
+        // Guard: incoming pending floats — bypassed when 'Allow Shift End Without Handover Acceptance' is true
+        if (!allowShiftEndWithoutHandoverAcceptance
+                && hasAtLeastOneFundTransferBillToReceive(null, null, sessionController.getLoggedUser(), null)) {
             JsfUtil.addErrorMessage("You have incoming float transfers awaiting your response. Please accept or decline them before closing your shift.");
             return null;
         }
 
-        boolean allowShiftEndWithoutHandoverAcceptance = configOptionApplicationController
-                .getBooleanValueByKey("Allow Shift End Without Handover Acceptance", false);
+        if (allowShiftEndWithoutHandoverAcceptance
+                && (hasAtLeastOneFundTransferBillToReceive(sessionController.getLoggedUser(), null, null, null)
+                || hasAtLeastOneFundTransferBillToReceive(null, null, sessionController.getLoggedUser(), null))) {
+            JsfUtil.addInfoMessage("Warning: You are ending your shift while a float transfer is still pending.");
+        }
 
         // Guard: outgoing pending handover — bypassed when 'Allow Shift End Without Handover Acceptance' is true
         if (!allowShiftEndWithoutHandoverAcceptance
@@ -3848,8 +3858,10 @@ public class FinancialTransactionController implements Serializable {
         // Validate pending transactions before allowing shift end
         fillFundTransferBillsForMeToReceive();
 
-        // Check for pending fund transfers that must be collected first
-        if (fundTransferBillsToReceive != null && !fundTransferBillsToReceive.isEmpty()) {
+        // Check for pending fund transfers that must be collected first — bypassed when
+        // 'Allow Shift End Without Handover Acceptance' is true (#22931)
+        if (!allowShiftEndWithoutHandoverAcceptance
+                && fundTransferBillsToReceive != null && !fundTransferBillsToReceive.isEmpty()) {
             JsfUtil.addErrorMessage("Please collect funds transferred to you before closing.");
             return null;
         }
@@ -3864,7 +3876,7 @@ public class FinancialTransactionController implements Serializable {
         boolean mustWaitUntilOtherUserAcceptsAllHandoversBeforeClosingShift = configOptionApplicationController
                 .getBooleanValueByKey("Must Wait Until Other User Accepts All Handovers Before Closing Shift", false);
 
-        if (mustReceiveAllFundTransfersBeforeClosingShift) {
+        if (!allowShiftEndWithoutHandoverAcceptance && mustReceiveAllFundTransfersBeforeClosingShift) {
             boolean haveFundTransfersForMeToReceive = hasAtLeastOneFundTransferBillToReceive(null, null, sessionController.getLoggedUser(), null);
             if (haveFundTransfersForMeToReceive) {
                 JsfUtil.addErrorMessage("There are Fund Transfers for you to receive. Please accept them before closing the shift.");
@@ -3872,7 +3884,7 @@ public class FinancialTransactionController implements Serializable {
             }
         }
 
-        if (mustWaitUntilOtherUserAcceptsAllFundTransfersBeforeClosingShift) {
+        if (!allowShiftEndWithoutHandoverAcceptance && mustWaitUntilOtherUserAcceptsAllFundTransfersBeforeClosingShift) {
             boolean haveFundTransfersToBeReceived = hasAtLeastOneFundTransferBillToReceive(sessionController.getLoggedUser(), null, null, null);
             if (haveFundTransfersToBeReceived) {
                 JsfUtil.addErrorMessage("There are Fund Transfers you have created yet to be received by another user. Please ask the other user to accept them. Until they accept your fund transfers, you can not close your shift.");
@@ -3880,7 +3892,7 @@ public class FinancialTransactionController implements Serializable {
             }
         }
 
-        if (mustReceiveAllHandoversBeforeClosingShift) {
+        if (!allowShiftEndWithoutHandoverAcceptance && mustReceiveAllHandoversBeforeClosingShift) {
             boolean haveHandoversForMeToReceive = hasAtLeastOneHandoverBillToReceive(null, null, sessionController.getLoggedUser(), null);
             if (haveHandoversForMeToReceive) {
                 JsfUtil.addErrorMessage("There are Handovers for you to receive. Please accept them before closing the shift.");
@@ -3888,7 +3900,7 @@ public class FinancialTransactionController implements Serializable {
             }
         }
 
-        if (mustWaitUntilOtherUserAcceptsAllHandoversBeforeClosingShift) {
+        if (!allowShiftEndWithoutHandoverAcceptance && mustWaitUntilOtherUserAcceptsAllHandoversBeforeClosingShift) {
             boolean haveHandoversToBeReceived = hasAtLeastOneHandoverBillToReceive(sessionController.getLoggedUser(), null, null, null);
             if (haveHandoversToBeReceived) {
                 JsfUtil.addErrorMessage("There are Handovers you have created yet to be received by another user. Please ask the other user to accept them. Until they accept your handovers, you can not close your shift.");
@@ -5844,17 +5856,22 @@ public class FinancialTransactionController implements Serializable {
         mustWaitUntilOtherUserAcceptsAllHandoversBeforeClosingShift = configOptionApplicationController
                 .getBooleanValueByKey("Must Wait Until Other User Accepts All Handovers Before Closing Shift", false);
 
+        // Read once — bypasses every pending-handover / pending-float-transfer guard below
+        // when a hospital does not practice handover/float-transfer acceptance systematically (#22931).
+        boolean allowShiftEndWithoutHandoverAcceptance = configOptionApplicationController
+                .getBooleanValueByKey("Allow Shift End Without Handover Acceptance", false);
+
         if (fundTransferBillsToReceive != null && !fundTransferBillsToReceive.isEmpty()) {
             fundTransferBillTocollect = true;
         }
 
         if (fundTransferBillTocollect) {
-            JsfUtil.addErrorMessage("Please collect funds transferred to you before closing.");
-            return "";
+            if (!allowShiftEndWithoutHandoverAcceptance) {
+                JsfUtil.addErrorMessage("Please collect funds transferred to you before closing.");
+                return "";
+            }
+            JsfUtil.addInfoMessage("Warning: You are ending your shift while a float transfer is still pending collection.");
         }
-
-        boolean allowShiftEndWithoutHandoverAcceptance = configOptionApplicationController
-                .getBooleanValueByKey("Allow Shift End Without Handover Acceptance", false);
 
         // Guard: outgoing pending handover — bypassed when 'Allow Shift End Without Handover Acceptance' is true (#19963)
         if (!allowShiftEndWithoutHandoverAcceptance
@@ -5875,7 +5892,7 @@ public class FinancialTransactionController implements Serializable {
             JsfUtil.addInfoMessage("Warning: You are ending your shift while a handover is still pending acceptance by the recipient.");
         }
 
-        if (mustReceiveAllFundTransfersBeforeClosingShift) {
+        if (!allowShiftEndWithoutHandoverAcceptance && mustReceiveAllFundTransfersBeforeClosingShift) {
             boolean haveFundTransfersForMeToReceive = hasAtLeastOneFundTransferBillToReceive(null, null, sessionController.getLoggedUser(), null);
             if (haveFundTransfersForMeToReceive) {
                 JsfUtil.addErrorMessage("There are Fund Transfers for you to receive. Please accept them before closing the shift.");
@@ -5883,7 +5900,7 @@ public class FinancialTransactionController implements Serializable {
             }
         }
 
-        if (mustWaitUntilOtherUserAcceptsAllFundTransfersBeforeClosingShift) {
+        if (!allowShiftEndWithoutHandoverAcceptance && mustWaitUntilOtherUserAcceptsAllFundTransfersBeforeClosingShift) {
             boolean haveFundTransfersToBeReceived = hasAtLeastOneFundTransferBillToReceive(sessionController.getLoggedUser(), null, null, null);
             if (haveFundTransfersToBeReceived) {
                 JsfUtil.addErrorMessage("There are Fund Transfers you have created yet to be received by another user. Please ask the other user to accept them. Until they accept your fund transfers, you can not close your shift.");
@@ -5891,7 +5908,7 @@ public class FinancialTransactionController implements Serializable {
             }
         }
 
-        if (mustReceiveAllHandoversBeforeClosingShift) {
+        if (!allowShiftEndWithoutHandoverAcceptance && mustReceiveAllHandoversBeforeClosingShift) {
             boolean haveHandoversForMeToReceive = hasAtLeastOneHandoverBillToReceive(null, null, sessionController.getLoggedUser(), null);
             if (haveHandoversForMeToReceive) {
                 JsfUtil.addErrorMessage("There are Handovers for you to receive. Please accept them before closing the shift.");
@@ -5899,7 +5916,7 @@ public class FinancialTransactionController implements Serializable {
             }
         }
 
-        if (mustWaitUntilOtherUserAcceptsAllHandoversBeforeClosingShift) {
+        if (!allowShiftEndWithoutHandoverAcceptance && mustWaitUntilOtherUserAcceptsAllHandoversBeforeClosingShift) {
             boolean haveHandoversToBeReceived = hasAtLeastOneHandoverBillToReceive(sessionController.getLoggedUser(), null, null, null);
             if (haveHandoversToBeReceived) {
                 JsfUtil.addErrorMessage("There are Handovers you have created yet to be received by another user. Please ask the other user to accept them. Until they accept your handovers, you can not close your shift.");
@@ -5909,7 +5926,7 @@ public class FinancialTransactionController implements Serializable {
 
         boolean requireHandoverBeforeShiftEnd = configOptionApplicationController
                 .getBooleanValueByKey("Require Handover Before Shift End", false);
-        if (requireHandoverBeforeShiftEnd) {
+        if (requireHandoverBeforeShiftEnd && !allowShiftEndWithoutHandoverAcceptance) {
             boolean hasCollections = bundle != null
                     && bundle.getBundles() != null
                     && !bundle.getBundles().isEmpty()
@@ -5926,10 +5943,11 @@ public class FinancialTransactionController implements Serializable {
                     return null;
                 }
             }
-            // Also block if a handover has been created but not yet accepted by the recipient,
-            // unless 'Allow Shift End Without Handover Acceptance' is enabled (#19963).
+            // Also block if a handover has been created but not yet accepted by the recipient.
+            // (The enclosing block is already skipped entirely when 'Allow Shift End Without
+            // Handover Acceptance' is enabled — see condition above, #19963/#22931.)
             boolean hasPendingHandover = hasAtLeastOneHandoverBillToReceive(sessionController.getLoggedUser(), null, null, null);
-            if (hasPendingHandover && !allowShiftEndWithoutHandoverAcceptance) {
+            if (hasPendingHandover) {
                 JsfUtil.addErrorMessage("Handover pending acceptance. Please wait for the recipient to accept your handover before ending your shift.");
                 return null;
             }
@@ -7478,6 +7496,14 @@ public class FinancialTransactionController implements Serializable {
         if (!requireHandoverBeforeShiftEnd) {
             return false;
         }
+        // 'Allow Shift End Without Handover Acceptance' overrides this check too, so the
+        // 'End the Current Shift' button is not left disabled when the hospital has opted
+        // out of strict handover enforcement (#22931).
+        boolean allowShiftEndWithoutHandoverAcceptance = configOptionApplicationController
+                .getBooleanValueByKey("Allow Shift End Without Handover Acceptance", false);
+        if (allowShiftEndWithoutHandoverAcceptance) {
+            return false;
+        }
         if (nonClosedShiftStartFundBill == null) {
             return false;
         }
@@ -7495,6 +7521,23 @@ public class FinancialTransactionController implements Serializable {
                 .getDoubleValueByKey("Maximum Allowed Difference for Shift End Handover", 0.01);
         double tolerance = (configuredTolerance == null) ? 0.01 : Math.max(0.0, configuredTolerance);
         return (totalCollections - totalHandedOver) > tolerance;
+    }
+
+    /**
+     * Non-blocking informational flag for the End Shift page: true when this user has a
+     * pending float transfer (outgoing not yet accepted, or incoming not yet collected) that
+     * would normally block shift end but is being bypassed because 'Allow Shift End Without
+     * Handover Acceptance' is enabled. Used purely to render an awareness banner — never
+     * disables the End Shift button (#22931).
+     */
+    public boolean isPendingFloatTransferBypassedForShiftEnd() {
+        boolean allowShiftEndWithoutHandoverAcceptance = configOptionApplicationController
+                .getBooleanValueByKey("Allow Shift End Without Handover Acceptance", false);
+        if (!allowShiftEndWithoutHandoverAcceptance) {
+            return false;
+        }
+        return hasAtLeastOneFundTransferBillToReceive(sessionController.getLoggedUser(), null, null, null)
+                || hasAtLeastOneFundTransferBillToReceive(null, null, sessionController.getLoggedUser(), null);
     }
 
     public void fillHandoverBillsForMeToReceive() {
@@ -10851,7 +10894,7 @@ public class FinancialTransactionController implements Serializable {
 
         shiftEndMetadata.addConfigOption(new ConfigOptionInfo(
                 "Allow Shift End Without Handover Acceptance",
-                "When enabled, a shift can be ended even if a handover has been created but not yet accepted by the recipient. A warning message is shown so the user is aware of the pending handover. Default: false (strict mode — shift end is blocked until all handovers are accepted).",
+                "Master override for hospitals that do not practice handover/float-transfer acceptance systematically. When enabled, a shift can be ended even when: a handover or float transfer has been created but not yet accepted by the recipient; a float transfer sent to this user has not yet been collected; the 'Must Receive/Wait ... Before Closing Shift' options would otherwise block; or the handed-over amount does not yet match collections ('Require Handover Before Shift End'). Informational warning messages are shown so the bypass is auditable. Default: false (strict mode — all of the above guards are enforced).",
                 OptionScope.APPLICATION
         ));
 

--- a/src/main/webapp/cashier/shift_end_for_handover.xhtml
+++ b/src/main/webapp/cashier/shift_end_for_handover.xhtml
@@ -84,6 +84,11 @@
                                                         <i class="pi pi-exclamation-triangle" style="margin-right:4px;"></i>
                                                         <h:outputText value="Handover not complete. Please complete the handover before ending your shift." />
                                                     </h:panelGroup>
+                                                    <h:panelGroup rendered="#{financialTransactionController.pendingFloatTransferBypassedForShiftEnd}"
+                                                                  style="color:#0c5460; background-color:#d1ecf1; border:1px solid #bee5eb; border-radius:4px; padding:4px 8px; display:inline-block;" class="mx-2">
+                                                        <i class="pi pi-info-circle" style="margin-right:4px;"></i>
+                                                        <h:outputText value="A float transfer is still pending. You are allowed to end the shift anyway ('Allow Shift End Without Handover Acceptance' is enabled)." />
+                                                    </h:panelGroup>
                                                     <p:commandButton
                                                         class="ui-button-danger mx-2"
                                                         ajax="false"


### PR DESCRIPTION
## Problem

The End Shift page is meant to let hospitals that do not practice handover/float-transfer acceptance systematically still close a shift, via the existing config option **`Allow Shift End Without Handover Acceptance`**. In practice the option only bypassed two of the many guards in the flow — outgoing/incoming pending *handover* acceptance — so users reported "the config option isn't working."

Root cause (confirmed by reading the code, no separate repro needed — see #22931): several other guards blocked shift end **unconditionally**, regardless of the option:

- `navigateToCreateShiftEndSummaryBillForHandover()` (the entry point from the cashier index "End Shift" button) had **unconditional** outgoing/incoming pending float-transfer guards that ran *before* the option was even read — so a user with any pending float transfer never reached the End Shift page at all.
- `settleShiftEnd()` had an unconditional "funds to collect" check.
- The four `Must Receive/Wait ... Before Closing Shift` config checks (fund transfers + handovers, both directions) ignored the override.
- The amount-mismatch sub-check inside `Require Handover Before Shift End` ignored the override.
- `isHandoverRequiredButNotComplete()` — which disables the "End the Current Shift" button and shows the "Handover not complete" warning on `shift_end_for_handover.xhtml` — never consulted the override either.

## Fix

- Read `allowShiftEndWithoutHandoverAcceptance` once at the top of both `navigateToCreateShiftEndSummaryBillForHandover()` and `settleShiftEnd()`, and gate **every** guard listed above on it.
- `isHandoverRequiredButNotComplete()` now also respects the override.
- Added a non-blocking info banner (`isPendingFloatTransferBypassedForShiftEnd()`) so a bypassed pending float transfer is visible on the page — mirrors the existing pending-handover banner.
- Updated the config option's registered description (shown in the page-config admin UI) to reflect the full bypass scope.
- The bypassed handover/float transfer itself is **not** cancelled or resolved — it's left exactly as-is for whoever needs to accept/collect it; only the shift-end block is lifted, with an info message so the bypass is auditable.

## Verification (local Payara, DB-verified)

1. Built and deployed locally (`mvn clean package -DskipTests` + `asadmin redeploy`), confirmed clean startup, no errors.
2. Used an existing shift for a test user with `Allow Shift End Without Handover Acceptance = true` (the hospital's actual current setting).
3. Inserted a genuinely pending outgoing float-transfer bill (`FUND_TRANSFER_BILL`, `referenceBill IS NULL`, `cancelled = false`) for that user as test fixture data.
4. Navigated to **End Shift** — reached the page successfully (previously would have been redirected back with "You have pending float transfers not yet accepted..."). Page showed the new info banner and an enabled "End the Current Shift" button:

   ![End Shift page with pending-float-transfer banner](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/22931-end-shift-pending-float-bypass.png)

5. Clicked "End the Current Shift" — shift closed successfully:

   ![Shift End Summary print confirming success](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/22931-shift-end-print-success.png)

6. DB-verified: shift-start bill `140525` → `COMPLETED=1`, new `FUND_SHIFT_END_BILL` (`13988674`) created referencing it with the correct total; the pending float-transfer fixture bill remained untouched (`RETIRED=0`, `CANCELLED=0`, `COMPLETED=0`, `REFERENCEBILL_ID IS NULL`) — proving the bypass genuinely skips the check rather than silently resolving the pending item.
7. Cleaned up the test fixture row afterward.

Wiki updated: [End-Shift](https://github.com/hmislk/hmis/wiki/End-Shift#ending-a-shift-when-handovers-or-float-transfers-arent-practiced-systematically)

Closes #22931

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable override that allows shifts to end without handover acceptance.
  * Shift closure can now bypass selected pending transfer, collection, waiting, and balance validations when enabled.
  * Informational warnings are displayed when pending float transfers are bypassed.

* **Documentation**
  * Updated the configuration description to explain which shift-closing validations are bypassed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->