### PR TITLE
fix(opd): stop OPD batch cancellation crash on billed items with BillComponent rows

### DIFF
--- a/src/main/java/com/divudi/bean/common/OpdBatchBillCancellationController.java
+++ b/src/main/java/com/divudi/bean/common/OpdBatchBillCancellationController.java
@@ -3051,7 +3051,6 @@ public class OpdBatchBillCancellationController implements Serializable, Control
 
         originalBill.setCancelled(true);
         originalBill.setCancelledBill(individualCancelltionBill);
-        originalBill.setBillItems(null);
         billService.saveBill(originalBill);
     }
 
@@ -3196,7 +3195,6 @@ public class OpdBatchBillCancellationController implements Serializable, Control
 
         originalBill.setCancelled(true);
         originalBill.setCancelledBill(individualCancelltionBill);
-        originalBill.setBillItems(null);
         billService.saveBill(originalBill);
     }
 


### PR DESCRIPTION
## Summary
- PR #23040 (commit `f8484aaced`) fixed cross-bill `BillFee` corruption on OPD batch cancellation by changing `originalBill.setBillItems(...)` from a re-fetch to `setBillItems(null)` right before the final save that marks the bill cancelled.
- That traded one bug for another: `Bill.billItems` is `@OneToMany(orphanRemoval=true)`, and assigning `null` is not a no-op for EclipseLink — it schedules every previously-attached `BillItem` for delete. Any bill with a `BillComponent` row (created during ordinary OPD billing) then crashes on `DELETE FROM BILLITEM` with a foreign key violation (`FK_BILLCOMPONENT_BILLITEM_ID`), aborting the whole cancellation transaction. This affects essentially any OPD batch bill cancellation, not just the repeat-cancellation edge case #23040 targeted.
- `createBillItemsForOpdBatchBillCancellation()` already replicates the original bill's `BillItem`/`BillFee`/`BillComponent` rows onto the new cancellation bill before these `setBillItems()` calls run, and `originalBill` is only ever meant to have `cancelled`/`cancelledBill` set — its own bill items/fees are never supposed to change. This PR removes the `setBillItems(...)` call entirely (in both `cancelSingleBillWhenCancellingOpdBatchBill` and its package-bill twin `cancelSingleBillWhenCancellingPackageBatchBill`) instead of setting it to `null`. Nothing reassigns the field, so `orphanRemoval` never fires, and #23040's original fix (avoiding a stale re-fetched collection) stays intact since the fix was never about touching the field — it was about not re-fetching stale state into it.

## QA performed (Playwright + DB, local `coop`)
- **TC1 (reproduce + confirm fixed) — Pass.** Reproduced the crash on `development` HEAD before this fix: bill `14029377` (`BillItem` 14298622, `BillComponent` 13935726) blocked the cascade delete with `SQLIntegrityConstraintViolationException` / `javax.ejb.EJBException: Transaction aborted`. After this fix, a same-patient two-bill repeat-cancellation (bill → cancel → rebill → cancel, the exact real-world trigger from the original prod incident) completed without error both times.
- **TC2 (single cancellation baseline) — Pass.** No regression on the ordinary single-cancellation path.
- Corruption-detection query (`billfee.BILL_ID <> billitem.BILL_ID`) returned **zero rows** for both cancellations. Each cancellation bill's own `BillFee` correctly references its own `BillItem`. The original bill's own `BillItem`/`BillComponent` rows are left untouched (only `cancelled=true` set), matching the intended invariant.
- No new `SEVERE`/exception entries in `server.log` after either cancellation.

## Not independently re-tested (flagging for follow-up, not blocking)
- **TC3 — Package bill cancellation** (the twin method `cancelSingleBillWhenCancellingPackageBatchBill`): same code pattern, same fix applied, but not separately exercised through the package-billing UI flow in this session. Low risk given the identical mechanism, but worth a quick pass before/after merging to `ruhunu-prod-migrated`.
- **TC4 — Different-patients-same-session negative control**: not re-run after this fix; was already known-good pre-#23040, and this fix doesn't touch that code path differently.
- **TC5 — General OPD cancellation regression pass** (multiple departments/payment methods): not re-run; recommend a quick manual smoke pass before wide rollout given how central this method is to OPD billing.

## Also needs porting
Per repo owner instruction: the same two-line fix needs to be applied to whichever PR is pending merge into `ruhunu-prod-migrated` for issue #23018/#23025, so that branch doesn't ship the `setBillItems(null)` crash either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)