### PR TITLE
fix(cc-payment): skip Payment record for CC Agent Payment bills on ruhunu-prod

### DIFF
--- a/developer_docs/configuration/application-options.md
+++ b/developer_docs/configuration/application-options.md
@@ -44,3 +44,9 @@ This document lists the configuration options used in the application and their 
 | ---------------------------------------------------------------- | --------- | ------- | ------------------------------------------------------------------------------------------------------- |
 | `Cost of Goods Sold Report - Display Stock Correction Section`  | Boolean   | `true`  | Controls whether the Stock Correction section is displayed and calculated in the Cost of Goods Sold report. |
 
+## Collecting Centre
+
+| Key                                                              | Type      | Default | Description                                                                                             |
+| ----------------------------------------------------------------  | --------- | ------- | ------------------------------------------------------------------------------------------------------- |
+| `Collecting Centre Agent Payment - Skip Payment Record`         | Boolean   | `true`  | When true, `CollectingCentrePaymentController.createPayment()` does not create a `Payment` record for Collecting Centre Agent Payment / Cancellation bills (`CC_AGENT_PAYMENT`, `CC_AGENT_PAYMENT_CANCELLATION`). These are agent/collecting-centre commission payouts, not cashier cash collections, and should not appear in cashier reports (All Cashier Summary, Cashier Summary, Cashier Details). The `Bill` itself is still created for agent-balance history and printing. See issue #21840. |
+

--- a/src/main/java/com/divudi/bean/common/CollectingCentrePaymentController.java
+++ b/src/main/java/com/divudi/bean/common/CollectingCentrePaymentController.java
@@ -64,6 +64,8 @@ public class CollectingCentrePaymentController implements Serializable {
     SessionController sessionController;
     @Inject
     AgentAndCcApplicationController agentAndCcApplicationController;
+    @Inject
+    ConfigOptionApplicationController configOptionApplicationController;
 // </editor-fold>
 
 // <editor-fold defaultstate="collapsed" desc="Variables">
@@ -587,6 +589,9 @@ public class CollectingCentrePaymentController implements Serializable {
     }
 
     public Payment createPayment(Bill bill, PaymentMethod pm) {
+        if (configOptionApplicationController.getBooleanValueByKey("Collecting Centre Agent Payment - Skip Payment Record", true)) {
+            return null;
+        }
         Payment p = new Payment();
         p.setBill(bill);
         setPaymentMethodData(p, pm);


### PR DESCRIPTION
## Summary
- Completes the CC Agent Payment fix on ruhunu-prod. PR #21841 already shipped the report-side exclusion (All Cashier Summary filters out `CC_AGENT_PAYMENT`/`CC_AGENT_PAYMENT_CANCELLATION`), but the second half of the fix that shipped to `development` in PR #21842 — a config option to stop creating the `Payment` record for these bills in the first place — was never ported to `ruhunu-prod`.
- Adds config option `Collecting Centre Agent Payment - Skip Payment Record` (Boolean, default `true`). When true, `CollectingCentrePaymentController.createPayment()` returns without creating a `Payment` record for CC Agent Payment / Cancellation bills. This is the more correct fix per Dushan (Ruhunu Hospital) — filtering downstream in every report is fragile. The `Bill` itself is still created for agent-balance history and printing.
- Both call sites of `createPayment()` already discard its return value, so returning `null` is safe.

Closes #21840

## Test plan
- [x] `mvn -o compile` — BUILD SUCCESS, `CollectingCentrePaymentController.class` regenerated cleanly
- [ ] Verify on ruhunu-prod: create a new CC Agent Payment bill, confirm no `Payment` row is created for it, confirm the `Bill` still prints and shows in agent balance history
- [ ] Confirm All Cashier Summary / Cashier Summary / Cashier Details still correctly exclude these bills (already covered by #21841)

🤖 Generated with [Claude Code](https://claude.com/claude-code)