### PR TITLE
fix(pharmacy): prioritize user-selected batch in multi-batch retail sale + reorganize Payment/Bill Details layout

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -1858,7 +1858,7 @@ code when the page itself is correct.
 *different* option first, then select the desired one back — each of those
 is a real change, so both `change` events fire and the bean field updates
 both times:
-```
+```text
 click dropdown → click a different option (e.g. "Credit Card")
 click dropdown → click the target option (e.g. "Cash")
 ```

--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -1837,6 +1837,36 @@ go through. Fix in automation: after any Fees-tab row shows a "Select Staff"
 dropdown, pick a value from it (PrimeFaces click-option pattern, §13) before
 clicking Settle. Found verifying issue #22916.
 
+## 71. A fresh `p:selectOneMenu` visually shows its first `<option>` as selected even when the bound model value is still `null` — clicking that same-looking option fires no `change` event
+
+On `pharmacy_bill_retail_sale_native.xhtml`'s Payment Method dropdown (default
+list order: Cash, Credit Card, Multiple Payment Methods, ...), a freshly
+loaded/newly-logged-in page renders the native `<select>` showing "Cash" as
+selected — this is just the browser defaulting an unset `<select>` to its
+first `<option>`, not evidence that `paymentMethod` is actually bound to
+`PaymentMethod.Cash` server-side. It's still `null` until the user makes a
+real selection. `browser_click` on that already-visually-"Cash" option is a
+no-op: the native select's `selectedIndex` doesn't change, so no `change`
+event fires, so `p:ajax event="change"` never runs and any `rendered="#{bean.paymentMethod
+eq 'Cash'}"` block downstream stays on its null-branch (nothing rendered)
+even though the dropdown *looks* set to Cash. Symptom: fields that should
+appear for Cash (e.g. Tendered/Balance) never show up, with no error and no
+network request — easy to misdiagnose as a `rendered` condition bug in the
+code when the page itself is correct.
+
+**Fix**: to genuinely land on the visually-default option, select a
+*different* option first, then select the desired one back — each of those
+is a real change, so both `change` events fire and the bean field updates
+both times:
+```
+click dropdown → click a different option (e.g. "Credit Card")
+click dropdown → click the target option (e.g. "Cash")
+```
+Only needed the first time a dropdown is touched in a fresh session/after a
+redeploy-forced relogin; once a real change has fired once, subsequent
+same-value clicks are fine since the model is no longer null. Found verifying
+issue #22991.
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController.java
@@ -818,33 +818,43 @@ public class RetailSaleNativeSqlController implements Serializable, ControllerWi
             return;
         }
 
-        // Multi-batch FEFO fill: merge the user-selected batch with additional batches and
-        // sort all candidates by expiry before allocating, so earlier-expiring stock is always
-        // dispensed first regardless of which batch the user picked.
+        // Priority allocation: fully satisfy from the batch the user selected (e.g. for its
+        // price) if it has enough stock; only top up the shortfall FEFO from other batches.
         double addedQty = 0.0;
 
-        List<StockDTO> candidates = new ArrayList<>();
-        candidates.add(stockDto);
-        candidates.addAll(findNextAvailableStockDtos(stockDto.getItemId(), selectedStockId));
-        candidates.sort(Comparator.comparing(
-                StockDTO::getDateOfExpire,
-                Comparator.nullsLast(Date::compareTo)));
+        // Priority 1: fully satisfy from the batch the user selected, if possible.
+        if (!isStockAlreadyOnBill(selectedStockId)) {
+            double selectedAvailable = stockDto.getStockQty() != null ? stockDto.getStockQty() : 0.0;
+            double takeFromSelected = Math.min(remainingQty, selectedAvailable);
+            if (takeFromSelected > 0) {
+                addBillItemLineForStock(stockDto, takeFromSelected);
+                addedQty += takeFromSelected;
+                remainingQty -= takeFromSelected;
+            }
+        }
 
