### PR TITLE
feat(pharmacy): add Search Any Medicine lookup dialog to native retail sale

### DIFF
--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_native.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_native.xhtml
@@ -31,6 +31,46 @@
                          ============================================================ -->
                     <p:panel rendered="#{!retailSaleForCashierNativeSqlController.billPreview}">
 
+                        <p:dialog
+                            header="Search Any Medicine..."
+                            widgetVar="findAMP"
+                            minHeight="300"
+                            width="1100"
+                            position="top"
+                            modal="true"
+                            closeOnEscape="true">
+                            <p:autoComplete
+                                id="exItem"
+                                forceSelection="true"
+                                class="w-100 formgrid grid"
+                                placeholder="Search Any Medicine..."
+                                maxResults="20"
+                                minQueryLength="3"
+                                inputStyleClass="w-100"
+                                queryDelay="300" completeMethod="#{itemController.completeAmpItem}"
+                                var="vt"
+                                onfocus="this.select()"
+                                itemLabel="#{vt.name}"
+                                itemValue="#{vt}">
+                                <p:column headerText="Code" style="padding: 6px;width: 4em;">
+                                    <h:outputLabel value="#{vt.code}" />
+                                </p:column>
+                                <p:column headerText="Item" style="width: 350px; padding: 6px;">
+                                    <h:outputLabel value="#{vt.name}" />
+                                </p:column>
+                                <p:column headerText="Stock" style="padding: 6px; text-align: center;width: 5em;">
+                                    <p:outputLabel value="#{stockController.departmentItemStock(sessionController.department, vt)}">
+                                        <f:convertNumber pattern="#,###" />
+                                    </p:outputLabel>
+                                </p:column>
+                                <p:column headerText="Price" style="padding: 6px; text-align: right;width: 6em;">
+                                    <p:outputLabel value="#{pharmacyPurchaseController.findLastRetailRate(vt)}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </p:outputLabel>
+                                </p:column>
+                            </p:autoComplete>
+                        </p:dialog>
+
                         <p:panel class="w-100">
                             <f:facet name="header">
                                 <div class="row w-100 align-items-center">
@@ -97,7 +137,18 @@
                                         <div class="row w-100 m-1 p-1">
                                             <div class="col-md-5">
                                                 <p:focus id="focusForAcIx" for="acStock" />
-                                                <p:outputLabel class="w-100" for="acStock">Medicines or Devices</p:outputLabel>
+                                                <p:outputLabel class="w-100" for="acStock">
+                                                    Medicines or Devices
+                                                    <i class="fas fa-shopping-cart"
+                                                       onclick="PF('findAMP').show()"
+                                                       onkeypress="if(event.key==='Enter'||event.key===' ')PF('findAMP').show()"
+                                                       role="button"
+                                                       tabindex="0"
+                                                       title="Search Any Medicine"
+                                                       aria-label="Open Search Any Medicine dialog"
+                                                       style="font-size: 14px; color: purple; margin-left: 8px; cursor: pointer;">
+                                                    </i>
+                                                </p:outputLabel>
                                                 <h:panelGroup id="acStock">
                                                     <p:autoComplete
                                                         id="acStockField"

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native.xhtml
@@ -25,6 +25,46 @@
                          ============================================================ -->
                     <p:panel rendered="#{!retailSaleNativeSqlController.billPreview}">
 
+                        <p:dialog
+                            header="Search Any Medicine..."
+                            widgetVar="findAMP"
+                            minHeight="300"
+                            width="1100"
+                            position="top"
+                            modal="true"
+                            closeOnEscape="true">
+                            <p:autoComplete
+                                id="exItem"
+                                forceSelection="true"
+                                class="w-100 formgrid grid"
+                                placeholder="Search Any Medicine..."
+                                maxResults="20"
+                                minQueryLength="3"
+                                inputStyleClass="w-100"
+                                queryDelay="300" completeMethod="#{itemController.completeAmpItem}"
+                                var="vt"
+                                onfocus="this.select()"
+                                itemLabel="#{vt.name}"
+                                itemValue="#{vt}">
+                                <p:column headerText="Code" style="padding: 6px;width: 4em;">
+                                    <h:outputLabel value="#{vt.code}" />
+                                </p:column>
+                                <p:column headerText="Item" style="width: 350px; padding: 6px;">
+                                    <h:outputLabel value="#{vt.name}" />
+                                </p:column>
+                                <p:column headerText="Stock" style="padding: 6px; text-align: center;width: 5em;">
+                                    <p:outputLabel value="#{stockController.departmentItemStock(sessionController.department, vt)}">
+                                        <f:convertNumber pattern="#,###" />
+                                    </p:outputLabel>
+                                </p:column>
+                                <p:column headerText="Price" style="padding: 6px; text-align: right;width: 6em;">
+                                    <p:outputLabel value="#{pharmacyPurchaseController.findLastRetailRate(vt)}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </p:outputLabel>
+                                </p:column>
+                            </p:autoComplete>
+                        </p:dialog>
+
                         <p:panel class="w-100">
                             <f:facet name="header">
                                 <div class="row w-100 align-items-center">
