### PR TITLE
feat(inward): make Adjusted Total field restrictions and mismatch validation configurable

### DIFF
--- a/src/main/webapp/inward/inward_bill_final.xhtml
+++ b/src/main/webapp/inward/inward_bill_final.xhtml
@@ -625,14 +625,15 @@
                                     id="catAdj" 
                                     class="w-100 text-end"
                                     value="#{c.adjustedTotal}"
-                                    disabled="#{c.inwardChargeType eq 'RoomCharges' 
+                                    disabled="#{!configOptionApplicationController.getBooleanValueByKeyReadOnly('Inward Final Bill - Allow Editing Adjusted Total For All Charge Types', false)
+                                                and (c.inwardChargeType eq 'RoomCharges'
                                                 or c.inwardChargeType eq 'MOCharges'
                                                 or c.inwardChargeType eq 'MaintainCharges'
                                                 or c.inwardChargeType eq 'NursingCharges'
                                                 or c.inwardChargeType eq 'LinenCharges'
                                                 or c.inwardChargeType eq 'MedicalCareICU'
                                                 or c.inwardChargeType eq 'AdministrationCharge'
-                                                or c.inwardChargeType eq 'ProfessionalCharge'}">
+                                                or c.inwardChargeType eq 'ProfessionalCharge')}">
                                     <f:convertNumber pattern="#,##0.00"/>
                                     <p:ajax process="@this" update=":#{p:resolveFirstComponentWithId('tot',view).clientId} "
                                             event="blur"


### PR DESCRIPTION
## Summary
Follow-up to #22962 for Southern Lanka: they want full manual control over Inward Final Bill category "Adjusted Total" values, with no validation blocking settlement on a mismatch.

Two guardrails were hardcoded for every deployment:

1. **Adjusted Total input disabled for a fixed charge-type list** (RoomCharges, MOCharges, MaintainCharges, NursingCharges, LinenCharges, MedicalCareICU, AdministrationCharge, ProfessionalCharge) — no way to opt out per institution.
2. **`checkCatTotal()` hard-blocks Save Final Bill** when the sum of category totals doesn't match the sum of adjusted totals ("There is a difference between actual and adjusted values. Please Adjust category amount correctly.").

(2) was already config-gated behind `Block Inward Final Bill When Category Adjusted Total Differs From Actual Total` (default `true`) from earlier work — no code change needed, just flip it per-institution via the config API.

(1) had no such gate, so this PR adds one: `Inward Final Bill - Allow Editing Adjusted Total For All Charge Types` (default `false`, unchanged behavior everywhere). When `true`, every row's Adjusted Total field becomes editable.

Both options are being set to enable full manual control for Southern Lanka via `/api/config/setBoolean` once this deploys.

## Testing
JSF/XHTML-only change (no Java touched) — per project convention this doesn't require compilation/testing. Diff is a single conditional wrap around the existing `disabled` expression; reviewed by inspection for correct EL syntax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)