### PR TITLE
fix(pharmacy): approve/approved transfer request lists filter on wrong department

### DIFF
--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -6913,6 +6913,13 @@ public class SearchController implements Serializable {
     }
 
     public void fillPharmacyTransferRequestsToApprove() {
+        // Approval happens from the SUPPLYING department's session (the department
+        // that will issue the stock), which is stored as b.toDepartment on a
+        // transfer-request bill (b.fromDepartment/b.department is the REQUESTER).
+        // Filtering on fromDepartment here meant a finalized request could never
+        // match the approver's session department, so this list was always empty
+        // for every department (found via Playwright E2E testing the transfer
+        // request -> approve -> issue workflow, 2026-08-14).
         String jpql = "SELECT new com.divudi.core.data.dto.PharmacyTransferRequestListDTO("
                 + "b.id, b.deptId, b.createdAt, COALESCE(toDept.name, ''), "
                 + "COALESCE(creatorPerson.name, ''), b.cancelled, "
@@ -6927,14 +6934,14 @@ public class SearchController implements Serializable {
                 + "WHERE b.checkedBy IS NOT NULL "
                 + "AND (b.completed = false OR b.completed IS NULL) "
                 + "AND b.institution = :ins "
-                + "AND b.fromDepartment = :fromDep "
+                + "AND b.toDepartment = :toDep "
                 + "AND b.createdAt BETWEEN :fromDate AND :toDate "
                 + "AND b.retired = false "
                 + "AND b.billTypeAtomic = :bTp "
                 + "ORDER BY b.createdAt DESC";
         Map<String, Object> params = new HashMap<>();
         params.put("ins", sessionController.getInstitution());
-        params.put("fromDep", sessionController.getDepartment());
+        params.put("toDep", sessionController.getDepartment());
         params.put("fromDate", getFromDate());
         params.put("toDate", getToDate());
         params.put("bTp", BillTypeAtomic.PHARMACY_TRANSFER_REQUEST_PRE);
@@ -6943,13 +6950,15 @@ public class SearchController implements Serializable {
     }
 
     public void fillApprovedPharmacyTransferRequests() {
+        // Same fix as fillPharmacyTransferRequestsToApprove() above: the approving/
+        // issuing department is stored in b.toDepartment, not b.fromDepartment.
         bills = null;
         HashMap tmp = new HashMap();
         String sql;
         sql = "Select b From Bill b where "
                 + " b.completed = true "
                 + " and b.institution = :ins "
-                + " and b.fromDepartment = :fromDep "
+                + " and b.toDepartment = :toDep "
                 + " and b.createdAt between :fromDate and :toDate "
                 + " and b.retired=false "
                 + " and b.billTypeAtomic= :bTp";
@@ -6958,7 +6967,7 @@ public class SearchController implements Serializable {
         tmp.put("toDate", getToDate());
         tmp.put("fromDate", getFromDate());
         tmp.put("ins", sessionController.getInstitution());
-        tmp.put("fromDep", sessionController.getDepartment());
+        tmp.put("toDep", sessionController.getDepartment());
         tmp.put("bTp", BillTypeAtomic.PHARMACY_TRANSFER_REQUEST_PRE);
 
         bills = getBillFacade().findByJpql(sql, tmp, TemporalType.TIMESTAMP, maxResult);


### PR DESCRIPTION
## What

`fillPharmacyTransferRequestsToApprove()` and `fillApprovedPharmacyTransferRequests()`
(`SearchController.java`) filtered on `b.fromDepartment = :fromDep`, binding the
current session department (the approver/supplier). But
`TransferRequestController` always sets `fromDepartment` to the **requesting**
department at creation — the supplier is stored in `toDepartment`. The query
therefore compared "requester's department" against "approver's session
department", which can never match for any real transfer.

**Effect: no finalized transfer request could ever be approved through the UI, and
no approved request could ever appear on the Approved Requests list — for any
department, system-wide.**

Fix: filter both queries on `b.toDepartment` instead (renamed the bound param
`fromDep` → `toDep` for clarity).

## How found

Found while QA-testing the transfer request → issue → receive workflow via
Playwright, following PR #22939 (the transfer-issue stock-shortfall hotfix). Full
details, plus a second (no-fix-needed) finding about #22939's hotfix target and a
verified end-to-end pass of the whole workflow after this fix, are in #22944.

## Verification

- Reproduced: created + finalized a real request via the UI
  (`TREQ/RHD/GSM/26/00035`) — confirmed it never appeared on "Approve Requests"
  logged in as the supplying department, despite `checkedBy` set and
  `completed=false` in the DB.
- Rebuilt + redeployed with the fix; same request now appears with a working
  "Approve Request" button and approves successfully.
- Continued the full cycle end-to-end (Approve → Issue → Receive) via Playwright,
  cross-checked against the DB at each step — `StockHistory` reconciles exactly
  against `Stock` for both departments. Details in #22944.

Closes #22944

🤖 Generated with [Claude Code](https://claude.com/claude-code)
