### PR TITLE
fix(pharmacy): restore requester-side approval for transfer requests

### DIFF
--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -6913,13 +6913,35 @@ public class SearchController implements Serializable {
     }
 
     public void fillPharmacyTransferRequestsToApprove() {
-        // Approval happens from the SUPPLYING department's session (the department
-        // that will issue the stock), which is stored as b.toDepartment on a
-        // transfer-request bill (b.fromDepartment/b.department is the REQUESTER).
-        // Filtering on fromDepartment here meant a finalized request could never
-        // match the approver's session department, so this list was always empty
-        // for every department (found via Playwright E2E testing the transfer
-        // request -> approve -> issue workflow, 2026-08-14).
+        // ============================================================================
+        // DO NOT "FIX" THIS TO b.toDepartment. Read this comment fully before touching
+        // the department filter below — this exact flip has already been made and
+        // reverted once (see #23039, which reverted #22944 / commit 1bc11999a4).
+        //
+        // Transfer Request approval is a maker-checker cycle WITHIN THE REQUESTING
+        // department, same pattern as Direct Purchase / Disposal Issue / Transfer
+        // Receive / Issue-for-Requests (see e.g. SearchController.createDirectPurchaseTableToApprove(),
+        // which filters on b.department = session department for exactly the same reason):
+        //   - b.department / b.fromDepartment = the department that CREATED the request
+        //     (set at creation in TransferRequestController). It does Save -> Finalize
+        //     -> APPROVE on its own bill, all within itself.
+        //   - b.toDepartment = the department that will SUPPLY the stock. It never
+        //     approves another department's request; it only sees the request AFTER
+        //     approval, through its own separate Issue-for-Requests cycle
+        //     (SearchController.createRequestTableDto(), which correctly filters on
+        //     b.toDepartment, feeding pharmacy_transfer_request_list.xhtml).
+        //
+        // Living proof of the correct direction: the older combined Edit/Approve/View
+        // page (pharmacy_transfer_request_list_search_for_approval.xhtml, backed by
+        // fillSavedTranserRequestBills() above) has always filtered on b.fromDepartment
+        // and has always worked correctly.
+        //
+        // #22944's "list is always empty" symptom was real, but filtering on toDepartment
+        // was the wrong diagnosis — it silently moved the Approve step from the requester
+        // to the supplier instead of fixing the actual defect. Re-diagnose empty-list
+        // reports against fromDepartment (e.g. checkedBy/completed not being set
+        // correctly by Finalize), not by flipping this filter again.
+        // ============================================================================
         String jpql = "SELECT new com.divudi.core.data.dto.PharmacyTransferRequestListDTO("
                 + "b.id, b.deptId, b.createdAt, COALESCE(toDept.name, ''), "
                 + "COALESCE(creatorPerson.name, ''), b.cancelled, "
@@ -6934,14 +6956,14 @@ public class SearchController implements Serializable {
                 + "WHERE b.checkedBy IS NOT NULL "
                 + "AND (b.completed = false OR b.completed IS NULL) "
                 + "AND b.institution = :ins "
-                + "AND b.toDepartment = :toDep "
+                + "AND b.fromDepartment = :fromDep "
                 + "AND b.createdAt BETWEEN :fromDate AND :toDate "
                 + "AND b.retired = false "
                 + "AND b.billTypeAtomic = :bTp "
                 + "ORDER BY b.createdAt DESC";
         Map<String, Object> params = new HashMap<>();
         params.put("ins", sessionController.getInstitution());
-        params.put("toDep", sessionController.getDepartment());
+        params.put("fromDep", sessionController.getDepartment());
         params.put("fromDate", getFromDate());
         params.put("toDate", getToDate());
         params.put("bTp", BillTypeAtomic.PHARMACY_TRANSFER_REQUEST_PRE);
@@ -6950,15 +6972,18 @@ public class SearchController implements Serializable {
     }
 
     public void fillApprovedPharmacyTransferRequests() {
-        // Same fix as fillPharmacyTransferRequestsToApprove() above: the approving/
-        // issuing department is stored in b.toDepartment, not b.fromDepartment.
+        // Same department model as fillPharmacyTransferRequestsToApprove() above —
+        // see the full explanation there. This lists the REQUESTING department's own
+        // approved-request history (pharmacy_transfer_request_list_approved.xhtml,
+        // "View Request" only), so it must stay scoped to b.fromDepartment, not
+        // b.toDepartment. DO NOT flip this again (#23039).
         bills = null;
         HashMap tmp = new HashMap();
         String sql;
         sql = "Select b From Bill b where "
                 + " b.completed = true "
                 + " and b.institution = :ins "
-                + " and b.toDepartment = :toDep "
+                + " and b.fromDepartment = :fromDep "
                 + " and b.createdAt between :fromDate and :toDate "
                 + " and b.retired=false "
                 + " and b.billTypeAtomic= :bTp";
@@ -6967,7 +6992,7 @@ public class SearchController implements Serializable {
         tmp.put("toDate", getToDate());
         tmp.put("fromDate", getFromDate());
         tmp.put("ins", sessionController.getInstitution());
-        tmp.put("toDep", sessionController.getDepartment());
+        tmp.put("fromDep", sessionController.getDepartment());
         tmp.put("bTp", BillTypeAtomic.PHARMACY_TRANSFER_REQUEST_PRE);
 
         bills = getBillFacade().findByJpql(sql, tmp, TemporalType.TIMESTAMP, maxResult);

--- a/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
@@ -628,6 +628,12 @@ public class TransferRequestController implements Serializable {
     public void saveTransferRequestPreBillAndBillItems() {
         getTransferRequestBillPre().setBillTypeAtomic(BillTypeAtomic.PHARMACY_TRANSFER_REQUEST_PRE);
         getTransferRequestBillPre().setBillType(BillType.PharmacyTransferRequest);
+        // fromDepartment (below) = the department creating this request; it is also the
+        // department that will later Save -> Finalize -> Approve it (maker-checker
+        // within itself). toDepartment only gets to see this bill AFTER approval, via
+        // its own separate Issue-for-Requests cycle. See the department-filter comment
+        // on SearchController.fillPharmacyTransferRequestsToApprove() (#23039) before
+        // changing which department is treated as the approver here.
         getTransferRequestBillPre().setToDepartment(getToDepartment());
         getTransferRequestBillPre().setToInstitution(getToDepartment().getInstitution());
         getTransferRequestBillPre().setFromDepartment(getSessionController().getDepartment());

--- a/src/main/webapp/pharmacy/pharmacy_transfer_request_list_to_approve.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_request_list_to_approve.xhtml
@@ -10,7 +10,7 @@
         <h:form>
             <p:panel>
                 <f:facet name="header">
-                    <p:outputLabel value="Finalize Transfer Requests"/>
+                    <p:outputLabel value="Transfer Requests to Approve"/>
                 </f:facet>
                 <div class="row">
                     <div class="col-md-2">


### PR DESCRIPTION
## What

Fixes a regression where Transfer Request approval was scoped to the wrong department (#23039).

`SearchController.fillPharmacyTransferRequestsToApprove()` and `fillApprovedPharmacyTransferRequests()` had been flipped from `b.fromDepartment` to `b.toDepartment` by commit `1bc11999a4` (closing #22944). That moved the Approve step from the **requesting** department to the **supplying** department — breaking the intra-department maker-checker pattern used by every other pharmacy Save→Finalize→Approve workflow (Direct Purchase, Disposal Issue, Transfer Receive, Issue-for-Requests all approve within the creating department) and duplicating the supplying department's own separate Issue-for-Requests approval step.

## Changes

- `SearchController.java`: revert both queries to filter on the creating department (`b.fromDepartment`/`b.department` = session department), matching the pattern used by `createDirectPurchaseTableToApprove()` and friends.
- Added durable comments at both query sites, and at `TransferRequestController`'s bill-creation department assignment, documenting the two-hop department model (`fromDepartment` = requester, approves its own bill; `toDepartment` = supplier, only sees it after approval via its own separate Issue-for-Requests cycle) so this doesn't get flipped again.
- `pharmacy_transfer_request_list_to_approve.xhtml`: fixed the panel header, which still read "Finalize Transfer Requests" despite being the Approve page.

## Verification

Tested end-to-end on local Payara against the `coop` DB, OPD Pharmacy (requester) → Main Pharmacy (supplier):

1. Created + saved + finalized a fresh transfer request (`MP/OP/26/000191`) as **OPD Pharmacy**.
2. It now appears on **OPD Pharmacy's own** "Transfer Requests to Approve" list (previously always empty for every department):
   ![OPD Pharmacy approve list](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/issue-23039-opd-pharmacy-approve-list.png)
3. Approved it from OPD Pharmacy — succeeds:
   ![Approved by OPD Pharmacy](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/issue-23039-approved-by-opd-pharmacy.png)
4. Logged in as **Main Pharmacy** — its own approve list does **not** show this request (only Main Pharmacy's own outgoing request to OPD Pharmacy), confirming correct department scoping:
   ![Main Pharmacy approve list empty](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/issue-23039-main-pharmacy-approve-list-empty.png)
5. The approved request correctly shows up on **Main Pharmacy's Issue queue** with an active "Issue" button:
   ![Main Pharmacy issue queue](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/issue-23039-main-pharmacy-issue-queue.png)

DB confirmed on the pre-bill and approved bill: `department`/`fromDepartment` = OPD Pharmacy (90094, the approver), `toDepartment` = Main Pharmacy (485, the supplier), `checkedBy`/`completed`/`approveUser` all set correctly.

Full details and query output in the issue comment: https://github.com/hmislk/hmis/issues/23039#issuecomment-5308282170

Fixes #23039

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Transfer request approval and approved-history views now show records for the correct requesting department.
  * Improved transfer request visibility so destination departments see requests only after approval.

* **User Interface**
  * Renamed the panel heading to “Transfer Requests to Approve” for clearer navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->