### PR TITLE
fix(inward): float filter-panel dropdowns above content via appendTo

### DIFF
--- a/src/main/webapp/inward/inpatient_search.xhtml
+++ b/src/main/webapp/inward/inpatient_search.xhtml
@@ -210,6 +210,7 @@
                                     value="#{admissionController.creditCompanyForSearch}"
                                     filter="true"
                                     autoWidth="false"
+                                    appendTo="@(body)"
                                     >
                                     <f:selectItem itemLabel="All"></f:selectItem>
                                     <f:selectItems value="#{institutionController.creditCompanies}" var="creditCompanyItem" itemLabel="#{creditCompanyItem.name}" itemValue="#{creditCompanyItem}" />
@@ -218,7 +219,8 @@
                                 <p:outputLabel value="Status" ></p:outputLabel>
                                 <p:selectOneMenu
                                     class="w-100"
-                                    value="#{admissionController.admissionStatusForSearch}" >
+                                    value="#{admissionController.admissionStatusForSearch}"
+                                    appendTo="@(body)" >
                                     <f:selectItem itemLabel="Any Status"></f:selectItem>
                                     <f:selectItems value="#{enumController.admissionStatuses}"
                                                    var="status"
@@ -228,7 +230,8 @@
                                 <p:outputLabel value="Admission Type" ></p:outputLabel>
                                 <p:selectOneMenu
                                     class="w-100"
-                                    value="#{admissionController.admissionTypeForSearch}" >
+                                    value="#{admissionController.admissionTypeForSearch}"
+                                    appendTo="@(body)" >
                                     <f:selectItem itemLabel="All"></f:selectItem>
                                     <f:selectItems value="#{admissionTypeController.items}" var="myItem" itemValue="#{myItem}" itemLabel="#{myItem.name}" />
                                 </p:selectOneMenu>
@@ -240,6 +243,7 @@
                                     value="#{admissionController.institutionForSearch}"
                                     filter="true"
                                     autoWidth="false"
+                                    appendTo="@(body)"
                                     >
                                     <f:selectItem itemLabel="All"></f:selectItem>
                                     <f:selectItems value="#{institutionController.companies}" var="ins" itemLabel="#{ins.name}" itemValue="#{ins}" />
@@ -256,6 +260,7 @@
                                         value="#{admissionController.site}"
                                         filter="true"
                                         autoWidth="false"
+                                        appendTo="@(body)"
                                         >
                                         <f:selectItem itemLabel="All"></f:selectItem>
                                         <f:selectItems value="#{institutionController.sites}" var="site" itemLabel="#{site.name}" itemValue="#{site}" />
@@ -271,6 +276,7 @@
                                         value="#{admissionController.loggedDepartment}"
                                         filter="true"
                                         autoWidth="false"
+                                        appendTo="@(body)"
                                         >
                                         <f:selectItem itemLabel="All"></f:selectItem>
                                         <f:selectItems


### PR DESCRIPTION
## Summary
Fixes #23049 — Status filter dropdown (and siblings) on Inpatient Search no longer visually corrupts/overlaps with fields below it.

## Decisions made without approval
- **Scope widened to all 6 dropdowns in the panel, not just Status**: while investigating, I found the exact same missing `appendTo="@(body)"` on the 5 sibling `p:selectOneMenu`s in the same narrow filter column (Insurance Company, Admission Type, Institution, Site, Department) — same root cause, same fix, same narrow `col-2` container. Fixing only Status would have left 5 identical bugs sitting right next to it. This matches the issue's own note ("worth checking other narrow-column filter panels for the same symptom").

## Root cause
`inward/inpatient_search.xhtml` — 6 `p:selectOneMenu`s in a narrow Bootstrap `col-2` filter column had no `appendTo`, so PrimeFaces rendered each overlay panel inline within the constrained column rather than at document-body level, causing the open panel to visually blend/corrupt with sibling field labels instead of floating cleanly above them.

## Fix
Added `appendTo="@(body)"` to all 6 `p:selectOneMenu`s in the filter panel.

## Verification
DOM-level (not just visual): before the fix, the Status panel rendered inline in the constrained column. After the fix, confirmed via `getComputedStyle()`:
- panel is a child of `<body>`
- `position: absolute`, `z-index: 1003`
- solid white background, proper `box-shadow`

Screenshot in the issue comment shows a clean, well-formed floating panel replacing the previous jumbled/bleeding appearance. The panel still temporarily covers whatever's directly beneath it while open — that's inherent to any dropdown, not a defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
