### PR TITLE
fix(inward): repoint currentPatientRoom when Remove Room retires the current room

### DIFF
--- a/src/main/java/com/divudi/bean/inward/RoomChangeController.java
+++ b/src/main/java/com/divudi/bean/inward/RoomChangeController.java
@@ -17,6 +17,7 @@ import com.divudi.core.entity.Patient;
 import com.divudi.core.entity.Consultant;
 import com.divudi.core.entity.inward.Admission;
 import com.divudi.core.entity.inward.GuardianRoom;
+import com.divudi.core.entity.PatientEncounter;
 import com.divudi.core.entity.inward.PatientRoom;
 import com.divudi.core.entity.inward.RoomFacilityCharge;
 import com.divudi.core.facade.AdmissionFacade;
@@ -462,11 +463,46 @@ public class RoomChangeController implements Serializable {
             JsfUtil.addErrorMessage("No Patient Room Detected");
             return;
         }
+
+        PatientEncounter encounter = pR.getPatientEncounter();
+        AdmissionTypeEnum admissionTypeEnum = encounter != null && encounter.getAdmissionType() != null
+                ? encounter.getAdmissionType().getAdmissionTypeEnum() : null;
+
+        // Can't remove a room from the middle of the chain - the most recent one has to go first,
+        // otherwise previousRoom/nextRoom linkage breaks. Mirrors the guard in remove() (Issue #22955).
+        if (admissionTypeEnum == AdmissionTypeEnum.Admission
+                && pR.getNextRoom() != null && !pR.getNextRoom().isRetired()) {
+            JsfUtil.addErrorMessage("To Delete Patient Room There next Room Should Be Empty");
+            return;
+        }
+
         Map<String, Object> beforeState = roomStateMap(pR);
         pR.setRetired(true);
         pR.setRetiredAt(new Date());
         pR.setRetirer(sessionController.getWebUser());
         getPatientRoomFacade().edit(pR);
+
+        // If the room being removed is the encounter's current room, repoint the encounter so it
+        // never keeps referencing a retired, non-discharged room - that left discharge blocked
+        // ("the current room has not been discharged") on a room nobody can see anymore (#22955).
+        if (encounter != null && pR.equals(encounter.getCurrentPatientRoom())) {
+            PatientRoom previousRoom = pR.getPreviousRoom();
+            if (previousRoom != null && !previousRoom.isRetired()) {
+                previousRoom.setDischarged(false);
+                previousRoom.setDischargedAt(null);
+                previousRoom.setDischargedBy(null);
+                getPatientRoomFacade().edit(previousRoom);
+                encounter.setCurrentPatientRoom(previousRoom);
+            } else {
+                // No usable previous room (this was the only/first room) - fall back to "not room
+                // admitted" rather than leave a dangling reference. The room details page and the
+                // discharge guard both already handle this state correctly.
+                encounter.setCurrentPatientRoom(null);
+                encounter.setRoomAdmitted(false);
+            }
+            patientEncounterFacade.edit(encounter);
+        }
+
         bhtSummeryController.setPatientRooms(null);
         bhtSummeryController.invalidateUnifiedGanttBarsCache();
         recordRoomAuditEvent(pR, "Room Removed", beforeState);

