### PR TITLE
feat(inward): show price-matrix Service Charge (Margin) on final bill

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -4852,7 +4852,13 @@ public class BhtSummeryController implements Serializable {
      * breakdown, not just the net total. Services/investigations
      * (BillItem-backed) come from a bulk JPQL sum grouped by InwardChargeType;
      * Professional/Assisting fees (BillFee-backed, staff fee records) are
-     * summed from the lists already fetched for their respective tabs.
+     * summed from the lists already fetched for their respective tabs;
+     * Room/Maintain/MO/Nursing/Medical Care/Administration/Linen charges
+     * (PatientRoom-backed) are summed in-memory from the already-recalculated
+     * {@link #getPatientRooms()} list, because PatientRoom's marginXxxCharge
+     * fields are {@code @Transient} — display-only, recomputed on every
+     * calculation, never persisted — so a JPQL sum over them is not possible
+     * (issue #22975).
      */
     private void setGrossMarginVatBreakdown() {
         Map<InwardChargeType, double[]> serviceBreakdown = getInwardBean().calServiceBillItemsGrossMarginVatByInwardChargeTypeBulk(getPatientEncounter(), childPatientEncouters);
@@ -4872,6 +4878,21 @@ public class BhtSummeryController implements Serializable {
                 cit.setVat(values[2]);
             } else {
                 cit.setGross(cit.getTotal());
+            }
+        }
+
+        // Room/maintain/MO/nursing/medical-care/administration/linen charges are
+        // computed straight from PatientRoom (not BillItem), so they never show up
+        // in serviceBreakdown above. Their own price-matrix margin (issue #22975)
+        // lives on PatientRoom's marginXxxCharge fields instead, and Total already
+        // has it folded in the same way BillItem's does — pull it out here so the
+        // Charge Types grid can show it as its own Matrix Value column.
+        Map<InwardChargeType, Double> roomMargins = sumRoomMatrixMargins();
+        for (ChargeItemTotal cit : chargeItemTotals) {
+            Double roomMargin = roomMargins.get(cit.getInwardChargeType());
+            if (roomMargin != null && roomMargin != 0.0) {
+                cit.setMargin(roomMargin);
+                cit.setGross(cit.getTotal() - roomMargin);
             }
         }
 
@@ -4923,6 +4944,26 @@ public class BhtSummeryController implements Serializable {
                 cit.setVat(0.0);
             }
         }
+    }
+
+    /**
+     * Sums each PatientRoom's transient price-matrix margin fields, grouped by
+     * the InwardChargeType they contribute to. Relies on {@link #getPatientRooms()}
+     * to trigger the same recalculation the "Mandatory Charge Types" room tabs
+     * already use, so the figures agree with what those tabs show.
+     */
+    private Map<InwardChargeType, Double> sumRoomMatrixMargins() {
+        Map<InwardChargeType, Double> margins = new HashMap<>();
+        for (PatientRoom p : getPatientRooms()) {
+            margins.merge(InwardChargeType.RoomCharges, p.getMarginRoomCharge(), Double::sum);
+            margins.merge(InwardChargeType.MaintainCharges, p.getMarginMaintainCharge(), Double::sum);
+            margins.merge(InwardChargeType.LinenCharges, p.getMarginLinenCharge(), Double::sum);
+            margins.merge(InwardChargeType.MOCharges, p.getMarginMoCharge(), Double::sum);
+            margins.merge(InwardChargeType.NursingCharges, p.getMarginNursingCharge(), Double::sum);
+            margins.merge(InwardChargeType.AdministrationCharge, p.getMarginAdministrationCharge(), Double::sum);
+            margins.merge(InwardChargeType.MedicalCareICU, p.getMarginMedicalCareCharge(), Double::sum);
+        }
+        return margins;
     }
 
     private void updateRoomChargeList() {

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -4886,13 +4886,17 @@ public class BhtSummeryController implements Serializable {
         // in serviceBreakdown above. Their own price-matrix margin (issue #22975)
         // lives on PatientRoom's marginXxxCharge fields instead, and Total already
         // has it folded in the same way BillItem's does — pull it out here so the
-        // Charge Types grid can show it as its own Matrix Value column.
+        // Charge Types grid can show it as its own Matrix Value column. Added
+        // (not set) onto whatever margin the charge type already has, since a
+        // charge type can combine a room-backed total with a service-backed one
+        // (e.g. additional/timed charges routed onto the same InwardChargeType)
+        // and overwriting would silently drop the service-side margin.
         Map<InwardChargeType, Double> roomMargins = sumRoomMatrixMargins();
         for (ChargeItemTotal cit : chargeItemTotals) {
             Double roomMargin = roomMargins.get(cit.getInwardChargeType());
             if (roomMargin != null && roomMargin != 0.0) {
-                cit.setMargin(roomMargin);
-                cit.setGross(cit.getTotal() - roomMargin);
+                cit.setMargin(cit.getMargin() + roomMargin);
+                cit.setGross(cit.getTotal() - cit.getMargin());
             }
         }
 
@@ -4948,13 +4952,32 @@ public class BhtSummeryController implements Serializable {
 
     /**
      * Sums each PatientRoom's transient price-matrix margin fields, grouped by
-     * the InwardChargeType they contribute to. Relies on {@link #getPatientRooms()}
-     * to trigger the same recalculation the "Mandatory Charge Types" room tabs
-     * already use, so the figures agree with what those tabs show.
+     * the InwardChargeType they contribute to.
+     * <p>
+     * {@link #getPatientRooms()} only recalculates via {@code setPatientRoomData()}
+     * the first time {@code patientRooms} is populated — the seven per-charge-type
+     * discount listeners (e.g. {@link #changeDiscountListenerPatientRoomRoomCharge})
+     * reload {@code patientRooms} straight from the DB afterward without calling
+     * it, which would leave these {@code @Transient} margin fields at their
+     * just-loaded default of 0. So the margin (and calculated-total) fields are
+     * recomputed here unconditionally before summing — cheap relative to the rest
+     * of a bill recalculation, and safe to repeat since {@code calculateRoomCharge()}
+     * and its siblings are pure functions of the room's own charge/duration fields
+     * plus the configured price matrix; they never touch discount/adjusted fields,
+     * so this can't clobber a discount the user just edited.
      */
     private Map<InwardChargeType, Double> sumRoomMatrixMargins() {
         Map<InwardChargeType, Double> margins = new HashMap<>();
         for (PatientRoom p : getPatientRooms()) {
+            calculateRoomCharge(p);
+            calculateMaintananceCharge(p);
+            calculateLinenCharge(p);
+            if (!(p instanceof GuardianRoom)) {
+                calculateNursingCharge(p);
+                calculateMoCharge(p);
+                calculateAdministrationCharge(p);
+                calculateMedicalCareCharge(p);
+            }
             margins.merge(InwardChargeType.RoomCharges, p.getMarginRoomCharge(), Double::sum);
             margins.merge(InwardChargeType.MaintainCharges, p.getMarginMaintainCharge(), Double::sum);
             margins.merge(InwardChargeType.LinenCharges, p.getMarginLinenCharge(), Double::sum);

--- a/src/main/webapp/inward/inward_bill_final.xhtml
+++ b/src/main/webapp/inward/inward_bill_final.xhtml
@@ -180,6 +180,14 @@
                                         <h:outputLabel value="#{bhtSummeryController.grantTotal}">
                                             <f:convertNumber pattern="#,##0.00"/>
                                         </h:outputLabel>
+                                        <h:outputLabel value="Gross Total" style="font-weight: bold" rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}"/>
+                                        <h:outputLabel value="#{bhtSummeryController.grossTotal}" rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </h:outputLabel>
+                                        <h:outputLabel value="Service Charge (Margin)" style="font-weight: bold" title="Price matrix value already included in Total Charges above" rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}"/>
+                                        <h:outputLabel value="#{bhtSummeryController.marginTotal}" rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </h:outputLabel>
                                         <h:outputLabel value="Item Discounts" style="font-weight: bold"/>
                                         <h:outputLabel value="#{bhtSummeryController.itemDiscountTotal}">
                                             <f:convertNumber pattern="#,##0.00"/>
@@ -584,6 +592,12 @@
 
                             <p:column headerText="Total" sortBy="#{c.total}" class="text-end" width="14em;">
                                 <h:outputLabel value="#{c.total}" class="w-100 text-end">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputLabel>
+                            </p:column>
+
+                            <p:column headerText="Service Charge (Margin)" sortBy="#{c.margin}" class="text-end" width="12em;" title="Price matrix value already included in Total for this charge type" rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
+                                <h:outputLabel value="#{c.margin}" class="w-100 text-end">
                                     <f:convertNumber pattern="#,##0.00"/>
                                 </h:outputLabel>
                             </p:column>


### PR DESCRIPTION
## Decisions made without approval

This was run via `dev-issue-unattended` — the user was unreachable, so these judgment calls were made autonomously and are listed here for review:

1. **"Total already includes the matrix value" — didn't literally implement `Net Total = Total + Matrix Value`.** The issue's example table suggests Net Total should be Total plus the matrix value, but reading `BhtSummeryController`/`InwardBeanController` showed Total is already `Gross + Matrix Value` (confirmed via the `sum(grossValue+marginValue)` JPQL for services, and `PatientRoom.calculatedXxxCharge = base + marginXxxCharge` for room charges). Implementing the literal formula would have double-counted the matrix value into Net Total. Instead, the fix exposes the existing margin as its own read-only figure next to Total.
2. **Column/row label "Service Charge (Margin)"**, not "Matrix Value" as first drafted. Found that `inward_bill_intrim.xhtml` already shows this exact figure (`bhtSummeryController.marginTotal`) under the label "Service Charge (Margin)", gated by the `ShowServiceCharges` privilege — matched that existing convention instead of inventing a new term, and applied the same privilege gate to the new final-bill elements.
3. **Room/Maintain/MO/Nursing/Linen/Medical Care/Administration charges never had their margin summed at all**, not just displayed with a wrong number — this was a second, related gap found while investigating: `setGrossMarginVatBreakdown()` only summed margin for BillItem-backed and BillFee-backed charges, never for PatientRoom-backed ones, so `marginTotal` undercounted whenever a room-facility-category price matrix applied (not just on the final bill — the interim bill's existing "Service Charge (Margin)" figure was silently wrong too). Fixed by summing PatientRoom's margin fields into `ChargeItemTotal.margin` as well.
4. **Summed the room margin in Java from the already-recalculated `getPatientRooms()` list, not a JPQL query.** PatientRoom's `marginRoomCharge`/etc. fields are `@Transient` ("display-only, recomputed on every calculation" per the existing code comment) — a JPQL `SUM()` over them isn't valid. Discovered this only after an initial JPQL-based attempt compiled but would have failed at runtime; reverted and re-implemented in-memory.

## What changed

- `inward_bill_final.xhtml`: added a **Service Charge (Margin)** column to the Charge Types grid (next to Total) and a **Gross Total** / **Service Charge (Margin)** row pair to the Charges Overview panel (next to Total Charges), both gated by the `ShowServiceCharges` privilege.
- `BhtSummeryController.java`: added `sumRoomMatrixMargins()` and wired it into `setGrossMarginVatBreakdown()` so PatientRoom-backed charge types' matrix margin is included in `ChargeItemTotal.margin`/`marginTotal`, same as service/professional charges already were.

## Verification

Local Playwright E2E against a real (non-finalized) admission, after adding a temporary room-category price matrix row (10% margin, department/payment-method/room-category matched) via the app's own Price Matrix admin page:

- **Charges Overview**: Total Charges 43,590.79 = Gross Total 40,286.39 + Service Charge (Margin) 3,304.40.
- **Charge Types grid, Room Charges row**: Total 28,710.00, Service Charge (Margin) 2,610.00 — exactly 10% of the base, matching the configured margin.

Test matrix row retired afterward via the same admin page so it doesn't affect real billing.

### Screenshot (patient/BHT/room redacted)

![Charges Overview and Charge Types showing Service Charge (Margin)](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/22975-01-charges-overview-and-charge-types-matrix-value.png)

More detail: [wiki § Price Matrix Value (Service Charge Margin)](https://github.com/hmislk/hmis/wiki/Inpatient-Final-Bill-Generation#price-matrix-value-service-charge-margin).

Closes #22975

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Payment overviews now display Gross Total and Service Charge (Margin) values based on access privileges.
  * Charge-type tables now include a Service Charge (Margin) column with explanatory tooltips.
  * Room-category margins are included in charge totals and margin calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->