### PR TITLE
fix(inward): exempt baby admissions from Patient NIC requirement

### DIFF
--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -915,8 +915,19 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
     }
 
     public String navigateToAddBabyAdmission() {
-        if (current == null) {
-            JsfUtil.addErrorMessage("No Admission selected");
+        // The disabled attribute on the "Add Baby Admission" buttons (Admission
+        // Profile, Nursing Workbench) is a UI convenience only and can go stale
+        // (page left open past discharge) or be bypassed (direct action call
+        // with no admission selected). Re-check server-side before creating the
+        // baby admission, since getCurrent() would otherwise happily hand back
+        // a transient, unsaved Admission as the parent. (#22998 review)
+        if (current == null || current.getId() == null || current.getPatient() == null
+                || current.getPatient().getId() == null) {
+            JsfUtil.addErrorMessage("Select a saved admission before adding a baby admission.");
+            return "";
+        }
+        if (current.getDischarged() != null && current.getDischarged()) {
+            JsfUtil.addErrorMessage("A discharged admission cannot have a baby admission.");
             return "";
         }
         if (current.getParentEncounter() != null) {

--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -921,23 +921,32 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         // with no admission selected). Re-check server-side before creating the
         // baby admission, since getCurrent() would otherwise happily hand back
         // a transient, unsaved Admission as the parent. (#22998 review)
-        if (current == null || current.getId() == null || current.getPatient() == null
-                || current.getPatient().getId() == null) {
+        if (current == null || current.getId() == null || current.getId() <= 0) {
             JsfUtil.addErrorMessage("Select a saved admission before adding a baby admission.");
             return "";
         }
-        if (current.getDischarged() != null && current.getDischarged()) {
+        // AdmissionController is @SessionScoped, so `current` can be a stale
+        // snapshot from earlier in the session (e.g. another tab/request
+        // discharged this same admission since it was loaded here). Re-read
+        // the parent from the DB rather than trusting the in-memory copy.
+        Admission persistedParent = getEjbFacade().findWithoutCache(current.getId());
+        if (persistedParent == null || persistedParent.getPatient() == null
+                || persistedParent.getPatient().getId() == null) {
+            JsfUtil.addErrorMessage("Select a saved admission before adding a baby admission.");
+            return "";
+        }
+        if (Boolean.TRUE.equals(persistedParent.getDischarged())) {
             JsfUtil.addErrorMessage("A discharged admission cannot have a baby admission.");
             return "";
         }
-        if (current.getParentEncounter() != null) {
+        if (persistedParent.getParentEncounter() != null) {
             // A baby admission's parentEncounter already points to the mother.
             // Do not allow a baby to have its own baby admission (e.g. grandmother
             // admits mother, mother admits daughter is not a realistic scenario).
             JsfUtil.addErrorMessage("A baby admission cannot have its own baby admission.");
             return "";
         }
-        parentAdmission = current;
+        parentAdmission = persistedParent;
         Admission ad = new Admission();
         if (ad.getDateOfAdmission() == null) {
             ad.setDateOfAdmission(CommonFunctions.getCurrentDateTime());

--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -2181,7 +2181,9 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
                     return true;
                 }
             }
-            if (configOptionApplicationController.getBooleanValueByKey("Patient NIC is Required in Patient Admission", false)) {
+            // Baby admissions typically have no NIC of their own yet, so this
+            // admission-specific NIC-required check is skipped for them. (Issue #22998)
+            if (!isBabyAdmission() && configOptionApplicationController.getBooleanValueByKey("Patient NIC is Required in Patient Admission", false)) {
                 if (getCurrent().getPatient().getPerson().getNic() == null || getCurrent().getPatient().getPerson().getNic().trim().isEmpty()) {
                     JsfUtil.addErrorMessage("Patient NIC is Required");
                     return true;

--- a/src/main/webapp/inward/admission_profile.xhtml
+++ b/src/main/webapp/inward/admission_profile.xhtml
@@ -296,7 +296,7 @@
                                 <h:panelGroup rendered="#{webUserController.hasPrivilege('InwardAdmissionsAdmission')}" layout="block" styleClass="col-6">
                                     <p:commandButton
                                         value="Add Baby Admission"
-                                        disabled="#{admissionController.current.discharged eq true or admissionController.current.parentEncounter != null}"
+                                        disabled="#{admissionController.current.id eq null or admissionController.current.patient eq null or admissionController.current.discharged eq true or admissionController.current.parentEncounter != null}"
                                         title="#{admissionController.current.parentEncounter != null ? 'A baby admission cannot have its own baby admission' : (admissionController.current.discharged eq true ? 'Patient is discharged' : '')}"
                                         action="#{admissionController.navigateToAddBabyAdmission}"
                                         icon="fa fa-baby"

--- a/src/main/webapp/nurse/index.xhtml
+++ b/src/main/webapp/nurse/index.xhtml
@@ -153,6 +153,21 @@
                                                             rendered="false"
                                                             class="w-100">
                                                         </p:commandButton>
+
+                                                        <h:panelGroup rendered="#{webUserController.hasPrivilege('InwardAdmissionsAdmission')}">
+                                                            <p:commandButton
+                                                                value="Add Baby Admission"
+                                                                disabled="#{admissionController.current.discharged eq true or admissionController.current.parentEncounter != null}"
+                                                                title="#{admissionController.current.parentEncounter != null ? 'A baby admission cannot have its own baby admission' : (admissionController.current.discharged eq true ? 'Patient is discharged' : '')}"
+                                                                action="#{admissionController.navigateToAddBabyAdmission}"
+                                                                icon="fa fa-baby"
+                                                                ajax="false"
+                                                                class="w-100">
+                                                                <f:setPropertyActionListener
+                                                                    value="#{admissionController.current}"
+                                                                    target="#{roomChangeController.current}" />
+                                                            </p:commandButton>
+                                                        </h:panelGroup>
                                                     </div>
 
                                                 </p:panel>

--- a/src/main/webapp/nurse/index.xhtml
+++ b/src/main/webapp/nurse/index.xhtml
@@ -157,7 +157,7 @@
                                                         <h:panelGroup rendered="#{webUserController.hasPrivilege('InwardAdmissionsAdmission')}">
                                                             <p:commandButton
                                                                 value="Add Baby Admission"
-                                                                disabled="#{admissionController.current.discharged eq true or admissionController.current.parentEncounter != null}"
+                                                                disabled="#{admissionController.current.id eq null or admissionController.current.patient eq null or admissionController.current.discharged eq true or admissionController.current.parentEncounter != null}"
                                                                 title="#{admissionController.current.parentEncounter != null ? 'A baby admission cannot have its own baby admission' : (admissionController.current.discharged eq true ? 'Patient is discharged' : '')}"
                                                                 action="#{admissionController.navigateToAddBabyAdmission}"
                                                                 icon="fa fa-baby"


### PR DESCRIPTION
## What changed

Issue #22998 reported that admitting a newborn baby fails "Patient NIC is Required" validation, since babies typically have no NIC. Investigation found a dedicated **"Admit a Baby"** flow already exists (`inward_admission_child.xhtml`, reached via **Add Baby Admission** on the mother's Admission Profile page), and it already skips the room-required check for babies. The real bug: `AdmissionController.errorCheck()` never exempted baby admissions from the **"Patient NIC is Required in Patient Admission"** config check — unlike the room check, which does.

1. **Fix** — `errorCheck()` now skips the patient's own NIC requirement for baby admissions (`isBabyAdmission()`), mirroring the existing room-required exemption pattern. The guardian (mother)'s NIC check is untouched — she's an adult and should still supply one when that option is required.
2. **Discoverability** — added an **"Admit a Baby"** button to the Nursing Workbench page, a second entry point into the same dedicated flow, since it wasn't reachable from the main menu and only lived on the mother's Admission Profile page.

## Files changed

- `src/main/java/com/divudi/bean/inward/AdmissionController.java` — 1 condition change + comment
- `src/main/webapp/nurse/index.xhtml` — 1 new button (JSF-only)

## Testing performed

Built and redeployed locally. With `Patient NIC is Required in Patient Admission` temporarily enabled in the local DB:

1. Logged in, selected the Inward department, opened an existing mother's admission (BHT/56750) in the Nursing Workbench — confirmed the new **Add Baby Admission** button appears and is enabled.
2. Clicked through to the "Admit a Baby" page (`parentEncounter` pre-linked to the mother).
3. Filled the minimum required fields, **left NIC blank**, clicked Admit — save succeeded with no "Patient NIC is Required" error (previously this would have blocked the save).
4. Verified in the DB: the new admission's `PARENTENCOUNTER_ID` correctly points to the mother's admission, and the baby's `PERSON.NIC` is empty.
5. Reverted the config option back to its original value and redeployed, leaving the local environment as found.

Screenshots (patient/BHT/guardian identifiers redacted — real local test data):

**New entry point on the Nursing Workbench:**
![Nursing Workbench - Add Baby Admission button](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/issue-22998-nursing-workbench-add-baby-button.png)

**Baby admission form with NIC left blank:**
![Admit a Baby form - NIC field blank](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/issue-22998-baby-admission-form-nic-blank.png)

**Save succeeds — no NIC validation error, admission linked to the mother's BHT:**
![Baby admission saved successfully](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/issue-22998-baby-admission-success.png)

Fixes #22998

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Add Baby Admission” action to the nurse workbench for eligible admissions.
  * Baby admissions can now be created without requiring a separate NIC for the newborn.

* **Bug Fixes**
  * Prevented baby-admission creation when admission or patient details are missing.
  * Prevented creation for discharged patients or admissions that already have a parent encounter.
  * Updated navigation to retain the selected admission when starting a baby admission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->