@@ -119,7 +159,18 @@
                                         <div class="row w-100 m-1 p-1">
                                             <div class="col-md-5">
                                                 <p:focus id="focusForAcIx" for="acStock" />
-                                                <p:outputLabel class="w-100" for="acStock">Medicines or Devices</p:outputLabel>
+                                                <p:outputLabel class="w-100" for="acStock">
+                                                    Medicines or Devices
+                                                    <i class="fas fa-shopping-cart"
+                                                       onclick="PF('findAMP').show()"
+                                                       onkeypress="if(event.key==='Enter'||event.key===' ')PF('findAMP').show()"
+                                                       role="button"
+                                                       tabindex="0"
+                                                       title="Search Any Medicine"
+                                                       aria-label="Open Search Any Medicine dialog"
+                                                       style="font-size: 14px; color: purple; margin-left: 8px; cursor: pointer;">
+                                                    </i>
+                                                </p:outputLabel>
                                                 <h:panelGroup id="acStock">
                                                     <p:autoComplete
                                                         id="acStockField"

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native_1.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native_1.xhtml
@@ -25,6 +25,46 @@
                          ============================================================ -->
                     <p:panel rendered="#{!retailSaleNativeSqlController1.billPreview}">
 
+                        <p:dialog
+                            header="Search Any Medicine..."
+                            widgetVar="findAMP"
+                            minHeight="300"
+                            width="1100"
+                            position="top"
+                            modal="true"
+                            closeOnEscape="true">
+                            <p:autoComplete
+                                id="exItem"
+                                forceSelection="true"
+                                class="w-100 formgrid grid"
+                                placeholder="Search Any Medicine..."
+                                maxResults="20"
+                                minQueryLength="3"
+                                inputStyleClass="w-100"
+                                queryDelay="300" completeMethod="#{itemController.completeAmpItem}"
+                                var="vt"
+                                onfocus="this.select()"
+                                itemLabel="#{vt.name}"
+                                itemValue="#{vt}">
+                                <p:column headerText="Code" style="padding: 6px;width: 4em;">
+                                    <h:outputLabel value="#{vt.code}" />
+                                </p:column>
+                                <p:column headerText="Item" style="width: 350px; padding: 6px;">
+                                    <h:outputLabel value="#{vt.name}" />
+                                </p:column>
+                                <p:column headerText="Stock" style="padding: 6px; text-align: center;width: 5em;">
+                                    <p:outputLabel value="#{stockController.departmentItemStock(sessionController.department, vt)}">
+                                        <f:convertNumber pattern="#,###" />
+                                    </p:outputLabel>
+                                </p:column>
+                                <p:column headerText="Price" style="padding: 6px; text-align: right;width: 6em;">
+                                    <p:outputLabel value="#{pharmacyPurchaseController.findLastRetailRate(vt)}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </p:outputLabel>
+                                </p:column>
+                            </p:autoComplete>
+                        </p:dialog>
+
                         <p:panel class="w-100">
                             <f:facet name="header">
                                 <div class="row w-100 align-items-center">
@@ -119,7 +159,18 @@
                                         <div class="row w-100 m-1 p-1">
                                             <div class="col-md-5">
                                                 <p:focus id="focusForAcIx" for="acStock" />
