### PR TITLE
fix(pharmacy): persist GRN Bill Expenses Description and item Comments

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/GrnCostingNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnCostingNativeSqlController.java
@@ -837,6 +837,7 @@ public class GrnCostingNativeSqlController implements Serializable {
         line.setReferenceBillItemId(bi.getReferanceBillItem() != null ? bi.getReferanceBillItem().getId() : null);
         line.setSerialNo(bi.getSearialNo());
         line.setCreaterId(sessionController.getLoggedUser().getId());
+        line.setDescription(bi.getDescreption());
 
         if (f == null) {
             return;
@@ -904,6 +905,7 @@ public class GrnCostingNativeSqlController implements Serializable {
         line.setLineGrossTotal(expense.getGrossValue());
         line.setLineNetTotal(expense.getNetValue());
         line.setConsideredForCosting(expense.isConsideredForCosting());
+        line.setDescription(expense.getDescreption());
         return line;
     }
 

--- a/src/main/java/com/divudi/core/data/dto/pharmacy/GrnLineData.java
+++ b/src/main/java/com/divudi/core/data/dto/pharmacy/GrnLineData.java
@@ -70,6 +70,12 @@ public class GrnLineData {
     private Date doe;
     private String batchNumber;
 
+    // Free-text "Comments" (regular item lines) / "Description" (Bill Expense
+    // lines) field -- backs BillItem.descreption / billitem.DESCREPTION.
+    // Missing from this DTO was the root cause of #22997, same bug class as
+    // #22892's doe/batchNumber omission in the same native-SQL save path.
+    private String description;
+
     // Used only by expense lines (GrnCostingNativeSqlService.saveExpenseLine) --
     // mirrors BillItem.consideredForCosting, whether this expense feeds the
     // bill-level cost-rate distribution or is display-only.
@@ -313,6 +319,14 @@ public class GrnLineData {
 
     public void setBatchNumber(String batchNumber) {
         this.batchNumber = batchNumber;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
     }
 
     public double getValueAtCostRate() {

--- a/src/main/java/com/divudi/service/pharmacy/GrnCostingNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/GrnCostingNativeSqlService.java
@@ -172,8 +172,8 @@ public class GrnCostingNativeSqlService {
                 "INSERT INTO " + billItemTable()
                 + " (bill_ID, item_ID, referanceBillItem_ID, qty, netValue, grossValue, Rate, netRate,"
                 + " discountRate, createdAt, creater_ID, retired, refunded, billItemRefunded,"
-                + " consideredForCosting, inwardChargeType, searialNo)"
-                + " VALUES (?,?,?,?,?,?,?,?,?,?,?,0,0,0,1,'Medicine',?)")
+                + " consideredForCosting, inwardChargeType, searialNo, DESCREPTION)"
+                + " VALUES (?,?,?,?,?,?,?,?,?,?,?,0,0,0,1,'Medicine',?,?)")
                 .setParameter(1, billId)
                 .setParameter(2, line.getItemId())
                 .setParameter(3, line.getReferenceBillItemId())
@@ -191,6 +191,11 @@ public class GrnCostingNativeSqlService {
                 .setParameter(10, new Timestamp(new Date().getTime()))
                 .setParameter(11, line.getCreaterId())
                 .setParameter(12, line.getSerialNo())
+                // DESCREPTION (legacy-typo'd column, backs BillItem.descreption) --
+                // the "Comments" field on this page's item list; omission here was
+                // the root cause of #22997, same bug class as #22892's doe/
+                // batchNumber omission above.
+                .setParameter(13, line.getDescription())
                 .executeUpdate();
             billItemId = ((Number) em.createNativeQuery("SELECT LAST_INSERT_ID()").getSingleResult()).longValue();
         } else {
@@ -198,7 +203,7 @@ public class GrnCostingNativeSqlService {
             em.createNativeQuery(
                 "UPDATE " + billItemTable()
                 + " SET item_ID=?, referanceBillItem_ID=?, qty=?, netValue=?, grossValue=?, Rate=?, netRate=?,"
-                + " discountRate=?, searialNo=? WHERE ID=?")
+                + " discountRate=?, searialNo=?, DESCREPTION=? WHERE ID=?")
                 .setParameter(1, line.getItemId())
                 .setParameter(2, line.getReferenceBillItemId())
                 .setParameter(3, line.getQuantity())
@@ -209,7 +214,8 @@ public class GrnCostingNativeSqlService {
                 .setParameter(7, line.getLineNetRate())
                 .setParameter(8, line.getLineDiscountRate())
                 .setParameter(9, line.getSerialNo())
-                .setParameter(10, billItemId)
+                .setParameter(10, line.getDescription())
+                .setParameter(11, billItemId)
                 .executeUpdate();
         }
 
@@ -365,8 +371,8 @@ public class GrnCostingNativeSqlService {
                 "INSERT INTO " + billItemTable()
                 + " (expenseBill_ID, item_ID, qty, netValue, grossValue, Rate, netRate,"
                 + " createdAt, creater_ID, retired, refunded, billItemRefunded,"
-                + " consideredForCosting, searialNo)"
-                + " VALUES (?,?,?,?,?,?,?,?,?,0,0,0,?,?)")
+                + " consideredForCosting, searialNo, DESCREPTION)"
+                + " VALUES (?,?,?,?,?,?,?,?,?,0,0,0,?,?,?)")
                 .setParameter(1, billId)
                 .setParameter(2, expenseLine.getItemId())
                 .setParameter(3, expenseLine.getQuantity())
@@ -378,13 +384,17 @@ public class GrnCostingNativeSqlService {
                 .setParameter(9, expenseLine.getCreaterId())
                 .setParameter(10, expenseLine.isConsideredForCosting() ? 1 : 0)
                 .setParameter(11, expenseLine.getSerialNo())
+                // DESCREPTION (legacy-typo'd column, backs BillItem.descreption) --
+                // the "Description" field on this page's Bill Expenses section;
+                // omission here was the root cause of #22997.
+                .setParameter(12, expenseLine.getDescription())
                 .executeUpdate();
             billItemId = ((Number) em.createNativeQuery("SELECT LAST_INSERT_ID()").getSingleResult()).longValue();
         } else {
             billItemId = expenseLine.getBillItemId();
             em.createNativeQuery(
                 "UPDATE " + billItemTable()
-                + " SET item_ID=?, qty=?, netValue=?, grossValue=?, Rate=?, netRate=?, consideredForCosting=?, searialNo=?"
+                + " SET item_ID=?, qty=?, netValue=?, grossValue=?, Rate=?, netRate=?, consideredForCosting=?, searialNo=?, DESCREPTION=?"
                 + " WHERE ID=?")
                 .setParameter(1, expenseLine.getItemId())
                 .setParameter(2, expenseLine.getQuantity())
@@ -394,7 +404,8 @@ public class GrnCostingNativeSqlService {
                 .setParameter(6, expenseLine.getLineNetRate())
                 .setParameter(7, expenseLine.isConsideredForCosting() ? 1 : 0)
                 .setParameter(8, expenseLine.getSerialNo())
-                .setParameter(9, billItemId)
+                .setParameter(9, expenseLine.getDescription())
+                .setParameter(10, billItemId)
                 .executeUpdate();
         }
         evictLineCache();


### PR DESCRIPTION
## What

Fixes #22997 — on the native-SQL GRN costing page (`pharmacy_grn_costing_native.xhtml`), both the regular item list's "Comments" field and the Bill Expenses section's "Description" field were silently dropped on every Save.

## Root cause

`GrnCostingNativeSqlController`/`GrnCostingNativeSqlService`'s native-SQL save path writes each `BillItem` row (line items and expense rows) via a plain-POJO DTO (`GrnLineData`) → hand-written `INSERT`/`UPDATE` SQL. `BillItem.descreption` (DB column `DESCREPTION` on `billitem`) had no field on the DTO at all, and neither `saveLine()` nor `saveExpenseLine()` included that column in their SQL — so whatever the user typed never reached the database, even though it looked correct in the UI until the next reload.

Same bug class as #22892 (Batch No / Date of Expiry silently dropped by the same native-SQL save path for the same reason) — same fix shape, same file.

## Fix

- `GrnLineData`: added a `description` field (correctly spelled; the DTO does not repeat the entity's legacy `descreption` typo).
- `GrnCostingNativeSqlController`: wired `BillItem.getDescreption()` into the DTO in both `populateLineData()` (shared by `toLineData()`/`toApproveLineData()` — regular items) and `toExpenseLineData()` (Bill Expenses).
- `GrnCostingNativeSqlService`: added the `DESCREPTION` column to all four native SQL statements (`saveLine` INSERT/UPDATE, `saveExpenseLine` INSERT/UPDATE), renumbering bound parameters accordingly.

The legacy entity-based `GrnCostingController`/`pharmacy_grn_costing_with_save_approve.xhtml` was not touched — it saves via `billItemFacade.edit()`/`.create()`, which already persists the full entity including `descreption`, and has no equivalent bug.

## Verification

Tested end-to-end on local Payara (Main Pharmacy department, GRN invoice 15861, PO `MP/PO/25/051368`):

1. Reopened an existing unfinalized GRN, entered an item "Comments" value and added a Bill Expense with a "Description" value, then Saved ("GRN Saved" confirmed).
2. Confirmed in the local DB that both values landed in `billitem.DESCREPTION`.
3. Reopened the same GRN again from "To Finalize GRNs" — both values now display correctly after a fresh reload from the DB:

![GRN reopened showing saved Comments/Description](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/22997-grn-description-comment-saved.png)

(Also confirmed the GRN-level "Comment" field — `bill.comments` — was already saving correctly, so no regression there.)

Closes #22997

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GRN costing lines now retain and display the descriptions from their source bill items.
  * Descriptions are preserved for both item and expense lines during creation and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->