### PR TITLE
fix(reports): stop dropping zero/negative-qty items from COGS Opening/Closing Stock

### DIFF
--- a/src/main/java/com/divudi/bean/report/PharmacyReportController.java
+++ b/src/main/java/com/divudi/bean/report/PharmacyReportController.java
@@ -12365,52 +12365,13 @@ public class PharmacyReportController implements Serializable {
                 jpql.append("AND sh.item.departmentType IN :departmentTypes ");
             }
 
-            // Group by item and filter positive quantities
-            jpql.append("AND sh.itemBatch.item.id IN (")
-                    .append("SELECT sh4.itemBatch.item.id FROM StockHistory sh4 ")
-                    .append("WHERE sh4.retired = :ret ")
-                    .append("AND sh4.id IN (")
-                    .append("SELECT MAX(sh5.id) FROM StockHistory sh5 ")
-                    .append("WHERE sh5.retired = :ret ")
-                    .append("AND sh5.createdAt <= :et3 ");
-
-            params.put("et3", date);
-
-            // Add filters to item filtering subqueries
-            addFilter(jpql, params, "sh5.institution", "ins4", institution);
-            addFilter(jpql, params, "sh5.department.site", "sit4", site);
-            addFilter(jpql, params, "sh5.department", "dep4", department);
-            addFilter(jpql, params, "sh5.item", "itm4", item);
-            if (selectedDepartmentTypes != null && !selectedDepartmentTypes.isEmpty()) {
-                jpql.append("AND sh5.item.departmentType IN :departmentTypes ");
-            }
-
-            jpql.append("GROUP BY sh5.department, sh5.itemBatch) ");
-
-            addFilter(jpql, params, "sh4.institution", "ins5", institution);
-            addFilter(jpql, params, "sh4.department.site", "sit5", site);
-            addFilter(jpql, params, "sh4.department", "dep5", department);
-            addFilter(jpql, params, "sh4.item", "itm5", item);
-            if (selectedDepartmentTypes != null && !selectedDepartmentTypes.isEmpty()) {
-                jpql.append("AND sh4.item.departmentType IN :departmentTypes ");
-            }
-
-            jpql.append("GROUP BY sh4.itemBatch.item.id ")
-                    .append("HAVING SUM(sh4.stockQty) > 0");
-
-            if (isConsignmentItem()) {
-                jpql.append(" AND SUM(sh4.stockQty) <= 0");
-            }
-
-            jpql.append(")");
-
             // NOTE: do NOT filter batches/items by SUM(stockQty) > 0 here. This snapshot
             // must include every batch's latest quantity as-of `date`, positive, zero, or
             // negative (oversold/backorder). Excluding negative-quantity items understates
             // Opening/Closing Stock only on the snapshot where the item's running total
             // happens to be negative, breaking the Opening + movements = Closing identity
             // and producing a phantom COGS variance the moment that item's total crosses
-            // zero within the report window (issue: COGS report variance, 2026-08-11).
+            // zero within the report window (issue #23018).
             // Execute the query
             List<Object[]> results = facade.findRawResultsByJpql(jpql.toString(), params, TemporalType.TIMESTAMP);
 


### PR DESCRIPTION
## Summary
- `calculateStockTotals()` in `PharmacyReportController` had a `HAVING SUM(sh4.stockQty) > 0` filter that silently excluded any item-batch sitting at zero/negative quantity as of the report's snapshot date from both Opening Stock and Closing Stock rows.
- The method already carried a comment (added in a prior session, referencing this exact defect) stating the filter must not be there — but the filter itself was never removed, so the bug remained live.
- This produced a phantom "Variance" row whenever a date range's boundary fell while an item was oversold/backordered, and made the variance appear to self-resolve when the range was widened past the date the item's stock recovered — without anything actually being fixed.
- Fix: remove the item-level `HAVING`/consignment-branch filter entirely. Opening/Closing Stock now include every item-batch's latest snapshot quantity regardless of sign, consistent with every other COGS row.

## Root cause (reproduced against Ruhunu Matara Pharmacy data, dept 3193897)
Report for **10 Jul 2026** showed Variance: Purchase -670.32 / Cost -670.32 / Retail -782.26.

Caused by two batches sitting at physically negative stock that day (fallout of an unrelated, separately-tracked "cancel return" data-integrity incident at Matara Pharmacy on 10 Jul):
- Astrocort Cream 1% 15G, batch 5164564: qty -2 → -564.00 purchase / -660.00 retail
- Hexilon 16Mg Tablet, batch 4609211: qty -2 → -106.32 purchase / -122.26 retail

Sum matches the report's Variance row exactly. Widening the range to 28 Jul made the variance disappear only because Hexilon's batch had been restocked above zero by then (re-included) and Astrocort sat at exactly 0 on both endpoints (excluded consistently, so its exclusion cancels out) — the variance was masked by the range boundary, not resolved.

Verified the fix mathematically by replicating the query against the live DB with the filter removed: the "corrected" Closing Stock value for 10 Jul (5,557,064.62 purchase / 6,486,967.23 retail) matches the report's own "Calculated Closing Stock Value" row exactly, i.e. Variance becomes 0.

## Note
This PR does not touch the underlying negative stock at Matara Pharmacy — that data correction is tracked separately.

Closes #23018

## Test plan
- [x] `mvn compile` succeeds
- [x] Verified fix via direct DB query replication against Ruhunu production data (dept 3193897, Matara - Pharmacy) — confirmed corrected Closing Stock matches Calculated Closing Stock Value exactly for 10 Jul 2026
- [ ] Reviewer to spot-check COGS report in a running environment if desired

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pharmacy stock reports now include the latest batch quantities even when stock levels are zero or negative.
  * Stock movements for oversold and backordered items are preserved accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->