### PR TITLE
fix(pharmacy): make Batch/Item Stock reports scroll horizontally

### DIFF
--- a/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_batch_dto.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_batch_dto.xhtml
@@ -127,7 +127,22 @@
                             </h:panelGroup>
                         </h:panelGroup>
 
-                        <h:panelGroup id="gpBillPreview" styleClass="noBorder summeryBorder" style="min-width: 100%!important;">
+                        <h:panelGroup id="gpBillPreview" styleClass="noBorder summeryBorder">
+
+                            <!-- Cells keep their natural (unwrapped) width so the table overflows its
+                                 container and scrolls horizontally (scrollable="true" below) instead of
+                                 wrapping long item names onto multiple lines. table-layout must be
+                                 overridden from PrimeFaces' default "fixed" (which silently clips
+                                 nowrap content to the container width) to "auto" so the table can
+                                 actually grow past the scrollable viewport. Issue #23052. -->
+                            <style>
+                                [id="frm:tbl"] td, [id="frm:tbl"] th { white-space: nowrap; }
+                                [id="frm:tbl"] .ui-datatable-scrollable-header table,
+                                [id="frm:tbl"] .ui-datatable-scrollable-body table {
+                                    table-layout: auto !important;
+                                    width: auto !important;
+                                }
+                            </style>
 
                             <p:dataTable id="tbl" rowIndexVar="ii"
                                          value="#{reportsStock.stockDtos}" var="i"
@@ -135,7 +150,9 @@
                                          paginator="#{reportsStock.paginator}"
                                          paginatorPosition="bottom"
                                          paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks}{NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
-                                         rowsPerPageTemplate="20, 50, 100">
+                                         rowsPerPageTemplate="20, 50, 100"
+                                         scrollable="true"
+                                         scrollWidth="100%">
 
                                 <f:facet name="header">
                                     <h:outputLabel value="Batch Stock Report - #{reportsStock.department.name}" />

--- a/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_item_DTO.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_item_DTO.xhtml
@@ -121,7 +121,22 @@
 
                         <h:panelGroup id="gpBillPreview"  styleClass="noBorder summeryBorder" class="w-100">
 
-                            <p:dataTable 
+                            <!-- Cells keep their natural (unwrapped) width so the table overflows its
+                                 container and scrolls horizontally (scrollable="true" below) instead of
+                                 wrapping long item names onto multiple lines. table-layout must be
+                                 overridden from PrimeFaces' default "fixed" (which silently clips
+                                 nowrap content to the container width) to "auto" so the table can
+                                 actually grow past the scrollable viewport. Issue #23052. -->
+                            <style>
+                                [id="frm:tbl"] td, [id="frm:tbl"] th { white-space: nowrap; }
+                                [id="frm:tbl"] .ui-datatable-scrollable-header table,
+                                [id="frm:tbl"] .ui-datatable-scrollable-body table {
+                                    table-layout: auto !important;
+                                    width: auto !important;
+                                }
+                            </style>
+
+                            <p:dataTable
                                 id="tbl" 
                                 rowIndexVar="ii" 
                                 value="#{reportsStock.stockReportByItemDTOS}" var="i"
@@ -129,7 +144,9 @@
                                 rows="#{reportsStock.paginator?'20':reportsStock.stockReportByItemDTOS.size()}"
                                 paginator="#{reportsStock.paginator}"
                                 paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
-                                rowsPerPageTemplate="20, 50, 100">
+                                rowsPerPageTemplate="20, 50, 100"
+                                scrollable="true"
+                                scrollWidth="100%">
                                 <f:facet name="header">
                                     <h:panelGroup layout="block">
                                         <h:outputLabel value="Stock Report by Item"/>


### PR DESCRIPTION
## Summary
Fixes #23052 — Batch Stock and Item Stock reports now scroll horizontally instead of wrapping item names onto multiple lines.

## Decisions made without approval
- **`scrollable="true"` alone was insufficient** — this was a genuine iteration during development, not a design choice: PrimeFaces renders scrollable tables with `table-layout: fixed`, which silently *clips* `white-space: nowrap` content to the container width rather than letting the table grow and produce a real scrollbar. Confirmed this via DOM inspection (`table-layout: fixed`, `scrollWidth === clientWidth`, no overflow) before adding the `table-layout: auto` override that actually fixes it. Documenting this since it means the fix is two CSS rules, not just the one attribute named in the issue's suggested fix.

## Changes
- `pharmacy_report_department_stock_by_batch_dto.xhtml` / `pharmacy_report_department_stock_by_item_DTO.xhtml`:
  - Added `scrollable="true" scrollWidth="100%"` to both `p:dataTable`s.
  - Removed `min-width: 100%!important` on the Batch Stock Report's wrapper (was actively fighting horizontal scroll).
  - Added scoped `<style>` overriding `table-layout: auto` (+ `white-space: nowrap` on cells) — required for the scrollbar to actually appear instead of silently clipping content.

## Verification
DOM-level: confirmed `table.offsetWidth (1622px) > scrollable-body.clientWidth (1340px)` on the Batch Stock Report — genuine overflow, not clipping.
Visual: both reports now render every row on a single line with full item names; see the issue comment for screenshots (Batch Stock Report shows the rightmost column cut off at the scroll boundary, confirming real horizontal scroll).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Stock reports now support horizontal scrolling for wider tables.
  * Table content remains on a single line, improving readability and preventing cramped cells.
  * Tables automatically expand to accommodate their contents while retaining existing pagination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->