### PR TITLE
fix(pharmacy): guard against NPE on transfer receive when staffStock is missing

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
@@ -1082,7 +1082,8 @@ public class TransferReceiveController implements Serializable {
 
     public void onEdit(RowEditEvent event) {
         BillItem tmp = (BillItem) event.getObject();
-        if (tmp.getPharmaceuticalBillItem().getStaffStock().getStock() < tmp.getQty()) {
+        if (tmp.getPharmaceuticalBillItem().getStaffStock() == null
+                || tmp.getPharmaceuticalBillItem().getStaffStock().getStock() < tmp.getQty()) {
             tmp.setTmpQty(0.0);
             JsfUtil.addErrorMessage("You cant recieved over than Issued Qty setted Old Value");
         }
@@ -1090,7 +1091,18 @@ public class TransferReceiveController implements Serializable {
         //   getPharmacyController().setPharmacyItem(tmp.getItem());
     }
 
+    /**
+     * A null staffStock means the corresponding issue-side line never
+     * actually moved stock to the porter - treat that the same as
+     * insufficient stock rather than letting the missing reference NPE.
+     * porterStockCoversAllLines() already rejects this case up front for
+     * settle()/settleApprove(); this guard covers onEdit() and any other
+     * caller that reaches a single line's stock check directly (#22951).
+     */
     public boolean errorCheck(BillItem billItem) {
+        if (billItem.getPharmaceuticalBillItem().getStaffStock() == null) {
+            return true;
+        }
         if (billItem.getPharmaceuticalBillItem().getStaffStock().getStock() < billItem.getQty()) {
             return true;
         }


### PR DESCRIPTION
## Summary
Proactive hotfix for Ruhunu production. `TransferReceiveController.errorCheck()` and `.onEdit()` both dereference `pharmaceuticalBillItem.getStaffStock().getStock()` without a null check. A null `staffStock` happens whenever the corresponding issue-side line never actually moved stock to the porter - the receive-side `PharmaceuticalBillItem` copies `staffStock` straight from the issue-side one via its copy-constructor, so it stays null if that never happened.

`porterStockCoversAllLines()` already rejects this case up front for both `settle()`/`doSettle()` and `settleApprove()` via a live per-batch porter-stock JPQL query - but `errorCheck()` is still called per-line inside both loops afterward, and `onEdit()` is independently reachable via the PrimeFaces row-edit AJAX event. All three could still NPE on a null `staffStock`, crashing the request mid-loop and leaving it in a partially-processed state (some lines committed with stock movement, others silently left unprocessed, no clear error shown).

## Why this matters for Ruhunu specifically
This exact crash **did happen** in coop production - confirmed via the coop Payara server log (`TransferReceiveController.errorCheck` NPE, 2026-08-13T15:34:04) while receiving `TI/COOP/26/000488`. It crashed `settle()` mid-loop and left 16 of 30 items on that transfer stuck at the porter with no stock movement to the receiving department, despite the receive bill showing them as received. Root cause tracked in #22938 / #22951.

Checked Ruhunu production's Payara logs in full (608 rotated log files, current back through mid-2025) - **no occurrence of this specific crash yet**. But `origin/ruhunu-prod` runs the identical unguarded code, so the same trigger condition (an issue-side line with no porter stock movement) would crash it the same way. Fixing proactively rather than waiting for it to happen here too.

## Changes
- `errorCheck()`: treat a null `staffStock` as a failing check instead of crashing.
- `onEdit()`: same null-guard, since it's independently reachable via the row-edit AJAX event.

## Test plan
- [x] Compiles clean (`mvn compile`)
- [ ] Deploy to Ruhunu production and confirm no regression on normal transfer-receive flow

Refs #22951