### PR TITLE
Add privilege to gate Cancel button on Sale Return Bill view page

### DIFF
--- a/src/main/java/com/divudi/bean/common/UserPrivilageController.java
+++ b/src/main/java/com/divudi/bean/common/UserPrivilageController.java
@@ -782,6 +782,7 @@ public class UserPrivilageController implements Serializable {
         TreeNode PharmacyReturnItemsOnly = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyReturnItemsOnly, "Pharmacy Return Items Only"), retailTransaction);
         TreeNode PharmacyReturnItemsAndPayments = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyReturnItemsAndPayments, "Pharmacy Return Items And Payments"), retailTransaction);
         TreeNode PharmacySearchReturnBill = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacySearchReturnBill, "Pharmacy Search ReturnBill"), retailTransaction);
+        TreeNode PharmacySearchReturnBillCancel = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacySearchReturnBillCancel, "Pharmacy Search Return Bill Cancel"), retailTransaction);
         TreeNode PharmacySaleReprint = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacySaleReprint, "Pharmacy Sale Reprint"), retailTransaction);
         TreeNode PrintOriginalPharmacyBillFromReprint = new DefaultTreeNode(new PrivilegeHolder(Privileges.PrintOriginalPharmacyBillFromReprint, "Print Original Pharmacy Bill From Reprint"), retailTransaction);
         TreeNode PharmacySaleCancel = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacySaleCancel, "Pharmacy Sale Bill Cancel"), retailTransaction);

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -619,6 +619,7 @@ public enum Privileges {
     PharmacyReturnItemsOnly("Pharmacy Return Items Only"),
     PharmacyReturnItemsAndPayments("Pharmacy Return Items and Payments"),
     PharmacySearchReturnBill("Pharmacy Search Return Bill"),
+    PharmacySearchReturnBillCancel("Pharmacy Search Return Bill Cancel"),
     PharmacyAddToStock("Pharmacy Add to Stock"),
     // Pharmacy Wholesale Transaction
     PharmacyWholeSaleTransactionMenue("Pharmacy Wholesale Transaction Menu"),
@@ -1069,6 +1070,7 @@ public enum Privileges {
             case PharmacyReturnItemsOnly:
             case PharmacyReturnItemsAndPayments:
             case PharmacySearchReturnBill:
+            case PharmacySearchReturnBillCancel:
             case PharmacyAddToStock:
             case PharmacyDonation:
 

--- a/src/main/webapp/pharmacy/pharmacy_reprint_bill_return_pre.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_reprint_bill_return_pre.xhtml
@@ -33,13 +33,14 @@
                                 </p:commandButton>
 
                                 <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Return Item Bill can be Cancelled', true)}">
-                                    <p:commandButton 
-                                        ajax="false" 
+                                    <p:commandButton
+                                        ajax="false"
                                         value="Cancel"
                                         icon="fas fa-ban"
                                         class="ui-button-danger mx-2"
                                         action="pharmacy_cancel_bill_return_pre?faces-redirect=true"
-                                        disabled="#{pharmacyBillSearch.bill.cancelled or pharmacyBillSearch.hasActiveReturnCashBill()}">
+                                        disabled="#{pharmacyBillSearch.bill.cancelled or pharmacyBillSearch.hasActiveReturnCashBill()}"
+                                        rendered="#{webUserController.hasPrivilege('PharmacySearchReturnBillCancel')}">
                                     </p:commandButton>
                                 </h:panelGroup>
                             </div>


### PR DESCRIPTION
## What changed

`pharmacy/pharmacy_reprint_bill_return_pre.xhtml` (the Sale Return Bill "View Bill" page, reached from **Search Return Bill (Item)**) has a **Cancel** button that cancels the return bill. It was previously gated only by a config option (`Pharmacy Return Item Bill can be Cancelled`), with no per-user privilege check, so any user who could view the bill could also cancel it.

This PR adds a dedicated privilege, `PharmacySearchReturnBillCancel`, and gates the Cancel button with it, following the exact same pattern as the existing `PharmacySaleCancel` privilege used on the regular sale-bill cancel buttons.

### Files changed
- `src/main/java/com/divudi/core/data/Privileges.java` — new enum value `PharmacySearchReturnBillCancel("Pharmacy Search Return Bill Cancel")`, added next to `PharmacySearchReturnBill` and included in the same `getCategory()` group (`"Pharmacy"`).
- `src/main/java/com/divudi/bean/common/UserPrivilageController.java` — new `TreeNode` for the privilege under the "Pharmacy Retail Transaction" node, so it can be assigned per role from **Admin → User Privileges**.
- `src/main/webapp/pharmacy/pharmacy_reprint_bill_return_pre.xhtml` — added `rendered="#{webUserController.hasPrivilege('PharmacySearchReturnBillCancel')}"` to the Cancel `p:commandButton`.

### Behavior
- Users **with** `PharmacySearchReturnBillCancel` see and can use the Cancel button (subject to the existing config option and bill-state checks, unchanged).
- Users **without** it no longer see the Cancel button at all.

## Verification

- `mvn compile` succeeds with the changed files (`Privileges.java`, `UserPrivilageController.java`) compiling cleanly.
- This remote session has no local Payara/MySQL instance available, so I could not run a live Playwright pass against a deployed app. Manual verification per the issue's steps is recommended before merge:
  1. Create two roles — one with `Pharmacy Search Return Bill Cancel`, one without.
  2. Log in with each, navigate to **Pharmacy → Search Return Bill (Item) → View Bill**, and confirm the Cancel button is shown/usable only for the role with the privilege.

Closes #22954

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VL72i2bTEmfjsdAVCyAXsb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated pharmacy privilege for canceling return bills.
  * Pharmacy return bill cancellation is now available only to users with the appropriate permission.

* **Bug Fixes**
  * Improved access control for the cancellation action on reprinted pharmacy return bills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->