### PR TITLE
fix(theater): close surgery-validation lock gaps and Bill Summary 404s

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
@@ -16,6 +16,7 @@ import com.divudi.bean.common.WebUserController;
 
 import com.divudi.core.util.JsfUtil;
 import com.divudi.bean.inward.InwardBeanController;
+import com.divudi.bean.inward.SurgeryBillController;
 import com.divudi.bean.membership.PaymentSchemeController;
 import com.divudi.core.data.BillClassType;
 import com.divudi.core.data.BillNumberSuffix;
@@ -199,6 +200,8 @@ public class PharmacySaleBhtController implements Serializable {
     UserNotificationController userNotificationController;
     @Inject
     WebUserController webUserController;
+    @Inject
+    SurgeryBillController surgeryBillController;
 ////////////////////////
     @EJB
     private BillFacade billFacade;
@@ -324,6 +327,11 @@ public class PharmacySaleBhtController implements Serializable {
 
     public void settleSurgeryBhtIssue() {
         if (getBatchBill() == null) {
+            return;
+        }
+        if (getBatchBill().getBillType() == BillType.SurgeryBill
+                && surgeryBillController.isSurgeryLockedForAdditions(getBatchBill())) {
+            JsfUtil.addErrorMessage("This surgery has been validated and is locked. Revert validation to make changes.");
             return;
         }
         if (getPreBill().getBillItems().isEmpty()) {

--- a/src/main/java/com/divudi/bean/store/StoreSaleBhtController.java
+++ b/src/main/java/com/divudi/bean/store/StoreSaleBhtController.java
@@ -10,6 +10,7 @@ import com.divudi.bean.common.PriceMatrixController;
 import com.divudi.bean.common.SessionController;
 import com.divudi.core.util.JsfUtil;
 import com.divudi.bean.inward.InwardBeanController;
+import com.divudi.bean.inward.SurgeryBillController;
 import com.divudi.bean.membership.PaymentSchemeController;
 import com.divudi.core.data.BillClassType;
 import com.divudi.core.data.BillNumberSuffix;
@@ -76,6 +77,8 @@ public class StoreSaleBhtController implements Serializable {
 
     @Inject
     SessionController sessionController;
+    @Inject
+    SurgeryBillController surgeryBillController;
 ////////////////////////
     @EJB
     private BillFacade billFacade;
@@ -483,6 +486,11 @@ public class StoreSaleBhtController implements Serializable {
     }
 
     public void settleStoreBhtIssue() {
+        if (getBatchBill() != null && getBatchBill().getBillType() == BillType.SurgeryBill
+                && surgeryBillController.isSurgeryLockedForAdditions(getBatchBill())) {
+            JsfUtil.addErrorMessage("This surgery has been validated and is locked. Revert validation to make changes.");
+            return;
+        }
         settleBhtIssue(BillType.StoreBhtPre, BillNumberSuffix.STISSUE);
     }
 

--- a/src/main/webapp/theater/inward_bill_surgery_list.xhtml
+++ b/src/main/webapp/theater/inward_bill_surgery_list.xhtml
@@ -215,6 +215,13 @@
                                         target="#{surgeryBillController.surgeryBill}"/>
                                 </p:commandButton>
                                 <p:commandButton
+                                    value="Bill Summary / Validate"
+                                    icon="fa fa-clipboard-check"
+                                    class="ui-button-success"
+                                    ajax="false"
+                                    action="#{surgeryBillController.navigateToSurgeryBillSummary(surg)}">
+                                </p:commandButton>
+                                <p:commandButton
                                     value="Delete"
                                     icon="fa fa-trash"
                                     class="ui-button-danger"

--- a/src/main/webapp/theater/issue_index.xhtml
+++ b/src/main/webapp/theater/issue_index.xhtml
@@ -68,12 +68,12 @@
                                 </f:facet>
 
                                 <p:commandButton
-                                    value="Direct Issue"
+                                    value="Direct Issue (use Medicine Issue)"
                                     class="w-100"
-                                    action="/store/store_retail_sale_bht?faces-redirect=true"
-                                    actionListener="#{pharmacySaleBhtController.resetAll()}"
-                                    rendered="#{webUserController.hasPrivilege('TheaterIssueStoreBhtBilling')}"
-                                    icon="pi pi-shopping-cart"
+                                    action="/theater/inward_bill_surgery_issue?faces-redirect=true"
+                                    actionListener="#{pharmacySaleBhtController.makeNull()}"
+                                    rendered="#{webUserController.hasPrivilege('TheaterIssuePharmacy')}"
+                                    icon="pi pi-check"
                                     ajax="false"/>
                                 <p:commandButton
                                     value="Search Issue Bill"

--- a/src/main/webapp/theater/surgery_bill_summary.xhtml
+++ b/src/main/webapp/theater/surgery_bill_summary.xhtml
@@ -95,7 +95,7 @@
                                 </p:column>
                                 <p:column>
                                     <p:commandButton ajax="false" rendered="#{ser.transBillItemCount ne 0}"
-                                                      action="inward_edit_bill_item_view?faces-redirect=true"
+                                                      action="/inward/inward_edit_bill_item_view?faces-redirect=true"
                                                       value="View Bill Items">
                                         <f:setPropertyActionListener value="#{ser}" target="#{bhtSummeryController.item}"/>
                                     </p:commandButton>
@@ -128,7 +128,7 @@
                         </p:panelGrid>
                         <p:commandButton ajax="false" value="View Bill"
                                           rendered="#{surgeryBillController.surgeryTimedServiceBill ne null}"
-                                          action="inward_reprint_bill?faces-redirect=true">
+                                          action="/inward/inward_reprint_bill?faces-redirect=true">
                             <f:setPropertyActionListener value="#{surgeryBillController.surgeryTimedServiceBill}" target="#{inwardSearch.bill}"/>
                         </p:commandButton>
                     </p:tab>
@@ -149,12 +149,12 @@
                                 </h:outputLabel>
                             </p:column>
                             <p:column headerText="Action">
-                                <p:commandButton ajax="false" action="pharmacy_reprint_bill_sale_bht?faces-redirect=true"
+                                <p:commandButton ajax="false" action="/inward/pharmacy_reprint_bill_sale_bht?faces-redirect=true"
                                                   rendered="#{iss.billClass eq 'class com.divudi.core.entity.PreBill'}"
                                                   value="View Issue">
                                     <f:setPropertyActionListener value="#{iss}" target="#{pharmacyBillSearch.bill}"/>
                                 </p:commandButton>
-                                <p:commandButton ajax="false" action="pharmacy_reprint_bill_return_bht?faces-redirect=true"
+                                <p:commandButton ajax="false" action="/inward/pharmacy_reprint_bill_return_bht?faces-redirect=true"
                                                   rendered="#{iss.billClass eq 'class com.divudi.core.entity.RefundBill'}"
                                                   value="View Return">
                                     <f:setPropertyActionListener value="#{iss}" target="#{pharmacyBillSearch.bill}"/>
@@ -179,12 +179,12 @@
                                 </h:outputLabel>
                             </p:column>
                             <p:column headerText="Action">
-                                <p:commandButton ajax="false" action="store_reprint_bill_sale_bht?faces-redirect=true"
+                                <p:commandButton ajax="false" action="/inward/store_reprint_bill_sale_bht?faces-redirect=true"
                                                   rendered="#{iss.billClass eq 'class com.divudi.core.entity.PreBill'}"
                                                   value="View Issue">
                                     <f:setPropertyActionListener value="#{iss}" target="#{storeBillSearch.bill}"/>
                                 </p:commandButton>
-                                <p:commandButton ajax="false" action="store_reprint_bill_return_bht?faces-redirect=true"
+                                <p:commandButton ajax="false" action="/inward/store_reprint_bill_return_bht?faces-redirect=true"
                                                   rendered="#{iss.billClass eq 'class com.divudi.core.entity.RefundBill'}"
                                                   value="View Return">
                                     <f:setPropertyActionListener value="#{iss}" target="#{storeBillSearch.bill}"/>
@@ -209,7 +209,7 @@
                                 </h:outputLabel>
                             </p:column>
                             <p:column headerText="Action">
-                                <p:commandButton ajax="false" action="inward_reprint_bill_professional?faces-redirect=true" value="View Bill">
+                                <p:commandButton ajax="false" action="/inward/inward_reprint_bill_professional?faces-redirect=true" value="View Bill">
                                     <f:setPropertyActionListener value="#{pf.bill}" target="#{inwardSearch.bill}"/>
                                 </p:commandButton>
                             </p:column>
@@ -232,7 +232,7 @@
                                 </h:outputLabel>
                             </p:column>
                             <p:column headerText="Action">
-                                <p:commandButton ajax="false" action="inward_reprint_bill_professional?faces-redirect=true" value="View Bill">
+                                <p:commandButton ajax="false" action="/inward/inward_reprint_bill_professional?faces-redirect=true" value="View Bill">
                                     <f:setPropertyActionListener value="#{pf.bill}" target="#{inwardSearch.bill}"/>
                                 </p:commandButton>
                             </p:column>


### PR DESCRIPTION
## What this does

Closes gaps in the surgery billing validation feature shipped in #22287 (see #22958 for the full write-up of what was found).

1. **Bug fix** — `PharmacySaleBhtController.settleSurgeryBhtIssue()` and `StoreSaleBhtController.settleStoreBhtIssue()` now enforce the surgery lock server-side (`SurgeryBillController.isSurgeryLockedForAdditions(...)`), matching the pattern already used for Services/Timed Services/Professional Fees. Previously the UI disabled the "Direct Issue Medicines" button once a surgery was validated, but the underlying save method had no matching guard — a stale page or any bypass of the disabled button could still issue medicines/store items against a validated surgery.
2. **Cleanup** — `theater/issue_index.xhtml`'s "Store Issues for Theatre → Direct Issue" now points at the same Pharmacy Direct Issue page used by Medicine Issue, since store items for surgeries are issued that way now. Search Issue Bill / Search Issue Bill Items are unchanged, for historical records.
3. **Enhancement** — Added a per-row **"Bill Summary / Validate"** button to "Manage Surgeries" (`theater/inward_bill_surgery_list.xhtml`), matching the existing button on the Surgery Workbench, so billing staff can reach the validate screen without going through the dashboard.
4. **Bonus bug fix (found during verification)** — All 6 "View Bill"/"View Issue"/"View Bill Items" buttons on `theater/surgery_bill_summary.xhtml` (from #22287) were 404ing. They used bare JSF navigation outcomes copied from `/inward/inward_bill_intrim.xhtml` (e.g. `action="pharmacy_reprint_bill_sale_bht?faces-redirect=true"`), which resolve relative to the current view's directory — correct from `/inward/`, but broken once reused from `/theater/`. This was blocking the actual "review and check bills before validating" workflow entirely, so it's fixed here rather than filed separately. All 6 outcomes are now absolute paths.

## Verification (Playwright + DB)

Tested against local Payara with surgery "Appendicectomy" (BHT/56755, surgery bill `13988664`):

1. Manage Surgeries shows the new button:
   ![Manage Surgeries link](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/surgery_bill_validation_01_manage_surgeries_link.png)

2. Checked the surgery's Medicine Issue bill via the now-working "View Issue" link; all bills checked, Validate Surgery enabled:
   ![All checked](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/surgery_bill_validation_02_all_checked.png)

3. Validated — badge flips to "Completed" (DB: `COMPLETED=1, COMPLETEDBY=buddhika, COMPLETEDAT=2026-08-15 06:06:59`):
   ![Validated](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/surgery_bill_validation_03_validated.png)

4. Attempted to issue a new medicine to the validated surgery via the previously-unguarded Store panel path — **server rejected it**, 0 new bills created in DB:
   ![Blocked](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/surgery_bill_validation_04_locked_error.png)

5. Reverted validation with a reason, then successfully issued the same medicine — DB shows new bill `theatre//26/038053` linked via `FORWARDREFERENCEBILL_ID=13988664`, created only after `COMPLETED` reverted to `0`:
   ![Allowed after revert](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/surgery_bill_validation_05_allowed_after_revert.png)

6. `issue_index.xhtml` Store panel now redirects to Medicine Issue:
   ![Store panel](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/surgery_bill_validation_06_store_issue_retired.png)

`StoreSaleBhtController`'s guard is verified by code inspection (identical, proven pattern) — its only UI entry point now selects by BHT, not surgery, so `batchBill` can no longer be set to a surgery through the UI at all; the guard is defense-in-depth.

## Docs

New wiki page: [Surgery Bill Summary / Validate](https://github.com/hmislk/hmis/wiki/Theatre-Surgery-Bill-Validation), cross-linked from [Theatre — Surgery Workbench](https://github.com/hmislk/hmis/wiki/Theatre-Surgery-Workbench).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
