### PR TITLE
fix(pharmacy): default null AMP fields from linked VMP on edit

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/AmpController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/AmpController.java
@@ -622,7 +622,37 @@ public class AmpController implements Serializable {
         if (current.getId() != null) {
             selectedAmpDto = createAmpDto(current);
         }
+        fillNullFieldsFromVmp(current);
         editable = true;
+    }
+
+    /**
+     * Back-fills null Category / Strength / Strength Unit / Dosage Form /
+     * Issue Unit on the AMP from its linked VMP, so the user only needs to
+     * override defaults rather than re-enter values the VMP already
+     * specifies. Fields that already have a value are left untouched.
+     * Issue #23051.
+     */
+    private void fillNullFieldsFromVmp(Amp amp) {
+        if (amp == null || amp.getVmp() == null) {
+            return;
+        }
+        Vmp vmp = amp.getVmp();
+        if (amp.getCategory() == null) {
+            amp.setCategory(vmp.getCategory());
+        }
+        if (amp.getStrengthOfAnIssueUnit() == null) {
+            amp.setStrengthOfAnIssueUnit(vmp.getStrengthOfAnIssueUnit());
+        }
+        if (amp.getStrengthUnit() == null) {
+            amp.setStrengthUnit(vmp.getStrengthUnit());
+        }
+        if (amp.getDosageForm() == null) {
+            amp.setDosageForm(vmp.getDosageForm());
+        }
+        if (amp.getIssueUnit() == null) {
+            amp.setIssueUnit(vmp.getIssueUnit());
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
Fixes #23051 — AMP edit now defaults null Category/Strength/Strength Unit/Dosage Form/Issue Unit from the linked VMP.

## Decisions made without approval
- **Verification AMP substitution**: the AMP named in the original issue ("Amoxil 500mg capsule") turned out to already have non-null values for these fields in the DB when checked directly — not a clean repro. Rather than guess at a separate root cause for that specific record, I re-verified the fix against a different AMP ("CAL-DZ Tablet") that genuinely has null fields, which cleanly demonstrates the fix working as specified. The original AMP's own dropdown-rendering behavior is out of scope for this issue (which is specifically about defaulting *null* fields) — flagging here in case it's worth a separate look, but did not investigate further.
- **Where the fill logic lives**: added as a private helper called from `edit()` (the single method that opens an AMP for editing) rather than duplicating logic elsewhere, since `prepareEdit()` already delegates to `edit()`.

## Changes
- `AmpController.java`: `edit()` now calls a new `fillNullFieldsFromVmp()` that copies Category/Strength/StrengthUnit/DosageForm/IssueUnit from `current.getVmp()` onto `current`, but only for fields that are currently null.

## Verification
Local Payara, Main Pharmacy department. AMP "CAL-DZ Tablet" linked to VMP "Diltiazem SR 60mg Tablet" (Strength=60, Strength Unit=mg, Issue Unit=mg), confirmed genuinely null via direct DB read before testing:
- Before fix: Dosage Form, Strength, Strength Unit, Issue Unit all blank on Edit Selected.
- After fix: all four correctly default from the VMP (Tablet / 60.0 / mg / mg); the already-set Category field is left unchanged at "Tablet".

See the issue comment for before/after screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
