### PR TITLE
docs(demonstrate-issues): handle content-free capture cues and forward-looking narration

### DIFF
--- a/.claude/skills/demonstrate-issues/SKILL.md
+++ b/.claude/skills/demonstrate-issues/SKILL.md
@@ -112,9 +112,9 @@ picture of each one is understood.
 
 If the cue to capture carries no description at all (e.g. just "capture", or
 "check playwrite"), don't capture speculatively and ask afterward what it
-was for — ask for the one-line description first (or in the same turn as the
-capture), so each recorded demo has its description attached from the start
-instead of needing a follow-up round-trip.
+was for — ask for the one-line description. If the user provides it in the
+same turn, capture the demo; otherwise wait and do not capture until the
+description is available.
 
 ### Forward-looking narration vs a firm bug cue
 
@@ -123,9 +123,10 @@ happened yet) from "see this, X is broken" (the actual cue). Narration that
 describes what's coming next is not itself a capture cue — wait for the
 concrete bug before recording anything.
 
-If a capture already happened and the user's next message reveals it wasn't
+If a capture already happened and the user later clarifies that demo #N was not
 meant as a bug report (e.g. "no error in this page yet, just gathering
-facts"), treat that as an explicit instruction to drop the prior capture:
+facts"), treat that as an explicit instruction to drop the prior capture —
+whether that clarification arrives in the very next message or a later one:
 acknowledge it ("Dropping demo #N — noted as context only") and exclude it
 from the investigation/filing phases. Don't carry the ambiguity forward and
 make the user re-resolve it during investigation.

--- a/.claude/skills/demonstrate-issues/SKILL.md
+++ b/.claude/skills/demonstrate-issues/SKILL.md
@@ -108,6 +108,28 @@ picture of each one is understood.
   the end signal.
 - Multiple issues can be demonstrated in one session, back to back.
 
+### Content-free capture cues
+
+If the cue to capture carries no description at all (e.g. just "capture", or
+"check playwrite"), don't capture speculatively and ask afterward what it
+was for — ask for the one-line description first (or in the same turn as the
+capture), so each recorded demo has its description attached from the start
+instead of needing a follow-up round-trip.
+
+### Forward-looking narration vs a firm bug cue
+
+Distinguish "I'm about to show you X" (scene-setting for a demo that hasn't
+happened yet) from "see this, X is broken" (the actual cue). Narration that
+describes what's coming next is not itself a capture cue — wait for the
+concrete bug before recording anything.
+
+If a capture already happened and the user's next message reveals it wasn't
+meant as a bug report (e.g. "no error in this page yet, just gathering
+facts"), treat that as an explicit instruction to drop the prior capture:
+acknowledge it ("Dropping demo #N — noted as context only") and exclude it
+from the investigation/filing phases. Don't carry the ambiguity forward and
+make the user re-resolve it during investigation.
+
 **HARD STOP** — do not read application code, form a root-cause hypothesis,
 or otherwise start investigating any demo until the end signal in step 4.
 


### PR DESCRIPTION
## Summary
Fixes #23056 — adds guidance to the `demonstrate-issues` skill for two process gaps found during a live multi-bug demonstration session.

## Decisions made without approval
- **Where to place the new guidance**: added as two new subsections under existing §3 "Demonstration loop" rather than a new top-level section, since both gaps are specifically about that phase (capture-cue handling), not the investigation or filing phases.
- **Scope of the "drop a prior capture" mechanism**: kept it lightweight (acknowledge + exclude from later phases) rather than introducing a new state/numbering scheme for demos, to match the skill's existing low-ceremony tone.

## Changes
- `.claude/skills/demonstrate-issues/SKILL.md` — §3 now instructs:
  1. Asking for a one-line description up front when a capture cue carries none (e.g. "capture" alone), instead of capturing then asking afterward.
  2. Distinguishing forward-looking narration ("I'm about to show you X") from a firm bug cue, and explicitly dropping/acknowledging a prior capture if the user's next message reveals it wasn't meant as a bug report.

## Verification
Doc-only change to a skill markdown file — no build/deploy/Playwright verification applicable (same as any JSF-only/no-Java change per this repo's testing rules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated demonstration guidance to require a description before capturing cues.
  * Clarified the difference between planned narration and actual bug reports.
  * Added instructions for discarding non-bug demonstrations before investigation or filing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->