### PR TITLE
feat(pharmacy): convert VTM/ATM admin selection to DTO-based

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/AtmController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/AtmController.java
@@ -442,21 +442,31 @@ public class AtmController implements Serializable {
      * @param selectedAtmDto The selected ATM DTO from UI
      */
     public void setSelectedAtmDto(AtmDto selectedAtmDto) {
-        System.out.println("setSelectedAtmDto called");
-        System.out.println("selectedAtmDto = " + selectedAtmDto);
         this.selectedAtmDto = selectedAtmDto;
 
-        // Sync with entity if DTO is selected
+        // Sync with entity if DTO is selected. Re-check the same scope condition
+        // completeAtmDto() already enforces (retired=false, departmentType=Pharmacy) -
+        // without this, a submitted ID for a retired or out-of-scope ATM would load
+        // straight into `current` and become editable/deletable, since this setter
+        // (and the converter below) round-trip on every postback, not just the initial
+        // search. CodeRabbit review on #23062.
         if (selectedAtmDto != null && selectedAtmDto.getId() != null) {
-            System.out.println("selectedAtmDto.getId() = " + selectedAtmDto.getId());
-            this.current = getFacade().find(selectedAtmDto.getId());
-            System.out.println("Loaded entity: " + (this.current != null ? this.current.getName() : "null"));
+            Atm loaded = getFacade().find(selectedAtmDto.getId());
+            this.current = isInPharmacyScope(loaded) ? loaded : null;
         } else {
             // Clear current entity when no DTO is selected
-            System.out.println("Clearing current entity (selectedAtmDto is null or has null ID)");
             this.current = null;
         }
-        System.out.println("current = " + current);
+    }
+
+    /**
+     * Same scope condition as completeAtmDto()'s WHERE clause, re-applied here
+     * because setSelectedAtmDto() and AtmDtoConverter.getAsObject() both resolve a
+     * client-submitted ID directly via facade lookup, with no other server-side check
+     * that the ID actually came from the scoped autocomplete results. Issue #23062.
+     */
+    private static boolean isInPharmacyScope(Atm atm) {
+        return atm != null && !atm.isRetired() && atm.getDepartmentType() == DepartmentType.Pharmacy;
     }
 
     /**
@@ -823,14 +833,17 @@ public class AtmController implements Serializable {
                     return null;
                 }
 
-                // Load entity from database and convert to DTO
+                // Load entity from database and convert to DTO. Re-checked against the
+                // same scope condition completeAtmDto() enforces - the converter round-trips
+                // on every postback, so without this check a submitted ID for a retired or
+                // out-of-scope ATM would silently resolve. Issue #23062.
                 Atm entity = controller.getFacade().find(id);
-                if (entity != null) {
+                if (isInPharmacyScope(entity)) {
                     AtmDto dto = controller.createAtmDto(entity);
                     System.out.println("Created DTO from entity: " + dto.getName());
                     return dto;
                 } else {
-                    System.out.println("Entity not found for ID: " + id);
+                    System.out.println("Entity not found or out of scope for ID: " + id);
                     return null;
                 }
 

--- a/src/main/java/com/divudi/bean/pharmacy/VtmController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/VtmController.java
@@ -720,13 +720,29 @@ public class VtmController implements Serializable {
     public void setSelectedVtmDto(VtmDto selectedVtmDto) {
         this.selectedVtmDto = selectedVtmDto;
 
-        // Sync with entity if DTO is selected
+        // Sync with entity if DTO is selected. Re-check the same scope condition
+        // completeVtmDto() already enforces (retired=false, departmentType=Pharmacy) -
+        // without this, a submitted ID for a retired or out-of-scope VTM would load
+        // straight into `current` and become editable/deletable, since this setter
+        // (and the converter below) round-trip on every postback, not just the initial
+        // search. CodeRabbit review on #23062.
         if (selectedVtmDto != null && selectedVtmDto.getId() != null) {
-            this.current = getFacade().find(selectedVtmDto.getId());
+            Vtm loaded = getFacade().find(selectedVtmDto.getId());
+            this.current = isInPharmacyScope(loaded) ? loaded : null;
         } else {
             // Clear current entity when no DTO is selected
             this.current = null;
         }
+    }
+
+    /**
+     * Same scope condition as completeVtmDto()'s WHERE clause, re-applied here
+     * because setSelectedVtmDto() and VtmDtoConverter.getAsObject() both resolve a
+     * client-submitted ID directly via facade lookup, with no other server-side check
+     * that the ID actually came from the scoped autocomplete results. Issue #23062.
+     */
+    private static boolean isInPharmacyScope(Vtm vtm) {
+        return vtm != null && !vtm.isRetired() && vtm.getDepartmentType() == DepartmentType.Pharmacy;
     }
 
     // Audit Events Methods
@@ -1070,9 +1086,12 @@ public class VtmController implements Serializable {
                     return null;
                 }
 
-                // Load entity from database and convert to DTO
+                // Load entity from database and convert to DTO. Re-checked against the
+                // same scope condition completeVtmDto() enforces - the converter round-trips
+                // on every postback, so without this check a submitted ID for a retired or
+                // out-of-scope VTM would silently resolve. Issue #23062.
                 Vtm entity = controller.getFacade().find(id);
-                if (entity != null) {
+                if (isInPharmacyScope(entity)) {
                     VtmDto dto = controller.createVtmDto(entity);
                     return dto;
                 } else {

--- a/src/main/webapp/pharmacy/admin/atm.xhtml
+++ b/src/main/webapp/pharmacy/admin/atm.xhtml
@@ -30,11 +30,17 @@
                                              action="#{atmController.navigateToAtmList()}" ajax="false"
                                              class="m-1 ui-button-secondary w-25" icon="fas fa-list"
                                              title="View and download the full list of ATMs"/>
-                            <p:selectOneListbox id="lstSelect" value="#{atmController.current}" filter="true" filterMatchMode="contains"
-                                                class="w-100" disabled="#{atmController.editable}">
-                                <f:selectItems value="#{atmController.items}" var="myItem" itemValue="#{myItem}" itemLabel="#{myItem.name}" />
-                                <p:ajax update="gpDetail btnEdit" process="lstSelect" />
-                            </p:selectOneListbox>
+                            <p:autoComplete id="lstSelect" class="w-100" inputStyleClass="w-100"
+                                            value="#{atmController.selectedAtmDto}"
+                                            completeMethod="#{atmController.completeAtmDto}"
+                                            converter="atmDtoConverter"
+                                            var="myItem" itemLabel="#{myItem.name}" itemValue="#{myItem}"
+                                            forceSelection="true"
+                                            minQueryLength="2"
+                                            placeholder="Search by name (minimum 2 characters)..."
+                                            disabled="#{atmController.editable}">
+                                <p:ajax event="itemSelect" update="gpDetail btnEdit" process="@this" />
+                            </p:autoComplete>
                         </div>
                         <div class="col-md-7">
                             <p:panel>

--- a/src/main/webapp/pharmacy/admin/atm.xhtml
+++ b/src/main/webapp/pharmacy/admin/atm.xhtml
@@ -39,7 +39,7 @@
                                             minQueryLength="2"
                                             placeholder="Search by name (minimum 2 characters)..."
                                             disabled="#{atmController.editable}">
-                                <p:ajax event="itemSelect" update="gpDetail btnEdit" process="@this" />
+                                <p:ajax event="itemSelect" update="gpDetail btnEdit btnDelete" process="@this" />
                             </p:autoComplete>
                         </div>
                         <div class="col-md-7">

--- a/src/main/webapp/pharmacy/admin/vtm.xhtml
+++ b/src/main/webapp/pharmacy/admin/vtm.xhtml
@@ -60,8 +60,9 @@
                             <p:autoComplete
                                 class="w-100"
                                 id="acVtm"
-                                value="#{vtmController.current}"
-                                completeMethod="#{vtmController.completeVtm}"
+                                value="#{vtmController.selectedVtmDto}"
+                                completeMethod="#{vtmController.completeVtmDto}"
+                                converter="vtmDtoConverter"
                                 var="i"
                                 itemLabel="#{i.name}"
                                 itemValue="#{i}"


### PR DESCRIPTION
## Summary
Fixes #23053 — VTM and ATM admin pages now select via DTO-based autocomplete, matching the existing VMP/AMP pattern.

## Decisions made without approval
- **Scope confirmation**: verified via code that VMP and AMP pages were already DTO-based (no work needed) and that VMPPs/AMPPs were correctly excluded from this issue.
- **No new backend code**: discovered both controllers already had complete, unused DTO infrastructure (`VtmDto`/`AtmDto`, `completeVtmDto()`/`completeAtmDto()`, sync-to-entity setters, registered converters) — treated this as license to do a pure UI swap rather than writing parallel new code, since reusing the existing (evidently already-designed-for-this) methods is the lower-risk path.
- **ATM UI pattern**: replaced the `p:selectOneListbox` with a `p:autoComplete` to match the VMP/AMP/VTM search-as-you-type pattern, rather than keeping a listbox bound to the DTO list (which would still load everything unpaginated) — this was the actual performance/UX fix the issue asked for.

## Changes
- `vtm.xhtml`: `Select VTM` autocomplete now binds to `selectedVtmDto` / `completeVtmDto` / `vtmDtoConverter`.
- `atm.xhtml`: listbox replaced with `p:autoComplete` on `selectedAtmDto` / `completeAtmDto` / `atmDtoConverter`.

## Verification
Local Payara, Main Pharmacy department:
- VTM: searched "Amoxicillin", selected it, confirmed entity sync (Name populated, Edit/Delete enabled), opened Edit successfully.
- ATM: searched "COZIL" (only ATM in this local dataset), selected "COZIL IV", confirmed entity sync (Name + linked VTM "Fluconazole" populated, Edit/Delete enabled).

See the issue comment for screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced ATM and VTM selection lists with autocomplete search fields.
  * Added search-as-you-type functionality after entering two characters.
  * Requires exact matches for valid selections.
  * Updates related details and editing options when an ATM is selected.
  * Added clearer search guidance through placeholder text.

* **Bug Fixes**
  * Prevented retired or out-of-scope pharmacy items from being selected or displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->