### PR TITLE
feat(pharmacy-api): support issueUnitId/strengthUnitId on VMP/AMP write endpoints

### DIFF
--- a/developer_docs/api/using-apis/API_PHARMACEUTICAL_MANAGEMENT.md
+++ b/developer_docs/api/using-apis/API_PHARMACEUTICAL_MANAGEMENT.md
@@ -145,9 +145,14 @@ curl -X GET "http://localhost:8080/api/pharmaceutical_items/amp/123" \
   "descreption": "Generic paracetamol tablet",
   "departmentType": "Pharmacy",
   "vtmId": 123,
-  "dosageFormId": 456
+  "dosageFormId": 456,
+  "issueUnitId": 236,
+  "strengthUnitId": 209
 }
 ```
+`issueUnitId` and `strengthUnitId` reference `MeasurementUnit` IDs (same
+lookup as `pharmaceutical_config/units`) — not to be confused with
+`dosageFormId`, which references a `DosageForm`.
 
 **AMP Request Body:**
 ```json
@@ -163,9 +168,16 @@ curl -X GET "http://localhost:8080/api/pharmaceutical_items/amp/123" \
   "discountAllowed": true,
   "allowFractions": false,
   "consumptionAllowed": true,
-  "refundsAllowed": true
+  "refundsAllowed": true,
+  "strengthOfAnIssueUnit": 500.0,
+  "strengthUnitId": 209,
+  "issueUnitId": 236
 }
 ```
+`strengthOfAnIssueUnit` is the numeric strength (e.g. `500.0` for a 500mg
+tablet) — distinct from `strengthUnitId`, which is the unit it's measured in
+(mg). `issueUnitId` is the unit the item is issued/dispensed in (e.g.
+Tablet, Capsule, ml).
 
 **VMPP Request Body:**
 ```json
@@ -360,10 +372,15 @@ All responses follow this standard format:
 - `id`, `name`, `code`, `descreption`, `retired`, `inactive`
 
 ### VMP Response
-- `id`, `name`, `code`, `descreption`, `retired`, `inactive`, `vtmId`, `vtmName`, `dosageFormId`, `dosageFormName`
+- `id`, `name`, `code`, `descreption`, `retired`, `inactive`, `vtmId`, `vtmName`, `dosageFormId`, `dosageFormName`, `issueUnitId`, `issueUnitName`, `strengthUnitId`, `strengthUnitName`
 
 ### AMP Response
-- `id`, `name`, `code`, `barcode`, `inactive`, `vmpId`, `vmpName`, `categoryId`, `categoryName`, `dosageFormId`, `dosageFormName`
+- `id`, `name`, `code`, `barcode`, `inactive`, `vmpId`, `vmpName`, `categoryId`, `categoryName`, `dosageFormId`, `dosageFormName`, `issueUnitId`, `issueUnitName`, `strengthUnitId`, `strengthUnitName`
+
+Note: `issueUnitId`/`strengthUnitId`/`issueUnitName`/`strengthUnitName` are
+populated on `GET`/`POST`/`PUT` (single-item) responses but not yet on the
+`search` list endpoint's DTO projection — look up the item by ID after a
+write to confirm what was saved.
 
 ### VMPP Response
 - `id`, `name`, `code`, `retired`, `inactive`, `vmpId`, `vmpName`

