### PR TITLE
fix(inward): highlight only actual returns in pharmacy issue summary

### DIFF
--- a/src/main/webapp/inward/reports/inpatient_pharmacy_item_list_dto.xhtml
+++ b/src/main/webapp/inward/reports/inpatient_pharmacy_item_list_dto.xhtml
@@ -164,21 +164,21 @@
 
                                 </f:facet>
 
-                                <p:column width="2em" style="padding: 2px" styleClass="#{(dto.referenceBillItemId ne null and dto.billTypeAtomic ne 'REQUEST_MEDICINE_INWARD') and !dto.billCancelled ? 'ui-messages-warn' : dto.referenceBillItemId ne null and dto.billCancelled ? 'ui-messages-fatal' : ''}">
+                                <p:column width="2em" style="padding: 2px" styleClass="#{dto.cancellationOrReturn and !dto.billCancelled ? 'ui-messages-warn' : dto.cancellationOrReturn and dto.billCancelled ? 'ui-messages-fatal' : ''}">
                                     <f:facet name="header">
                                         <h:outputLabel value="No" />
                                     </f:facet>
                                     <h:outputLabel value="#{rowIndex+1}" />
                                 </p:column>
 
-                                <p:column width="20em" style="padding: 2px" styleClass="#{(dto.referenceBillItemId ne null and dto.billTypeAtomic ne 'REQUEST_MEDICINE_INWARD') and !dto.billCancelled ? 'ui-messages-warn' : dto.referenceBillItemId ne null and dto.billCancelled ? 'ui-messages-fatal' : ''}">
+                                <p:column width="20em" style="padding: 2px" styleClass="#{dto.cancellationOrReturn and !dto.billCancelled ? 'ui-messages-warn' : dto.cancellationOrReturn and dto.billCancelled ? 'ui-messages-fatal' : ''}">
                                     <f:facet name="header">
                                         <h:outputLabel value="Item Name" />
                                     </f:facet>
                                     <h:outputLabel value="#{dto.itemName}" />
                                 </p:column>
 
-                                <p:column width="2em" style="padding: 2px" styleClass="#{(dto.referenceBillItemId ne null and dto.billTypeAtomic ne 'REQUEST_MEDICINE_INWARD') and !dto.billCancelled ? 'ui-messages-warn' : dto.referenceBillItemId ne null and dto.billCancelled ? 'ui-messages-fatal' : ''}">
+                                <p:column width="2em" style="padding: 2px" styleClass="#{dto.cancellationOrReturn and !dto.billCancelled ? 'ui-messages-warn' : dto.cancellationOrReturn and dto.billCancelled ? 'ui-messages-fatal' : ''}">
                                     <f:facet name="header">
                                         <h:outputLabel value="QTY" />
                                     </f:facet>
@@ -187,7 +187,7 @@
                                     </p:outputLabel>
                                 </p:column>
 
-                                <p:column width="3em" style="text-align: right; padding: 2px" styleClass="#{(dto.referenceBillItemId ne null and dto.billTypeAtomic ne 'REQUEST_MEDICINE_INWARD') and !dto.billCancelled ? 'ui-messages-warn' : dto.referenceBillItemId ne null and dto.billCancelled ? 'ui-messages-fatal' : ''}">
+                                <p:column width="3em" style="text-align: right; padding: 2px" styleClass="#{dto.cancellationOrReturn and !dto.billCancelled ? 'ui-messages-warn' : dto.cancellationOrReturn and dto.billCancelled ? 'ui-messages-fatal' : ''}">
                                     <f:facet name="header">
                                         <h:outputLabel value="Rate" />
                                     </f:facet>
@@ -196,7 +196,7 @@
                                     </h:outputLabel>
                                 </p:column>
 
-                                <p:column width="4em" style="text-align: right; padding: 2px" styleClass="#{(dto.referenceBillItemId ne null and dto.billTypeAtomic ne 'REQUEST_MEDICINE_INWARD') and !dto.billCancelled ? 'ui-messages-warn' : dto.referenceBillItemId ne null and dto.billCancelled ? 'ui-messages-fatal' : ''}" rendered="#{configOptionApplicationController.getBooleanValueByKey('Inpatient Reports - Show Gross Value, Discount and Service Charge', true)}">
+                                <p:column width="4em" style="text-align: right; padding: 2px" styleClass="#{dto.cancellationOrReturn and !dto.billCancelled ? 'ui-messages-warn' : dto.cancellationOrReturn and dto.billCancelled ? 'ui-messages-fatal' : ''}" rendered="#{configOptionApplicationController.getBooleanValueByKey('Inpatient Reports - Show Gross Value, Discount and Service Charge', true)}">
                                     <f:facet name="header">
                                         <h:outputLabel value="Gross Value" />
                                     </f:facet>
@@ -210,7 +210,7 @@
                                     </f:facet>
                                 </p:column>
 
