### PR TITLE
fix(pharmacy): default inpatient issue-return qty to 0, not full balance

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/BhtIssueReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/BhtIssueReturnController.java
@@ -534,7 +534,11 @@ public class BhtIssueReturnController implements Serializable {
             }
 
             tmp.setQtyInUnit(tmpQty);
-            bi.setQty(tmpQty);
+            // Returning qty stays at the 0.0 default set above so the user must
+            // opt in to returning each item; tmpQty (the true max returnable
+            // balance) is kept on remainingQty for display/reference only, not
+            // written back into the editable qty (issue #23023).
+            bi.setRemainingQty(tmpQty);
 
             bi.setPharmaceuticalBillItem(tmp);
 

--- a/src/main/webapp/inward/pharmacy_bill_return_bht_issue.xhtml
+++ b/src/main/webapp/inward/pharmacy_bill_return_bht_issue.xhtml
@@ -165,7 +165,7 @@
                             </p:column>  
 
                             <p:column headerText="Balance Qty in Unit" style="padding: 9px; width: 12em;">
-                                <h:outputText value="#{ph.pharmaceuticalBillItem.qty}" >
+                                <h:outputText value="#{ph.remainingQty}" >
                                     <f:convertNumber pattern="#0.####" />
                                 </h:outputText>
                             </p:column>  

--- a/src/main/webapp/pharmacy/pharmacy_bill_return_bht_issue.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_return_bht_issue.xhtml
@@ -41,9 +41,9 @@
 
                     </p:column>  
 
-                    <p:column headerText="Balance Qty in Unit" style="width:25px!important;"> 
-                        <h:outputText value="#{ph.pharmaceuticalBillItem.qty}" />                   
-                    </p:column>  
+                    <p:column headerText="Balance Qty in Unit" style="width:25px!important;">
+                        <h:outputText value="#{ph.remainingQty}" />
+                    </p:column>
 
                     <p:column headerText="Purchase Rate" style="width:25px!important;"> 
                         <h:outputText value="#{ph.rate}"  />                        


### PR DESCRIPTION
## What changed

Fixes #23023: on both the **Inpatient Direct Issue return** and **Inpatient Issue-on-Request return** screens, every returnable item's "Returning Qty" was pre-filled with its full remaining returnable balance instead of `0`. With many issued drugs and only one or two to return, users had to manually zero out every other row before submitting.

Root cause: `BhtIssueReturnController.generateBillComponent()` (shared by both flows) set `bi.setQty(0.0)`, then a few lines later unconditionally overwrote it with `tmpQty` (the max-returnable amount). Fix removes that overwrite and instead stores `tmpQty` on `BillItem.remainingQty` for display — the same pattern `IssueReturnController` (Disposal Issue returns) already uses.

Also fixed a related display bug found while investigating: the **"Balance Qty in Unit"** column (both `inward/pharmacy_bill_return_bht_issue.xhtml` and `pharmacy/pharmacy_bill_return_bht_issue.xhtml`) was reading `pharmaceuticalBillItem.qty` — the item's *original* full issued quantity, never decremented by prior returns — instead of the true remaining balance. It now reads the corrected `remainingQty`.

## Why this doesn't regress validation

Both the per-row blur check (`onEdit()` → `PharmacyCalculation.calQty4()`) and the settle-time check in `settle()` recompute the live max-returnable amount from the database on every check — neither depends on the row's starting `qty` value. Verified this holds by testing an over-limit entry after the fix (see below).

## Verification (Playwright + DB, local Payara)

Tested against BHT/56587, bill `MP//26/033794` (Main Pharmacy) — 13 issued items, one (Metrogyl Injection) already partially returned (issued 2, previously returned 1).

**1. Defaults + Balance column fix** — every row now defaults to `0`, and Metrogyl's Balance column correctly shows `1` (previously would have shown `2`, the stale original-issued figure):

![Returning Qty defaults to zero](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23023-return-qty-defaults-to-zero.png)

**2. Partial return persists correctly** — entered qty=1 on only the Nexium row, left the other 12 at 0, submitted. DB check: return bill `MPPHISSRET/2110` (id 13988704) was created with exactly **one** `BillItem` (Nexium, qty 1) — the 12 zero-qty rows were correctly skipped.

**3. Over-return still blocked (no regression)** — re-opened the return page, entered qty=5 for Zinacef (balance 2). Existing validation rejected it and reset the field to 0:

![Over-return still blocked](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23023-over-return-still-blocked.png)

**Issue-on-Request flow**: shares the exact same `generateBillComponent()` method (verified by code reading — `settle()` only branches on which save method to call, not on item population), so the fix applies identically. Live click-through on this specific flow was blocked by an unrelated, pre-existing bug (`PharmacyCalculation.getTotalQty()` billType collision between `ISSUE_MEDICINE_ON_REQUEST_INWARD` and `ACCEPT_ISSUED_MEDICINE_INWARD` bills causes some items to be miscounted as fully returned) — flagged separately, out of scope for this PR since it predates this change and isn't a regression.

Full details and evidence: #23023 (comment)

🤖 Generated with [Claude Code](https://claude.ai/code)
