### PR TITLE
fix(pharmacy): avoid duplicate expense BillItem row on Direct Purchase draft re-save

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
@@ -1533,11 +1533,24 @@ public class PharmacyDirectPurchaseController implements Serializable {
         getBill().setChecked(false);
         getBill().setCompleted(false);
 
+        // For a brand-new bill, create it now so items/expenses below have a
+        // real Bill FK to attach to. For an already-persisted draft, do NOT
+        // edit(bill) here yet: at this point Bill.billExpenses (CascadeType.ALL)
+        // may still hold a newly-added, not-yet-persisted expense (added via
+        // addExpense(), which also appends to Bill.billExpenses for live total
+        // calculations). An early edit()/merge() here would cascade-persist
+        // that transient expense as a phantom row (with a generated ID this
+        // in-memory session never learns about), which the explicit
+        // create()-vs-edit() check in the expense-persist loop below can't
+        // see -- causing a duplicate BillItem row (caught and soft-retired by
+        // the "retire removed expenses" cleanup, but still wasteful, same
+        // flavor of bug as the #23005 orphan-bill issue). The header field
+        // changes made above are flushed later by this method's final
+        // syncBillItemsCollectionFromDatabase()+edit(bill) call, once every
+        // item/expense already has a real ID and cascade-merge can no longer
+        // duplicate anything.
         if (getBill().getId() == null) {
             getBillFacade().create(getBill());
-        } else {
-            syncBillItemsCollectionFromDatabase();
-            getBillFacade().edit(getBill());
         }
 
         // Retire any previously persisted items that were removed from the session list


### PR DESCRIPTION
## What

Follow-up to #23009 (merged). Found live during a full end-to-end QA pass of the Direct Purchase feature (single-step Settle flow + multi-stage draft flow, both verified through to Approve with COGS/Bin Card/F15 reconciliation).

`persistDraftDirectPurchase()` called an early `getBillFacade().edit(bill)` for already-persisted drafts, **before** the explicit expense-persist loop ran. `Bill.billExpenses` (`CascadeType.ALL`) still held any newly-added, not-yet-persisted expense at that point — `addExpense()` appends to it for live total calculations. That early `edit()`/`merge()` cascade-persisted the transient expense as a phantom row whose generated ID this session never learns about, so the explicit `create()`-vs-`edit()` check further down created a **second, duplicate** `BillItem` row.

The duplicate was caught and soft-retired by the existing "retire removed expenses" cleanup, so reports were never affected — but every Save Draft that included a freshly-added expense left one wasted retired row behind. Same flavor of bug as the orphan bare-Bill issue #23009 already fixed, just for expense line items instead of bare bills.

## Fix

For an existing draft, skip the early `edit(bill)` entirely. The header field changes (`billTypeAtomic`, `department`, `institution`, etc.) already get flushed by this method's final `syncBillItemsCollectionFromDatabase()` + `edit(bill)` call, which runs after every item/expense already has a real persisted ID — so cascade-merge can no longer duplicate anything. Brand-new bills (`create()` path) were never affected, since `persist()` assigns generated IDs in place.

## Verification

Rebuilt, redeployed to local Payara, and reproduced the exact repro sequence against the running app + `coop` DB:
1. New draft → add item → Save Draft (creates bill, `create()` path)
2. Add expense → Save Draft (second save, `edit()` path — previously created 2 expense rows, 1 active + 1 phantom-retired)
3. **After fix: exactly 1 active expense row**, confirmed via direct SQL
4. Repeated Save Draft a third time — still exactly 1 row
5. Edited item qty (5→7) and re-saved — updated in place, no duplication
6. Finalized → Approved end-to-end — `BILLTYPEATOMIC`/`COMPLETED`/`CHECKED` all correct, Stock incremented correctly, zero regression

Also re-ran the full #23005 QA pass (Scenario A single-step Settle, Scenario B multi-stage draft with qty-edit/item-removal/item-add/search-resume/finalize/approve) — all passed, with COGS/Bin Card/F15 reconciling to zero variance both before and after this fix. Orphan-Bill-row count stayed flat throughout (135, unchanged) confirming #23009's fix still holds.

Refs #23005

🤖 Generated with [Claude Code](https://claude.com/claude-code)