-                                <p:column width="4em" style="text-align: right; padding: 2px" styleClass="#{(dto.referenceBillItemId ne null and dto.billTypeAtomic ne 'REQUEST_MEDICINE_INWARD') and !dto.billCancelled ? 'ui-messages-warn' : dto.referenceBillItemId ne null and dto.billCancelled ? 'ui-messages-fatal' : ''}" rendered="#{configOptionApplicationController.getBooleanValueByKey('Inpatient Reports - Show Gross Value, Discount and Service Charge', true)}">
+                                <p:column width="4em" style="text-align: right; padding: 2px" styleClass="#{dto.cancellationOrReturn and !dto.billCancelled ? 'ui-messages-warn' : dto.cancellationOrReturn and dto.billCancelled ? 'ui-messages-fatal' : ''}" rendered="#{configOptionApplicationController.getBooleanValueByKey('Inpatient Reports - Show Gross Value, Discount and Service Charge', true)}">
                                     <f:facet name="header">
                                         <h:outputLabel value="Discount" />
                                     </f:facet>
@@ -224,7 +224,7 @@
                                     </f:facet>
                                 </p:column>
 
-                                <p:column width="4em" style="text-align: right; padding: 2px" styleClass="#{(dto.referenceBillItemId ne null and dto.billTypeAtomic ne 'REQUEST_MEDICINE_INWARD') and !dto.billCancelled ? 'ui-messages-warn' : dto.referenceBillItemId ne null and dto.billCancelled ? 'ui-messages-fatal' : ''}" rendered="#{configOptionApplicationController.getBooleanValueByKey('Inpatient Reports - Show Gross Value, Discount and Service Charge', true)}">
+                                <p:column width="4em" style="text-align: right; padding: 2px" styleClass="#{dto.cancellationOrReturn and !dto.billCancelled ? 'ui-messages-warn' : dto.cancellationOrReturn and dto.billCancelled ? 'ui-messages-fatal' : ''}" rendered="#{configOptionApplicationController.getBooleanValueByKey('Inpatient Reports - Show Gross Value, Discount and Service Charge', true)}">
                                     <f:facet name="header">
                                         <h:outputLabel value="Service Charge" />
                                     </f:facet>
@@ -238,7 +238,7 @@
                                     </f:facet>
                                 </p:column>
 
-                                <p:column width="4em" style="text-align: right; padding: 2px" styleClass="#{(dto.referenceBillItemId ne null and dto.billTypeAtomic ne 'REQUEST_MEDICINE_INWARD') and !dto.billCancelled ? 'ui-messages-warn' : dto.referenceBillItemId ne null and dto.billCancelled ? 'ui-messages-fatal' : ''}">
+                                <p:column width="4em" style="text-align: right; padding: 2px" styleClass="#{dto.cancellationOrReturn and !dto.billCancelled ? 'ui-messages-warn' : dto.cancellationOrReturn and dto.billCancelled ? 'ui-messages-fatal' : ''}">
                                     <f:facet name="header">
                                         <h:outputLabel value="Net Value" />
                                     </f:facet>


### PR DESCRIPTION
## Summary
- Fixes the yellow warning highlight in the Inpatient Dashboard (DTO - Optimized) → Medicine Issued Department grid (`inpatient_pharmacy_item_list_dto.xhtml`), which was wrongly applied to ordinary drug-issue rows.
- Root cause: the `styleClass` on all 8 grid columns was keyed off `dto.referenceBillItemId ne null`, but that field is populated for any bill item with a reference link (e.g. ward-request fulfillment issues), not exclusively for returns/cancellations.
- Fix: switch to `dto.cancellationOrReturn`, the DTO's existing semantic flag for "is this a return/cancellation" — already used correctly elsewhere on the same page (QTY, Gross Value, Service Charge, Net Value sign-flip).

Closes #22959

## Test plan
- [x] Reproduced the bug on Southern Lanka staging (screenshot: rows 18–51 wrongly highlighted, only 59–60 are actual returns)
- [x] Rebuilt and redeployed locally against `coop` dev DB
- [x] Verified with Playwright against admission BHT/57201 (encounter 13860464): 4 actual `DIRECT_ISSUE_INWARD_MEDICINE_RETURN` items (rows 7–10) correctly highlighted; all 33 plain `DIRECT_ISSUE_INWARD_MEDICINE` items correctly unhighlighted
- [x] Cross-checked against DB (`REFERANCEBILLITEM_ID`, `BILLTYPEATOMIC`, `CANCELLED`) — matches the rendered highlight state
- [x] No errors in `server.log` after redeploy

### Before (staging)
![before](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/22959-01-staging-before-wrong-highlight.png)

### After (local, fix applied)
![after](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/22959-02-local-after-fix-correct-highlight.png)

🤖 Generated with [Claude Code](https://claude.ai/code)