### PR TITLE
fix(inward): stop double-counting Cancelled/Returned Medicine on final bill

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -2751,10 +2751,12 @@ public class BhtSummeryController implements Serializable {
             totalAllocated += alloc.getAllocatedAmount();
         }
         if (Math.abs(totalAllocated - expected) > 0.01) {
-            JsfUtil.addErrorMessage("Total allocation (" + String.format("%.2f", totalAllocated)
-                    + ") must equal the net due amount (" + String.format("%.2f", expected)
-                    + "). Difference: " + String.format("%.2f", totalAllocated - expected));
-            return true;
+            if (configOptionApplicationController.getBooleanValueByKey("Block Inward Final Bill When Credit Allocation Total Differs From Net Due Amount", true)) {
+                JsfUtil.addErrorMessage("Total allocation (" + String.format("%.2f", totalAllocated)
+                        + ") must equal the net due amount (" + String.format("%.2f", expected)
+                        + "). Difference: " + String.format("%.2f", totalAllocated - expected));
+                return true;
+            }
         }
         return false;
     }

--- a/src/main/java/com/divudi/core/data/inward/InwardChargeType.java
+++ b/src/main/java/com/divudi/core/data/inward/InwardChargeType.java
@@ -22,7 +22,7 @@ public enum InwardChargeType {
     MedicalCareICU("Medical Care", CalculationMethod.PATIENT_ROOM, true),//Goes With Room
     MedicalServices("Medical Services", true),
     Medicine("Medicine", CalculationMethod.PHARMACY_BILL, true),//For BHT ISSUE
-    CancelledReturnedMedicine("Cancelled/Returned Medicine", true),//Value of cancelled/returned medicine issues, shown separately so it is visible on printed breakups (issue #22674)
+    CancelledReturnedMedicine("Cancelled/Returned Medicine", false),//Value of cancelled/returned medicine issues; NOT shown as its own final-bill row because it is already netted into the Medicine charge type's own total (its bill-type list includes the cancellation/return types) — showing it separately (issue #22674) double-counted it into the bill grand total. Kept allowToSetItems=false rather than deleted so the value/label are still available if a future print breakup needs it without touching bill totals.
     MedicinesAndSurgicalSupplies("Medicines and Surgical Supplies", true),//For Surgery Bill Medicines
     MOCharges("MO Charges", CalculationMethod.PATIENT_ROOM, true),//GOES WITH PATIENT ROOM
     MaintainCharges("Maintain Charges", CalculationMethod.PATIENT_ROOM, true),//GOES WITH PATIENT ROOM

--- a/src/main/webapp/inward/inward_bill_final.xhtml
+++ b/src/main/webapp/inward/inward_bill_final.xhtml
@@ -58,7 +58,7 @@
                             <!-- RIGHT: actions — left=least important, right=primary -->
                             <div class="d-flex gap-2 align-items-center">
                                 <p:commandButton
-                                    update="dList tot @all settle saveProvisional"
+                                    update="dList tot @all settle"
                                     value="Process"
                                     actionListener="#{bhtSummeryController.processFinalBill()}"
                                     process="@this"
@@ -73,7 +73,7 @@
                                     icon="fas fa-cogs"
                                     value="Process Bill"
                                     process="@this"
-                                    update="dList tot settle saveProvisional @all printTempBill"
+                                    update="dList tot settle @all printTempBill"
                                     action="#{bhtSummeryController.createTempBill()}"
                                     rendered="#{configOptionApplicationController.getBooleanValueByKey('Show an Intermediate Bill on Final Bill Edit',false)}" >
                                 </p:commandButton>
@@ -84,18 +84,6 @@
                                     value="Check Final Bill"
                                     rendered="#{configOptionApplicationController.getBooleanValueByKey('Show an Intermediate Bill on Final Bill Edit',false) and configOptionApplicationController.getBooleanValueByKey('Show Print Button For Intermediate Bill on Final Bill Edit',false)}">
                                     <p:printer target="printTempBill" />
-                                </p:commandButton>
-
-                                <p:commandButton
-                                    value="Save Provisional Bill"
-                                    action="#{bhtSummeryController.saveProvisionalBill()}"
-                                    id="saveProvisional"
-                                    ajax="false"
-                                    disabled="#{bhtSummeryController.changed}"
-                                    styleClass="ui-button-warning"
-                                    icon="fa fa-save"
-                                    style="width: 200px; padding: 1px; margin: auto;"
-                                    rendered="#{configOptionApplicationController.getBooleanValueByKey('Show Save Provisional on Final Bill Edit',false) and webUserController.hasPrivilege('InwardSaveProvisionalFinalBill')}">
                                 </p:commandButton>
 
                                 <p:commandButton


### PR DESCRIPTION
## Summary
Urgent fix for a real overcharge on the Inward Final Bill page, plus two related small changes made while in this area.

### 1. Cancelled/Returned Medicine double-counted into the final bill total
The "Cancelled/Returned Medicine" row (added by #22674 purely so cancelled/returned medicine value is visible as its own breakup line) is already netted into the "Medicine" row's own total — `calCostOfIssueByBill`'s bill-type list for `Medicine` already includes the cancellation/return bill types. Because the final bill's grand total sums every row shown on the page, this breakup row's value was being added a second time, inflating the patient's bill by the full cancelled/returned amount.

Fix: `InwardChargeType.CancelledReturnedMedicine.allowToSetItems` is now `false`, so the row is no longer generated at all for the final bill — not displayed, not turned into a `BillItem`, not summed. Nothing is lost financially since Medicine's own total already reflects the net amount; this only removes a redundant, miscounted display line.

Found live on `stg-migrated.carecode.org/southernlanka` (BHT/9583) with a real patient bill overstated by Rs. 2,643.44.

### 2. Removed "Save Provisional Bill" button from the Final Bill page
Provisional bills are still saved from `inward_provisional_bill_edit.xhtml`; this button was redundant on the Final Bill page. Also cleaned up the two AJAX `update=` lists that referenced its `saveProvisional` id directly (the other ~19 references elsewhere in the page already use the null-safe `p:resolveFirstComponentWithId` pattern, so those didn't need changes).

### 3. Made the credit-allocation total check configurable
`checkCreditAllocationTotal()` hard-blocks settlement when the credit company + patient allocation rows don't sum exactly to the net due amount ("Total allocation (...) must equal the net due amount (...). Difference: ..."). Added a config option, **"Block Inward Final Bill When Credit Allocation Total Differs From Net Due Amount"** (default `true`, so behavior is unchanged unless explicitly turned off), so this can be relaxed per-deployment when needed.

## Testing
- `mvn compile` — clean, no errors.
- JSF/XHTML-only change (button removal) needs no separate test per project convention; the two Java changes are small, isolated, and reviewed line-by-line against the actual query/summation logic that produces `grantTotal`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable control for blocking final bill settlement when credit allocations differ from the net due amount.
  * Final bills no longer display cancelled or returned medicines as a separate line item.

* **Changes**
  * Removed the “Save Provisional Bill” action from the final billing screen.
  * Updated final billing actions to reflect the streamlined workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->