### PR TITLE
fix(pharmacy): guard transfer receive against missing staffStock link

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
@@ -1190,6 +1190,9 @@ public class TransferReceiveController implements Serializable {
      */
     private String findMissingStaffStockError() {
         for (BillItem i : getReceivedBill().getBillItems()) {
+            if (receiveQtyInUnits(i) <= 0.0) {
+                continue;
+            }
             PharmaceuticalBillItem pbi = i.getPharmaceuticalBillItem();
             if (pbi == null) {
                 continue;

--- a/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
@@ -594,6 +594,14 @@ public class TransferReceiveController implements Serializable {
             return;
         }
 
+        // Reject any line whose staffStock link is missing before anything is
+        // written, instead of letting errorCheck() NPE mid-loop (#22951).
+        String missingStaffStockError = findMissingStaffStockError();
+        if (missingStaffStockError != null) {
+            JsfUtil.addErrorMessage(missingStaffStockError);
+            return;
+        }
+
         saveBill();
         for (BillItem i : getReceivedBill().getBillItems()) {
             // Get quantity from user input (BillItemFinanceDetails) and convert to units
@@ -1022,6 +1030,14 @@ public class TransferReceiveController implements Serializable {
             return;
         }
 
+        // Reject any line whose staffStock link is missing before anything is
+        // written, instead of letting errorCheck() NPE mid-loop (#22951).
+        String missingStaffStockError = findMissingStaffStockError();
+        if (missingStaffStockError != null) {
+            JsfUtil.addErrorMessage(missingStaffStockError);
+            return;
+        }
+
         getReceivedBill().setApproveAt(new Date());
         getReceivedBill().setApproveUser(getSessionController().getLoggedUser());
 
@@ -1136,7 +1152,8 @@ public class TransferReceiveController implements Serializable {
 
     public void onEdit(RowEditEvent event) {
         BillItem tmp = (BillItem) event.getObject();
-        if (tmp.getPharmaceuticalBillItem().getStaffStock().getStock() < tmp.getQty()) {
+        if (tmp.getPharmaceuticalBillItem().getStaffStock() == null
+                || tmp.getPharmaceuticalBillItem().getStaffStock().getStock() < tmp.getQty()) {
             tmp.setTmpQty(0.0);
             JsfUtil.addErrorMessage("You cant recieved over than Issued Qty setted Old Value");
         }
@@ -1144,11 +1161,47 @@ public class TransferReceiveController implements Serializable {
         //   getPharmacyController().setPharmacyItem(tmp.getItem());
     }
 
+    /**
+     * A null staffStock means the corresponding issue-side line never
+     * actually moved stock to the porter (see #22938) - treat that the
+     * same as insufficient stock rather than letting the missing
+     * reference NPE. findMissingStaffStockError() already rejects this
+     * case up front for settle()/settleApprove(); this guard covers
+     * onEdit() and any other caller that reaches a single line's stock
+     * check directly (see #22951).
+     */
     public boolean errorCheck(BillItem billItem) {
+        if (billItem.getPharmaceuticalBillItem().getStaffStock() == null) {
+            return true;
+        }
         if (billItem.getPharmaceuticalBillItem().getStaffStock().getStock() < billItem.getQty()) {
             return true;
         }
         return false;
+    }
+
+    /**
+     * Finds the first receive line whose PharmaceuticalBillItem has no
+     * staffStock link - e.g. because the corresponding issue-side line
+     * never actually moved stock to the porter (see #22938). Checked
+     * before any persistence starts so a bad line reports a clear error
+     * instead of letting errorCheck() NPE mid-loop and leave the request
+     * in a partially-processed state (see #22951).
+     */
+    private String findMissingStaffStockError() {
+        for (BillItem i : getReceivedBill().getBillItems()) {
+            PharmaceuticalBillItem pbi = i.getPharmaceuticalBillItem();
+            if (pbi == null) {
+                continue;
+            }
+            if (pbi.getStaffStock() == null) {
+                String itemName = i.getItem() != null ? i.getItem().getName() : "one of the items";
+                return "Cannot receive " + itemName + " - it was never actually transferred out by the "
+                        + "issuing department (no stock movement found for it), even though the transfer "
+                        + "note lists it. Please check the original Transfer Issue before retrying this receive.";
+            }
+        }
+        return null;
     }
 
     public void saveBill() {

--- a/src/main/java/com/divudi/bean/pharmacy/TransferReceiveNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferReceiveNativeSqlController.java
@@ -341,8 +341,10 @@ public class TransferReceiveNativeSqlController implements Serializable {
 
         List<String> stockErrors = transferReceiveNativeSqlService.checkSourceStockSufficiency(itemRowList);
         if (!stockErrors.isEmpty()) {
+            // Each message is already fully worded by checkSourceStockSufficiency() —
+            // it covers both a quantity shortfall and a missing staffStockId link (#22951).
             for (String msg : stockErrors) {
-                JsfUtil.addErrorMessage("Insufficient source stock — " + msg);
+                JsfUtil.addErrorMessage(msg);
             }
             return;
         }
@@ -391,8 +393,10 @@ public class TransferReceiveNativeSqlController implements Serializable {
 
         List<String> stockErrors = transferReceiveNativeSqlService.checkSourceStockSufficiency(itemRowList);
         if (!stockErrors.isEmpty()) {
+            // Each message is already fully worded by checkSourceStockSufficiency() —
+            // it covers both a quantity shortfall and a missing staffStockId link (#22951).
             for (String msg : stockErrors) {
-                JsfUtil.addErrorMessage("Insufficient source stock — " + msg);
+                JsfUtil.addErrorMessage(msg);
             }
             return;
         }

--- a/src/main/java/com/divudi/service/pharmacy/TransferReceiveNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/TransferReceiveNativeSqlService.java
@@ -239,10 +239,20 @@ public class TransferReceiveNativeSqlService {
 
     /**
      * Checks that each item's source stock (staffStockId) holds at least the
-     * units being requested before settlement begins.
+     * units being requested before settlement begins, and flags any line
+     * whose staffStockId is missing entirely.
+     *
+     * A null staffStockId on a positive-qty line means the issue-side line
+     * never actually moved stock to a porter (see #22938) - previously this
+     * was silently skipped here, which let settle() credit the receiving
+     * department with stock while deducting nothing from anywhere, since
+     * settle() only guards the deduction step, not the dept-stock credit
+     * (see #22951). Flag it instead so the user gets a clear error before
+     * any phantom stock is created.
      *
      * Returns a list of human-readable error strings — one per stock row that
-     * would go negative. An empty list means all stocks are sufficient.
+     * would go negative, plus one per line with a missing staffStockId. An
+     * empty list means all stocks are sufficient and correctly linked.
      *
      * Call this before settle() so the user gets a clear message rather than
      * a mid-transaction RuntimeException.
@@ -260,8 +270,15 @@ public class TransferReceiveNativeSqlService {
         Map<Long, String> labelByStock = new HashMap<>();
         for (TransferReceiveItemRowDto item : items) {
             if (item.getReceivingQty() == null
-                    || item.getReceivingQty().compareTo(BigDecimal.ZERO) <= 0
-                    || item.getStaffStockId() == null) {
+                    || item.getReceivingQty().compareTo(BigDecimal.ZERO) <= 0) {
+                continue;
+            }
+            if (item.getStaffStockId() == null) {
+                errors.add(item.getItemName() + " (batch " + item.getBatchNo() + "): "
+                        + "was never actually transferred out by the issuing department "
+                        + "(no stock movement found for it), even though the transfer note "
+                        + "lists it. Please check the original Transfer Issue before retrying "
+                        + "this receive.");
                 continue;
             }
             double units = item.getReceivingQty().doubleValue() * item.getUnitsPerPack();
@@ -275,7 +292,7 @@ public class TransferReceiveNativeSqlService {
             double required = entry.getValue();
             double available = fetchStockQty(stockId);
             if (available < required - 0.001) {
-                errors.add(labelByStock.get(stockId)
+                errors.add("Insufficient source stock — " + labelByStock.get(stockId)
                         + ": needs " + required
                         + " units, only " + available + " available in source stock");
             }
@@ -300,7 +317,12 @@ public class TransferReceiveNativeSqlService {
      * 10. Build and return TransferReceivePrintDto (caller enriches dept/institution fields)
      *
      * @param bill              pre-populated BilledBill with type, dates, parties set by controller
-     * @param items             row DTOs from the UI; items with zero or null receivingQty are skipped
+     * @param items             row DTOs from the UI; items with zero or null receivingQty, or a
+     *                          missing staffStockId, are skipped (the controller should already
+     *                          have blocked a missing staffStockId via
+     *                          {@link #checkSourceStockSufficiency} — this filter is
+     *                          defense-in-depth so a bypassed pre-check can never result in
+     *                          phantom stock at the destination, see #22951)
      * @param receivingDeptId   ID of the receiving department (for stock creation)
      * @param receivingInstId   ID of the receiving institution (for stock history aggregates)
      * @return partial print DTO populated with financial totals and line items
@@ -314,11 +336,14 @@ public class TransferReceiveNativeSqlService {
 
         long t0 = System.currentTimeMillis();
 
-        // Filter to items with positive receivingQty before persisting anything
+        // Filter to items with positive receivingQty and a real staffStockId before
+        // persisting anything. A null staffStockId here means the deduction step
+        // below would be silently skipped while the dept-stock credit step still ran
+        // unconditionally, fabricating stock at the destination (see #22951).
         List<TransferReceiveItemRowDto> itemsToProcess = new ArrayList<>();
         for (TransferReceiveItemRowDto item : items) {
             BigDecimal rqty = item.getReceivingQty();
-            if (rqty != null && rqty.compareTo(BigDecimal.ZERO) > 0) {
+            if (rqty != null && rqty.compareTo(BigDecimal.ZERO) > 0 && item.getStaffStockId() != null) {
                 itemsToProcess.add(item);
             }
         }
@@ -402,8 +427,10 @@ public class TransferReceiveNativeSqlService {
             double packs = item.getReceivingQty().doubleValue();
             double units = packs * item.getUnitsPerPack();
 
-            // 3a. Deduct from staff stock (atomic — throws if insufficient)
-            // staffStockId is null when the issue had no toStaff; skip deduction in that case.
+            // 3a. Deduct from staff stock (atomic — throws if insufficient).
+            // itemsToProcess is already filtered to staffStockId != null above; the null
+            // check here is just defense-in-depth against a future caller of this method
+            // that skips that filter.
             if (item.getStaffStockId() != null) {
                 deductStock(item.getStaffStockId(), units);
             }


### PR DESCRIPTION
## Summary

Fixes #22951 — `TransferReceiveController.errorCheck()`/`onEdit()` NPE when a receive line's `PharmaceuticalBillItem.staffStock` is null (issue-side line never actually moved stock to the porter, root cause #22938). The fix existed on `coop-prod` (`c78ce830a8`) and on a never-merged hotfix branch (`bfcce69e9b`), but neither had reached `development`.

While verifying, found the *live* replacement path (`TransferReceiveNativeSqlController`/`Service` — `TransferReceiveController`'s UI entry point was retired in #21337) doesn't NPE, but had a related gap: it silently skipped sufficiency-checking any line with a missing `staffStockId`, and `settle()` would still credit the receiving department with stock while deducting nothing from anywhere — a silent phantom-stock bug. Fixed both in this PR per discussion on the issue.

## Changes

- **`TransferReceiveController`**: null-guard `errorCheck()`/`onEdit()`; new `findMissingStaffStockError()` pre-loop check wired into `doSettle()` and `settleApprove()`, consistent with the existing `porterStockCoversAllLines()` guard (#21266). Kept for parity even though its UI entry point is currently retired — the class is explicitly "retained for reference."
- **`TransferReceiveNativeSqlService.checkSourceStockSufficiency()`**: now flags (instead of silently skipping) any positive-qty line with a missing `staffStockId`, with a clear user-facing message.
- **`TransferReceiveNativeSqlService.settle()`**: defense-in-depth filter excludes any line with a missing `staffStockId` from processing, so a bypassed pre-check can never fabricate stock.
- **`TransferReceiveNativeSqlController`**: simplified error message plumbing now that `checkSourceStockSufficiency()`'s messages are fully self-worded.

## Testing performed (local Payara)

- `mvn clean package` — BUILD SUCCESS, 207/207 unit tests passing.
- Built a real Transfer Issue (Main Pharmacy → OPD Pharmacy, "Glycomet sr 500mg", qty 10), left the Receive unsettled.
- Nulled `STAFFSTOCK_ID` on the issue-side `PharmaceuticalBillItem` via SQL to simulate the #22938 corrupted state.
- Attempted receive via the live native path: blocked with a clear error (*"...was never actually transferred out by the issuing department..."*), no bill created, no stock movement anywhere (verified via DB).
- Restored the `STAFFSTOCK_ID` link, re-received: succeeded normally (Receive No `OPPHTI/503`), porter stock 10→0, destination department stock correctly +10 — confirms no regression to the happy path.

Full narrative + screenshot: https://github.com/hmislk/hmis/issues/22951#issuecomment-5301011699

Closes #22951


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Transfer receiving now validates every receive line before settlement, approval, or stock movement.
  - Clear error messages identify missing stock references and insufficient source quantities.
  - Prevented stock from being credited when corresponding source stock information is missing.
  - Editing and validation screens now handle incomplete stock details without unexpected errors.
  - Stock-shortage messages are displayed consistently, including relevant quantity and stock-reference details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->