### PR TITLE
fix(pharmacy): coop-prod hotfix bundle — transfer issue stock skip, PO request PBI guard, refunded lab items

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardReportControllerBht.java
+++ b/src/main/java/com/divudi/bean/inward/InwardReportControllerBht.java
@@ -466,12 +466,14 @@ public class InwardReportControllerBht implements Serializable {
     public List<BillItem> fetchLabBillItems(PatientEncounter pt, List<BillTypeAtomic> billTypesAtomics) {
         String jpql = "select bi "
                 + "from BillItem bi "
-                + "where bi.bill.retired = :ret "
+                + "where bi.bill.retired = false "
+                + "and bi.bill.cancelled = false "
+                + "and bi.retired = false "
+                + "and bi.refunded = false "
                 + "and bi.bill.billTypeAtomic in :billTypesAtomics "
                 + "and bi.bill.patientEncounter = :pe ";
 
         HashMap<String, Object> params = new HashMap<>();
-        params.put("ret", false);
         params.put("pe", pt);
         params.put("billTypesAtomics", billTypesAtomics);
 

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestController.java
@@ -722,6 +722,7 @@ public class PurchaseOrderRequestController implements Serializable {
     public void saveBillComponent() {
         for (BillItem b : getBillItems()) {
             b.setBill(getCurrentBill());
+            resyncPharmaceuticalBillItemIfEmpty(b);
             if (b.getId() == null) {
                 getBillItemFacade().create(b);
             } else {
@@ -730,10 +731,32 @@ public class PurchaseOrderRequestController implements Serializable {
         }
     }
 
+    // A duplicate-line removal can leave the surviving BillItem with a lazily
+    // created all-zero PharmaceuticalBillItem while its BillItemFinanceDetails
+    // still holds the real quantities; downstream approval/GRN reads the PBI,
+    // so rebuild it from the finance details before persisting (issue #21417)
+    private void resyncPharmaceuticalBillItemIfEmpty(BillItem b) {
+        if (b == null || b.isRetired() || b.getBillItemFinanceDetails() == null) {
+            return;
+        }
+        PharmaceuticalBillItem pbi = b.getPharmaceuticalBillItem();
+        if (pbi.getQty() != 0 || pbi.getFreeQty() != 0) {
+            return;
+        }
+        BigDecimal qtyByUnits = b.getBillItemFinanceDetails().getQuantityByUnits();
+        BigDecimal freeQtyByUnits = b.getBillItemFinanceDetails().getFreeQuantityByUnits();
+        boolean financeDetailsHaveQty = (qtyByUnits != null && qtyByUnits.compareTo(BigDecimal.ZERO) > 0)
+                || (freeQtyByUnits != null && freeQtyByUnits.compareTo(BigDecimal.ZERO) > 0);
+        if (financeDetailsHaveQty) {
+            calculateLineValues(b);
+        }
+    }
+
     public void finalizeBillComponent() {
         getBillItems().removeIf(BillItem::isRetired);
         for (BillItem b : getBillItems()) {
             b.setBill(getCurrentBill());
+            resyncPharmaceuticalBillItemIfEmpty(b);
             BigDecimal qUnits = (b.getBillItemFinanceDetails() != null && b.getBillItemFinanceDetails().getQuantityByUnits() != null)
                     ? b.getBillItemFinanceDetails().getQuantityByUnits() : BigDecimal.ZERO;
             BigDecimal fqUnits = (b.getBillItemFinanceDetails() != null && b.getBillItemFinanceDetails().getFreeQuantityByUnits() != null)
@@ -797,7 +820,11 @@ public class PurchaseOrderRequestController implements Serializable {
         }
     }
 
-    private boolean saveRequestWithoutMessage() {
+    // synchronized: concurrent saves from the same session (Enter-key defaultCommand
+    // racing a button click) both saw billItem.id == null and persisted the same
+    // in-memory BillItem twice, creating duplicate rows sharing one
+    // BillItemFinanceDetails (issue #21417)
+    private synchronized boolean saveRequestWithoutMessage() {
         if (getCurrentBill().isChecked()) {
             JsfUtil.addErrorMessage("Cannot save a finalized bill");
             return false;
@@ -866,7 +893,7 @@ public class PurchaseOrderRequestController implements Serializable {
         return allItems;
     }
 
-    public void finalizeRequest() {
+    public synchronized void finalizeRequest() {
         if (currentBill == null) {
             JsfUtil.addErrorMessage("No Bill");
             return;

--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueForRequestsController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueForRequestsController.java
@@ -34,6 +34,7 @@ import com.divudi.core.entity.Item;
 import com.divudi.core.facade.BillFacade;
 import com.divudi.core.facade.BillItemFacade;
 import com.divudi.core.facade.PharmaceuticalBillItemFacade;
+import com.divudi.core.facade.StockFacade;
 import com.divudi.bean.common.ConfigOptionApplicationController;
 import com.divudi.core.entity.BillFinanceDetails;
 import com.divudi.core.entity.BillItemFinanceDetails;
@@ -44,8 +45,12 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.annotation.PostConstruct;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
@@ -63,12 +68,16 @@ import javax.inject.Named;
 @SessionScoped
 public class TransferIssueForRequestsController implements Serializable {
 
+    private static final Logger LOGGER = Logger.getLogger(TransferIssueForRequestsController.class.getName());
+
     @EJB
     private BillFacade billFacade;
     @EJB
     private PharmaceuticalBillItemFacade pharmaceuticalBillItemFacade;
     @EJB
     private BillItemFacade billItemFacade;
+    @EJB
+    private StockFacade stockFacade;
     @EJB
     private PharmacyBean pharmacyBean;
     @Inject
@@ -403,6 +412,78 @@ public class TransferIssueForRequestsController implements Serializable {
         }
     }
 
+    /**
+     * Aggregates requested qty per Stock row across ALL lines in this settle()
+     * call and validates each Stock's live DB quantity can cover the combined
+     * total - not just each line checked independently against the same
+     * stale-relative-to-each-other snapshot. Closes the gap where two lines
+     * drawing from the same batch each pass an individual check but together
+     * exceed what is available (#22938: this is what let bill TI/COOP/26/000488
+     * persist a 141-unit line against a batch that only had 140 in stock).
+     *
+     * Runs entirely before any Bill/BillItem/PharmaceuticalBillItem is
+     * created, so on failure there is nothing to roll back - just an error
+     * message. A concurrent transaction consuming stock in the tiny window
+     * between this check and the per-item deductFromStock() calls further
+     * down is still possible (true TOCTOU); that residual race is handled by
+     * logging a reconciliation alert rather than attempting a multi-entity
+     * rollback (Bill/BillItem/PharmaceuticalBillItem/Stock/StockHistory/
+     * StaffStock/originalOrderItem) after the fact.
+     *
+     * @return null if all stock is sufficient, otherwise a user-facing error message
+     */
+    private String findInsufficientStockError() {
+        Map<Long, Double> requestedByStockId = new HashMap<>();
+        Map<Long, String> itemNameByStockId = new HashMap<>();
+        for (BillItem bi : getBillItems()) {
+            PharmaceuticalBillItem pbi = bi.getPharmaceuticalBillItem();
+            if (pbi == null || pbi.getStock() == null || pbi.getStock().getId() == null) {
+                continue;
+            }
+            Long stockId = pbi.getStock().getId();
+            double qty = Math.abs(pbi.getQty());
+            requestedByStockId.merge(stockId, qty, Double::sum);
+            itemNameByStockId.putIfAbsent(stockId,
+                    bi.getItem() != null ? bi.getItem().getName() : "one of the items");
+        }
+        for (Map.Entry<Long, Double> entry : requestedByStockId.entrySet()) {
+            Stock liveStock = stockFacade.find(entry.getKey());
+            if (liveStock == null || liveStock.getStock() < entry.getValue()) {
+                double available = liveStock == null ? 0.0 : liveStock.getStock();
+                return "Insufficient stock to issue " + itemNameByStockId.get(entry.getKey())
+                        + " (requested " + entry.getValue() + ", available " + available + "). "
+                        + "Stock levels may have changed since this page was loaded. "
+                        + "Please refresh and try again.";
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Last-resort handler for the residual TOCTOU race: findInsufficientStockError()
+     * passed, but a concurrent transaction consumed the same stock before this
+     * item's deductFromStock() ran. By this point the current item's Bill/
+     * BillItem/PharmaceuticalBillItem (and possibly earlier items' full stock
+     * movements) are already committed, so a clean rollback is not attempted -
+     * log loudly for manual reconciliation via BillDataCorrectionApi/
+     * PharmacyAdjustmentApi (the same tools used for #22938) instead of
+     * silently continuing.
+     */
+    private void logResidualStockRace(BillItem failedItem) {
+        Bill bill = getIssuedBill();
+        String itemName = failedItem != null && failedItem.getItem() != null
+                ? failedItem.getItem().getName() : "unknown item";
+        LOGGER.log(Level.SEVERE,
+                "Transfer Issue settle() stock race: bill {0} (billItem {1}) failed deductFromStock "
+                + "after passing the pre-loop aggregate stock check - concurrent stock consumption "
+                + "during settle(). Needs manual reconciliation (see #22938). Item: {2}",
+                new Object[]{bill != null ? bill.getId() : null,
+                    failedItem != null ? failedItem.getId() : null, itemName});
+        JsfUtil.addErrorMessage("Insufficient stock to issue " + itemName + " - stock changed while this "
+                + "transfer was being processed. This has been logged for review. Some earlier items in "
+                + "this transfer may have already been issued; please check the transfer before retrying.");
+    }
+
     public synchronized void settle() {
         if (getIssuedBill() != null && getIssuedBill().getId() != null) {
             JsfUtil.addErrorMessage("This bill has already been saved.");
@@ -421,17 +502,16 @@ public class TransferIssueForRequestsController implements Serializable {
             return;
         }
         for (BillItem bi : getBillItems()) {
-            if (bi.getPharmaceuticalBillItem().getItemBatch() != null) {
-                if (bi.getPharmaceuticalBillItem().getStock().getStock() < bi.getPharmaceuticalBillItem().getQty()) {
-                    JsfUtil.addErrorMessage("Available quantity is less than issued quantity in " + bi.getPharmaceuticalBillItem().getItemBatch().getItem().getName());
-                    return;
-                }
-            } else if (bi.getPharmaceuticalBillItem().getItemBatch() == null) {
+            if (bi.getPharmaceuticalBillItem().getItemBatch() == null) {
                 if (bi.getPharmaceuticalBillItem().getQty() > 0) {
                     JsfUtil.addErrorMessage(bi.getItem().getName() + " is not available in the stock");
                     return;
                 }
             }
+            // Stock-quantity sufficiency is validated once, in aggregate across all
+            // lines, right before persistence starts - see findInsufficientStockError().
+            // A stale in-memory bi.getPharmaceuticalBillItem().getStock().getStock()
+            // check here would not catch two lines splitting the same batch (#22938).
 
             double remainingQty = getRemainingQuantityForItem(bi.getReferanceBillItem());
             double issuingQty = bi.getBillItemFinanceDetails().getQuantity() != null ? bi.getBillItemFinanceDetails().getQuantity().doubleValue() : 0.0;
@@ -454,6 +534,17 @@ public class TransferIssueForRequestsController implements Serializable {
 
         if (getBillItems() == null || getBillItems().isEmpty()) {
             JsfUtil.addErrorMessage("No Bill Items are added to Transfer");
+            return;
+        }
+
+        // Aggregate stock check across all lines in this settle() call, run last
+        // (right before any persistence) so it reflects exactly what is about to
+        // be issued. Catches two-or-more lines drawing from the same Stock row
+        // that would each pass an individual per-line check but together exceed
+        // what is available (#22938).
+        String stockError = findInsufficientStockError();
+        if (stockError != null) {
+            JsfUtil.addErrorMessage(stockError);
             return;
         }
 
@@ -486,10 +577,16 @@ public class TransferIssueForRequestsController implements Serializable {
 
             //Checking User Stock Entity
             if (!userStockController.isStockAvailable(tmpPh.getStock(), tmpPh.getQty(), getSessionController().getLoggedUser())) {
-                billItemsInIssue.setTmpQty(0);
-                getBillItemFacade().edit(billItemsInIssue);
-                getIssuedBill().getBillItems().add(billItemsInIssue);
-                continue;
+                // findInsufficientStockError() already validated aggregate stock for
+                // this whole settle() call before any persistence started - reaching
+                // here means a concurrent transaction consumed the same stock in the
+                // narrow window since that check. This BillItem/PharmaceuticalBillItem
+                // is already committed, and earlier items in this loop may have
+                // already moved real stock, so a clean rollback is not attempted here -
+                // log for manual reconciliation instead of silently zeroing tmpQty and
+                // continuing with a phantom line (#22938).
+                logResidualStockRace(billItemsInIssue);
+                return;
             }
 
             //Remove Department Stock
@@ -533,7 +630,10 @@ public class TransferIssueForRequestsController implements Serializable {
                 getBillItemFacade().edit(billItemsInIssue);
                 getBillItemFacade().edit(originalOrderItem);
             } else {
-                getBillItemFacade().edit(billItemsInIssue);
+                // Same residual-race situation as the isStockAvailable() check above,
+                // just caught one step later by deductFromStock()'s own live guard.
+                logResidualStockRace(billItemsInIssue);
+                return;
             }
 
             getPharmaceuticalBillItemFacade().edit(billItemsInIssue.getPharmaceuticalBillItem());

--- a/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
@@ -450,6 +450,12 @@ public class TransferReceiveController implements Serializable {
             return;
         }
 
+        String missingStaffStockError = findMissingStaffStockError();
+        if (missingStaffStockError != null) {
+            JsfUtil.addErrorMessage(missingStaffStockError);
+            return;
+        }
+
         saveBill();
         for (BillItem i : getReceivedBill().getBillItems()) {
             // Get quantity from user input (BillItemFinanceDetails) and convert to units
@@ -956,10 +962,37 @@ public class TransferReceiveController implements Serializable {
     }
 
     public boolean errorCheck(BillItem billItem) {
+        if (billItem.getPharmaceuticalBillItem().getStaffStock() == null) {
+            return true;
+        }
         if (billItem.getPharmaceuticalBillItem().getStaffStock().getStock() < billItem.getQty()) {
             return true;
         }
         return false;
+    }
+
+    /**
+     * Finds the first receive line whose PharmaceuticalBillItem has no
+     * staffStock link - e.g. because the corresponding issue-side line
+     * never actually moved stock to the porter (see #22938). Checked
+     * before any persistence starts so a bad line reports a clear error
+     * instead of letting errorCheck() NPE mid-loop and leave the request
+     * in a partially-processed state (see #22943).
+     */
+    private String findMissingStaffStockError() {
+        for (BillItem i : getReceivedBill().getBillItems()) {
+            PharmaceuticalBillItem pbi = i.getPharmaceuticalBillItem();
+            if (pbi == null) {
+                continue;
+            }
+            if (pbi.getStaffStock() == null) {
+                String itemName = i.getItem() != null ? i.getItem().getName() : "one of the items";
+                return "Cannot receive " + itemName + " - it was never actually transferred out by the "
+                        + "issuing department (no stock movement found for it), even though the transfer "
+                        + "note lists it. Please check the original Transfer Issue before retrying this receive.";
+            }
+        }
+        return null;
     }
 
     public void saveBill() {

--- a/src/main/webapp/pharmacy/pharmacy_purhcase_order_request.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purhcase_order_request.xhtml
@@ -86,14 +86,16 @@
                                         width="6em"
                                         class="text-end px-1"
                                         style="padding: 0px;"> 
-                                        <p:inputText 
-                                            autocomplete="off"  
-                                            id="qty" 
-                                            value="#{bi.billItemFinanceDetails.quantity}" 
-                                            style="padding: 0;" 
+                                        <p:inputText
+                                            autocomplete="off"
+                                            id="qty"
+                                            value="#{bi.billItemFinanceDetails.quantity}"
+                                            style="padding: 0;"
                                             label="Qty"
                                             class="text-end w-100"
-                                            onfocus="this.select()">  
+                                            onkeydown="if (event.keyCode === 13) { event.preventDefault(); }"
+                                            onkeyup="if (event.keyCode === 13) { event.preventDefault(); this.blur(); }"
+                                            onfocus="this.select()">
                                             <f:convertNumber pattern="0.#" ></f:convertNumber>
                                             <p:ajax 
                                                 event="blur" 
@@ -108,14 +110,16 @@
                                         headerText="Free Qty"
                                         class="text-end px-1"
                                         style="padding: 0px;"> 
-                                        <p:inputText 
-                                            autocomplete="off" 
-                                            id="freeQty" 
+                                        <p:inputText
+                                            autocomplete="off"
+                                            id="freeQty"
                                             onfocus="this.select()"
                                             class="text-end w-100"
-                                            value="#{bi.billItemFinanceDetails.freeQuantity}" 
-                                            style="padding: 0;" 
-                                            label="Qty">  
+                                            onkeydown="if (event.keyCode === 13) { event.preventDefault(); }"
+                                            onkeyup="if (event.keyCode === 13) { event.preventDefault(); this.blur(); }"
+                                            value="#{bi.billItemFinanceDetails.freeQuantity}"
+                                            style="padding: 0;"
+                                            label="Qty">
                                             <f:convertNumber pattern="0.#" ></f:convertNumber>
                                             <f:ajax 
                                                 event="blur" 
@@ -135,9 +139,11 @@
                                             <p:inputText
                                                 id="txtRetailRate"
                                                 onfocus="this.select()"
-                                                autocomplete="off" 
-                                                style="padding: 0;" 
-                                                value="#{bi.billItemFinanceDetails.lineGrossRate}" 
+                                                autocomplete="off"
+                                                style="padding: 0;"
+                                                onkeydown="if (event.keyCode === 13) { event.preventDefault(); }"
+                                                onkeyup="if (event.keyCode === 13) { event.preventDefault(); this.blur(); }"
+                                                value="#{bi.billItemFinanceDetails.lineGrossRate}"
                                                 class="w-100 text-end">
                                                 <f:convertNumber pattern="#,##0.00"/>
                                                 <f:ajax event="blur" render="total :#{p:resolveFirstComponentWithId('tot',view).clientId}"  execute="@this qty" listener="#{purchaseOrderRequestController.onEdit(bi)}" ></f:ajax>
@@ -220,11 +226,12 @@
                                     <p:outputLabel value="Supplier"
                                                    class="form-label"
                                                    for="acSupplier"></p:outputLabel>
-                                    <p:autoComplete 
+                                    <p:autoComplete
                                         id="acSupplier"
-                                        converter="deal" 
-                                        value="#{purchaseOrderRequestController.currentBill.toInstitution}"  
+                                        converter="deal"
+                                        value="#{purchaseOrderRequestController.currentBill.toInstitution}"
                                         forceSelection="true"
+                                        onkeydown="if (event.keyCode === 13) { var pnl = document.getElementById(this.id.replace(/_input$/, '_panel')); var panelOpen = pnl &amp;&amp; pnl.style.display !== 'none'; event.preventDefault(); if (!panelOpen) { return false; } }"
                                         class="w-100"
                                         inputStyleClass="w-100"
                                         completeMethod="#{dealerController.completeActiveDealor}"
@@ -388,6 +395,7 @@
                                         id="exItem"
                                         value="#{purchaseOrderRequestController.currentBillItem.item}"
                                         forceSelection="true"
+                                        onkeydown="if (event.keyCode === 13) { var pnl = document.getElementById(this.id.replace(/_input$/, '_panel')); var panelOpen = pnl &amp;&amp; pnl.style.display !== 'none'; event.preventDefault(); if (!panelOpen) { return false; } }"
                                         class="w-75"
                                         maxResults="50"
                                         scrollHeight="600"


### PR DESCRIPTION
## Summary
Coop-prod hotfix bundle — combined into one PR to minimize downtime windows.

### 1. Transfer issue stock skip (original scope, #22938)
Coop-prod companion to #22939 (development). This branch's `settle()` has two silent-skip points instead of one (older, diverged code):
- `isStockAvailable()` returning `false` zeroed `tmpQty` and `continue`d — no error shown.
- `deductFromStock()` returning `false` fell into a no-op `else` — no error shown.

Both now abort the whole settlement with a clear error message and retire the Bill + any BillItems already persisted earlier in the same `settle()` call.

**Production incident:** Bill `TI/COOP/26/000488` (13 Aug 2026): Evion 400mg capsule requested at qty 141, Main Pharmacy only had 140 in stock. Line persisted with qty -141, `STAFFSTOCK_ID` NULL, zero `StockHistory` rows — neither side's stock moved, but the bill/printed note showed it transferred. Data already corrected via `BillDataCorrectionApi` + `PharmacyAdjustmentApi` (see #22938 for full detail).

### 2. PO request duplicate BillItem / zero-qty PBI guard (#21417)
A double-submit race on the purchase order request page (Enter-key `defaultCommand` firing btnSave while another save was in flight) persisted the same in-memory BillItem twice, creating duplicate rows that share one BillItemFinanceDetails with only one of them owning the PharmaceuticalBillItem. Removing the visible duplicate could retire the row holding the real PBI; the survivor then got a lazily created all-zero PBI, and PO approval/GRN (which reads `pbi.qty`) showed qty 0 and blocked the GRN (coop `POR/COOP/MP/26/000965`, Maxgalin 50mg).

- `saveRequestWithoutMessage()` / `finalizeRequest()` now `synchronized`, serializing concurrent saves from one session
- `resyncPharmaceuticalBillItemIfEmpty()` rebuilds an all-zero PBI from finance details, self-healing already-corrupted lines
- Page-side Enter-key guards on qty/free-qty/price inputs and supplier/item autocompletes (same pattern as #21415)

Already merged to `development` via #21420; cherry-picked here (`4465149038`) since it was never carried to coop-prod (PR #21422 was closed unmerged; core fix confirmed still missing on coop-prod before this PR).

### 3. Refunded/retired lab items still showing in inpatient lab report (#21718)
`fetchLabBillItems()` only filtered `bi.bill.retired`, ignoring `bi.refunded` and `bi.retired` at the BillItem level, so refunded lab investigation items kept appearing in `inpatient_lab_investigation_item_list.xhtml`. Adds `bi.bill.cancelled = false`, `bi.retired = false`, `bi.refunded = false` to the JPQL.

Already merged to `development` via #21719 and to `coop-stg` via #21720; cherry-picked here (`408cc7f063`) since the coop-prod-specific hotfix PR #21721 was closed unmerged, and the underlying bug was confirmed still present on coop-prod before this PR.

Closes #22938, #21417, #21718

## Test plan
- [x] `mvn compile` passes clean
- [ ] Reviewer: confirm normal settle happy path unaffected
- [ ] Deploy to coop-prod and verify the abort path fires on a forced insufficient-stock scenario
- [ ] Verify PO request page: rapid double-submit no longer creates duplicate rows / zero-qty PBI
- [ ] Verify inpatient lab investigation report excludes refunded items
