### PR TITLE
fix(pharmacy): allow starting a new Direct Purchase while another is pending approval

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyDirectPurchaseController.java
@@ -99,58 +99,15 @@ public class PharmacyDirectPurchaseController implements Serializable {
     // </editor-fold>  
     // <editor-fold defaultstate="collapsed" desc="Navigation Methods">
     public String navigateToStartNewDirectPurchaseBill() {
-        if (hasDirectPurchaseAwaitingApprovalInDepartment()) {
-            return null;
-        }
         prepareForNewDIrectPurchaseBill();
         draftMode = false;
         return "/pharmacy/direct_purchase?faces-redirect=true";
     }
 
     public String navigateToStartNewDirectPurchaseDraft() {
-        if (hasDirectPurchaseAwaitingApprovalInDepartment()) {
-            return null;
-        }
         prepareForNewDIrectPurchaseBill();
         draftMode = true;
         return "/pharmacy/direct_purchase?faces-redirect=true";
-    }
-
-    /**
-     * Blocks starting a brand-new Direct Purchase (draft or single-step) while
-     * this department already has one finalized but not yet approved -- i.e.
-     * BILLTYPEATOMIC still PHARMACY_DIRECT_PURCHASE_PRE, completed=true (past
-     * Finalize), checked=false (not yet through Approve). Department-scoped
-     * (not per-user): forces any pending approval to be resolved before more
-     * purchases pile up unapproved, since Approve is what actually adds stock
-     * — related to issue #23005's concurrency follow-up.
-     *
-     * Names the blocking bill's date/deptId in the error message rather than
-     * just saying "check the Approve List": that list's default search range
-     * is the current day, so a bill finalized on an earlier date is a real
-     * match for this guard but would be invisible there without manually
-     * widening the date filter -- the message needs to tell the user what
-     * they're looking for.
-     */
-    private boolean hasDirectPurchaseAwaitingApprovalInDepartment() {
-        String jpql = "SELECT b FROM Bill b WHERE b.department = :dept "
-                + "AND b.billTypeAtomic = :type AND b.completed = true "
-                + "AND b.checked = false AND b.retired = false ORDER BY b.createdAt";
-        java.util.Map<String, Object> params = new java.util.HashMap<>();
-        params.put("dept", getSessionController().getDepartment());
-        params.put("type", BillTypeAtomic.PHARMACY_DIRECT_PURCHASE_PRE);
-        List<com.divudi.core.entity.Bill> pending = getBillFacade().findByJpql(jpql, params);
-        if (pending != null && !pending.isEmpty()) {
-            com.divudi.core.entity.Bill blocker = pending.get(0);
-            String createdAtStr = blocker.getCreatedAt() == null ? "unknown date"
-                    : new SimpleDateFormat("dd MMM yyyy HH:mm").format(blocker.getCreatedAt());
-            String identifier = blocker.getDeptId() != null ? blocker.getDeptId() : ("ID " + blocker.getId());
-            JsfUtil.addErrorMessage("This department already has a Direct Purchase (" + identifier
-                    + ", finalized " + createdAtStr + ") waiting to be approved. Please approve (or address) it "
-                    + "via the Approve List (widen the date range if it doesn't show today) before starting a new one.");
-            return true;
-        }
-        return false;
     }
 
     public String loadDraftForEditing(com.divudi.core.entity.Bill draft) {
@@ -1486,8 +1443,8 @@ public class PharmacyDirectPurchaseController implements Serializable {
             getBillFacade().edit(getBill());
         }
     }
-    
-    
+
+
     // <editor-fold defaultstate="collapsed" desc="Draft Workflow Methods">
 
     /**


### PR DESCRIPTION
## Summary

Removes `hasDirectPurchaseAwaitingApprovalInDepartment()`, a department-wide guard added in `87997c96c2` (closing #23005's concurrency follow-up) that blocked `navigateToStartNewDirectPurchaseBill()`/`...Draft()` whenever the department had **any** earlier finalized-but-unapproved Direct Purchase, with no limit on count or age. In normal operation a department routinely has more than one Direct Purchase in flight (different suppliers delivering the same day, one bill waiting on the approver while staff start the next), so this over-applied — it serialized all new Direct Purchase creation in a department on approval turnaround time.

Closes #23042

## What stays unchanged (verified, not just untouched by omission)

The actual concurrency protection this guard was meant to reinforce is unaffected:

- `finalizeDraftDirectPurchase()` → `DirectPurchaseApprovingNativeSqlService.claimForFinalize()`: atomic `UPDATE ... WHERE ID=? AND COMPLETED=0 AND CHECKED=0 AND BILLTYPEATOMIC='PHARMACY_DIRECT_PURCHASE_PRE'`.
- `approveDirectPurchaseDraft()` → `claimForApproval()`: atomic `UPDATE ... WHERE ID=? AND BILLTYPEATOMIC='PHARMACY_DIRECT_PURCHASE_PRE' AND COMPLETED=1 AND CHECKED=0`.

These single-UPDATE atomic claims (not the removed Java-level check) are what actually prevent the same bill from being finalized twice or approved twice — that protection is fully intact, confirmed by diff review.

## Verification

Verified via Playwright + DB against local `coop` DB (Main Pharmacy department).

**Before** — clicking "Direct Purchase" while bill 13861696 (finalized, unapproved) existed in the department was hard-blocked with an error growl, no new-bill page opened:

![Before](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/issue-23042-direct-purchase-blocked-before.png)

**After** — with bill 13861696 confirmed unchanged (`COMPLETED=1, CHECKED=0`) throughout, clicking "Direct Purchase" now opens a fresh, empty new-bill form as expected:

![After](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/issue-23042-direct-purchase-unblocked-after.png)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * New direct purchases and purchase drafts can now be started without being blocked by department-level pending approvals.
  * New purchases consistently open with the appropriate draft status and navigate to the purchase page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->