### PR TITLE
fix(reports): stop hiding negative-qty items in Closing/Opening Stock drill-down

### DIFF
--- a/src/main/java/com/divudi/bean/report/PharmacyReportController.java
+++ b/src/main/java/com/divudi/bean/report/PharmacyReportController.java
@@ -11620,13 +11620,16 @@ public class PharmacyReportController implements Serializable {
             }
 
             // Consignment filter: Use item stock quantity (not batch qty)
+            // NOTE: hide zero-stock items (normal, expected), but never hide negative
+            // quantities - a negative net qty means oversold/backorder data that must
+            // stay visible instead of being silently dropped from the report (issue #23026).
             double itemQty = row.getStockQty() != null ? row.getStockQty() : 0.0;
             if (isConsignmentItem()) {
                 if (itemQty > 0) {
                     continue;
                 }
             } else {
-                if (itemQty <= 0) {
+                if (itemQty == 0) {
                     continue;
                 }
             }
@@ -11681,7 +11684,7 @@ public class PharmacyReportController implements Serializable {
                         continue;
                     }
                 } else {
-                    if (itemQty <= 0) {
+                    if (itemQty == 0) {
                         continue;
                     }
                 }
@@ -11891,13 +11894,16 @@ public class PharmacyReportController implements Serializable {
             }
 
             // Consignment filter (unchanged - stays in Java)
+            // NOTE: hide zero-stock batches (normal, expected), but never hide negative
+            // quantities - a negative batch qty means oversold/backorder data that must
+            // stay visible instead of being silently dropped from the report (issue #23026).
             double batchQty = row.getStockQty() != null ? row.getStockQty() : 0.0;
             if (isConsignmentItem()) {
                 if (batchQty > 0) {
                     continue;
                 }
             } else {
-                if (batchQty <= 0) {
+                if (batchQty == 0) {
                     continue;
                 }
             }
@@ -11949,7 +11955,7 @@ public class PharmacyReportController implements Serializable {
                         continue;
                     }
                 } else {
-                    if (batchQty <= 0) {
+                    if (batchQty == 0) {
                         continue;
                     }
                 }


### PR DESCRIPTION
## Summary

Closes #23028.

Fixes the same bug class as #23018/#23019, but in the drill-down report reached by clicking "Closing Stock" or "Opening Stock" from the Cost of Goods Sold report (`closing_stock_report.xhtml`). Both the item-wise and batch-wise variants (live and archived) filtered out any row with net quantity `<= 0`, which correctly hides normal zero-stock items but also silently drops items/batches sitting at a **negative** quantity.

Found while investigating the Ruhunu Matara Pharmacy COGS variance thread (10/17/23 Jul 2026) - after the COGS summary fix, drilling into "Closing Stock" from that report could still show a detail list missing rows for negative-quantity items (e.g. Astrocort Cream 1% 15G, batch 5164564), so the itemized list wouldn't visibly reconcile against the now-correct COGS total.

## Fix

Changed `itemQty <= 0` / `batchQty <= 0` to `== 0` at all 4 live call sites (item-wise + batch-wise, each with a live and an archived variant). Zero-stock rows stay hidden as before; negative-quantity rows now show up instead of being silently dropped. The `@Deprecated` `processClosingStockForItemReportOld()` method (not called anywhere) was left untouched.

## Test plan

- [ ] Item Wise report, a department with a known negative-quantity batch (e.g. Ruhunu Matara Pharmacy, Astrocort Cream 1% 15G) - row now appears with negative quantity, instead of being missing
- [ ] Item Wise report, a normal zero-stock item - still hidden (unchanged)
- [ ] Batch Wise report - same two checks
- [ ] Include Archived toggle on, same checks against archived data
- [ ] Consignment-item branch unaffected (logic untouched)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated stock filtering to hide only non-consignment items and batches with zero quantity.
  * Items and batches with negative quantities remain visible.
  * Consignment stock filtering behavior is unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->