### PR TITLE
fix(pharmacy): defer native popup print() until stylesheet load

### DIFF
--- a/src/main/webapp/resources/pharmacy/saleBill_Header_Inward_native.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBill_Header_Inward_native.xhtml
@@ -203,7 +203,14 @@
                 printWindow.document.write('<body>' + billContent + '</body></html>');
                 printWindow.document.close();
                 printWindow.onafterprint = function() { printWindow.close(); };
-                printWindow.print();
+
+                // Wait for the popup (including the linked stylesheet) to finish loading
+                // before printing - printing immediately after document.close() races the
+                // browser's rendering of the popup and can produce a blank page.
+                printWindow.onload = function() {
+                    printWindow.focus();
+                    printWindow.print();
+                };
             }
         </script>
 

--- a/src/main/webapp/resources/pharmacy/saleBill_Header_native.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBill_Header_native.xhtml
@@ -340,7 +340,14 @@
                 printWindow.onafterprint = function () {
                     printWindow.close();
                 };
-                printWindow.print();
+
+                // Wait for the popup (including the linked stylesheet) to finish loading
+                // before printing - printing immediately after document.close() races the
+                // browser's rendering of the popup and can produce a blank page.
+                printWindow.onload = function() {
+                    printWindow.focus();
+                    printWindow.print();
+                };
             }
         </script>
 


### PR DESCRIPTION
## Summary

Fixes #23014.

Two **native** print composites called `printWindow.print()` immediately after `printWindow.document.close()`, racing the popup's own load of its linked stylesheet — producing an intermittent blank printed page (timing-dependent on network/cache). This surfaced as "print button clicked, bill not rendered" under the `Pharmacy Bill Support for Native Printers` config path.

This is the same defect class fixed for the **legacy** popup-print composites in PR #22342 ("Ports the fix already merged on southernlanka-prod (PR #22340) to all 6 affected composites on development"). Those 6 legacy composites all correctly defer `print()` to `onload` today.

`saleBill_Header_native.xhtml` and `saleBill_Header_Inward_native.xhtml` were created afterward (~2026-07-28, for the native retail-sale migration) — evidently copy-pasted from a pre-fix version of the header composite — and never got the `onload` deferral. Confirmed present on `development` and on `southernlanka-stg-migrated` (found while triaging a real print-not-rendering report there).

## Fix

Same pattern as #22342 — defer `printWindow.print()` to the popup's `onload` event instead of calling it synchronously after `document.close()`:

```js
printWindow.onload = function() {
    printWindow.focus();
    printWindow.print();
};
```

## Files changed

- `src/main/webapp/resources/pharmacy/saleBill_Header_native.xhtml` — `printSaleBillHeaderNative()`, used by native retail sale / cashier bill pages
- `src/main/webapp/resources/pharmacy/saleBill_Header_Inward_native.xhtml` — `printBillNative()`, used by native BHT/inward issue printing

## Testing

XHTML-only change (no Java) — per project convention this does not require compilation. The diff is a mechanical, verified-in-production pattern port (same fix already live on 6 sibling composites since PR #22342); no other behavior touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bill printing reliability by waiting for the print window and its content to finish loading before printing.
  * Ensured linked stylesheets are applied, preventing incomplete or improperly formatted printed bills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->