-        for (StockDTO next : candidates) {
-            if (remainingQty <= 0) {
-                break;
+        // Priority 2: only the shortfall (if any) is topped up FEFO from other batches.
+        if (remainingQty > 0) {
+            List<StockDTO> others = findNextAvailableStockDtos(stockDto.getItemId(), selectedStockId);
+            others.sort(Comparator.comparing(
+                    StockDTO::getDateOfExpire,
+                    Comparator.nullsLast(Date::compareTo)));
+            for (StockDTO next : others) {
+                if (remainingQty <= 0) {
+                    break;
+                }
+                if (isStockAlreadyOnBill(next.getId())) {
+                    continue;
+                }
+                double available = next.getStockQty() != null ? next.getStockQty() : 0.0;
+                double take = Math.min(remainingQty, available);
+                if (take <= 0) {
+                    continue;
+                }
+                addBillItemLineForStock(next, take);
+                addedQty += take;
+                remainingQty -= take;
             }
-            if (isStockAlreadyOnBill(next.getId())) {
-                continue;
-            }
-            double available = next.getStockQty() != null ? next.getStockQty() : 0.0;
-            double take = Math.min(remainingQty, available);
-            if (take <= 0) {
-                continue;
-            }
-            addBillItemLineForStock(next, take);
-            addedQty += take;
-            remainingQty -= take;
         }
 
         if (addedQty <= 0) {

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController.java
@@ -145,7 +145,7 @@ public class RetailSaleNativeSqlController implements Serializable, ControllerWi
     private String comment = "";
     private double cashPaid;
     private double balance;
-    private PaymentMethod paymentMethod;
+    private PaymentMethod paymentMethod = PaymentMethod.Cash;
     private PaymentScheme paymentScheme;
     private PaymentMethodData paymentMethodData;
     private Staff toStaff;
@@ -1355,7 +1355,7 @@ public class RetailSaleNativeSqlController implements Serializable, ControllerWi
         comment = "";
         cashPaid = 0.0;
         balance = 0.0;
-        paymentMethod = null;
+        paymentMethod = PaymentMethod.Cash;
         paymentScheme = null;
         paymentMethodData = null;
         toStaff = null;

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController1.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController1.java
@@ -157,7 +157,7 @@ public class RetailSaleNativeSqlController1 implements Serializable, ControllerW
     private String comment = "";
     private double cashPaid;
     private double balance;
-    private PaymentMethod paymentMethod;
+    private PaymentMethod paymentMethod = PaymentMethod.Cash;
     private PaymentScheme paymentScheme;
     private PaymentMethodData paymentMethodData;
     private Staff toStaff;
@@ -1367,7 +1367,7 @@ public class RetailSaleNativeSqlController1 implements Serializable, ControllerW
         comment = "";
         cashPaid = 0.0;
         balance = 0.0;
-        paymentMethod = null;
+        paymentMethod = PaymentMethod.Cash;
         paymentScheme = null;
         paymentMethodData = null;
         toStaff = null;

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController1.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController1.java
@@ -830,33 +830,43 @@ public class RetailSaleNativeSqlController1 implements Serializable, ControllerW
             return;
         }
 
-        // Multi-batch FEFO fill: merge the user-selected batch with additional batches and
-        // sort all candidates by expiry before allocating, so earlier-expiring stock is always
-        // dispensed first regardless of which batch the user picked.
+        // Priority allocation: fully satisfy from the batch the user selected (e.g. for its
+        // price) if it has enough stock; only top up the shortfall FEFO from other batches.
         double addedQty = 0.0;
 
-        List<StockDTO> candidates = new ArrayList<>();
-        candidates.add(stockDto);
-        candidates.addAll(findNextAvailableStockDtos(stockDto.getItemId(), selectedStockId));
-        candidates.sort(Comparator.comparing(
-                StockDTO::getDateOfExpire,
-                Comparator.nullsLast(Date::compareTo)));
+        // Priority 1: fully satisfy from the batch the user selected, if possible.
+        if (!isStockAlreadyOnBill(selectedStockId)) {
+            double selectedAvailable = stockDto.getStockQty() != null ? stockDto.getStockQty() : 0.0;
+            double takeFromSelected = Math.min(remainingQty, selectedAvailable);
+            if (takeFromSelected > 0) {
+                addBillItemLineForStock(stockDto, takeFromSelected);
+                addedQty += takeFromSelected;
+                remainingQty -= takeFromSelected;
+            }
+        }
 
-        for (StockDTO next : candidates) {
-            if (remainingQty <= 0) {
-                break;
+        // Priority 2: only the shortfall (if any) is topped up FEFO from other batches.
+        if (remainingQty > 0) {
+            List<StockDTO> others = findNextAvailableStockDtos(stockDto.getItemId(), selectedStockId);
+            others.sort(Comparator.comparing(
+                    StockDTO::getDateOfExpire,
+                    Comparator.nullsLast(Date::compareTo)));
+            for (StockDTO next : others) {
+                if (remainingQty <= 0) {
+                    break;
+                }
+                if (isStockAlreadyOnBill(next.getId())) {
+                    continue;
+                }
+                double available = next.getStockQty() != null ? next.getStockQty() : 0.0;
+                double take = Math.min(remainingQty, available);
+                if (take <= 0) {
+                    continue;
+                }
+                addBillItemLineForStock(next, take);
+                addedQty += take;
+                remainingQty -= take;
             }
-            if (isStockAlreadyOnBill(next.getId())) {
-                continue;
-            }
-            double available = next.getStockQty() != null ? next.getStockQty() : 0.0;
-            double take = Math.min(remainingQty, available);
-            if (take <= 0) {
-                continue;
-            }
-            addBillItemLineForStock(next, take);
-            addedQty += take;
-            remainingQty -= take;
         }
 
         if (addedQty <= 0) {

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController2.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController2.java
@@ -830,33 +830,43 @@ public class RetailSaleNativeSqlController2 implements Serializable, ControllerW
             return;
         }
 
-        // Multi-batch FEFO fill: merge the user-selected batch with additional batches and
-        // sort all candidates by expiry before allocating, so earlier-expiring stock is always
-        // dispensed first regardless of which batch the user picked.
+        // Priority allocation: fully satisfy from the batch the user selected (e.g. for its
+        // price) if it has enough stock; only top up the shortfall FEFO from other batches.
         double addedQty = 0.0;
 
-        List<StockDTO> candidates = new ArrayList<>();
-        candidates.add(stockDto);
-        candidates.addAll(findNextAvailableStockDtos(stockDto.getItemId(), selectedStockId));
-        candidates.sort(Comparator.comparing(
-                StockDTO::getDateOfExpire,
-                Comparator.nullsLast(Date::compareTo)));
+        // Priority 1: fully satisfy from the batch the user selected, if possible.
+        if (!isStockAlreadyOnBill(selectedStockId)) {
+            double selectedAvailable = stockDto.getStockQty() != null ? stockDto.getStockQty() : 0.0;
+            double takeFromSelected = Math.min(remainingQty, selectedAvailable);
+            if (takeFromSelected > 0) {
+                addBillItemLineForStock(stockDto, takeFromSelected);
+                addedQty += takeFromSelected;
+                remainingQty -= takeFromSelected;
+            }
+        }
 
-        for (StockDTO next : candidates) {
-            if (remainingQty <= 0) {
-                break;
+        // Priority 2: only the shortfall (if any) is topped up FEFO from other batches.
+        if (remainingQty > 0) {
+            List<StockDTO> others = findNextAvailableStockDtos(stockDto.getItemId(), selectedStockId);
+            others.sort(Comparator.comparing(
+                    StockDTO::getDateOfExpire,
+                    Comparator.nullsLast(Date::compareTo)));
+            for (StockDTO next : others) {
+                if (remainingQty <= 0) {
+                    break;
+                }
+                if (isStockAlreadyOnBill(next.getId())) {
+                    continue;
+                }
+                double available = next.getStockQty() != null ? next.getStockQty() : 0.0;
+                double take = Math.min(remainingQty, available);
+                if (take <= 0) {
+                    continue;
+                }
+                addBillItemLineForStock(next, take);
+                addedQty += take;
+                remainingQty -= take;
             }
-            if (isStockAlreadyOnBill(next.getId())) {
-                continue;
-            }
-            double available = next.getStockQty() != null ? next.getStockQty() : 0.0;
-            double take = Math.min(remainingQty, available);
-            if (take <= 0) {
-                continue;
-            }
-            addBillItemLineForStock(next, take);
-            addedQty += take;
-            remainingQty -= take;
         }
 
         if (addedQty <= 0) {

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController2.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController2.java
@@ -157,7 +157,7 @@ public class RetailSaleNativeSqlController2 implements Serializable, ControllerW
     private String comment = "";
     private double cashPaid;
     private double balance;
-    private PaymentMethod paymentMethod;
+    private PaymentMethod paymentMethod = PaymentMethod.Cash;
     private PaymentScheme paymentScheme;
     private PaymentMethodData paymentMethodData;
     private Staff toStaff;
@@ -1367,7 +1367,7 @@ public class RetailSaleNativeSqlController2 implements Serializable, ControllerW
         comment = "";
         cashPaid = 0.0;
         balance = 0.0;
-        paymentMethod = null;
+        paymentMethod = PaymentMethod.Cash;
         paymentScheme = null;
         paymentMethodData = null;
         toStaff = null;

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController3.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController3.java
@@ -830,33 +830,43 @@ public class RetailSaleNativeSqlController3 implements Serializable, ControllerW
             return;
         }
 
-        // Multi-batch FEFO fill: merge the user-selected batch with additional batches and
-        // sort all candidates by expiry before allocating, so earlier-expiring stock is always
-        // dispensed first regardless of which batch the user picked.
+        // Priority allocation: fully satisfy from the batch the user selected (e.g. for its
+        // price) if it has enough stock; only top up the shortfall FEFO from other batches.
         double addedQty = 0.0;
 
-        List<StockDTO> candidates = new ArrayList<>();
-        candidates.add(stockDto);
-        candidates.addAll(findNextAvailableStockDtos(stockDto.getItemId(), selectedStockId));
-        candidates.sort(Comparator.comparing(
-                StockDTO::getDateOfExpire,
-                Comparator.nullsLast(Date::compareTo)));
+        // Priority 1: fully satisfy from the batch the user selected, if possible.
+        if (!isStockAlreadyOnBill(selectedStockId)) {
+            double selectedAvailable = stockDto.getStockQty() != null ? stockDto.getStockQty() : 0.0;
+            double takeFromSelected = Math.min(remainingQty, selectedAvailable);
+            if (takeFromSelected > 0) {
+                addBillItemLineForStock(stockDto, takeFromSelected);
+                addedQty += takeFromSelected;
+                remainingQty -= takeFromSelected;
+            }
+        }
 
-        for (StockDTO next : candidates) {
-            if (remainingQty <= 0) {
-                break;
+        // Priority 2: only the shortfall (if any) is topped up FEFO from other batches.
+        if (remainingQty > 0) {
+            List<StockDTO> others = findNextAvailableStockDtos(stockDto.getItemId(), selectedStockId);
+            others.sort(Comparator.comparing(
+                    StockDTO::getDateOfExpire,
+                    Comparator.nullsLast(Date::compareTo)));
+            for (StockDTO next : others) {
+                if (remainingQty <= 0) {
+                    break;
+                }
+                if (isStockAlreadyOnBill(next.getId())) {
+                    continue;
+                }
+                double available = next.getStockQty() != null ? next.getStockQty() : 0.0;
+                double take = Math.min(remainingQty, available);
+                if (take <= 0) {
+                    continue;
+                }
+                addBillItemLineForStock(next, take);
+                addedQty += take;
+                remainingQty -= take;
             }
-            if (isStockAlreadyOnBill(next.getId())) {
-                continue;
-            }
-            double available = next.getStockQty() != null ? next.getStockQty() : 0.0;
-            double take = Math.min(remainingQty, available);
-            if (take <= 0) {
-                continue;
-            }
-            addBillItemLineForStock(next, take);
-            addedQty += take;
-            remainingQty -= take;
         }
 
         if (addedQty <= 0) {

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController3.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController3.java
@@ -157,7 +157,7 @@ public class RetailSaleNativeSqlController3 implements Serializable, ControllerW
     private String comment = "";
     private double cashPaid;
     private double balance;
-    private PaymentMethod paymentMethod;
+    private PaymentMethod paymentMethod = PaymentMethod.Cash;
     private PaymentScheme paymentScheme;
     private PaymentMethodData paymentMethodData;
     private Staff toStaff;
@@ -1367,7 +1367,7 @@ public class RetailSaleNativeSqlController3 implements Serializable, ControllerW
         comment = "";
         cashPaid = 0.0;
         balance = 0.0;
-        paymentMethod = null;
+        paymentMethod = PaymentMethod.Cash;
         paymentScheme = null;
         paymentMethodData = null;
         toStaff = null;

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native.xhtml
@@ -28,7 +28,7 @@
                         <p:panel class="w-100">
                             <f:facet name="header">
                                 <div class="row w-100 align-items-center">
-                                    <div class="col-4">
+                                    <div class="col-md-3">
                                         <h:outputText styleClass="fas fa-mortar-pestle" />
                                         <h:outputLabel value="Pharmacy Retail Sale (Sale 1)" class="mx-2" />
                                         <h:panelGroup rendered="#{webUserController.hasPrivilege('Admin')}">
@@ -41,35 +41,7 @@
                                                 class="ui-button-secondary mx-1" />
                                         </h:panelGroup>
                                     </div>
-                                    <div class="col-4 text-center">
-                                        <p:commandButton
-                                            icon="fa fa-search"
-                                            value="Search Sale Bills"
-                                            ajax="false"
-                                            action="/pharmacy/pharmacy_search_sale_bill?faces-redirect=true"
-                                            actionListener="#{searchController.makeListNull}"
-                                            class="ui-button-info" />
-                                    </div>
-                                    <div class="col-4 text-end">
-                                        <p:commandButton
-                                            ajax="false"
-                                            accesskey="s"
-                                            value="Settle"
-                                            icon="fa fa-check"
-                                            class="ui-button-success mx-1"
-                                            onclick="if (!confirm('Are you sure?')) return false"
-                                            action="#{retailSaleNativeSqlController.settleBillWithPay}" />
-                                        <p:commandButton
-                                            icon="fa fa-plus"
-                                            value="New Bill"
-                                            ajax="false"
-                                            action="pharmacy_bill_retail_sale_native"
-                                            class="ui-button-warning"
-                                            actionListener="#{retailSaleNativeSqlController.resetAll()}" />
-                                    </div>
-                                </div>
-                                <div class="row w-100 align-items-center">
-                                    <div class="col-12 text-center">
+                                    <div class="col-md-5 text-center">
                                         <p:commandButton
                                             class="m-1"
                                             icon="fas fa-file-invoice"
@@ -106,6 +78,32 @@
                                             action="pharmacy_bill_retail_sale_native_3?faces-redirect=true"
                                             actionListener="#{retailSaleNativeSqlController3.switchToThisSaleWindow()}"
                                             rendered="#{webUserController.hasPrivilege('PharmacySale')}" />
+                                    </div>
+                                    <div class="col-md-2 text-center">
+                                        <p:commandButton
+                                            icon="fa fa-search"
+                                            value="Search Sale Bills"
+                                            ajax="false"
+                                            action="/pharmacy/pharmacy_search_sale_bill?faces-redirect=true"
+                                            actionListener="#{searchController.makeListNull}"
+                                            class="ui-button-info" />
+                                    </div>
+                                    <div class="col-md-2 text-end">
+                                        <p:commandButton
+                                            ajax="false"
+                                            accesskey="s"
+                                            value="Settle"
+                                            icon="fa fa-check"
+                                            class="ui-button-success mx-1"
+                                            onclick="if (!confirm('Are you sure?')) return false"
+                                            action="#{retailSaleNativeSqlController.settleBillWithPay}" />
+                                        <p:commandButton
+                                            icon="fa fa-plus"
+                                            value="New Bill"
+                                            ajax="false"
+                                            action="pharmacy_bill_retail_sale_native"
+                                            class="ui-button-warning"
+                                            actionListener="#{retailSaleNativeSqlController.resetAll()}" />
                                     </div>
                                 </div>
                             </f:facet>
@@ -588,7 +586,7 @@
                                                         <h:outputLabel value="Payment Details" class="mx-4" />
                                                     </f:facet>
                                                     <div class="row">
-                                                        <div class="col-md-5">
+                                                        <div class="col-md-6">
                                                             <p:selectOneMenu
                                                                 id="pay"
                                                                 value="#{retailSaleNativeSqlController.paymentMethod}"
@@ -597,7 +595,8 @@
                                                                 <f:selectItems value="#{enumController.paymentMethodsForPharmacyBilling}" var="p" itemLabel="#{p.label}" itemValue="#{p}" />
                                                                 <p:ajax process="@this cmbPs cmbPaymentScheme" update="panelBillDetails panelPaymentDetails" event="change" listener="#{retailSaleNativeSqlController.listnerForPaymentMethodChange()}" />
                                                             </p:selectOneMenu>
-
+                                                        </div>
+                                                        <div class="col-md-6">
                                                             <p:selectOneMenu
                                                                 id="cmbPaymentScheme"
                                                                 value="#{retailSaleNativeSqlController.paymentScheme}"
@@ -607,8 +606,60 @@
                                                                 <f:selectItems value="#{paymentSchemeController.items}" var="i" itemLabel="#{i.name}" itemValue="#{i}" />
                                                                 <p:ajax process="@this pay" update="panelBillDetails panelPaymentDetails" event="change" listener="#{retailSaleNativeSqlController.listnerForPaymentMethodChange()}" />
                                                             </p:selectOneMenu>
+
+                                                            <p:selectOneMenu
+                                                                id="cmbPs"
+                                                                value="#{retailSaleNativeSqlController.paymentScheme}"
+                                                                rendered="#{sessionController.loggedPreference.checkPaymentSchemeValidation eq false}"
+                                                                class="my-1">
+                                                                <f:selectItem itemLabel="Discount Scheme" />
+                                                                <f:selectItems value="#{paymentSchemeController.paymentSchemesForPharmacy}" var="i" itemLabel="#{i.name}" itemValue="#{i}" />
+                                                                <p:ajax process="@this pay" update="panelBillDetails panelPaymentDetails" event="change" listener="#{retailSaleNativeSqlController.listnerForPaymentMethodChange()}" />
+                                                            </p:selectOneMenu>
                                                         </div>
                                                     </div>
+
+                                                    <!-- Bill totals (merged former Bill Details panel) -->
+                                                    <h:panelGroup layout="block" id="panelBillDetails" class="my-1">
+                                                        <h:panelGrid columns="2" columnClasses="numberCol, textCol">
+                                                            <h:outputLabel value="Total" styleClass="fw-bold" />
+                                                            <h:panelGroup layout="block" class="text-end mx-4 my-1">
+                                                                <h:outputLabel id="total" value="#{retailSaleNativeSqlController.preBill.total}" styleClass="fw-bold">
+                                                                    <f:convertNumber pattern="#,##0.00" />
+                                                                </h:outputLabel>
+                                                            </h:panelGroup>
+                                                            <h:outputLabel value="Discount" styleClass="fw-bold" />
+                                                            <h:panelGroup layout="block" class="text-end mx-4 my-1">
+                                                                <h:outputLabel id="dis" value="#{retailSaleNativeSqlController.preBill.discount}" styleClass="fw-bold">
+                                                                    <f:convertNumber pattern="#,##0.00" />
+                                                                </h:outputLabel>
+                                                            </h:panelGroup>
+                                                            <h:outputLabel value="Net Total" styleClass="fw-bold fs-5 text-primary" />
+                                                            <h:panelGroup layout="block" class="text-end mx-4 my-1">
+                                                                <h:outputLabel id="netTotal" value="#{retailSaleNativeSqlController.preBill.netTotal}" styleClass="fw-bold fs-5 text-primary">
+                                                                    <f:convertNumber pattern="#,##0.00" />
+                                                                </h:outputLabel>
+                                                            </h:panelGroup>
+                                                            <h:outputLabel value="Tendered" rendered="#{retailSaleNativeSqlController.paymentMethod eq 'Cash'}" />
+                                                            <h:panelGroup layout="block" class="text-end mx-4 my-1" rendered="#{retailSaleNativeSqlController.paymentMethod eq 'Cash'}">
+                                                                <p:inputText
+                                                                    id="paid"
+                                                                    value="#{retailSaleNativeSqlController.cashPaid}"
+                                                                    class="form-control text-end"
+                                                                    autocomplete="off"
+                                                                    accesskey="t"
+                                                                    onfocus="this.select()">
+                                                                    <p:ajax process="total dis netTotal paid" update="balance netTotal" event="keyup" />
+                                                                </p:inputText>
+                                                            </h:panelGroup>
+                                                            <h:outputLabel value="Balance" rendered="#{retailSaleNativeSqlController.paymentMethod eq 'Cash'}" />
+                                                            <h:panelGroup layout="block" class="text-end mx-4 my-1" rendered="#{retailSaleNativeSqlController.paymentMethod eq 'Cash'}">
+                                                                <h:outputLabel id="balance" value="#{retailSaleNativeSqlController.balance}">
+                                                                    <f:convertNumber pattern="#,##0.00" />
+                                                                </h:outputLabel>
+                                                            </h:panelGroup>
+                                                        </h:panelGrid>
+                                                    </h:panelGroup>
 
                                                     <div class="row">
                                                         <div class="my-1">
@@ -731,18 +782,7 @@
                                                         </div>
                                                     </div>
 
-                                                    <div class="col-5">
-                                                        <p:selectOneMenu
-                                                            id="cmbPs"
-                                                            value="#{retailSaleNativeSqlController.paymentScheme}"
-                                                            rendered="#{sessionController.loggedPreference.checkPaymentSchemeValidation eq false}"
-                                                            class="my-1">
-                                                            <f:selectItem itemLabel="Discount Scheme" />
-                                                            <f:selectItems value="#{paymentSchemeController.paymentSchemesForPharmacy}" var="i" itemLabel="#{i.name}" itemValue="#{i}" />
-                                                            <p:ajax process="@this pay" update="panelBillDetails panelPaymentDetails" event="change" listener="#{retailSaleNativeSqlController.listnerForPaymentMethodChange()}" />
-                                                        </p:selectOneMenu>
-                                                    </div>
-
+                                                    <h:outputLabel value="Additional Details" styleClass="fw-bold mb-1 d-block" />
                                                     <h:panelGrid columns="2" class="my-2">
                                                         <p:outputLabel value="Referring Doctor" />
                                                         <p:autoComplete
@@ -756,52 +796,6 @@
                                                             inputStyleClass="form-control" />
                                                         <p:outputLabel value="Comments" />
                                                         <p:inputTextarea id="txtComment" class="w-100 mx-4" value="#{retailSaleNativeSqlController.comment}" />
-                                                    </h:panelGrid>
-                                                </p:panel>
-
-                                                <!-- Bill Details panel -->
-                                                <p:panel id="panelBillDetails" class="my-1">
-                                                    <f:facet name="header">
-                                                        <h:outputText styleClass="fas fa-list" />
-                                                        <h:outputLabel value="Bill Details" class="mx-4" />
-                                                    </f:facet>
-                                                    <h:panelGrid columns="2" columnClasses="numberCol, textCol">
-                                                        <h:outputLabel value="Total" />
-                                                        <h:panelGroup layout="block" class="text-end mx-4 my-1">
-                                                            <h:outputLabel id="total" value="#{retailSaleNativeSqlController.preBill.total}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputLabel>
-                                                        </h:panelGroup>
-                                                        <h:outputLabel value="Discount" />
-                                                        <h:panelGroup layout="block" class="text-end mx-4 my-1">
-                                                            <h:outputLabel id="dis" value="#{retailSaleNativeSqlController.preBill.discount}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputLabel>
-                                                        </h:panelGroup>
-                                                        <h:outputLabel value="Net Total" />
-                                                        <h:panelGroup layout="block" class="text-end mx-4 my-1">
-                                                            <h:outputLabel id="netTotal" value="#{retailSaleNativeSqlController.preBill.netTotal}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputLabel>
-                                                        </h:panelGroup>
-                                                        <h:outputLabel value="Tendered" />
-                                                        <h:panelGroup layout="block" class="text-end mx-4 my-1">
-                                                            <p:inputText
-                                                                id="paid"
-                                                                value="#{retailSaleNativeSqlController.cashPaid}"
-                                                                class="form-control text-end"
-                                                                autocomplete="off"
-                                                                accesskey="t"
-                                                                onfocus="this.select()">
-                                                                <p:ajax process="total dis netTotal paid" update="balance netTotal" event="keyup" />
-                                                            </p:inputText>
-                                                        </h:panelGroup>
-                                                        <h:outputLabel value="Balance" />
-                                                        <h:panelGroup layout="block" class="text-end mx-4 my-1">
-                                                            <h:outputLabel id="balance" value="#{retailSaleNativeSqlController.balance}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputLabel>
-                                                        </h:panelGroup>
                                                     </h:panelGrid>
                                                 </p:panel>
                                             </div>

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native_1.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native_1.xhtml
@@ -28,7 +28,7 @@
                         <p:panel class="w-100">
                             <f:facet name="header">
                                 <div class="row w-100 align-items-center">
-                                    <div class="col-4">
+                                    <div class="col-md-3">
                                         <h:outputText styleClass="fas fa-mortar-pestle" />
                                         <h:outputLabel value="Pharmacy Retail Sale (Sale 2)" class="mx-2" />
                                         <h:panelGroup rendered="#{webUserController.hasPrivilege('Admin')}">
@@ -41,35 +41,7 @@
                                                 class="ui-button-secondary mx-1" />
                                         </h:panelGroup>
                                     </div>
-                                    <div class="col-4 text-center">
-                                        <p:commandButton
-                                            icon="fa fa-search"
-                                            value="Search Sale Bills"
-                                            ajax="false"
-                                            action="/pharmacy/pharmacy_search_sale_bill?faces-redirect=true"
-                                            actionListener="#{searchController.makeListNull}"
-                                            class="ui-button-info" />
-                                    </div>
-                                    <div class="col-4 text-end">
-                                        <p:commandButton
-                                            ajax="false"
-                                            accesskey="s"
-                                            value="Settle"
-                                            icon="fa fa-check"
-                                            class="ui-button-success mx-1"
-                                            onclick="if (!confirm('Are you sure?')) return false"
-                                            action="#{retailSaleNativeSqlController1.settleBillWithPay}" />
-                                        <p:commandButton
-                                            icon="fa fa-plus"
-                                            value="New Bill"
-                                            ajax="false"
-                                            action="pharmacy_bill_retail_sale_native_1"
-                                            class="ui-button-warning"
-                                            actionListener="#{retailSaleNativeSqlController1.resetAll()}" />
-                                    </div>
-                                </div>
-                                <div class="row w-100 align-items-center">
-                                    <div class="col-12 text-center">
+                                    <div class="col-md-5 text-center">
                                         <p:commandButton
                                             class="m-1"
                                             icon="fas fa-file-invoice"
@@ -106,6 +78,32 @@
                                             action="pharmacy_bill_retail_sale_native_3?faces-redirect=true"
                                             actionListener="#{retailSaleNativeSqlController3.switchToThisSaleWindow()}"
                                             rendered="#{webUserController.hasPrivilege('PharmacySale')}" />
+                                    </div>
+                                    <div class="col-md-2 text-center">
+                                        <p:commandButton
+                                            icon="fa fa-search"
+                                            value="Search Sale Bills"
+                                            ajax="false"
+                                            action="/pharmacy/pharmacy_search_sale_bill?faces-redirect=true"
+                                            actionListener="#{searchController.makeListNull}"
+                                            class="ui-button-info" />
+                                    </div>
+                                    <div class="col-md-2 text-end">
+                                        <p:commandButton
+                                            ajax="false"
+                                            accesskey="s"
+                                            value="Settle"
+                                            icon="fa fa-check"
+                                            class="ui-button-success mx-1"
+                                            onclick="if (!confirm('Are you sure?')) return false"
+                                            action="#{retailSaleNativeSqlController1.settleBillWithPay}" />
+                                        <p:commandButton
+                                            icon="fa fa-plus"
+                                            value="New Bill"
+                                            ajax="false"
+                                            action="pharmacy_bill_retail_sale_native_1"
+                                            class="ui-button-warning"
+                                            actionListener="#{retailSaleNativeSqlController1.resetAll()}" />
                                     </div>
                                 </div>
                             </f:facet>
@@ -588,7 +586,7 @@
                                                         <h:outputLabel value="Payment Details" class="mx-4" />
                                                     </f:facet>
                                                     <div class="row">
-                                                        <div class="col-md-5">
+                                                        <div class="col-md-6">
                                                             <p:selectOneMenu
                                                                 id="pay"
                                                                 value="#{retailSaleNativeSqlController1.paymentMethod}"
@@ -597,7 +595,8 @@
                                                                 <f:selectItems value="#{enumController.paymentMethodsForPharmacyBilling}" var="p" itemLabel="#{p.label}" itemValue="#{p}" />
                                                                 <p:ajax process="@this cmbPs cmbPaymentScheme" update="panelBillDetails panelPaymentDetails" event="change" listener="#{retailSaleNativeSqlController1.listnerForPaymentMethodChange()}" />
                                                             </p:selectOneMenu>
-
+                                                        </div>
+                                                        <div class="col-md-6">
                                                             <p:selectOneMenu
                                                                 id="cmbPaymentScheme"
                                                                 value="#{retailSaleNativeSqlController1.paymentScheme}"
@@ -607,8 +606,60 @@
                                                                 <f:selectItems value="#{paymentSchemeController.items}" var="i" itemLabel="#{i.name}" itemValue="#{i}" />
                                                                 <p:ajax process="@this pay" update="panelBillDetails panelPaymentDetails" event="change" listener="#{retailSaleNativeSqlController1.listnerForPaymentMethodChange()}" />
                                                             </p:selectOneMenu>
+
+                                                            <p:selectOneMenu
+                                                                id="cmbPs"
+                                                                value="#{retailSaleNativeSqlController1.paymentScheme}"
+                                                                rendered="#{sessionController.loggedPreference.checkPaymentSchemeValidation eq false}"
+                                                                class="my-1">
+                                                                <f:selectItem itemLabel="Discount Scheme" />
+                                                                <f:selectItems value="#{paymentSchemeController.paymentSchemesForPharmacy}" var="i" itemLabel="#{i.name}" itemValue="#{i}" />
+                                                                <p:ajax process="@this pay" update="panelBillDetails panelPaymentDetails" event="change" listener="#{retailSaleNativeSqlController1.listnerForPaymentMethodChange()}" />
+                                                            </p:selectOneMenu>
                                                         </div>
                                                     </div>
+
+                                                    <!-- Bill totals (merged former Bill Details panel) -->
+                                                    <h:panelGroup layout="block" id="panelBillDetails" class="my-1">
+                                                        <h:panelGrid columns="2" columnClasses="numberCol, textCol">
+                                                            <h:outputLabel value="Total" styleClass="fw-bold" />
+                                                            <h:panelGroup layout="block" class="text-end mx-4 my-1">
+                                                                <h:outputLabel id="total" value="#{retailSaleNativeSqlController1.preBill.total}" styleClass="fw-bold">
+                                                                    <f:convertNumber pattern="#,##0.00" />
+                                                                </h:outputLabel>
+                                                            </h:panelGroup>
+                                                            <h:outputLabel value="Discount" styleClass="fw-bold" />
+                                                            <h:panelGroup layout="block" class="text-end mx-4 my-1">
+                                                                <h:outputLabel id="dis" value="#{retailSaleNativeSqlController1.preBill.discount}" styleClass="fw-bold">
+                                                                    <f:convertNumber pattern="#,##0.00" />
+                                                                </h:outputLabel>
+                                                            </h:panelGroup>
+                                                            <h:outputLabel value="Net Total" styleClass="fw-bold fs-5 text-primary" />
+                                                            <h:panelGroup layout="block" class="text-end mx-4 my-1">
+                                                                <h:outputLabel id="netTotal" value="#{retailSaleNativeSqlController1.preBill.netTotal}" styleClass="fw-bold fs-5 text-primary">
+                                                                    <f:convertNumber pattern="#,##0.00" />
+                                                                </h:outputLabel>
+                                                            </h:panelGroup>
+                                                            <h:outputLabel value="Tendered" rendered="#{retailSaleNativeSqlController1.paymentMethod eq 'Cash'}" />
+                                                            <h:panelGroup layout="block" class="text-end mx-4 my-1" rendered="#{retailSaleNativeSqlController1.paymentMethod eq 'Cash'}">
+                                                                <p:inputText
+                                                                    id="paid"
+                                                                    value="#{retailSaleNativeSqlController1.cashPaid}"
+                                                                    class="form-control text-end"
+                                                                    autocomplete="off"
+                                                                    accesskey="t"
+                                                                    onfocus="this.select()">
+                                                                    <p:ajax process="total dis netTotal paid" update="balance netTotal" event="keyup" />
+                                                                </p:inputText>
+                                                            </h:panelGroup>
+                                                            <h:outputLabel value="Balance" rendered="#{retailSaleNativeSqlController1.paymentMethod eq 'Cash'}" />
+                                                            <h:panelGroup layout="block" class="text-end mx-4 my-1" rendered="#{retailSaleNativeSqlController1.paymentMethod eq 'Cash'}">
+                                                                <h:outputLabel id="balance" value="#{retailSaleNativeSqlController1.balance}">
+                                                                    <f:convertNumber pattern="#,##0.00" />
+                                                                </h:outputLabel>
+                                                            </h:panelGroup>
+                                                        </h:panelGrid>
+                                                    </h:panelGroup>
 
                                                     <div class="row">
                                                         <div class="my-1">
@@ -731,18 +782,7 @@
                                                         </div>
                                                     </div>
 
-                                                    <div class="col-5">
-                                                        <p:selectOneMenu
-                                                            id="cmbPs"
-                                                            value="#{retailSaleNativeSqlController1.paymentScheme}"
-                                                            rendered="#{sessionController.loggedPreference.checkPaymentSchemeValidation eq false}"
-                                                            class="my-1">
-                                                            <f:selectItem itemLabel="Discount Scheme" />
-                                                            <f:selectItems value="#{paymentSchemeController.paymentSchemesForPharmacy}" var="i" itemLabel="#{i.name}" itemValue="#{i}" />
-                                                            <p:ajax process="@this pay" update="panelBillDetails panelPaymentDetails" event="change" listener="#{retailSaleNativeSqlController1.listnerForPaymentMethodChange()}" />
-                                                        </p:selectOneMenu>
-                                                    </div>
-
+                                                    <h:outputLabel value="Additional Details" styleClass="fw-bold mb-1 d-block" />
                                                     <h:panelGrid columns="2" class="my-2">
                                                         <p:outputLabel value="Referring Doctor" />
                                                         <p:autoComplete
@@ -756,52 +796,6 @@
                                                             inputStyleClass="form-control" />
                                                         <p:outputLabel value="Comments" />
                                                         <p:inputTextarea id="txtComment" class="w-100 mx-4" value="#{retailSaleNativeSqlController1.comment}" />
-                                                    </h:panelGrid>
-                                                </p:panel>
-
-                                                <!-- Bill Details panel -->
-                                                <p:panel id="panelBillDetails" class="my-1">
-                                                    <f:facet name="header">
-                                                        <h:outputText styleClass="fas fa-list" />
-                                                        <h:outputLabel value="Bill Details" class="mx-4" />
-                                                    </f:facet>
-                                                    <h:panelGrid columns="2" columnClasses="numberCol, textCol">
-                                                        <h:outputLabel value="Total" />
-                                                        <h:panelGroup layout="block" class="text-end mx-4 my-1">
-                                                            <h:outputLabel id="total" value="#{retailSaleNativeSqlController1.preBill.total}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputLabel>
-                                                        </h:panelGroup>
-                                                        <h:outputLabel value="Discount" />
-                                                        <h:panelGroup layout="block" class="text-end mx-4 my-1">
-                                                            <h:outputLabel id="dis" value="#{retailSaleNativeSqlController1.preBill.discount}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputLabel>
-                                                        </h:panelGroup>
-                                                        <h:outputLabel value="Net Total" />
-                                                        <h:panelGroup layout="block" class="text-end mx-4 my-1">
-                                                            <h:outputLabel id="netTotal" value="#{retailSaleNativeSqlController1.preBill.netTotal}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputLabel>
-                                                        </h:panelGroup>
-                                                        <h:outputLabel value="Tendered" />
-                                                        <h:panelGroup layout="block" class="text-end mx-4 my-1">
-                                                            <p:inputText
-                                                                id="paid"
-                                                                value="#{retailSaleNativeSqlController1.cashPaid}"
-                                                                class="form-control text-end"
-                                                                autocomplete="off"
-                                                                accesskey="t"
-                                                                onfocus="this.select()">
-                                                                <p:ajax process="total dis netTotal paid" update="balance netTotal" event="keyup" />
-                                                            </p:inputText>
-                                                        </h:panelGroup>
-                                                        <h:outputLabel value="Balance" />
-                                                        <h:panelGroup layout="block" class="text-end mx-4 my-1">
-                                                            <h:outputLabel id="balance" value="#{retailSaleNativeSqlController1.balance}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputLabel>
-                                                        </h:panelGroup>
                                                     </h:panelGrid>
                                                 </p:panel>
                                             </div>

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native_2.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native_2.xhtml
@@ -28,7 +28,7 @@
                         <p:panel class="w-100">
                             <f:facet name="header">
                                 <div class="row w-100 align-items-center">
-                                    <div class="col-4">
+                                    <div class="col-md-3">
                                         <h:outputText styleClass="fas fa-mortar-pestle" />
                                         <h:outputLabel value="Pharmacy Retail Sale (Sale 3)" class="mx-2" />
                                         <h:panelGroup rendered="#{webUserController.hasPrivilege('Admin')}">
@@ -41,35 +41,7 @@
                                                 class="ui-button-secondary mx-1" />
                                         </h:panelGroup>
                                     </div>
-                                    <div class="col-4 text-center">
-                                        <p:commandButton
-                                            icon="fa fa-search"
-                                            value="Search Sale Bills"
-                                            ajax="false"
-                                            action="/pharmacy/pharmacy_search_sale_bill?faces-redirect=true"
-                                            actionListener="#{searchController.makeListNull}"
-                                            class="ui-button-info" />
-                                    </div>
-                                    <div class="col-4 text-end">
-                                        <p:commandButton
-                                            ajax="false"
-                                            accesskey="s"
-                                            value="Settle"
-                                            icon="fa fa-check"
-                                            class="ui-button-success mx-1"
-                                            onclick="if (!confirm('Are you sure?')) return false"
-                                            action="#{retailSaleNativeSqlController2.settleBillWithPay}" />
-                                        <p:commandButton
-                                            icon="fa fa-plus"
-                                            value="New Bill"
-                                            ajax="false"
-                                            action="pharmacy_bill_retail_sale_native_2"
-                                            class="ui-button-warning"
-                                            actionListener="#{retailSaleNativeSqlController2.resetAll()}" />
-                                    </div>
-                                </div>
-                                <div class="row w-100 align-items-center">
-                                    <div class="col-12 text-center">
+                                    <div class="col-md-5 text-center">
                                         <p:commandButton
                                             class="m-1"
                                             icon="fas fa-file-invoice"
@@ -106,6 +78,32 @@
                                             action="pharmacy_bill_retail_sale_native_3?faces-redirect=true"
                                             actionListener="#{retailSaleNativeSqlController3.switchToThisSaleWindow()}"
                                             rendered="#{webUserController.hasPrivilege('PharmacySale')}" />
+                                    </div>
+                                    <div class="col-md-2 text-center">
+                                        <p:commandButton
+                                            icon="fa fa-search"
+                                            value="Search Sale Bills"
+                                            ajax="false"
+                                            action="/pharmacy/pharmacy_search_sale_bill?faces-redirect=true"
+                                            actionListener="#{searchController.makeListNull}"
+                                            class="ui-button-info" />
+                                    </div>
+                                    <div class="col-md-2 text-end">
+                                        <p:commandButton
+                                            ajax="false"
+                                            accesskey="s"
+                                            value="Settle"
+                                            icon="fa fa-check"
+                                            class="ui-button-success mx-1"
+                                            onclick="if (!confirm('Are you sure?')) return false"
+                                            action="#{retailSaleNativeSqlController2.settleBillWithPay}" />
+                                        <p:commandButton
+                                            icon="fa fa-plus"
+                                            value="New Bill"
+                                            ajax="false"
+                                            action="pharmacy_bill_retail_sale_native_2"
+                                            class="ui-button-warning"
+                                            actionListener="#{retailSaleNativeSqlController2.resetAll()}" />
                                     </div>
                                 </div>
                             </f:facet>
@@ -588,7 +586,7 @@
                                                         <h:outputLabel value="Payment Details" class="mx-4" />
                                                     </f:facet>
                                                     <div class="row">
-                                                        <div class="col-md-5">
+                                                        <div class="col-md-6">
                                                             <p:selectOneMenu
                                                                 id="pay"
                                                                 value="#{retailSaleNativeSqlController2.paymentMethod}"
@@ -597,7 +595,8 @@
                                                                 <f:selectItems value="#{enumController.paymentMethodsForPharmacyBilling}" var="p" itemLabel="#{p.label}" itemValue="#{p}" />
                                                                 <p:ajax process="@this cmbPs cmbPaymentScheme" update="panelBillDetails panelPaymentDetails" event="change" listener="#{retailSaleNativeSqlController2.listnerForPaymentMethodChange()}" />
                                                             </p:selectOneMenu>
-
+                                                        </div>
+                                                        <div class="col-md-6">
                                                             <p:selectOneMenu
                                                                 id="cmbPaymentScheme"
                                                                 value="#{retailSaleNativeSqlController2.paymentScheme}"
@@ -607,8 +606,60 @@
                                                                 <f:selectItems value="#{paymentSchemeController.items}" var="i" itemLabel="#{i.name}" itemValue="#{i}" />
                                                                 <p:ajax process="@this pay" update="panelBillDetails panelPaymentDetails" event="change" listener="#{retailSaleNativeSqlController2.listnerForPaymentMethodChange()}" />
                                                             </p:selectOneMenu>
+
+                                                            <p:selectOneMenu
+                                                                id="cmbPs"
+                                                                value="#{retailSaleNativeSqlController2.paymentScheme}"
+                                                                rendered="#{sessionController.loggedPreference.checkPaymentSchemeValidation eq false}"
+                                                                class="my-1">
+                                                                <f:selectItem itemLabel="Discount Scheme" />
+                                                                <f:selectItems value="#{paymentSchemeController.paymentSchemesForPharmacy}" var="i" itemLabel="#{i.name}" itemValue="#{i}" />
+                                                                <p:ajax process="@this pay" update="panelBillDetails panelPaymentDetails" event="change" listener="#{retailSaleNativeSqlController2.listnerForPaymentMethodChange()}" />
+                                                            </p:selectOneMenu>
                                                         </div>
                                                     </div>
+
+                                                    <!-- Bill totals (merged former Bill Details panel) -->
+                                                    <h:panelGroup layout="block" id="panelBillDetails" class="my-1">
+                                                        <h:panelGrid columns="2" columnClasses="numberCol, textCol">
+                                                            <h:outputLabel value="Total" styleClass="fw-bold" />
+                                                            <h:panelGroup layout="block" class="text-end mx-4 my-1">
+                                                                <h:outputLabel id="total" value="#{retailSaleNativeSqlController2.preBill.total}" styleClass="fw-bold">
+                                                                    <f:convertNumber pattern="#,##0.00" />
+                                                                </h:outputLabel>
+                                                            </h:panelGroup>
+                                                            <h:outputLabel value="Discount" styleClass="fw-bold" />
+                                                            <h:panelGroup layout="block" class="text-end mx-4 my-1">
+                                                                <h:outputLabel id="dis" value="#{retailSaleNativeSqlController2.preBill.discount}" styleClass="fw-bold">
+                                                                    <f:convertNumber pattern="#,##0.00" />
+                                                                </h:outputLabel>
+                                                            </h:panelGroup>
+                                                            <h:outputLabel value="Net Total" styleClass="fw-bold fs-5 text-primary" />
+                                                            <h:panelGroup layout="block" class="text-end mx-4 my-1">
+                                                                <h:outputLabel id="netTotal" value="#{retailSaleNativeSqlController2.preBill.netTotal}" styleClass="fw-bold fs-5 text-primary">
+                                                                    <f:convertNumber pattern="#,##0.00" />
+                                                                </h:outputLabel>
+                                                            </h:panelGroup>
+                                                            <h:outputLabel value="Tendered" rendered="#{retailSaleNativeSqlController2.paymentMethod eq 'Cash'}" />
+                                                            <h:panelGroup layout="block" class="text-end mx-4 my-1" rendered="#{retailSaleNativeSqlController2.paymentMethod eq 'Cash'}">
+                                                                <p:inputText
+                                                                    id="paid"
+                                                                    value="#{retailSaleNativeSqlController2.cashPaid}"
+                                                                    class="form-control text-end"
+                                                                    autocomplete="off"
+                                                                    accesskey="t"
+                                                                    onfocus="this.select()">
+                                                                    <p:ajax process="total dis netTotal paid" update="balance netTotal" event="keyup" />
+                                                                </p:inputText>
+                                                            </h:panelGroup>
+                                                            <h:outputLabel value="Balance" rendered="#{retailSaleNativeSqlController2.paymentMethod eq 'Cash'}" />
+                                                            <h:panelGroup layout="block" class="text-end mx-4 my-1" rendered="#{retailSaleNativeSqlController2.paymentMethod eq 'Cash'}">
+                                                                <h:outputLabel id="balance" value="#{retailSaleNativeSqlController2.balance}">
+                                                                    <f:convertNumber pattern="#,##0.00" />
+                                                                </h:outputLabel>
+                                                            </h:panelGroup>
+                                                        </h:panelGrid>
+                                                    </h:panelGroup>
 
                                                     <div class="row">
                                                         <div class="my-1">
@@ -731,18 +782,7 @@
                                                         </div>
                                                     </div>
 
-                                                    <div class="col-5">
-                                                        <p:selectOneMenu
-                                                            id="cmbPs"
-                                                            value="#{retailSaleNativeSqlController2.paymentScheme}"
-                                                            rendered="#{sessionController.loggedPreference.checkPaymentSchemeValidation eq false}"
-                                                            class="my-1">
-                                                            <f:selectItem itemLabel="Discount Scheme" />
-                                                            <f:selectItems value="#{paymentSchemeController.paymentSchemesForPharmacy}" var="i" itemLabel="#{i.name}" itemValue="#{i}" />
-                                                            <p:ajax process="@this pay" update="panelBillDetails panelPaymentDetails" event="change" listener="#{retailSaleNativeSqlController2.listnerForPaymentMethodChange()}" />
-                                                        </p:selectOneMenu>
-                                                    </div>
-
+                                                    <h:outputLabel value="Additional Details" styleClass="fw-bold mb-1 d-block" />
                                                     <h:panelGrid columns="2" class="my-2">
                                                         <p:outputLabel value="Referring Doctor" />
                                                         <p:autoComplete
@@ -756,52 +796,6 @@
                                                             inputStyleClass="form-control" />
                                                         <p:outputLabel value="Comments" />
                                                         <p:inputTextarea id="txtComment" class="w-100 mx-4" value="#{retailSaleNativeSqlController2.comment}" />
-                                                    </h:panelGrid>
-                                                </p:panel>
-
-                                                <!-- Bill Details panel -->
-                                                <p:panel id="panelBillDetails" class="my-1">
-                                                    <f:facet name="header">
-                                                        <h:outputText styleClass="fas fa-list" />
-                                                        <h:outputLabel value="Bill Details" class="mx-4" />
-                                                    </f:facet>
-                                                    <h:panelGrid columns="2" columnClasses="numberCol, textCol">
-                                                        <h:outputLabel value="Total" />
-                                                        <h:panelGroup layout="block" class="text-end mx-4 my-1">
-                                                            <h:outputLabel id="total" value="#{retailSaleNativeSqlController2.preBill.total}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputLabel>
-                                                        </h:panelGroup>
-                                                        <h:outputLabel value="Discount" />
-                                                        <h:panelGroup layout="block" class="text-end mx-4 my-1">
-                                                            <h:outputLabel id="dis" value="#{retailSaleNativeSqlController2.preBill.discount}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputLabel>
-                                                        </h:panelGroup>
-                                                        <h:outputLabel value="Net Total" />
-                                                        <h:panelGroup layout="block" class="text-end mx-4 my-1">
-                                                            <h:outputLabel id="netTotal" value="#{retailSaleNativeSqlController2.preBill.netTotal}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputLabel>
-                                                        </h:panelGroup>
-                                                        <h:outputLabel value="Tendered" />
-                                                        <h:panelGroup layout="block" class="text-end mx-4 my-1">
-                                                            <p:inputText
-                                                                id="paid"
-                                                                value="#{retailSaleNativeSqlController2.cashPaid}"
-                                                                class="form-control text-end"
-                                                                autocomplete="off"
-                                                                accesskey="t"
-                                                                onfocus="this.select()">
-                                                                <p:ajax process="total dis netTotal paid" update="balance netTotal" event="keyup" />
-                                                            </p:inputText>
-                                                        </h:panelGroup>
-                                                        <h:outputLabel value="Balance" />
-                                                        <h:panelGroup layout="block" class="text-end mx-4 my-1">
-                                                            <h:outputLabel id="balance" value="#{retailSaleNativeSqlController2.balance}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputLabel>
-                                                        </h:panelGroup>
                                                     </h:panelGrid>
                                                 </p:panel>
                                             </div>

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native_3.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native_3.xhtml
@@ -28,7 +28,7 @@
                         <p:panel class="w-100">
                             <f:facet name="header">
                                 <div class="row w-100 align-items-center">
-                                    <div class="col-4">
+                                    <div class="col-md-3">
                                         <h:outputText styleClass="fas fa-mortar-pestle" />
                                         <h:outputLabel value="Pharmacy Retail Sale (Sale 4)" class="mx-2" />
                                         <h:panelGroup rendered="#{webUserController.hasPrivilege('Admin')}">
@@ -41,35 +41,7 @@
                                                 class="ui-button-secondary mx-1" />
                                         </h:panelGroup>
                                     </div>
-                                    <div class="col-4 text-center">
-                                        <p:commandButton
-                                            icon="fa fa-search"
-                                            value="Search Sale Bills"
-                                            ajax="false"
-                                            action="/pharmacy/pharmacy_search_sale_bill?faces-redirect=true"
-                                            actionListener="#{searchController.makeListNull}"
-                                            class="ui-button-info" />
-                                    </div>
-                                    <div class="col-4 text-end">
-                                        <p:commandButton
-                                            ajax="false"
-                                            accesskey="s"
-                                            value="Settle"
-                                            icon="fa fa-check"
-                                            class="ui-button-success mx-1"
-                                            onclick="if (!confirm('Are you sure?')) return false"
-                                            action="#{retailSaleNativeSqlController3.settleBillWithPay}" />
-                                        <p:commandButton
-                                            icon="fa fa-plus"
-                                            value="New Bill"
-                                            ajax="false"
-                                            action="pharmacy_bill_retail_sale_native_3"
-                                            class="ui-button-warning"
-                                            actionListener="#{retailSaleNativeSqlController3.resetAll()}" />
-                                    </div>
-                                </div>
-                                <div class="row w-100 align-items-center">
-                                    <div class="col-12 text-center">
+                                    <div class="col-md-5 text-center">
                                         <p:commandButton
                                             class="m-1"
                                             icon="fas fa-file-invoice"
@@ -106,6 +78,32 @@
                                             action="pharmacy_bill_retail_sale_native_3?faces-redirect=true"
                                             actionListener="#{retailSaleNativeSqlController3.switchToThisSaleWindow()}"
                                             rendered="#{webUserController.hasPrivilege('PharmacySale')}" />
+                                    </div>
+                                    <div class="col-md-2 text-center">
+                                        <p:commandButton
+                                            icon="fa fa-search"
+                                            value="Search Sale Bills"
+                                            ajax="false"
+                                            action="/pharmacy/pharmacy_search_sale_bill?faces-redirect=true"
+                                            actionListener="#{searchController.makeListNull}"
+                                            class="ui-button-info" />
+                                    </div>
+                                    <div class="col-md-2 text-end">
+                                        <p:commandButton
+                                            ajax="false"
+                                            accesskey="s"
+                                            value="Settle"
+                                            icon="fa fa-check"
+                                            class="ui-button-success mx-1"
+                                            onclick="if (!confirm('Are you sure?')) return false"
+                                            action="#{retailSaleNativeSqlController3.settleBillWithPay}" />
+                                        <p:commandButton
+                                            icon="fa fa-plus"
+                                            value="New Bill"
+                                            ajax="false"
+                                            action="pharmacy_bill_retail_sale_native_3"
+                                            class="ui-button-warning"
+                                            actionListener="#{retailSaleNativeSqlController3.resetAll()}" />
                                     </div>
                                 </div>
                             </f:facet>
@@ -588,7 +586,7 @@
                                                         <h:outputLabel value="Payment Details" class="mx-4" />
                                                     </f:facet>
                                                     <div class="row">
-                                                        <div class="col-md-5">
+                                                        <div class="col-md-6">
                                                             <p:selectOneMenu
                                                                 id="pay"
                                                                 value="#{retailSaleNativeSqlController3.paymentMethod}"
@@ -597,7 +595,8 @@
                                                                 <f:selectItems value="#{enumController.paymentMethodsForPharmacyBilling}" var="p" itemLabel="#{p.label}" itemValue="#{p}" />
                                                                 <p:ajax process="@this cmbPs cmbPaymentScheme" update="panelBillDetails panelPaymentDetails" event="change" listener="#{retailSaleNativeSqlController3.listnerForPaymentMethodChange()}" />
                                                             </p:selectOneMenu>
-
+                                                        </div>
+                                                        <div class="col-md-6">
                                                             <p:selectOneMenu
                                                                 id="cmbPaymentScheme"
                                                                 value="#{retailSaleNativeSqlController3.paymentScheme}"
@@ -607,8 +606,60 @@
                                                                 <f:selectItems value="#{paymentSchemeController.items}" var="i" itemLabel="#{i.name}" itemValue="#{i}" />
                                                                 <p:ajax process="@this pay" update="panelBillDetails panelPaymentDetails" event="change" listener="#{retailSaleNativeSqlController3.listnerForPaymentMethodChange()}" />
                                                             </p:selectOneMenu>
+
+                                                            <p:selectOneMenu
+                                                                id="cmbPs"
+                                                                value="#{retailSaleNativeSqlController3.paymentScheme}"
+                                                                rendered="#{sessionController.loggedPreference.checkPaymentSchemeValidation eq false}"
+                                                                class="my-1">
+                                                                <f:selectItem itemLabel="Discount Scheme" />
+                                                                <f:selectItems value="#{paymentSchemeController.paymentSchemesForPharmacy}" var="i" itemLabel="#{i.name}" itemValue="#{i}" />
+                                                                <p:ajax process="@this pay" update="panelBillDetails panelPaymentDetails" event="change" listener="#{retailSaleNativeSqlController3.listnerForPaymentMethodChange()}" />
+                                                            </p:selectOneMenu>
                                                         </div>
                                                     </div>
+
+                                                    <!-- Bill totals (merged former Bill Details panel) -->
+                                                    <h:panelGroup layout="block" id="panelBillDetails" class="my-1">
+                                                        <h:panelGrid columns="2" columnClasses="numberCol, textCol">
+                                                            <h:outputLabel value="Total" styleClass="fw-bold" />
+                                                            <h:panelGroup layout="block" class="text-end mx-4 my-1">
+                                                                <h:outputLabel id="total" value="#{retailSaleNativeSqlController3.preBill.total}" styleClass="fw-bold">
+                                                                    <f:convertNumber pattern="#,##0.00" />
+                                                                </h:outputLabel>
+                                                            </h:panelGroup>
+                                                            <h:outputLabel value="Discount" styleClass="fw-bold" />
+                                                            <h:panelGroup layout="block" class="text-end mx-4 my-1">
+                                                                <h:outputLabel id="dis" value="#{retailSaleNativeSqlController3.preBill.discount}" styleClass="fw-bold">
+                                                                    <f:convertNumber pattern="#,##0.00" />
+                                                                </h:outputLabel>
+                                                            </h:panelGroup>
+                                                            <h:outputLabel value="Net Total" styleClass="fw-bold fs-5 text-primary" />
+                                                            <h:panelGroup layout="block" class="text-end mx-4 my-1">
+                                                                <h:outputLabel id="netTotal" value="#{retailSaleNativeSqlController3.preBill.netTotal}" styleClass="fw-bold fs-5 text-primary">
+                                                                    <f:convertNumber pattern="#,##0.00" />
+                                                                </h:outputLabel>
+                                                            </h:panelGroup>
+                                                            <h:outputLabel value="Tendered" rendered="#{retailSaleNativeSqlController3.paymentMethod eq 'Cash'}" />
+                                                            <h:panelGroup layout="block" class="text-end mx-4 my-1" rendered="#{retailSaleNativeSqlController3.paymentMethod eq 'Cash'}">
+                                                                <p:inputText
+                                                                    id="paid"
+                                                                    value="#{retailSaleNativeSqlController3.cashPaid}"
+                                                                    class="form-control text-end"
+                                                                    autocomplete="off"
+                                                                    accesskey="t"
+                                                                    onfocus="this.select()">
+                                                                    <p:ajax process="total dis netTotal paid" update="balance netTotal" event="keyup" />
+                                                                </p:inputText>
+                                                            </h:panelGroup>
+                                                            <h:outputLabel value="Balance" rendered="#{retailSaleNativeSqlController3.paymentMethod eq 'Cash'}" />
+                                                            <h:panelGroup layout="block" class="text-end mx-4 my-1" rendered="#{retailSaleNativeSqlController3.paymentMethod eq 'Cash'}">
+                                                                <h:outputLabel id="balance" value="#{retailSaleNativeSqlController3.balance}">
+                                                                    <f:convertNumber pattern="#,##0.00" />
+                                                                </h:outputLabel>
+                                                            </h:panelGroup>
+                                                        </h:panelGrid>
+                                                    </h:panelGroup>
 
                                                     <div class="row">
                                                         <div class="my-1">
@@ -731,18 +782,7 @@
                                                         </div>
                                                     </div>
 
-                                                    <div class="col-5">
-                                                        <p:selectOneMenu
-                                                            id="cmbPs"
-                                                            value="#{retailSaleNativeSqlController3.paymentScheme}"
-                                                            rendered="#{sessionController.loggedPreference.checkPaymentSchemeValidation eq false}"
-                                                            class="my-1">
-                                                            <f:selectItem itemLabel="Discount Scheme" />
-                                                            <f:selectItems value="#{paymentSchemeController.paymentSchemesForPharmacy}" var="i" itemLabel="#{i.name}" itemValue="#{i}" />
-                                                            <p:ajax process="@this pay" update="panelBillDetails panelPaymentDetails" event="change" listener="#{retailSaleNativeSqlController3.listnerForPaymentMethodChange()}" />
-                                                        </p:selectOneMenu>
-                                                    </div>
-
+                                                    <h:outputLabel value="Additional Details" styleClass="fw-bold mb-1 d-block" />
                                                     <h:panelGrid columns="2" class="my-2">
                                                         <p:outputLabel value="Referring Doctor" />
                                                         <p:autoComplete
@@ -756,52 +796,6 @@
                                                             inputStyleClass="form-control" />
                                                         <p:outputLabel value="Comments" />
                                                         <p:inputTextarea id="txtComment" class="w-100 mx-4" value="#{retailSaleNativeSqlController3.comment}" />
-                                                    </h:panelGrid>
-                                                </p:panel>
-
-                                                <!-- Bill Details panel -->
-                                                <p:panel id="panelBillDetails" class="my-1">
-                                                    <f:facet name="header">
-                                                        <h:outputText styleClass="fas fa-list" />
-                                                        <h:outputLabel value="Bill Details" class="mx-4" />
-                                                    </f:facet>
-                                                    <h:panelGrid columns="2" columnClasses="numberCol, textCol">
-                                                        <h:outputLabel value="Total" />
-                                                        <h:panelGroup layout="block" class="text-end mx-4 my-1">
-                                                            <h:outputLabel id="total" value="#{retailSaleNativeSqlController3.preBill.total}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputLabel>
-                                                        </h:panelGroup>
-                                                        <h:outputLabel value="Discount" />
-                                                        <h:panelGroup layout="block" class="text-end mx-4 my-1">
-                                                            <h:outputLabel id="dis" value="#{retailSaleNativeSqlController3.preBill.discount}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputLabel>
-                                                        </h:panelGroup>
-                                                        <h:outputLabel value="Net Total" />
-                                                        <h:panelGroup layout="block" class="text-end mx-4 my-1">
-                                                            <h:outputLabel id="netTotal" value="#{retailSaleNativeSqlController3.preBill.netTotal}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputLabel>
-                                                        </h:panelGroup>
-                                                        <h:outputLabel value="Tendered" />
-                                                        <h:panelGroup layout="block" class="text-end mx-4 my-1">
-                                                            <p:inputText
-                                                                id="paid"
-                                                                value="#{retailSaleNativeSqlController3.cashPaid}"
-                                                                class="form-control text-end"
-                                                                autocomplete="off"
-                                                                accesskey="t"
-                                                                onfocus="this.select()">
-                                                                <p:ajax process="total dis netTotal paid" update="balance netTotal" event="keyup" />
-                                                            </p:inputText>
-                                                        </h:panelGroup>
-                                                        <h:outputLabel value="Balance" />
-                                                        <h:panelGroup layout="block" class="text-end mx-4 my-1">
-                                                            <h:outputLabel id="balance" value="#{retailSaleNativeSqlController3.balance}">
-                                                                <f:convertNumber pattern="#,##0.00" />
-                                                            </h:outputLabel>
-                                                        </h:panelGroup>
                                                     </h:panelGrid>
                                                 </p:panel>
                                             </div>


### PR DESCRIPTION
## Summary

Closes #22991. Fixes a functional bug and reorganizes the Payment/Bill Details layout across all 4 Pharmacy Retail Sale (native) Sale windows.

### 1. Batch-selection bug

`addBillItem()` in `RetailSaleNativeSqlController` / `1` / `2` / `3` previously merged the user-selected batch with *every* other batch of the item and allocated the whole requested quantity earliest-expiry-first, regardless of which batch the user deliberately picked (e.g. for its price) — this only manifests when `"Add quantity from multiple batches in pharmacy retail billing"` is enabled.

Now:
- Priority 1: fully satisfy from the selected batch if it has enough stock.
- Priority 2: only the shortfall (if any) is topped up FEFO (earliest-expiry-first) from the other batches.
- If total stock across all batches is still insufficient, a warning is shown instead of a silent partial/failed add.

### 2. Layout reorganization (all 4 Sale-window pages)

- Header (title/Config, Sale 1–4 switcher, Search Sale Bills, Settle/New Bill) merged from two rows into one.
- Payment Method + Discount Scheme placed side by side.
- Bill Details merged into Payment Details: Total/Discount/Net Total always shown and highlighted; Tendered/Balance shown only for Cash; all payment-method sub-panels (Credit, Staff, Card, Multiple Payment Methods, etc.) render below the totals instead of above; Referring Doctor/Comments moved into an "Additional Details" section at the end.

All 4 Sale-window `.xhtml` files are deliberate copies of each other (differing only in bean name / title / disabled button), so the same structural edit was applied identically to all 4 — verified via diff.

## Testing

Verified end-to-end against local Payara, Main Pharmacy department:

- **Batch allocation**: with the config temporarily enabled, tested against an item with 4 batches (differing expiries, same rate in this dev DB). Confirmed: (a) selecting the latest-expiry batch for a qty it fully covers uses only that batch; (b) selecting a batch with less stock than requested tops up the shortfall from the earliest-expiry *other* batch, not a later one; (c) requesting more than total available stock shows the "Only N of the requested M is available across all batches" warning. Settled the bill and confirmed in the DB that all 4 `PHARMACEUTICALBILLITEM.ITEMBATCH_ID` rows match the expected batch IDs and quantities. Reverted the config flag to its original `false` afterward.
- **Layout**: confirmed one-row header, side-by-side Payment Method/Discount Scheme, merged/highlighted totals, Cash-only Tendered/Balance, sub-panels below totals (tested Credit Card and Multiple Payment Methods), and Additional Details section — on Sale 1, then smoke-tested Sale 2/3/4 for identical rendering.

Screenshots and full verification notes posted on #22991: https://github.com/hmislk/hmis/issues/22991#issuecomment-5301541256

![Batch allocation fix](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/retail_sale_22991_batch_allocation_fix.png)

![Layout reorg](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/retail_sale_22991_layout_reorg.png)

## Out of scope

`RetailSaleForCashierNativeSqlController` (a separate single-window page) has the same FEFO-merge pattern in its `addBillItem()` but wasn't touched here — worth a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retail sales now prioritize the selected stock batch before using other batches by earliest expiry.
  * Pharmacy billing screens now provide responsive layouts with reorganized payment controls, totals, cash fields, and additional details.
  * Payment scheme options are shown according to validation settings.

* **Bug Fixes**
  * Improved multi-batch allocation while preserving insufficient-stock handling.
  * Cash tendered and balance fields appear only for cash payments.

* **Documentation**
  * Added troubleshooting guidance for selecting the first dropdown option during automated testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->