-                                                <p:outputLabel class="w-100" for="acStock">Medicines or Devices</p:outputLabel>
+                                                <p:outputLabel class="w-100" for="acStock">
+                                                    Medicines or Devices
+                                                    <i class="fas fa-shopping-cart"
+                                                       onclick="PF('findAMP').show()"
+                                                       onkeypress="if(event.key==='Enter'||event.key===' ')PF('findAMP').show()"
+                                                       role="button"
+                                                       tabindex="0"
+                                                       title="Search Any Medicine"
+                                                       aria-label="Open Search Any Medicine dialog"
+                                                       style="font-size: 14px; color: purple; margin-left: 8px; cursor: pointer;">
+                                                    </i>
+                                                </p:outputLabel>
                                                 <h:panelGroup id="acStock">
                                                     <p:autoComplete
                                                         id="acStockField"

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native_2.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native_2.xhtml
@@ -25,6 +25,46 @@
                          ============================================================ -->
                     <p:panel rendered="#{!retailSaleNativeSqlController2.billPreview}">
 
+                        <p:dialog
+                            header="Search Any Medicine..."
+                            widgetVar="findAMP"
+                            minHeight="300"
+                            width="1100"
+                            position="top"
+                            modal="true"
+                            closeOnEscape="true">
+                            <p:autoComplete
+                                id="exItem"
+                                forceSelection="true"
+                                class="w-100 formgrid grid"
+                                placeholder="Search Any Medicine..."
+                                maxResults="20"
+                                minQueryLength="3"
+                                inputStyleClass="w-100"
+                                queryDelay="300" completeMethod="#{itemController.completeAmpItem}"
+                                var="vt"
+                                onfocus="this.select()"
+                                itemLabel="#{vt.name}"
+                                itemValue="#{vt}">
+                                <p:column headerText="Code" style="padding: 6px;width: 4em;">
+                                    <h:outputLabel value="#{vt.code}" />
+                                </p:column>
+                                <p:column headerText="Item" style="width: 350px; padding: 6px;">
+                                    <h:outputLabel value="#{vt.name}" />
+                                </p:column>
+                                <p:column headerText="Stock" style="padding: 6px; text-align: center;width: 5em;">
+                                    <p:outputLabel value="#{stockController.departmentItemStock(sessionController.department, vt)}">
+                                        <f:convertNumber pattern="#,###" />
+                                    </p:outputLabel>
+                                </p:column>
+                                <p:column headerText="Price" style="padding: 6px; text-align: right;width: 6em;">
+                                    <p:outputLabel value="#{pharmacyPurchaseController.findLastRetailRate(vt)}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </p:outputLabel>
+                                </p:column>
+                            </p:autoComplete>
+                        </p:dialog>
+
                         <p:panel class="w-100">
                             <f:facet name="header">
                                 <div class="row w-100 align-items-center">
@@ -119,7 +159,18 @@
                                         <div class="row w-100 m-1 p-1">
                                             <div class="col-md-5">
                                                 <p:focus id="focusForAcIx" for="acStock" />
-                                                <p:outputLabel class="w-100" for="acStock">Medicines or Devices</p:outputLabel>
+                                                <p:outputLabel class="w-100" for="acStock">
+                                                    Medicines or Devices
+                                                    <i class="fas fa-shopping-cart"
+                                                       onclick="PF('findAMP').show()"
+                                                       onkeypress="if(event.key==='Enter'||event.key===' ')PF('findAMP').show()"
+                                                       role="button"
+                                                       tabindex="0"
+                                                       title="Search Any Medicine"
+                                                       aria-label="Open Search Any Medicine dialog"
+                                                       style="font-size: 14px; color: purple; margin-left: 8px; cursor: pointer;">
+                                                    </i>
+                                                </p:outputLabel>
                                                 <h:panelGroup id="acStock">
                                                     <p:autoComplete
                                                         id="acStockField"

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native_3.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native_3.xhtml
@@ -25,6 +25,46 @@
                          ============================================================ -->
                     <p:panel rendered="#{!retailSaleNativeSqlController3.billPreview}">
 
