### PR TITLE
fix(pharmacy): correct JPQL param key in VmpController.getItems()

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/VmpController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/VmpController.java
@@ -773,10 +773,10 @@ public class VmpController implements Serializable {
             // Apply status filter
             if ("active".equals(filterStatus)) {
                 j += "and v.retired=:retired ";
-                params.put("inactive", false);
+                params.put("retired", false);
             } else if ("inactive".equals(filterStatus)) {
                 j += "and v.retired=:retired ";
-                params.put("inactive", true);
+                params.put("retired", true);
             }
             // For "all", no additional filter needed
 


### PR DESCRIPTION
## Summary
Fixes #23050 — VMP Save left the edit panel stuck in "editing" mode with no success/failure message.

## Decisions made without approval
- None — the fix is a one-line parameter-name correction directly confirmed by the server.log stack trace; no design judgment was needed. Checked `AmpController.getItems()` as a companion case and confirmed it does **not** have the same bug (its parameter key already matches), so no additional files needed the same fix.

## Root cause
`VmpController.getItems()` (`src/main/java/com/divudi/bean/pharmacy/VmpController.java`) built JPQL with a `:retired` placeholder for the status filter but bound the parameter under the wrong map key (`"inactive"` instead of `"retired"`). `save()`, `saveSelected()`, and `delete()` all call `getItems()` immediately after committing their edit, so this threw `IllegalArgumentException` (wrapped in `EJBException`) and aborted the AJAX response **before** `editable = false` and the growl message could render — even though the underlying edit had already committed successfully in an earlier, separate transaction.

## Fix
Corrected `params.put("inactive", ...)` → `params.put("retired", ...)` in both the `active`/`inactive` branches of `getItems()`.

## Verification
Local Payara, Main Pharmacy department, VMP "Amoxicillin 250.0mg capsules":
- Edited the VMP, clicked Save.
- Panel now returns to a selectable state (Select VMP re-enabled, Add New/Edit/Delete/Deactivate re-enabled).
- "Updated Successfully." growl message now appears.
- `server.log` shows no exception on this save (previously threw at `VmpController.java:784`, called from `save()` at line 690 — see the issue comment for the full stack trace and a before/after screenshot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the pharmacy item filter so active and inactive items are displayed according to the selected status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->