### PR TITLE
fix(pharmacy): show Total Drug Amount for Ordering Store on transfer approval

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
@@ -349,6 +349,20 @@ public class TransferRequestController implements Serializable {
         return getAvailableQtyAtOrderingStore(bi) < bi.getQty();
     }
 
+    // Value of the stock already available at the Ordering Store, priced at the
+    // same config-selected transfer rate (see determineTransferRate) already
+    // shown in the row's Transfer Rate/Transfer Value columns.
+    public double getTotalDrugAmountAtOrderingStore(BillItem bi) {
+        if (bi == null || bi.getBillItemFinanceDetails() == null) {
+            return 0.0;
+        }
+        BigDecimal rate = bi.getBillItemFinanceDetails().getLineGrossRate();
+        if (rate == null) {
+            return 0.0;
+        }
+        return getAvailableQtyAtOrderingStore(bi) * rate.doubleValue();
+    }
+
     public void saveBill() {
         if (getBill().getId() == null) {
 

--- a/src/main/webapp/pharmacy/pharmacy_transfer_request_approval.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_request_approval.xhtml
@@ -103,6 +103,13 @@
                                         </h:outputText>
                                     </p:column>
 
+                                    <p:column headerText="Total Drug Amount (Ordering Store)" class="text-end" width="10em">
+                                        <h:outputText
+                                            value="#{transferRequestController.getTotalDrugAmountAtOrderingStore(bi)}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </h:outputText>
+                                    </p:column>
+
                                     <p:column headerText="Transfer Rate" class="text-end" width="8em">
                                         <p:inputText value="#{bi.billItemFinanceDetails.lineGrossRate}" class="w-100 text-end">
                                             <f:convertNumber pattern="#,##0.00" />


### PR DESCRIPTION
## What changed

Adds a **"Total Drug Amount (Ordering Store)"** column to the Log Department's transfer request approval page (`pharmacy_transfer_request_approval.xhtml`), next to the existing "Available Qty (Ordering Store)" column, so approvers see the monetary value of stock already at the destination store — not just its quantity.

`Total Drug Amount (Ordering Store) = Available Qty (Ordering Store) × Transfer Rate`

Both terms are already computed on this page:
- `getAvailableQtyAtOrderingStore(bi)` — already sums stock across **all** batches at the destination department (confirmed correct with the reporter before implementing; the ambiguity was about qty basis, not a code change).
- `bi.getBillItemFinanceDetails().getLineGrossRate()` — the row's already config-driven Transfer Rate (`Pharmacy Transfer is by Purchase Rate` / `... by Cost Rate` / `... by Retail Rate`), reused instead of a new hardcoded/duplicate rate lookup.

## Files changed
- `TransferRequestController.java` — new `getTotalDrugAmountAtOrderingStore(BillItem)` getter, no new caching/service methods needed.
- `pharmacy_transfer_request_approval.xhtml` — new `p:column` in the existing `itemList` dataTable (already re-renders on the existing Qty/Rate `p:ajax` updates).

## Verification

Tested end-to-end on local Payara against pending transfer request **OP/MP/26/000005** (Main Pharmacy → OPD Pharmacy, item "Rapidene", qty 600 requested):
- OPD Pharmacy (Ordering Store) held 542 units in stock.
- Active config: `Pharmacy Transfer is by Retail Rate = true` → Transfer Rate 16.50.
- New column rendered **8,943.00** = 542 × 16.50, matching hand calculation.
- Cross-checked against DB: `RETAILSALERATE = 16.5` for the item's batch at Main Pharmacy.
- Confirmed the pending bill was left untouched (not approved) by this verification pass.

![Total Drug Amount column](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/22907-after-total-drug-amount-column.png)

Closes #22907

🤖 Generated with [Claude Code](https://claude.com/claude-code)