+                        <p:dialog
+                            header="Search Any Medicine..."
+                            widgetVar="findAMP"
+                            minHeight="300"
+                            width="1100"
+                            position="top"
+                            modal="true"
+                            closeOnEscape="true">
+                            <p:autoComplete
+                                id="exItem"
+                                forceSelection="true"
+                                class="w-100 formgrid grid"
+                                placeholder="Search Any Medicine..."
+                                maxResults="20"
+                                minQueryLength="3"
+                                inputStyleClass="w-100"
+                                queryDelay="300" completeMethod="#{itemController.completeAmpItem}"
+                                var="vt"
+                                onfocus="this.select()"
+                                itemLabel="#{vt.name}"
+                                itemValue="#{vt}">
+                                <p:column headerText="Code" style="padding: 6px;width: 4em;">
+                                    <h:outputLabel value="#{vt.code}" />
+                                </p:column>
+                                <p:column headerText="Item" style="width: 350px; padding: 6px;">
+                                    <h:outputLabel value="#{vt.name}" />
+                                </p:column>
+                                <p:column headerText="Stock" style="padding: 6px; text-align: center;width: 5em;">
+                                    <p:outputLabel value="#{stockController.departmentItemStock(sessionController.department, vt)}">
+                                        <f:convertNumber pattern="#,###" />
+                                    </p:outputLabel>
+                                </p:column>
+                                <p:column headerText="Price" style="padding: 6px; text-align: right;width: 6em;">
+                                    <p:outputLabel value="#{pharmacyPurchaseController.findLastRetailRate(vt)}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </p:outputLabel>
+                                </p:column>
+                            </p:autoComplete>
+                        </p:dialog>
+
                         <p:panel class="w-100">
                             <f:facet name="header">
                                 <div class="row w-100 align-items-center">
@@ -119,7 +159,18 @@
                                         <div class="row w-100 m-1 p-1">
                                             <div class="col-md-5">
                                                 <p:focus id="focusForAcIx" for="acStock" />
-                                                <p:outputLabel class="w-100" for="acStock">Medicines or Devices</p:outputLabel>
+                                                <p:outputLabel class="w-100" for="acStock">
+                                                    Medicines or Devices
+                                                    <i class="fas fa-shopping-cart"
+                                                       onclick="PF('findAMP').show()"
+                                                       onkeypress="if(event.key==='Enter'||event.key===' ')PF('findAMP').show()"
+                                                       role="button"
+                                                       tabindex="0"
+                                                       title="Search Any Medicine"
+                                                       aria-label="Open Search Any Medicine dialog"
+                                                       style="font-size: 14px; color: purple; margin-left: 8px; cursor: pointer;">
+                                                    </i>
+                                                </p:outputLabel>
                                                 <h:panelGroup id="acStock">
                                                     <p:autoComplete
                                                         id="acStockField"


### PR DESCRIPTION
## What changed

Ports the "Search Any Medicine" cart-icon lookup dialog from the legacy pharmacy retail sale page to the native retail sale pages, closing the gap reported in #23022.

- **Files:** `pharmacy_bill_retail_sale_native.xhtml` (+ `_1`/`_2`/`_3` windows), `pharmacy_bill_retail_sale_for_cashier_native.xhtml`
- The dialog lets staff search any medicine (not just stocked ones) and see its Code / Item / Stock / Price — useful when the normal item-entry autocomplete hides an item because it has zero stock.
- **No config gate** — shows unconditionally (legacy version was gated behind `Find Last Sale Rate of Medicines in Retail Sale`, off by default).
- **Restyled trigger** — small icon inline with the "Medicines or Devices" label inside the "Add New Items" panel, instead of the legacy's large (60px), absolutely-positioned corner icon.
- XHTML-only change; reuses existing beans (`itemController`, `stockController`, `pharmacyPurchaseController`) already used by the legacy dialog — no Java changes.

## Testing performed

Rebuilt and redeployed to local Payara, then verified end-to-end with Playwright against the local `Main Pharmacy` department:

- Confirmed the icon renders correctly next to "Medicines or Devices" on native "Sale" (base + window 2), and on native "Sale for Cashier".
- Opened the dialog and searched for a zero-stock item (`Norium 5mg`) — confirmed it surfaces Code/Item/Stock(0)/Price, proving the lookup works for items hidden from the normal autocomplete.
- Confirmed the normal item-entry autocomplete and add-item flow is unaffected (selected a well-stocked item, values populated correctly).
- No server errors in `server.log` during any of the above.

Screenshots posted to the issue: https://github.com/hmislk/hmis/issues/23022#issuecomment-5306376473

Closes #23022

🤖 Generated with [Claude Code](https://claude.com/claude-code)