--- a/src/main/java/com/divudi/bean/inward/RoomChangeController.java
+++ b/src/main/java/com/divudi/bean/inward/RoomChangeController.java
@@ -311,13 +311,25 @@ public class RoomChangeController implements Serializable {
         pR.setRetiredAt(new Date());
         getPatientRoomFacade().edit(pR);
 
-        if (admissionTypeEnum == AdmissionTypeEnum.Admission) {
-            pR.getPreviousRoom().setDischarged(false);
-            pR.getPreviousRoom().setDischargedAt(null);
-            pR.getPreviousRoom().setDischargedBy(null);
-            getPatientRoomFacade().edit(pR.getPreviousRoom());
-            getCurrent().setCurrentPatientRoom(pR.getPreviousRoom());
-            getEjbFacade().edit(getCurrent());
+        // Repoint the encounter off a retired room so it never keeps referencing one that's
+        // neither visible nor discharged. Previously this only ran for Admission-type encounters,
+        // which left DayCase encounters with the same dangling-currentPatientRoom bug fixed in
+        // removeRoom() (Issue #22955) - reading pR.getPatientEncounter() directly (not getCurrent())
+        // also avoids the session-staleness trap noted in BhtSummeryController's discharge guard.
+        PatientEncounter encounter = pR.getPatientEncounter();
+        if (encounter != null && pR.equals(encounter.getCurrentPatientRoom())) {
+            PatientRoom previousRoom = pR.getPreviousRoom();
+            if (previousRoom != null && !previousRoom.isRetired()) {
+                previousRoom.setDischarged(false);
+                previousRoom.setDischargedAt(null);
+                previousRoom.setDischargedBy(null);
+                getPatientRoomFacade().edit(previousRoom);
+                encounter.setCurrentPatientRoom(previousRoom);
+            } else {
+                encounter.setCurrentPatientRoom(null);
+                encounter.setRoomAdmitted(false);
+            }
+            patientEncounterFacade.edit(encounter);
         }
 
         recordRoomAuditEvent(pR, "Room Removed", beforeState);

--- a/src/main/webapp/home.xhtml
+++ b/src/main/webapp/home.xhtml
@@ -1993,10 +1993,10 @@
                 <!-- Room Change -->
                 <h:panelGroup rendered="#{ui.icon eq 'Room_Change' and webUserController.hasPrivilege('InwardRoomRoomChange')}" layout="block" class="col-1 p-1">
                     <h:form>
-                        <p:tooltip for="Room_Change" value="Room Change" showDelay="0" hideDelay="0"/>
+                        <p:tooltip for="Room_Change" value="Room Change (Deprecated - use Patient Room Details instead)" showDelay="0" hideDelay="0"/>
                         <p:commandLink id="Room_Change" ajax="false" action="#{admissionController.navigateToRoomChange()}" styleClass="svg-link">
                             <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="Room_Change.svg" style="cursor: pointer;" width="80" height="80"/>
-                            <h:outputText style="display: none;" value="Room Change"/>
+                            <h:outputText style="display: none;" value="Room Change (Deprecated)"/>
                         </p:commandLink>
                     </h:form>
                 </h:panelGroup>
@@ -2004,10 +2004,10 @@
                 <!-- Guardian Room Change -->
                 <h:panelGroup rendered="#{ui.icon eq 'Guardian_Room_Change' and webUserController.hasPrivilege('InwardRoomGurdianRoomChange')}" layout="block" class="col-1 p-1">
                     <h:form>
-                        <p:tooltip for="Guardian_Room_Change" value="Guardian Room Change" showDelay="0" hideDelay="0"/>
+                        <p:tooltip for="Guardian_Room_Change" value="Guardian Room Change (Deprecated - use Patient Room Details instead)" showDelay="0" hideDelay="0"/>
                         <p:commandLink id="Guardian_Room_Change" ajax="false" action="#{admissionController.navigateToGuardianRoomChange()}" styleClass="svg-link">
                             <p:graphicImage class="img-thumbnail" cache="true" library="icons" name="Guardian_Room_Change.svg" style="cursor: pointer;" width="80" height="80"/>
-                            <h:outputText style="display: none;" value="Guardian Room Change"/>
+                            <h:outputText style="display: none;" value="Guardian Room Change (Deprecated)"/>
                         </p:commandLink>
                     </h:form>
                 </h:panelGroup>

--- a/src/main/webapp/inward/inward_room_change.xhtml
+++ b/src/main/webapp/inward/inward_room_change.xhtml
@@ -12,6 +12,10 @@
 
     <ui:define name="content">
         <h:form>
+            <div class="alert alert-warning d-flex align-items-center gap-2 my-3" role="alert">
+                <i class="fa-solid fa-triangle-exclamation"></i>
+                <h:outputText value="This page is deprecated. Please use Patient Room Details (from the Interim Bill or Admission Profile page) for room management going forward. This page is kept only as a fallback and will be removed later." />
+            </div>
             <p:panel class="my-3" rendered="#{roomChangeController.current eq null}" styleClass="shadow-sm">
                 <f:facet name="header">
                     <div class="d-flex justify-content-between align-items-center">

--- a/src/main/webapp/inward/inward_room_change_guardian.xhtml
+++ b/src/main/webapp/inward/inward_room_change_guardian.xhtml
@@ -12,6 +12,10 @@
     <ui:define name="content">
 
         <h:form>
+            <div class="alert alert-warning d-flex align-items-center gap-2 my-3" role="alert">
+                <i class="fa-solid fa-triangle-exclamation"></i>
+                <h:outputText value="This page is deprecated. Please use Patient Room Details (from the Interim Bill or Admission Profile page) for room management going forward. This page is kept only as a fallback and will be removed later." />
+            </div>
             <p:panel rendered="#{roomChangeController.current eq null}" styleClass="shadow-sm">
                 <f:facet name="header">
                     <div class="d-flex justify-content-between align-items-center">

--- a/src/main/webapp/nurse/index.xhtml
+++ b/src/main/webapp/nurse/index.xhtml
@@ -124,7 +124,8 @@
                                                         </p:commandButton>
 
                                                         <p:commandButton
-                                                            value="Room Change"
+                                                            value="Room Change (Deprecated)"
+                                                            title="Deprecated - use Patient Room Details instead"
                                                             ajax="false"
                                                             rendered="#{webUserController.hasPrivilege('InwardRoomRoomChange')}"
                                                             action="#{admissionController.navigateToRoomChange()}"
@@ -134,7 +135,8 @@
                                                         </p:commandButton>
 
                                                         <p:commandButton
-                                                            value="Guardian Room Change"
+                                                            value="Guardian Room Change (Deprecated)"
+                                                            title="Deprecated - use Patient Room Details instead"
                                                             ajax="false"
                                                             rendered="#{webUserController.hasPrivilege('InwardRoomGurdianRoomChange')}"
                                                             action="#{admissionController.navigateToGuardianRoomChange()}"

--- a/src/main/webapp/resources/ezcomp/menu.xhtml
+++ b/src/main/webapp/resources/ezcomp/menu.xhtml
@@ -490,20 +490,22 @@
                             rendered="#{webUserController.hasPrivilege('WatingRoomAdmitPatient') and not configOptionApplicationController.getBooleanValueByKey('Patient admission and room assignment are simultaneous processes.', true)}" >
                         </p:menuitem>
 
-                        <p:menuitem 
-                            ajax="false" 
-                            action="#{admissionController.navigateToRoomChange()}" 
-                            value="Room Change" 
-                            icon="fa fa-exchange-alt" 
-                            actionListener="#{roomChangeController.recreate()}" 
+                        <p:menuitem
+                            ajax="false"
+                            action="#{admissionController.navigateToRoomChange()}"
+                            value="Room Change (Deprecated)"
+                            title="Deprecated - use Patient Room Details on the Interim Bill / Admission Profile page instead"
+                            icon="fa fa-exchange-alt"
+                            actionListener="#{roomChangeController.recreate()}"
                             rendered="#{webUserController.hasPrivilege('InwardRoomRoomChange')}" >
                         </p:menuitem>
-                        <p:menuitem 
-                            ajax="false" 
-                            action="#{admissionController.navigateToGuardianRoomChange()}" 
-                            value="Guardian Room Change" 
-                            icon="fa fa-user-edit" 
-                            actionListener="#{roomChangeController.recreate()}" 
+                        <p:menuitem
+                            ajax="false"
+                            action="#{admissionController.navigateToGuardianRoomChange()}"
+                            value="Guardian Room Change (Deprecated)"
+                            title="Deprecated - use Patient Room Details on the Interim Bill / Admission Profile page instead"
+                            icon="fa fa-user-edit"
+                            actionListener="#{roomChangeController.recreate()}"
                             rendered="#{webUserController.hasPrivilege('InwardRoomGurdianRoomChange')}" >
                         </p:menuitem>
                         <p:menuitem


### PR DESCRIPTION
## Summary
`removeRoom()` (used by the new **Patient Room Details** page's "Remove Room" button) retired the `PatientRoom` row but never updated `PatientEncounter.currentPatientRoom`. If the removed room was the encounter's current room, the encounter was left pointing at a retired, never-discharged room indefinitely — which then incorrectly blocked **Discharge** with *"the current room has not been discharged"*, even though the room actually visible to staff was fully discharged.

Reproduced and confirmed live on `southernlankaprod` (BHT/9583) via the `Room Changed` → `Room Removed` audit trail; a one-off data fix was applied there to unblock that specific admission, but the code path itself was still broken for any future occurrence.

## Root cause
`RoomChangeController` has three "remove room" implementations, and the two older ones already handled this correctly for the common case:
- **`remove(PatientRoom pR)`** — used by the older `inward_room_change.xhtml` page. Guards against out-of-order removal and repoints `currentPatientRoom` to `previousRoom` when the retired room is current — but only for `AdmissionTypeEnum.Admission` encounters, silently missing `DayCase` encounters.
- **`removeGuardianRoom(PatientRoom pR)`** — used by `inward_room_change_guardian.xhtml`. Checked, and no fix needed: guardian rooms never populate `currentPatientRoom` (they're tracked independently via `getLastGuardianRoom()`).
- **`removeRoom(PatientRoom pR)`** — used by the newer `inward_patient_room_details.xhtml` page. A simplified duplicate missing the invariant-preserving logic entirely.

## Fix
- `removeRoom()`: if the retired room has a non-retired `previousRoom`, repoint `currentPatientRoom` to it and un-discharge that room; otherwise (no usable previous room) fall back to `currentPatientRoom=null` / `roomAdmitted=false`. Also ports `remove()`'s out-of-order guard ("next room should be empty").
- `remove()`: generalized the same repoint-or-null-fallback logic so it also covers `DayCase` encounters, and reads `pR.getPatientEncounter()` directly instead of the session-scoped `getCurrent()` (avoids the staleness trap already called out in `BhtSummeryController`'s discharge guard).

## Deprecating the old page
Since staff may still need `inward_room_change.xhtml` / `inward_room_change_guardian.xhtml` as a fallback while the newer Patient Room Details page takes over, they are **not being deleted yet** — just labelled deprecated:
- In-page warning banner on both old pages.
- `(Deprecated)` + explanatory tooltip/title on every entry point: main menu, home dashboard icons, and the nurse dashboard (which has both the old and new room-management buttons side by side today).

**Scope**: `RoomChangeController.java` (logic), plus `inward_room_change.xhtml`, `inward_room_change_guardian.xhtml`, `menu.xhtml`, `home.xhtml`, `nurse/index.xhtml` (deprecation labeling only, no behavior change). No entity/schema changes.

Closes #22955

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved room removal handling by validating room-chain order.
  - Preserves a patient’s previous usable room when the current room is removed.
  - Correctly clears room assignment and admission status when no prior room exists.
  - Ensures room updates are saved and reflected consistently in records and audit history.

- **User Guidance**
  - Marked Room Change and Guardian Room Change options as deprecated.
  - Added guidance directing users to Patient Room Details for room management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->