### PR TITLE
fix(inward): stop stale cached prices from leaking across patients on Add Services

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -1819,6 +1819,24 @@ before you spend time debugging "missing" log output:
   Recovery: `kill -9` the stuck DAS `java` process (find via `ps aux | grep domains/<name>`),
   `asadmin start-domain <name>`, then a plain `deploy` (not `redeploy`).
 
+## 70. `inward/inward_bill_service.xhtml`'s "Settle" button silently returns to the edit screen — with the same items still loaded — when a fee row needs a Staff pick
+
+Clicking **Settle** (`ajax="false"`, `confirm()`-guarded) for a bill whose Fees tab
+has a row with a non-null `speciality` (e.g. a "Technician Fee") but no `staff`
+selected does **not** navigate to print preview and does **not** throw a visible
+error near the button — the page does a full reload and lands back on the exact
+same "Add Services" edit view, Bill Items/Fees tabs still populated, looking
+almost identical to the pre-click state. The only server-side evidence is a
+`Growl` message baked into the reloaded HTML (`msgs:[{summary:"Please select
+Staff",...,severity:'error'}]`), which is easy to miss since no dialog or
+distinct page state change signals failure. Confirm success/failure by grepping
+the full-postback response body for `Growl`/`severity:'error'` (per §32's
+pattern), or simply check whether the "Investigation or Service" picker /
+"Add" button are still rendered afterward — their presence means Settle did not
+go through. Fix in automation: after any Fees-tab row shows a "Select Staff"
+dropdown, pick a value from it (PrimeFaces click-option pattern, §13) before
+clicking Settle. Found verifying issue #22916.
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.

--- a/src/main/java/com/divudi/bean/inward/BillBhtController.java
+++ b/src/main/java/com/divudi/bean/inward/BillBhtController.java
@@ -82,6 +82,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import javax.annotation.PostConstruct;
@@ -197,7 +198,8 @@ public class BillBhtController implements Serializable {
     private Department selectedInwardItemDepartment;
     private List<Department> inwardItemDepartments;
     private List<ItemLight> inwardItem;
-    
+    private PatientEncounter inwardItemCacheKey;
+
     private Priority currentBillItemPriority;
     private Double currentBillItemQty;
 
@@ -1970,8 +1972,9 @@ public class BillBhtController implements Serializable {
     }
 
     public List<ItemLight> getInwardItem() {
-        if (inwardItem == null) {
+        if (inwardItem == null || !Objects.equals(inwardItemCacheKey, patientEncounter)) {
             inwardItem = fillInwardItem();
+            inwardItemCacheKey = patientEncounter;
         }
         return inwardItem;
     }


### PR DESCRIPTION
## Summary

Fixes #22916 — Foreign Fee displayed for non-foreign patients on `inward/inward_bill_service.xhtml`.

**Root cause:** `BillBhtController` is `@SessionScoped`, so the "Investigation or Service" price list is built once and cached (`inwardItem`), baking in whichever patient's foreigner status was current at build time (`applyInwardFeeTotals()`). Nothing invalidated that cache when the operator switched to a different patient (New Bill, re-selecting a patient, item-request seeding, etc.) — so a foreign patient's higher (`ffee`) rates kept showing in the item picker for a later local patient in the same session.

The amount actually **billed** on Add was always correct (`BillBeanController.createBillFee()` picks `fee` vs `ffee` from the live `patientEncounter` on every add) — this was purely a **display** bug in the price list shown before adding an item.

## Fix

`src/main/java/com/divudi/bean/inward/BillBhtController.java`:
- Added `inwardItemCacheKey` to track which `PatientEncounter` the cached `inwardItem` list reflects.
- `getInwardItem()` now rebuilds whenever the currently selected `patientEncounter` differs from that cache key (`PatientEncounter.equals()` is ID-based, so this correctly detects "different patient", including the null → non-null transition).
- `getDepartmentInwardItems()`/`departmentChanged()` already re-derive from `getInwardItem()` on every call, so no other caching needed to change. No XHTML changes required.

Also appended a new gotcha (`#70`) to `developer_docs/testing/playwright-e2e-workflow.md`: the Settle button on this page silently returns to the edit screen (not print preview) with no visible error when a fee row needs a Staff pick — only a `Growl` error in the reloaded HTML signals the failure.

## Verification

Tested with Playwright against local Payara (department: Inward, Galle Co-Operative Hospital):

1. Selected a foreign patient — `DENTAL X RAY` listed at **1,500.00** (foreign rate: Hospital Fee 1350 + Technician Fee 150).
2. Clicked **New Bill**, selected a local patient — same item now correctly shows **750.00** (local rate: 675 + 75) instead of the stale foreign price.
3. Added the item to the local patient's bill and settled it — the Fees tab and the persisted `BILLFEE` DB rows both show the local amounts (675.00 + 75.00 = 750.00), matching `FEE.FEE`, not `FEE.FFEE` (1350/150).

Full verification details posted on the issue: https://github.com/hmislk/hmis/issues/22916#issuecomment-5300486076

Closes #22916

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Inward item lists now refresh correctly when switching between patient encounters.
  * Improved handling of inward service bill settlement when applicable fee rows lack selected staff.

* **Documentation**
  * Added testing guidance for validating settlement failures and ensuring staff are selected for applicable fee rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->