### PR TITLE
fix(opd): stop cross-bill BillFee corruption on batch bill cancellation

### DIFF
--- a/src/main/java/com/divudi/bean/common/OpdBatchBillCancellationController.java
+++ b/src/main/java/com/divudi/bean/common/OpdBatchBillCancellationController.java
@@ -3049,9 +3049,9 @@ public class OpdBatchBillCancellationController implements Serializable, Control
         }
         billService.saveBill(individualCancelltionBill);
 
-        originalBill.setBillItems(billService.fetchBillItems(originalBill));
         originalBill.setCancelled(true);
         originalBill.setCancelledBill(individualCancelltionBill);
+        originalBill.setBillItems(null);
         billService.saveBill(originalBill);
     }
 
@@ -3194,9 +3194,9 @@ public class OpdBatchBillCancellationController implements Serializable, Control
         }
         billService.saveBill(individualCancelltionBill);
 
-        originalBill.setBillItems(billService.fetchBillItems(originalBill));
         originalBill.setCancelled(true);
         originalBill.setCancelledBill(individualCancelltionBill);
+        originalBill.setBillItems(null);
         billService.saveBill(originalBill);
     }
 


### PR DESCRIPTION
## Summary

Root-caused during the Ruhunu Labeema Daily Return vs QB Report discrepancy investigation. `Bill.billItems` is mapped `orphanRemoval=true`. `cancelSingleBillWhenCancellingOpdBatchBill()` and its package-bill twin `cancelSingleBillWhenCancellingPackageBatchBill()` re-fetched `originalBill`'s own `billItems` and re-set them onto the entity right before the final `billFacade.edit()` merge that marks it cancelled.

`OpdBatchBillCancellationController` is `@SessionScoped`. When two similar OPD batch cancellations run back-to-back in the same login session, that re-fetched collection can reflect stale/shared JPA state at merge time — so the `orphanRemoval` cascade re-parents the new cancellation's `BillFee` rows onto the **wrong bill's** `BillItem`. Daily Return and Cashier Summary (payment-based) stay correct since they read a different table; only item/fee-based reports (QB Report) show the corruption.

## Fix

`setBillItems(null)` immediately before that merge, so EclipseLink skips the collection entirely instead of treating a stale snapshot as authoritative — the same guard already established in the pharmacy module's `orphanRemoval` fixes (e.g. `1e263fc3ff`, `81b462634e`).

## Evidence

- Git history confirms this exact cascade path was never touched by any prior fix — the pharmacy-module fix pattern was never ported to this OPD controller.
- Live DB query on Ruhunu prod: 28 corrupted bills across 6 OPD departments (Labeema, Ranna, Makadura, OPD-Matara, RHD Matara, OPD-Ranna) between 29.01.2025 and 15.02.2026. Dormant since only because no OPD batch cancellations have occurred at all since mid-Feb — not because of any prior fix.
- Two live incidents manually corrected (15.11.2025, 17.03.2026, 19.08.2025, all Ruhunu Labeema) — verified against QB Report in the browser after the data fix.

## Test plan
- [x] `mvn compile` succeeds
- [x] Diff scoped to the two affected merge call sites only, in both twin cancellation methods
- [ ] Manual: two similar OPD batch cancellations back-to-back in one session, verify no cross-bill BillFee attachment in DB afterward

## Related

Ports the same fix already applied to `ruhunu-prod-migrated` in PR #23025 (deployed tonight during the maintenance window).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OPD batch and package batch cancellations now correctly mark the original bills as cancelled.
  * Cancelled bills no longer retain their original bill items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->