### PR TITLE
feat(api): expose staffCode on StaffApi GET/PUT; add nic filter to GET

### DIFF
--- a/src/main/java/com/divudi/ws/common/StaffApi.java
+++ b/src/main/java/com/divudi/ws/common/StaffApi.java
@@ -72,7 +72,7 @@ public class StaffApi {
     private static final Gson gson = new GsonBuilder().setDateFormat("yyyy-MM-dd HH:mm:ss").create();
 
     // -------------------------------------------------------------------------
-    // GET /api/staff?query=&departmentId=&size=
+    // GET /api/staff?query=&nic=&departmentId=&size=
     // -------------------------------------------------------------------------
     @GET
     @Produces(MediaType.APPLICATION_JSON)
@@ -82,6 +82,7 @@ public class StaffApi {
             if (apiUser == null) return errorResponse("Not a valid key", 401);
 
             String q = value("query");
+            String nic = value("nic");
             int size = Math.min(Math.max(parseInt(value("size"), 50), 1), 200);
             String departmentIdStr = value("departmentId");
 
@@ -105,6 +106,10 @@ public class StaffApi {
                     jpql += " and (upper(s.person.name) like :q or upper(s.code) like :q)";
                     params.put("q", "%" + q.trim().toUpperCase() + "%");
                 }
+            }
+            if (nic != null && !nic.trim().isEmpty()) {
+                jpql += " and upper(s.person.nic) = :nic";
+                params.put("nic", nic.trim().toUpperCase());
             }
             jpql += " order by s.person.name";
 
@@ -195,7 +200,7 @@ public class StaffApi {
 
     // -------------------------------------------------------------------------
     // PUT /api/staff/{id}
-    // Partial update — only supplied fields change (name, code, designation)
+    // Partial update — only supplied fields change (name, code, staffCode, designation)
     // -------------------------------------------------------------------------
     @PUT
     @Path("/{id}")
@@ -224,6 +229,10 @@ public class StaffApi {
             if (req.containsKey("code")) {
                 String code = (String) req.get("code");
                 staff.setCode(code != null ? code.trim() : null);
+            }
+            if (req.containsKey("staffCode")) {
+                String staffCode = (String) req.get("staffCode");
+                staff.setStaffCode(staffCode != null ? staffCode.trim() : null);
             }
             if (req.containsKey("designation")) {
                 String designation = (String) req.get("designation");
@@ -287,6 +296,7 @@ public class StaffApi {
         Map<String, Object> m = new HashMap<>();
         m.put("id", s.getId());
         m.put("code", s.getCodeRaw());
+        m.put("staffCode", s.getStaffCode());
         m.put("designation", s.getDescription());
         m.put("retired", s.isRetired());
         m.put("personId", s.getPerson() != null ? s.getPerson().getId() : null);


### PR DESCRIPTION
## Context

Follow-up to #22491. The staffCode display/search fixes (PR #22986, #22992, both merged) fixed the code side. The remaining part of the issue is a data-entry task: most staff records on RH staging/production have `staffCode` unset, so even with search/display fixed there's nothing meaningful to find/show for most staff.

Populating ~972 records by hand isn't realistic, and there's no bulk path today because `StaffApi` doesn't expose `staffCode` at all, and there's no way to look a staff member up by NIC (the only reliable key for matching an external HR spreadsheet to existing HMIS records — names don't match cleanly across sources due to formatting/initials differences).

This PR is purely additive groundwork for that import — it does not do the import itself.

## Changes

`src/main/java/com/divudi/ws/common/StaffApi.java`:
- `GET /api/staff/{id}` and `GET /api/staff` now include `staffCode` in the response (`toStaffMap`).
- `PUT /api/staff/{id}` accepts an optional `staffCode` field, following the exact same partial-update pattern already used for `code`/`designation`.
- `GET /api/staff` gains an optional `?nic=` parameter — exact, case-insensitive match on `Person.nic` — combinable with the existing `query`/`departmentId` filters.

`POST` (create) was intentionally left untouched — the planned import only updates existing staff records matched by NIC, never creates new ones, so extending create wasn't needed and would have widened the diff for no reason.

## Testing

- Compiled clean (`mvn package`), redeployed to local Payara.
- `PUT /api/staff/{id}` with `{"staffCode":"737"}` round-tripped correctly against the local `ruhunu` DB — confirmed via direct DB read that `STAFFCODE` was persisted, then reverted the test write back to empty afterward.
- `GET /api/staff?nic=...` executes without error against the local DB (which happens to have no NIC data populated in this snapshot, so it correctly returns an empty result rather than an error).
- No production/staging hosts were touched by this PR — it's a code-only change. The actual data import against staging (and later production, separately) will follow in a later, explicitly-approved step once this is merged and deployed.

Refs #22491

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Staff listings can now be filtered by NIC.
  * Staff records support updating and displaying a staff code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->