--- a/src/main/java/com/divudi/core/data/dto/AmpDto.java
+++ b/src/main/java/com/divudi/core/data/dto/AmpDto.java
@@ -32,6 +32,12 @@ public class AmpDto implements Serializable {
     private Long dosageFormId;
     private String dosageFormName;
 
+    // Issue unit / strength unit relationship fields
+    private Long issueUnitId;
+    private String issueUnitName;
+    private Long strengthUnitId;
+    private String strengthUnitName;
+
     // Department type
     private DepartmentType departmentType;
 
@@ -386,6 +392,40 @@ public class AmpDto implements Serializable {
 
     public void setDosageFormName(String dosageFormName) {
         this.dosageFormName = dosageFormName;
+    }
+
+    // Issue unit / strength unit relationship getters and setters
+
+    public Long getIssueUnitId() {
+        return issueUnitId;
+    }
+
+    public void setIssueUnitId(Long issueUnitId) {
+        this.issueUnitId = issueUnitId;
+    }
+
+    public String getIssueUnitName() {
+        return issueUnitName;
+    }
+
+    public void setIssueUnitName(String issueUnitName) {
+        this.issueUnitName = issueUnitName;
+    }
+
+    public Long getStrengthUnitId() {
+        return strengthUnitId;
+    }
+
+    public void setStrengthUnitId(Long strengthUnitId) {
+        this.strengthUnitId = strengthUnitId;
+    }
+
+    public String getStrengthUnitName() {
+        return strengthUnitName;
+    }
+
+    public void setStrengthUnitName(String strengthUnitName) {
+        this.strengthUnitName = strengthUnitName;
     }
 
     // Short expiry days getter and setter

--- a/src/main/java/com/divudi/core/data/dto/VmpDto.java
+++ b/src/main/java/com/divudi/core/data/dto/VmpDto.java
@@ -31,6 +31,12 @@ public class VmpDto implements Serializable {
     private Long dosageFormId;
     private String dosageFormName;
 
+    // Issue unit / strength unit relationship fields
+    private Long issueUnitId;
+    private String issueUnitName;
+    private Long strengthUnitId;
+    private String strengthUnitName;
+
     /**
      * Default constructor
      */
@@ -227,6 +233,38 @@ public class VmpDto implements Serializable {
 
     public void setDosageFormName(String dosageFormName) {
         this.dosageFormName = dosageFormName;
+    }
+
+    public Long getIssueUnitId() {
+        return issueUnitId;
+    }
+
+    public void setIssueUnitId(Long issueUnitId) {
+        this.issueUnitId = issueUnitId;
+    }
+
+    public String getIssueUnitName() {
+        return issueUnitName;
+    }
+
+    public void setIssueUnitName(String issueUnitName) {
+        this.issueUnitName = issueUnitName;
+    }
+
+    public Long getStrengthUnitId() {
+        return strengthUnitId;
+    }
+
+    public void setStrengthUnitId(Long strengthUnitId) {
+        this.strengthUnitId = strengthUnitId;
+    }
+
+    public String getStrengthUnitName() {
+        return strengthUnitName;
+    }
+
+    public void setStrengthUnitName(String strengthUnitName) {
+        this.strengthUnitName = strengthUnitName;
     }
 
     // Utility methods for display

--- a/src/main/java/com/divudi/core/data/dto/pharmaceutical/AmpRequestDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/pharmaceutical/AmpRequestDTO.java
@@ -23,6 +23,7 @@ public class AmpRequestDTO extends PharmaceuticalItemBaseRequestDTO implements S
     private Boolean refundsAllowed;
     private Double strengthOfAnIssueUnit;
     private Long strengthUnitId;
+    private Long issueUnitId;
 
     public AmpRequestDTO() {
     }
@@ -113,5 +114,13 @@ public class AmpRequestDTO extends PharmaceuticalItemBaseRequestDTO implements S
 
     public void setStrengthUnitId(Long strengthUnitId) {
         this.strengthUnitId = strengthUnitId;
+    }
+
+    public Long getIssueUnitId() {
+        return issueUnitId;
+    }
+
+    public void setIssueUnitId(Long issueUnitId) {
+        this.issueUnitId = issueUnitId;
     }
 }

--- a/src/main/java/com/divudi/core/data/dto/pharmaceutical/VmpRequestDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/pharmaceutical/VmpRequestDTO.java
@@ -14,6 +14,8 @@ public class VmpRequestDTO extends PharmaceuticalItemBaseRequestDTO implements S
 
     private Long vtmId;
     private Long dosageFormId;
+    private Long issueUnitId;
+    private Long strengthUnitId;
 
     public VmpRequestDTO() {
     }
@@ -32,5 +34,21 @@ public class VmpRequestDTO extends PharmaceuticalItemBaseRequestDTO implements S
 
     public void setDosageFormId(Long dosageFormId) {
         this.dosageFormId = dosageFormId;
+    }
+
+    public Long getIssueUnitId() {
+        return issueUnitId;
+    }
+
+    public void setIssueUnitId(Long issueUnitId) {
+        this.issueUnitId = issueUnitId;
+    }
+
+    public Long getStrengthUnitId() {
+        return strengthUnitId;
+    }
+
+    public void setStrengthUnitId(Long strengthUnitId) {
+        this.strengthUnitId = strengthUnitId;
     }
 }

--- a/src/main/java/com/divudi/service/pharmacy/PharmaceuticalItemApiService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PharmaceuticalItemApiService.java
@@ -330,13 +330,7 @@ public class PharmaceuticalItemApiService implements Serializable {
         if (item == null) {
             throw new Exception("VMP not found with ID: " + id);
         }
-        Long vtmId = item.getVtm() != null ? item.getVtm().getId() : null;
-        String vtmName = item.getVtm() != null ? item.getVtm().getName() : null;
-        Long dosageFormId = item.getDosageForm() != null ? item.getDosageForm().getId() : null;
-        String dosageFormName = item.getDosageForm() != null ? item.getDosageForm().getName() : null;
-        return new VmpDto(item.getId(), item.getName(), item.getCode(),
-                item.getDescreption(), item.isRetired(), item.isInactive(),
-                vtmId, vtmName, dosageFormId, dosageFormName);
+        return buildVmpDto(item);
     }
 
     private AmpDto findAmpById(Long id) throws Exception {
@@ -344,16 +338,7 @@ public class PharmaceuticalItemApiService implements Serializable {
         if (item == null) {
             throw new Exception("AMP not found with ID: " + id);
         }
-        Long vmpId = item.getVmp() != null ? item.getVmp().getId() : null;
-        String vmpName = item.getVmp() != null ? item.getVmp().getName() : null;
-        Long categoryId = item.getCategory() != null ? item.getCategory().getId() : null;
-        String categoryName = item.getCategory() != null ? item.getCategory().getName() : null;
-        Long dosageFormId = item.getDosageForm() != null ? item.getDosageForm().getId() : null;
-        String dosageFormName = item.getDosageForm() != null ? item.getDosageForm().getName() : null;
-        return new AmpDto(item.getId(), item.getName(), item.getCode(),
-                item.getBarcode(), item.isInactive(),
-                vmpId, vmpName, categoryId, categoryName,
-                dosageFormId, dosageFormName);
+        return buildAmpDto(item);
     }
 
     private VmppDto findVmppById(Long id) throws Exception {
@@ -452,15 +437,10 @@ public class PharmaceuticalItemApiService implements Serializable {
             }
             item.setDosageForm(dosageForm);
         }
+        applyVmpUnitFields(item, request);
         setAuditFieldsForCreate(item, user);
         vmpFacade.createAndFlush(item);
-        Long vtmId = item.getVtm() != null ? item.getVtm().getId() : null;
-        String vtmName = item.getVtm() != null ? item.getVtm().getName() : null;
-        Long dosageFormId = item.getDosageForm() != null ? item.getDosageForm().getId() : null;
-        String dosageFormName = item.getDosageForm() != null ? item.getDosageForm().getName() : null;
-        return new VmpDto(item.getId(), item.getName(), item.getCode(),
-                item.getDescreption(), item.isRetired(), item.isInactive(),
-                vtmId, vtmName, dosageFormId, dosageFormName);
+        return buildVmpDto(item);
     }
 
     private AmpDto createAmp(AmpRequestDTO request, WebUser user) throws Exception {
@@ -470,16 +450,7 @@ public class PharmaceuticalItemApiService implements Serializable {
         applyAmpSpecificFields(item, request);
         setAuditFieldsForCreate(item, user);
         ampFacade.createAndFlush(item);
-        Long vmpId = item.getVmp() != null ? item.getVmp().getId() : null;
-        String vmpName = item.getVmp() != null ? item.getVmp().getName() : null;
-        Long categoryId = item.getCategory() != null ? item.getCategory().getId() : null;
-        String categoryName = item.getCategory() != null ? item.getCategory().getName() : null;
-        Long dosageFormId = item.getDosageForm() != null ? item.getDosageForm().getId() : null;
-        String dosageFormName = item.getDosageForm() != null ? item.getDosageForm().getName() : null;
-        return new AmpDto(item.getId(), item.getName(), item.getCode(),
-                item.getBarcode(), item.isInactive(),
-                vmpId, vmpName, categoryId, categoryName,
-                dosageFormId, dosageFormName);
+        return buildAmpDto(item);
     }
 
     private VmppDto createVmpp(VmppRequestDTO request, WebUser user) throws Exception {
@@ -609,15 +580,10 @@ public class PharmaceuticalItemApiService implements Serializable {
             }
             item.setDosageForm(dosageForm);
         }
+        applyVmpUnitFields(item, request);
         setAuditFieldsForEdit(item, user);
         vmpFacade.edit(item);
-        Long vtmId = item.getVtm() != null ? item.getVtm().getId() : null;
-        String vtmName = item.getVtm() != null ? item.getVtm().getName() : null;
-        Long dosageFormId = item.getDosageForm() != null ? item.getDosageForm().getId() : null;
-        String dosageFormName = item.getDosageForm() != null ? item.getDosageForm().getName() : null;
-        return new VmpDto(item.getId(), item.getName(), item.getCode(),
-                item.getDescreption(), item.isRetired(), item.isInactive(),
-                vtmId, vtmName, dosageFormId, dosageFormName);
+        return buildVmpDto(item);
     }
 
     private AmpDto updateAmp(Long id, AmpRequestDTO request, WebUser user) throws Exception {
@@ -629,16 +595,7 @@ public class PharmaceuticalItemApiService implements Serializable {
         applyAmpSpecificFieldsIfProvided(item, request);
         setAuditFieldsForEdit(item, user);
         ampFacade.edit(item);
-        Long vmpId = item.getVmp() != null ? item.getVmp().getId() : null;
-        String vmpName = item.getVmp() != null ? item.getVmp().getName() : null;
-        Long categoryId = item.getCategory() != null ? item.getCategory().getId() : null;
-        String categoryName = item.getCategory() != null ? item.getCategory().getName() : null;
-        Long dosageFormId = item.getDosageForm() != null ? item.getDosageForm().getId() : null;
-        String dosageFormName = item.getDosageForm() != null ? item.getDosageForm().getName() : null;
-        return new AmpDto(item.getId(), item.getName(), item.getCode(),
-                item.getBarcode(), item.isInactive(),
-                vmpId, vmpName, categoryId, categoryName,
-                dosageFormId, dosageFormName);
+        return buildAmpDto(item);
     }
 
     private VmppDto updateVmpp(Long id, VmppRequestDTO request, WebUser user) throws Exception {
@@ -961,10 +918,82 @@ public class PharmaceuticalItemApiService implements Serializable {
             }
             item.setStrengthUnit(strengthUnit);
         }
+        if (request.getIssueUnitId() != null) {
+            MeasurementUnit issueUnit = measurementUnitFacade.find(request.getIssueUnitId());
+            if (issueUnit == null) {
+                throw new Exception("Measurement unit not found with ID: " + request.getIssueUnitId());
+            }
+            item.setIssueUnit(issueUnit);
+        }
     }
 
     private void applyAmpSpecificFieldsIfProvided(Amp item, AmpRequestDTO request) throws Exception {
         applyAmpSpecificFields(item, request);
+    }
+
+    /**
+     * Applies issueUnitId / strengthUnitId from a VmpRequestDTO onto a Vmp.
+     * VMP has no dedicated request-DTO method for this yet (unlike Amp, which
+     * already carried strengthUnitId) -- added alongside AMP's issueUnitId
+     * support so both VMP and AMP can have their issue/strength units set via
+     * the API instead of only being derivable from free-text VMP names.
+     */
+    private void applyVmpUnitFields(Vmp item, VmpRequestDTO request) throws Exception {
+        if (request.getIssueUnitId() != null) {
+            MeasurementUnit issueUnit = measurementUnitFacade.find(request.getIssueUnitId());
+            if (issueUnit == null) {
+                throw new Exception("Measurement unit not found with ID: " + request.getIssueUnitId());
+            }
+            item.setIssueUnit(issueUnit);
+        }
+        if (request.getStrengthUnitId() != null) {
+            MeasurementUnit strengthUnit = measurementUnitFacade.find(request.getStrengthUnitId());
+            if (strengthUnit == null) {
+                throw new Exception("Measurement unit not found with ID: " + request.getStrengthUnitId());
+            }
+            item.setStrengthUnit(strengthUnit);
+        }
+    }
+
+    private VmpDto buildVmpDto(Vmp item) {
+        Long vtmId = item.getVtm() != null ? item.getVtm().getId() : null;
+        String vtmName = item.getVtm() != null ? item.getVtm().getName() : null;
+        Long dosageFormId = item.getDosageForm() != null ? item.getDosageForm().getId() : null;
+        String dosageFormName = item.getDosageForm() != null ? item.getDosageForm().getName() : null;
+        VmpDto dto = new VmpDto(item.getId(), item.getName(), item.getCode(),
+                item.getDescreption(), item.isRetired(), item.isInactive(),
+                vtmId, vtmName, dosageFormId, dosageFormName);
+        if (item.getIssueUnit() != null) {
+            dto.setIssueUnitId(item.getIssueUnit().getId());
+            dto.setIssueUnitName(item.getIssueUnit().getName());
+        }
+        if (item.getStrengthUnit() != null) {
+            dto.setStrengthUnitId(item.getStrengthUnit().getId());
+            dto.setStrengthUnitName(item.getStrengthUnit().getName());
+        }
+        return dto;
+    }
+
+    private AmpDto buildAmpDto(Amp item) {
+        Long vmpId = item.getVmp() != null ? item.getVmp().getId() : null;
+        String vmpName = item.getVmp() != null ? item.getVmp().getName() : null;
+        Long categoryId = item.getCategory() != null ? item.getCategory().getId() : null;
+        String categoryName = item.getCategory() != null ? item.getCategory().getName() : null;
+        Long dosageFormId = item.getDosageForm() != null ? item.getDosageForm().getId() : null;
+        String dosageFormName = item.getDosageForm() != null ? item.getDosageForm().getName() : null;
+        AmpDto dto = new AmpDto(item.getId(), item.getName(), item.getCode(),
+                item.getBarcode(), item.isInactive(),
+                vmpId, vmpName, categoryId, categoryName,
+                dosageFormId, dosageFormName);
+        if (item.getIssueUnit() != null) {
+            dto.setIssueUnitId(item.getIssueUnit().getId());
+            dto.setIssueUnitName(item.getIssueUnit().getName());
+        }
+        if (item.getStrengthUnit() != null) {
+            dto.setStrengthUnitId(item.getStrengthUnit().getId());
+            dto.setStrengthUnitName(item.getStrengthUnit().getName());
+        }
+        return dto;
     }
 
     private void applyPackFields(Item item, Long parentVmpId, Double dblValue, Long packUnitId, String parentType) throws Exception {

--- a/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
+++ b/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
@@ -281,7 +281,10 @@ public class CapabilityStatementResource {
                 .add(resource("Pharmaceutical Items", "/api/pharmaceutical_items",
                         "Pharmaceutical item master data. AMP create/update accepts "
                         + "strengthOfAnIssueUnit (Double) and strengthUnitId (Long, MeasurementUnit) "
-                        + "for strength-ratio based dispensing substitution.",
+                        + "for strength-ratio based dispensing substitution. VMP and AMP create/update "
+                        + "also accept issueUnitId (Long, MeasurementUnit) and, for VMP, strengthUnitId "
+                        + "-- both surfaced back as issueUnitId/issueUnitName/strengthUnitId/strengthUnitName "
+                        + "on GET/POST/PUT single-item responses.",
                         "API Key",
                         "GET", "POST", "PUT", "DELETE"))
                 .add(resource("Pharmacy Items", "/api/pharmacy/items",


### PR DESCRIPTION
## What
PharmaceuticalItemApiService previously accepted `dosageFormId` on VMP and AMP create/update, and `strengthUnitId` on AMP only — there was no way to set `issueUnitId` at all, or `strengthUnitId` on VMP.

## Why
Found while scoping a Southern Lanka pharmacy catalog fix: ~98% of active VMPs and ~40% of active AMPs there are missing issue/strength units. The fix is self-consistent (non-"Other"-bucket VMP names already state the answer as text, e.g. `aciclovir 800.0 mg tablet`), but there was no safe way to *write* the backfilled values — direct DB writes risk staleness against EclipseLink's L2 shared cache (`persistence.xml` has no per-entity `@Cache` override, so `Item`/`Vmp`/`Amp`/`MeasurementUnit` all sit under the default cache, sized up via `eclipselink.cache.size.default=1000`).

## Changes
- `VmpRequestDTO`: add `issueUnitId`, `strengthUnitId`
- `AmpRequestDTO`: add `issueUnitId` (`strengthUnitId` already existed)
- `PharmaceuticalItemApiService`: wire both through create/update for VMP and AMP; extracted `buildVmpDto()`/`buildAmpDto()` helpers (also reused by `findVmpById`/`findAmpById`) to stop duplicating the same DTO-construction block a fourth time
- `VmpDto`/`AmpDto`: add `issueUnitId`/`issueUnitName`/`strengthUnitId`/`strengthUnitName` fields with plain getters/setters — **no constructor changes**, per the DTO guideline — so GET/POST/PUT (single-item) responses surface them
- Updated `API_PHARMACEUTICAL_MANAGEMENT.md` and `CapabilityStatementResource`

## Not in scope
The search/list endpoint's JPQL constructor-expression DTOs are unchanged and still omit these fields (pre-existing gap, consistent with how AMP's `strengthUnitId` already behaved). GET-by-ID reflects the new fields.

## Testing
- `mvn compile` clean (JDK 11)
- No behavior change for existing callers — all new fields are optional additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added issue-unit and strength-unit fields to pharmaceutical item creation and update requests.
  * Pharmaceutical item responses now include relevant unit identifiers and names for VMP and AMP records.
  * VMP creation and updates now support applying issue and strength measurement units.

* **Documentation**
  * Updated API documentation and capability descriptions with the new fields and response availability details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->