### PR TITLE
docs(dev-issue): auto-select Subagent-Driven for writing-plans handoff

### DIFF
--- a/.claude/skills/dev-issue/SKILL.md
+++ b/.claude/skills/dev-issue/SKILL.md
@@ -17,6 +17,11 @@ Invoking this skill is the explicit authorization for every commit/push/PR
 step below — do not re-ask before each one. Discussion gates (steps 2a
 non-repro case, 3, 4, 14) are the points where you pause for the user.
 
+This authorization also covers `superpowers:writing-plans`' Execution
+Handoff question, if that chain gets invoked anywhere in this flow (e.g.
+during step 5): auto-select **option 1, Subagent-Driven** without asking —
+do not stop for it as an additional discussion gate.
+
 ## 1. Setup
 
 Run the `start-issue` skill for `$0`: creates the branch from


### PR DESCRIPTION
## What changed

`.claude/skills/dev-issue/SKILL.md` now extends its existing standing-authorization paragraph to also cover `superpowers:writing-plans`' **Execution Handoff** question. If a `dev-issue` run passes through `superpowers:brainstorming` → `superpowers:writing-plans` (e.g. during step 5 "Develop"), that question is no longer treated as an extra discussion gate — option 1 (Subagent-Driven) is auto-selected, consistent with dev-issue's existing no-re-ask authorization for commit/push/PR steps.

## Why

Discussion gates in `dev-issue` are limited to specific named points (2a non-repro case, 3, 4, 14). The `writing-plans` handoff question wasn't one of them, but it stopped the flow anyway, asking a question whose answer is almost always the skill's own stated recommendation — pure friction with no change in outcome.

## Scope note

The issue also floated an optional addendum inside `writing-plans` itself. That skill lives in the `superpowers` plugin cache, outside this repo, so it's out of scope for this PR — flagging it here rather than silently dropping it.

## Verification

Doc-only change to a markdown skill instruction file — no code/build/Playwright/DB surface. Verified by re-reading the edited section in context (see issue comment).

Closes #22956

🤖 Generated with [Claude Code](https://claude.com/claude-code)