### PR TITLE
Add Print to Original Bill for Collecting Centre bills

### DIFF
--- a/src/main/java/com/divudi/bean/common/BillSearch.java
+++ b/src/main/java/com/divudi/bean/common/BillSearch.java
@@ -6130,6 +6130,10 @@ public class BillSearch implements Serializable, ControllerWithMultiplePayments 
         return "/collecting_centre/view/cc_bill_view?faces-redirect=true";
     }
 
+    public String navigateToCcOriginalBillPrint() {
+        return "/collecting_centre/view/cc_original_bill_reprint?faces-redirect=true";
+    }
+
     public String navigateToViewCcBillCancellation(Bill bill) {
         loadBillDetails(bill);
         return "/collecting_centre/view/cc_bill_cancellation_view?faces-redirect=true";

--- a/src/main/java/com/divudi/bean/common/UserPrivilageController.java
+++ b/src/main/java/com/divudi/bean/common/UserPrivilageController.java
@@ -720,6 +720,7 @@ public class UserPrivilageController implements Serializable {
         new DefaultTreeNode(new PrivilegeHolder(Privileges.SearchIssuedReferenceBook, "Search Collecting Centre Reference Book"), collectingCentreManageNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.ChangeCreditLimitInCC, "Change Collecting Centre Credit Limit"), collectingCentreManageNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.PayCollectingCentre, "Pay Collecting Centre"), collectingCentreManageNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.CollectingCentreReprintOriginalBill, "Reprint the Original Bill"), collectingCentreManageNode);
 
         TreeNode creditDebitNoteNode = new DefaultTreeNode(new PrivilegeHolder(null, "Credit/Debit Note"), collectingCentreNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.CollectingCentreCreditDebitNoteMenu, "Credit/Debit Note Menu"), creditDebitNoteNode);

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -778,6 +778,7 @@ public enum Privileges {
     SearchIssuedReferenceBook("Search CC Reference Book"),
     ChangeCreditLimitInCC("Change CC Credit Limit"),
     PayCollectingCentre("Pay Collecting Centre"),
+    CollectingCentreReprintOriginalBill("Collecting Centre Reprint Original Bill"),
     CollectingCentreCreditDebitNoteMenu("CC Credit/Debit Note Menu"),
     CollectingCentreCreditNote("CC Credit Note"),
     CollectingCentreDebitNote("CC Debit Note"),
@@ -1188,6 +1189,7 @@ public enum Privileges {
             case SearchIssuedReferenceBook:
             case ChangeCreditLimitInCC:
             case PayCollectingCentre:
+            case CollectingCentreReprintOriginalBill:
             case CollectingCentreCreditDebitNoteMenu:
             case CollectingCentreCreditNote:
             case CollectingCentreDebitNote:

--- a/src/main/webapp/collecting_centre/view/cc_bill_view.xhtml
+++ b/src/main/webapp/collecting_centre/view/cc_bill_view.xhtml
@@ -17,8 +17,16 @@
                             <div class="d-flex align-items-center justify-content-between">
                                 <div></div>
                                 <div>
-                                    <p:commandButton 
-                                        ajax="false" 
+                                    <p:commandButton
+                                        value="Print to Original Bill"
+                                        class="ui-button-info m-1"
+                                        icon="fa fa-print"
+                                        action="#{billSearch.navigateToCcOriginalBillPrint()}"
+                                        rendered="#{webUserController.hasPrivilege('CollectingCentreReprintOriginalBill')}"
+                                        ajax="false">
+                                    </p:commandButton>
+                                    <p:commandButton
+                                        ajax="false"
                                         value="To Cancel"
                                         action="#{billSearch.navigateToCancelCollectingCentreBill}" 
                                         disabled="#{billSearch.bill.cancelled or billSearch.bill.refunded}" 

--- a/src/main/webapp/collecting_centre/view/cc_original_bill_reprint.xhtml
+++ b/src/main/webapp/collecting_centre/view/cc_original_bill_reprint.xhtml
@@ -1,0 +1,135 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:bi="http://xmlns.jcp.org/jsf/composite/bill/cc_bill">
+
+    <h:body>
+        <ui:composition template="/collecting_centre/index.xhtml">
+            <ui:define name="subcontent">
+                <h:form>
+                    <h:panelGroup rendered="#{!webUserController.hasPrivilege('CollectingCentreReprintOriginalBill')}">
+                        <div class="row d-grid align-items-center" style="height: 70vh;">
+                            <div class="col-12  justify-content-center " >
+                                <div class="d-flex justify-content-center">
+                                    <i class="fa fa-exclamation-triangle" style="font-size: 10rem; color:#008DDA "></i>
+                                </div>
+                                <div class="d-flex justify-content-center">
+                                    <p:outputLabel value="You are not authorized to access this page.. !" class="m-2" style="font-size: 40px; color: red; font-weight: 700;"></p:outputLabel>
+                                </div>
+                                <div class="d-flex justify-content-center">
+                                    <p:commandButton
+                                        ajax="false"
+                                        action="/home?faces-redirect=true"
+                                        icon="pi pi-home"
+                                        class="ui-button-success px-5 px-5"
+                                        value="Go to Home">
+                                    </p:commandButton>
+                                </div>
+                            </div>
+                        </div>
+                    </h:panelGroup>
+
+                    <p:panel rendered="#{webUserController.hasPrivilege('CollectingCentreReprintOriginalBill')}">
+                        <f:facet name="header">
+                            <div class="d-flex align-items-center justify-content-between">
+                                <p:outputLabel value="Reprint CC Original Bill" class="mt-2"></p:outputLabel>
+                                <p:commandButton
+                                    class="ui-button-secondary m-1"
+                                    icon="fa-solid fa-arrow-left"
+                                    value="Back"
+                                    action="/collecting_centre/view/cc_bill_view?faces-redirect=true"
+                                    ajax="false">
+                                </p:commandButton>
+                            </div>
+                        </f:facet>
+                        <div class="row ">
+                            <div class="col-md-6">
+                                <p:panel>
+                                    <f:facet name="header">
+                                        <p:outputLabel value="Bill for Collecting Center"  class="mt-2"/>
+                                        <p:commandButton
+                                            value="Print"
+                                            class="ui-button-info m-1"
+                                            icon="fa fa-print"
+                                            style="float: right;"
+                                            ajax="false">
+                                            <p:printer target="centerBillPriview" ></p:printer>
+                                        </p:commandButton>
+                                    </f:facet>
+
+                                    <h:panelGroup id="centerBillPriview">
+
+                                        <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Bill for Collecting Center(CC) size is POS paper')}" >
+                                            <ui:repeat value="#{billSearch.bill}" var="pp">
+                                                <bi:posCCBill_CC bill="#{pp}" duplicate="false"/>
+                                            </ui:repeat>
+                                        </h:panelGroup>
+
+                                        <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Bill For Collecting Center(CC) size is FiveFive paper')}" >
+                                            <ui:repeat value="#{billSearch.bill}" var="pp">
+                                                <bi:fiveFiveCCBill_CC bill="#{pp}" duplicate="false"/>
+                                            </ui:repeat>
+                                        </h:panelGroup>
+
+                                        <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Bill For Collecting Center(CC) size is FiveFiveCustom1 paper')}" >
+                                            <bi:fiveFiveCCBill_CC_Custom1 bill="#{billSearch.bill}" duplicate="false"/>
+                                        </h:panelGroup>
+
+                                        <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Bill For Collecting Center(CC) size is FiveFiveCustom3 paper')}" >
+                                            <bi:cc_five_five_custom_3 bill="#{billSearch.bill}" duplicate="false"/>
+                                        </h:panelGroup>
+
+                                    </h:panelGroup>
+
+                                </p:panel>
+                            </div>
+                            <div class="col-md-6">
+                                <p:panel>
+                                    <f:facet name="header">
+                                        <p:outputLabel value="Bill for Patinet " class="mt-2"/>
+                                        <p:commandButton
+                                            value="Print Patient"
+                                            class="ui-button-info m-1"
+                                            icon="fa fa-print"
+                                            style="float: right;"
+                                            ajax="false">
+                                            <p:printer target="parinetBillPriview" ></p:printer>
+                                        </p:commandButton>
+                                    </f:facet>
+                                    <h:panelGroup id="parinetBillPriview">
+
+                                        <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Bill for Patient by CC is POS paper')}" >
+                                            <ui:repeat value="#{billSearch.bill}" var="pp">
+                                                <bi:posCCBill_Patient bill="#{pp}" duplicate="false"/>
+                                            </ui:repeat>
+                                        </h:panelGroup>
+
+                                        <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Bill for Patient by CC is FiveFive paper')}" >
+                                            <ui:repeat value="#{billSearch.bill}" var="pp">
+                                                <bi:fiveFiveCCBill_Patient bill="#{pp}" duplicate="false"/>
+                                            </ui:repeat>
+                                        </h:panelGroup>
+
+                                        <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Bill for Patient by CC is FiveFiveCustom1 paper')}" >
+                                            <bi:fiveFiveCCBill_Patient_Custom1 bill="#{billSearch.bill}" duplicate="false"/>
+                                        </h:panelGroup>
+
+                                        <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Bill for Patient by CC is FiveFiveCustom3 paper')}" >
+                                            <bi:cc_five_five_custom_3_patient bill="#{billSearch.bill}" duplicate="false"/>
+                                        </h:panelGroup>
+
+                                    </h:panelGroup>
+
+                                </p:panel>
+                            </div>
+                        </div>
+                    </p:panel>
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/resources/pharmacy/saleBill_Header_native.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBill_Header_native.xhtml
@@ -246,9 +246,12 @@
                             <h:outputLabel rendered="#{cc.attrs.bill.discountPercentPharmacy ne 0.0 and cc.attrs.bill.discount ne 0.0}" value="Discount Percent" style="font-weight: bolder!important;"/>
                         </td>
                         <td class="totalsBlock1" style="text-align: right!important; font-weight: bold;">
-                            <h:outputLabel rendered="#{cc.attrs.bill.discountPercentPharmacy ne 0.0 and cc.attrs.bill.discount ne 0.0}" value="#{cc.attrs.bill.discountPercentPharmacy} %">
-                                <f:convertNumber pattern="#,##0.0"/>
+                            <div style="display: flex; float: right;">
+                                <h:outputLabel rendered="#{cc.attrs.bill.discountPercentPharmacy ne 0.0 and cc.attrs.bill.discount ne 0.0}" value="#{cc.attrs.bill.discountPercentPharmacy}">
+                                <f:convertNumber pattern="#,##0.00"/>
                             </h:outputLabel>
+                                <h:outputLabel rendered="#{cc.attrs.bill.discountPercentPharmacy ne 0.0 and cc.attrs.bill.discount ne 0.0}" value="%"></h:outputLabel>
+                            </div>
                         </td>
                     </tr>
 


### PR DESCRIPTION
## Summary
- Adds a new `CollectingCentreReprintOriginalBill` privilege to gate reprinting the original (non-duplicate) collecting centre bill, mirroring the existing `OpdReprintOriginalBill` pattern used for OPD bills, and registers it in the User Privileges admin tree under Collecting Centre > Manage.
- Adds a "Print to Original Bill" button to `collecting_centre/view/cc_bill_view.xhtml`, visible only to users holding the new privilege, which navigates to a new reprint page.
- Adds a new page `collecting_centre/view/cc_original_bill_reprint.xhtml` that reprints both the "Bill for Collecting Center" and "Bill for Patient" copies with `duplicate="false"` (i.e. the original, not the "DUPLICATE"-stamped copy), each with its own Print button, plus a Back button to return to the bill view page. Includes an unauthorized-access fallback panel for users without the privilege.

## Note
This branch also carries one pre-existing commit already ahead of `southernlanka-stg-migrated` on the source branch (`fix(pharmacy): separate discount percent value and % sign on native sale bill header`), which was not authored in this session but is included since it was already on top of this branch's history.

## Test plan
- [ ] Deploy and log in as a user WITHOUT `CollectingCentreReprintOriginalBill` — confirm the "Print to Original Bill" button is hidden on the CC bill view page, and confirm direct navigation to the new reprint page shows the "not authorized" panel.
- [ ] Assign the `CollectingCentreReprintOriginalBill` privilege to a test user via User Privileges admin (Collecting Centre > Manage > Reprint the Original Bill) — confirm the button appears and navigates correctly.
- [ ] On the new reprint page, verify both the CC copy and Patient copy print previews render without the "DUPLICATE" stamp, for each configured paper type (POS / FiveFive / FiveFiveCustom1 / FiveFiveCustom3).
- [ ] Verify the Back button returns to `cc_bill_view.xhtml` with the same bill still loaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)