### PR TITLE
fix(hr): extend staffCode search to remaining staff autocompletes; add Staff Code column

### DIFF
--- a/src/main/java/com/divudi/bean/hr/StaffController.java
+++ b/src/main/java/com/divudi/bean/hr/StaffController.java
@@ -774,10 +774,10 @@ public class StaffController implements Serializable {
         } else {
             sql = "select p from Staff p "
                     + " where p.retired=false "
-                    + " and LENGTH(p.code) > 0 "
                     + " and LENGTH(p.person.name) > 0 "
                     + " and ((p.person.name) like '%" + query.toUpperCase() + "%' "
-                    + " or (p.code) like '%" + query.toUpperCase() + "%' )"
+                    + " or (p.code) like '%" + query.toUpperCase() + "%' "
+                    + " or (p.staffCode) like '%" + query.toUpperCase() + "%' )"
                     + " order by p.person.name";
 
             //////System.out.println(sql);
@@ -807,25 +807,27 @@ public class StaffController implements Serializable {
         return suggestions;
     }
 
-    public List<Staff> completeStaffCodeChannel(String query) {
-        List<Staff> suggestions;
-        String sql;
-        if (query == null) {
-            suggestions = new ArrayList<>();
-        } else {
-            sql = "select p from Staff p "
-                    + " where p.retired=false "
-                    + " and LENGTH(p.code) > 0 "
-                    + " and LENGTH(p.person.name) > 0 "
-                    + " and ((p.person.name) like '%" + query.toUpperCase() + "%' "
-                    + " or (p.code)='" + query.toUpperCase() + "' )"
-                    + " order by p.person.name";
-
-            //////System.out.println(sql);
-            suggestions = getEjbFacade().findByJpql(sql, 20);
-        }
-        return suggestions;
-    }
+    // Unused (no XHTML references completeStaffCodeChannel) — kept commented
+    // pending removal in a dead-code cleanup pass. See #22491 follow-up.
+    // public List<Staff> completeStaffCodeChannel(String query) {
+    //     List<Staff> suggestions;
+    //     String sql;
+    //     if (query == null) {
+    //         suggestions = new ArrayList<>();
+    //     } else {
+    //         sql = "select p from Staff p "
+    //                 + " where p.retired=false "
+    //                 + " and LENGTH(p.code) > 0 "
+    //                 + " and LENGTH(p.person.name) > 0 "
+    //                 + " and ((p.person.name) like '%" + query.toUpperCase() + "%' "
+    //                 + " or (p.code)='" + query.toUpperCase() + "' )"
+    //                 + " order by p.person.name";
+    //
+    //         //////System.out.println(sql);
+    //         suggestions = getEjbFacade().findByJpql(sql, 20);
+    //     }
+    //     return suggestions;
+    // }
 
     public List<Staff> completeStaffCodeChannelWithOutResignOrRetierd(String query) {
         List<Staff> suggestions;
@@ -837,10 +839,10 @@ public class StaffController implements Serializable {
             sql = "select p from Staff p "
                     + " where p.retired=false "
                     + " and (p.dateLeft is null or p.dateLeft>:cd)"
-                    + " and LENGTH(p.code) > 0 "
                     + " and LENGTH(p.person.name) > 0 "
                     + " and ((p.person.name) like '%" + query.toUpperCase() + "%' "
-                    + " or (p.code)='" + query.toUpperCase() + "' )"
+                    + " or (p.code)='" + query.toUpperCase() + "' "
+                    + " or (p.staffCode)='" + query.toUpperCase() + "' )"
                     + " order by p.person.name";
 
             m.put("cd", new Date());
@@ -939,7 +941,8 @@ public class StaffController implements Serializable {
                 + " where p.retired=false "
                 + " and p.roster=:rs "
                 + " and ((p.person.name) like :q "
-                + " or  (p.code) like :q )"
+                + " or  (p.code) like :q "
+                + " or  (p.staffCode) like :q )"
                 + " order by p.person.name";
         //////System.out.println(sql);
         HashMap hm = new HashMap();

--- a/src/main/webapp/channel/add_booking.xhtml
+++ b/src/main/webapp/channel/add_booking.xhtml
@@ -263,6 +263,9 @@
                                                 <p:column headerText="Code" style="padding: 5px;">
                                                     #{mys.code}
                                                 </p:column>
+                                                <p:column headerText="Staff Code" style="padding: 5px;">
+                                                    #{mys.staffCode}
+                                                </p:column>
                                                 <p:column headerText="EPF No" style="padding: 5px;">
                                                     #{mys.epfNo}
                                                 </p:column>

--- a/src/main/webapp/hr/hr_change_staff.xhtml
+++ b/src/main/webapp/hr/hr_change_staff.xhtml
@@ -30,6 +30,9 @@
                                 <p:column headerText="Code">
                                     #{mys.code}
                                 </p:column>
+                                <p:column headerText="Staff Code">
+                                    #{mys.staffCode}
+                                </p:column>
                             </p:autoComplete>
                         </p:panel>
 

--- a/src/main/webapp/hr/hr_staff_basic_individual.xhtml
+++ b/src/main/webapp/hr/hr_staff_basic_individual.xhtml
@@ -38,6 +38,9 @@
                                         <p:column headerText="Code">
                                             <h:outputLabel value="#{mys.code}" />
                                         </p:column>
+                                        <p:column headerText="Staff Code">
+                                            <h:outputLabel value="#{mys.staffCode}" />
+                                        </p:column>
                                     </p:autoComplete>
                                 </div>
 

--- a/src/main/webapp/hr/hr_staff_leave_entitle.xhtml
+++ b/src/main/webapp/hr/hr_staff_leave_entitle.xhtml
@@ -66,6 +66,9 @@
                                         <p:column headerText="Code">
                                             <h:outputLabel value="#{mys.code}" />
                                         </p:column>
+                                        <p:column headerText="Staff Code">
+                                            <h:outputLabel value="#{mys.staffCode}" />
+                                        </p:column>
                                         <p:ajax event="itemSelect" process="@this staff" update="stfDetail" />
                                     </p:autoComplete>
                                 </div>

--- a/src/main/webapp/hr/hr_staff_paysheet_component_individual.xhtml
+++ b/src/main/webapp/hr/hr_staff_paysheet_component_individual.xhtml
@@ -36,6 +36,9 @@
                                         <p:column headerText="Code">
                                             <h:outputLabel value="#{mys.code}" />
                                         </p:column>
+                                        <p:column headerText="Staff Code">
+                                            <h:outputLabel value="#{mys.staffCode}" />
+                                        </p:column>
                                     </p:autoComplete>
                                 </div>
 

--- a/src/main/webapp/resources/autocomplete/completeRosterStaff.xhtml
+++ b/src/main/webapp/resources/autocomplete/completeRosterStaff.xhtml
@@ -21,9 +21,12 @@
             <p:column headerText="Name">
                 #{mys.person.name}
             </p:column>
-            <p:column headerText="Name">
+            <p:column headerText="Code">
                 #{mys.code}
             </p:column>
-        </p:autoComplete> 
+            <p:column headerText="Staff Code">
+                #{mys.staffCode}
+            </p:column>
+        </p:autoComplete>
             </cc:implementation>
 </html>

--- a/src/main/webapp/resources/autocomplete/completeStaff.xhtml
+++ b/src/main/webapp/resources/autocomplete/completeStaff.xhtml
@@ -26,6 +26,9 @@
             <p:column headerText="Code">
                 #{mys.code}
             </p:column>
-        </p:autoComplete> 
+            <p:column headerText="Staff Code">
+                #{mys.staffCode}
+            </p:column>
+        </p:autoComplete>
             </cc:implementation>
 </html>

--- a/src/main/webapp/resources/autocomplete/completeStaffChannel.xhtml
+++ b/src/main/webapp/resources/autocomplete/completeStaffChannel.xhtml
@@ -28,6 +28,9 @@
             <p:column headerText="Code" style="padding: 6px;">
                 #{mys.code}
             </p:column>
+            <p:column headerText="Staff Code" style="padding: 6px;">
+                #{mys.staffCode}
+            </p:column>
             <p:column headerText="EPF No" style="padding: 6px;">
                 #{mys.epfNo}
             </p:column>


### PR DESCRIPTION
## Context

Follow-up to #22491. The first fix (PR #22986, merged) covered the two ward-pharmacy pages named directly in the issue (**BHT Issue**, **Return Medicines to Pharmacy**) — both already used `StaffController.completeStaffWithoutDoctors`, which already searched `code` **and** `staffCode`, so that PR only needed to fix the results-table display column.

Auditing the rest of `StaffController.java`'s staff-autocomplete backends found four more methods that only searched `name` + `code`, not `staffCode`:

| Method | Before | After |
|---|---|---|
| `completeStaffCode` | name, code | name, code, staffCode |
| `completeStaffCodeChannelWithOutResignOrRetierd` | name, code | name, code, staffCode |
| `completeRosterStaff` | name, code | name, code, staffCode |
| `completeStaffCodeChannel` | name, code | **commented out** — unused, see below |

## Changes

**Backend** (`StaffController.java`):
- `completeStaffCode`, `completeStaffCodeChannelWithOutResignOrRetierd`, `completeRosterStaff` — added `staffCode` to the search OR clause.
- `completeStaffCode` also had a stale `LENGTH(p.code) > 0` guard that would wrongly exclude a staff member who has `staffCode` set but a blank `code`. Removed it — the `LENGTH(p.person.name) > 0` guard was already sufficient and is untouched.
- `completeStaffCodeChannel` — grepped the whole `src/main/webapp` tree and confirmed it has **zero** XHTML references (dead code). Commented out rather than fixed, per discussion — a follow-up cleanup pass will remove commented-dead-code like this across the codebase together.

**Frontend** — added a "Staff Code" column next to the existing "Code" column in every autocomplete results table that uses one of the above methods:
- `resources/autocomplete/completeStaff.xhtml`, `completeStaffChannel.xhtml`, `completeRosterStaff.xhtml` (composite components — also fixed a pre-existing bug in `completeRosterStaff.xhtml` where the second column's `headerText` duplicated "Name" instead of saying "Code")
- `hr/hr_staff_paysheet_component_individual.xhtml`, `hr_staff_leave_entitle.xhtml`, `hr_staff_basic_individual.xhtml`, `hr_change_staff.xhtml`
- `channel/add_booking.xhtml`

Four other usage sites (`hr_form_staff_transfer.xhtml` ×2, `_hr_shift_ammendment.xhtml`, `report_income_by_professional_fees_and_bht.xhtml`) call these methods but render no results-table columns at all (plain single-value autocomplete), so there was nothing to add there.

## Testing

- Java change — compiled clean (`mvn clean package`), redeployed to local Payara, no errors in `server.log`.
- XHTML diffs are purely additive (one new `<p:column>` per affected page/composite, plus the one column-label typo fix) — verified each by reading the surrounding markup before and after.

Refs #22491

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Staff searches now match staff codes in addition to existing search details.
  * Autocomplete results now display staff codes in a dedicated column across staff-related screens.
  * Roster searches clearly separate staff codes from other identifying codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->