### PR TITLE
feat(pharmacy): add VMP Stock Report, rename Item Stock to Item (AMP) Stock

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/ReportsStock.java
+++ b/src/main/java/com/divudi/bean/pharmacy/ReportsStock.java
@@ -1206,6 +1206,84 @@ public class ReportsStock implements Serializable, ControllerWithReportFilters {
     }
 
     /**
+     * VMP Stock Report — aggregates stock across every AMP (brand) linked to
+     * a VMP into a single row per VMP, so e.g. "Amoxicillin 500mg capsule"
+     * shows one combined quantity/value across all its brands, instead of
+     * one row per AMP as the AMP-level Item Stock report does. Reuses
+     * {@link StockReportByItemDTO} since its shape (code, name, qty,
+     * purchaseValue, saleValue) is identical at the VMP level. Items with no
+     * VMP link (e.g. store/lab items) are excluded, since there's nothing to
+     * aggregate them under. Issue #23054.
+     */
+    public void fillDepartmentVmpStocks() {
+        reportTimerController.trackReportExecution(() -> {
+            Map<String, Object> m = new HashMap<>();
+            StringBuilder jpql = new StringBuilder(
+                    "select new com.divudi.core.data.dto.StockReportByItemDTO("
+                    + "s.itemBatch.item.vmp.code, "
+                    + "s.itemBatch.item.vmp.name, "
+                    + "sum(s.stock), "
+                    + "sum(s.itemBatch.purcahseRate * s.stock), "
+                    + "sum(s.itemBatch.retailsaleRate * s.stock)) "
+                    + "from Stock s "
+                    + "left join s.itemBatch.item.category cat "
+                    + "left join s.itemBatch.item.dosageForm df "
+                    + "where s.itemBatch.item.vmp is not null");
+            if (!includeZeroStock) {
+                jpql.append(" and s.stock > 0");
+            }
+            if (department != null) {
+                jpql.append(" and s.department=:d");
+                m.put("d", department);
+            }
+            if (site != null) {
+                jpql.append(" and s.department.site=:site");
+                m.put("site", site);
+            }
+            if (institution != null) {
+                jpql.append(" and s.department.institution=:ins");
+                m.put("ins", institution);
+            }
+            if (selectedDepartmentTypes != null && !selectedDepartmentTypes.isEmpty()) {
+                jpql.append(" and s.itemBatch.item.departmentType IN :departmentTypes");
+                m.put("departmentTypes", selectedDepartmentTypes);
+            }
+            if (category != null) {
+                jpql.append(" and s.itemBatch.item.category=:cat");
+                m.put("cat", category);
+            }
+            if (dosageForm != null) {
+                jpql.append(" and s.itemBatch.item.dosageForm=:df");
+                m.put("df", dosageForm);
+            }
+            jpql.append(" group by s.itemBatch.item.vmp.name, s.itemBatch.item.vmp.code order by s.itemBatch.item.vmp.name");
+            List<StockReportByItemDTO> lsts = (List) getStockFacade().findLightsByJpql(jpql.toString(), m);
+            stockPurchaseValue = 0.0;
+            stockSaleValue = 0.0;
+            for (StockReportByItemDTO r : lsts) {
+                stockPurchaseValue += r.getPurchaseValue();
+                stockSaleValue += r.getSaleValue();
+            }
+            stockReportByVmpDTOS = lsts;
+        }, PharmacyReports.STOCK_REPORT_BY_VMP, sessionController.getLoggedUser());
+    }
+
+    private List<StockReportByItemDTO> stockReportByVmpDTOS;
+
+    public List<StockReportByItemDTO> getStockReportByVmpDTOS() {
+        return stockReportByVmpDTOS;
+    }
+
+    public void setStockReportByVmpDTOS(List<StockReportByItemDTO> stockReportByVmpDTOS) {
+        this.stockReportByVmpDTOS = stockReportByVmpDTOS;
+    }
+
+    public String navigateToVmpStockReport() {
+        stockReportByVmpDTOS = new ArrayList<>();
+        return "/pharmacy/pharmacy_report_department_stock_by_vmp_dto?faces-redirect=true";
+    }
+
+    /**
      * {@code p:dataExporter} postProcessor for the "Stock Report by Item"
      * page - adds the report title, active filters, and a Printed By/At
      * footer around the exported table (issue #17615).

--- a/src/main/java/com/divudi/core/data/reports/PharmacyReports.java
+++ b/src/main/java/com/divudi/core/data/reports/PharmacyReports.java
@@ -21,6 +21,7 @@ public enum PharmacyReports implements IReportType {
     SALE_SUMMARY_BY_PAYMENT_METHOD_BY_BILL("Sale summary by payment method by Bill"),
     STOCK_REPORT_BY_EXPIRY("Stock report by Expiry"),
     STOCK_REPORT_BY_ITEM("Stock report by Item"),
+    STOCK_REPORT_BY_VMP("Stock report by VMP"),
     STOCK_REPORT_BY_ZERO_ITEM("Stock report by Zero Item"),
     DEPARTMENT_VICE_STOCK_REPORT("Department Vice Stock Report"),
     ORDERING_REQUIREMENT_REPORT("Ordering Requirement Report");

--- a/src/main/webapp/pharmacy/pharmacy_analytics.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_analytics.xhtml
@@ -145,9 +145,16 @@
                                             <h:panelGroup layout="block" styleClass="d-flex align-items-center gap-1 w-100" rendered="#{webUserController.hasPrivilege('PharmacyAnalyticsItemStock') and configOptionApplicationController.getBooleanValueByKey('Pharmacy Analytics - Show Stock Report by Item') and userFavoriteReportController.isFavorite('pharmacyAnalytics_itemStock')}"><p:commandButton
                                                 class="w-100 ui-button-success"
                                                 icon="fa fa-box"
-                                                value="Item Stock"
+                                                value="Item (AMP) Stock"
                                                 action="#{reportsStock.navigateToPharmacyReportDepartmentStockByItemDTO()}"
-                                                ajax="false"/><fav:favoriteStar reportKey="pharmacyAnalytics_itemStock" label="Item Stock" category="Stock Reports" /></h:panelGroup>
+                                                ajax="false"/><fav:favoriteStar reportKey="pharmacyAnalytics_itemStock" label="Item (AMP) Stock" category="Stock Reports" /></h:panelGroup>
+                                            <h:panelGroup layout="block" styleClass="d-flex align-items-center gap-1 w-100" rendered="#{webUserController.hasPrivilege('PharmacyAnalyticsItemStock') and configOptionApplicationController.getBooleanValueByKey('Pharmacy Analytics - Show VMP Stock Report', true) and userFavoriteReportController.isFavorite('pharmacyAnalytics_vmpStockReport')}"><p:commandButton
+                                                class="w-100 ui-button-success"
+                                                icon="fa fa-layer-group"
+                                                value="VMP Stock Report"
+                                                action="#{reportsStock.navigateToVmpStockReport()}"
+                                                ajax="false"
+                                                title="Aggregates stock across every AMP (brand) linked to a VMP into one row per VMP"/><fav:favoriteStar reportKey="pharmacyAnalytics_vmpStockReport" label="VMP Stock Report" category="Stock Reports" /></h:panelGroup>
                                             <h:panelGroup layout="block" styleClass="d-flex align-items-center gap-1 w-100" rendered="#{webUserController.hasPrivilege('PharmacyAnalyticsExpiringStock') and configOptionApplicationController.getBooleanValueByKey('Pharmacy Analytics - Show Stock Report by Expiry') and userFavoriteReportController.isFavorite('pharmacyAnalytics_expiringStock')}"><p:commandButton
                                                 class="w-100 ui-button-warning"
                                                 icon="fa fa-clock"
@@ -592,9 +599,18 @@
                                                 rendered="#{webUserController.hasPrivilege('PharmacyAnalyticsItemStock') and configOptionApplicationController.getBooleanValueByKey('Pharmacy Analytics - Show Stock Report by Item')}"
                                                 class="w-100 ui-button-success"
                                                 icon="fa fa-box"
-                                                value="Item Stock"
+                                                value="Item (AMP) Stock"
                                                 action="#{reportsStock.navigateToPharmacyReportDepartmentStockByItemDTO()}"
-                                                ajax="false"/><fav:favoriteStar reportKey="pharmacyAnalytics_itemStock" label="Item Stock" category="Stock Reports" visible="#{webUserController.hasPrivilege('PharmacyAnalyticsItemStock') and configOptionApplicationController.getBooleanValueByKey('Pharmacy Analytics - Show Stock Report by Item')}" /></div>
+                                                ajax="false"/><fav:favoriteStar reportKey="pharmacyAnalytics_itemStock" label="Item (AMP) Stock" category="Stock Reports" visible="#{webUserController.hasPrivilege('PharmacyAnalyticsItemStock') and configOptionApplicationController.getBooleanValueByKey('Pharmacy Analytics - Show Stock Report by Item')}" /></div>
+
+                                            <div class="d-flex align-items-center gap-1 w-100"><p:commandButton
+                                                rendered="#{webUserController.hasPrivilege('PharmacyAnalyticsItemStock') and configOptionApplicationController.getBooleanValueByKey('Pharmacy Analytics - Show VMP Stock Report', true)}"
+                                                class="w-100 ui-button-success"
+                                                icon="fa fa-layer-group"
+                                                value="VMP Stock Report"
+                                                action="#{reportsStock.navigateToVmpStockReport()}"
+                                                ajax="false"
+                                                title="Aggregates stock across every AMP (brand) linked to a VMP into one row per VMP"/><fav:favoriteStar reportKey="pharmacyAnalytics_vmpStockReport" label="VMP Stock Report" category="Stock Reports" visible="#{webUserController.hasPrivilege('PharmacyAnalyticsItemStock') and configOptionApplicationController.getBooleanValueByKey('Pharmacy Analytics - Show VMP Stock Report', true)}" /></div>
 
                                             <div class="d-flex align-items-center gap-1 w-100"><p:commandButton
                                                 rendered="#{webUserController.hasPrivilege('PharmacyAnalyticsExpiringStock') and configOptionApplicationController.getBooleanValueByKey('Pharmacy Analytics - Show Stock Report by Expiry')}"

--- a/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_vmp_dto.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_vmp_dto.xhtml
@@ -1,0 +1,262 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:common="http://xmlns.jcp.org/jsf/composite/ezcomp/common">
+
+    <h:body>
+
+        <ui:composition template="/pharmacy/pharmacy_analytics.xhtml">
+
+            <ui:define name="subcontent">
+                <h:form id="frm">
+                    <p:panel header="VMP Stock Report" >
+
+                        <common:institution_site_department_filter controller="#{reportsStock}"/>
+
+                        <h:panelGroup id="panelDeptType" layout="block" styleClass="container-fluid my-2">
+                            <h:panelGroup layout="block" styleClass="row">
+                                <!-- Category Filter -->
+                                <h:panelGroup layout="block" styleClass="col-lg-4 col-md-6 col-sm-12 mb-3">
+                                    <h:panelGroup layout="block" styleClass="form-group">
+                                        <h:panelGroup layout="block" styleClass="d-flex align-items-center mb-2">
+                                            <h:outputText styleClass="fa fa-tags mr-2" />
+                                            <h:outputLabel value="Category" for="categoryFilter" styleClass="mb-0"/>
+                                        </h:panelGroup>
+                                        <p:selectOneMenu
+                                            id="categoryFilter"
+                                            value="#{reportsStock.category}"
+                                            styleClass="w-100"
+                                            filter="true"
+                                            filterMatchMode="contains">
+                                            <f:selectItem itemLabel="All Categories"/>
+                                            <f:selectItems value="#{pharmaceuticalItemCategoryController.items}" var="cat" itemLabel="#{cat.name}" itemValue="#{cat}"/>
+                                        </p:selectOneMenu>
+                                    </h:panelGroup>
+                                </h:panelGroup>
+                                <!-- Dosage Form Filter -->
+                                <h:panelGroup layout="block" styleClass="col-lg-4 col-md-6 col-sm-12 mb-3">
+                                    <h:panelGroup layout="block" styleClass="form-group">
+                                        <h:panelGroup layout="block" styleClass="d-flex align-items-center mb-2">
+                                            <h:outputText styleClass="fa fa-capsules mr-2" />
+                                            <h:outputLabel value="Dosage Form" for="dosageFormFilter" styleClass="mb-0"/>
+                                        </h:panelGroup>
+                                        <p:selectOneMenu
+                                            id="dosageFormFilter"
+                                            value="#{reportsStock.dosageForm}"
+                                            styleClass="w-100"
+                                            filter="true"
+                                            filterMatchMode="contains">
+                                            <f:selectItem itemLabel="All Dosage Forms"/>
+                                            <f:selectItems value="#{dosageFormController.items}" var="df" itemLabel="#{df.name}" itemValue="#{df}"/>
+                                        </p:selectOneMenu>
+                                    </h:panelGroup>
+                                </h:panelGroup>
+                                <!-- Department Type Filter -->
+                                <h:panelGroup layout="block" styleClass="col-lg-4 col-md-6 col-sm-12 mb-3">
+                                    <h:panelGroup layout="block" styleClass="form-group">
+                                        <h:panelGroup layout="block" styleClass="d-flex align-items-center mb-2">
+                                            <h:outputText value="&#xf0e8;" styleClass="fa mr-2" />
+                                            <h:outputLabel value="Department Types" for="departmentTypeFilter" styleClass="mb-0"/>
+                                        </h:panelGroup>
+                                        <p:selectCheckboxMenu
+                                            id="departmentTypeFilter"
+                                            value="#{reportsStock.selectedDepartmentTypes}"
+                                            label="Select Department Types"
+                                            updateLabel="true"
+                                            styleClass="w-100"
+                                            filter="true"
+                                            filterMatchMode="contains"
+                                            showHeader="true"
+                                            scrollHeight="200">
+                                            <f:selectItems
+                                                value="#{reportsStock.availableDepartmentTypes}"
+                                                var="depType"
+                                                itemLabel="#{depType.label}"
+                                                itemValue="#{depType}"/>
+                                        </p:selectCheckboxMenu>
+                                        <p:tooltip for="departmentTypeFilter" value="Leave empty to include all departments"/>
+                                    </h:panelGroup>
+                                </h:panelGroup>
+                            </h:panelGroup>
+                        </h:panelGroup>
+
+                        <h:panelGroup id="panelZeroStock" layout="block" styleClass="container-fluid my-2">
+                            <h:panelGroup layout="block" styleClass="row">
+                                <!-- Include Zero Stock Filter -->
+                                <h:panelGroup layout="block" styleClass="col-lg-4 col-md-6 col-sm-12 mb-3">
+                                    <h:panelGroup layout="block" styleClass="form-group">
+                                        <h:panelGroup layout="block" styleClass="d-flex align-items-center mb-2">
+                                            <h:outputText styleClass="fa fa-box-open mr-2" />
+                                            <h:outputLabel value="Include Zero Stock" styleClass="mb-0"/>
+                                        </h:panelGroup>
+                                        <h:selectBooleanCheckbox id="includeZeroStockFilter" value="#{reportsStock.includeZeroStock}" />
+                                        <h:outputLabel for="includeZeroStockFilter" value=" Include VMPs with zero stock" styleClass="ms-1"/>
+                                    </h:panelGroup>
+                                </h:panelGroup>
+                                <!-- Action Buttons -->
+                                <h:panelGroup layout="block" styleClass="col-lg-8 col-md-6 col-sm-12 mb-3">
+                                    <h:panelGroup layout="block" styleClass="d-flex align-items-center mb-2">
+                                        <h:outputLabel value="&#160;" styleClass="mb-0"/>
+                                    </h:panelGroup>
+                                    <p:commandButton ajax="false" value="Process" icon="fas fa-cogs" styleClass="ui-button-warning mx-1"
+                                                     actionListener="#{reportsStock.fillDepartmentVmpStocks()}" />
+                                    <p:commandButton styleClass="ui-button-success mx-1" icon="fas fa-file-excel" value="Excel" ajax="false">
+                                        <p:dataExporter type="xlsx" target="tbl" fileName="Stock_Report_By_VMP" postProcessor="#{reportsStock.postProcessXLSStockReportByItem}"/>
+                                    </p:commandButton>
+                                    <p:commandButton styleClass="ui-button-info mx-1" icon="fas fa-print" value="Print"
+                                                     actionListener="#{reportsStock.prepareForPrint()}"
+                                                     oncomplete="$('#frm\\:print').click()"
+                                                     update=":frm:tbl"/>
+                                    <p:commandButton id="print" value="Actual print" style="display: none">
+                                        <p:ajax event="click" listener="#{reportsStock.prepareForView()}" update=":frm:tbl"/>
+                                        <p:printer target=":frm:tbl" />
+                                    </p:commandButton>
+                                </h:panelGroup>
+                            </h:panelGroup>
+                        </h:panelGroup>
+
+                        <h:panelGroup id="gpBillPreview"  styleClass="noBorder summeryBorder" class="w-100">
+
+                            <!-- Cells keep their natural (unwrapped) width so the table overflows its
+                                 container and scrolls horizontally instead of wrapping long VMP names
+                                 onto multiple lines. table-layout must be overridden from PrimeFaces'
+                                 default "fixed" (which silently clips nowrap content to the container
+                                 width) to "auto" so the table can actually grow past the scrollable
+                                 viewport. See issue #23052 for the same fix on the sibling reports. -->
+                            <style>
+                                [id="frm:tbl"] td, [id="frm:tbl"] th { white-space: nowrap; }
+                                [id="frm:tbl"] .ui-datatable-scrollable-header table,
+                                [id="frm:tbl"] .ui-datatable-scrollable-body table {
+                                    table-layout: auto !important;
+                                    width: auto !important;
+                                }
+                            </style>
+
+                            <p:dataTable
+                                id="tbl"
+                                rowIndexVar="ii"
+                                value="#{reportsStock.stockReportByVmpDTOS}" var="i"
+                                rendered="#{reportsStock.stockReportByVmpDTOS.size() ne 0 }"
+                                rows="#{reportsStock.paginator?'20':reportsStock.stockReportByVmpDTOS.size()}"
+                                paginator="#{reportsStock.paginator}"
+                                paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                rowsPerPageTemplate="20, 50, 100"
+                                scrollable="true"
+                                scrollWidth="100%">
+                                <f:facet name="header">
+                                    <h:panelGroup layout="block">
+                                        <h:outputLabel value="VMP Stock Report"/>
+                                        <h:panelGroup layout="block" style="font-size: 11px; font-weight: 400;">
+                                            <h:outputText value="Institution: #{not empty reportsStock.institution ? reportsStock.institution.name : 'All'}   |   "/>
+                                            <h:outputText value="Site: #{not empty reportsStock.site ? reportsStock.site.name : 'All'}   |   "/>
+                                            <h:outputText value="Department: #{not empty reportsStock.department ? reportsStock.department.name : 'All'}   |   "/>
+                                            <h:outputText value="Category: #{not empty reportsStock.category ? reportsStock.category.name : 'All'}   |   "/>
+                                            <h:outputText value="Dosage Form: #{not empty reportsStock.dosageForm ? reportsStock.dosageForm.name : 'All'}   |   "/>
+                                            <h:outputText value="Department Types: #{reportsStock.selectedDepartmentTypesPrintDisplay}   |   "/>
+                                            <h:outputText value="Include Zero Stock: #{reportsStock.includeZeroStock ? 'Yes' : 'No'}"/>
+                                        </h:panelGroup>
+                                    </h:panelGroup>
+                                </f:facet>
+                                <f:facet name="footer">
+                                    <common:report_print_footer/>
+                                </f:facet>
+
+                                <p:column width="20px;" headerText="No" sortBy="#{ii}"
+                                          style="width: 20px;">
+                                    <h:outputLabel value="#{ii+1}" />
+                                </p:column>
+
+                                <p:column headerText="Code"
+                                          sortBy="#{i.code}" filterBy="#{i.code}"
+                                          styleClass="averageNumericColumn"
+                                          filterMatchMode="startsWith">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Code"/>
+                                    </f:facet>
+                                    <h:outputLabel value="#{i.code}" />
+                                </p:column>
+
+                                <p:column headerText="VMP"
+                                          sortBy="#{i.name}" filterBy="#{i.name}"
+                                          filterMatchMode="contains">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="VMP"/>
+                                    </f:facet>
+                                    <h:outputLabel value="#{i.name}" />
+                                </p:column>
+
+                                <p:column headerText="Quantity"
+                                          styleClass="averageNumericColumn"
+                                          style="text-align: right;" sortBy="#{i.qty}">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Quantity"/>
+                                    </f:facet>
+                                    <h:outputLabel value="#{i.qty}"  >
+                                        <f:convertNumber pattern="#,###" />
+                                    </h:outputLabel>
+                                </p:column>
+
+
+                                <p:column headerText="Purchase Value"
+                                          styleClass="averageNumericColumn"
+                                          style="text-align: right;" sortBy="#{i.purchaseValue}">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Purchase Value"/>
+                                    </f:facet>
+                                    <h:outputLabel value="#{i.purchaseValue}"  >
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </p:column>
+
+
+                                <p:column headerText="Retail Sale Value"
+                                          styleClass="averageNumericColumn"
+                                          style="text-align: right;" sortBy="#{i.saleValue}">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Sale Value"/>
+                                    </f:facet>
+                                    <h:outputLabel value="#{i.saleValue}"  >
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </p:column>
+                                <p:columnGroup type="footer">
+                                    <p:row>
+                                        <p:column colspan="4" footerText="Total">
+                                            <f:facet name="footer">
+                                                <h:outputLabel value="Total" />
+                                            </f:facet>
+                                        </p:column>
+                                        <p:column style="text-align: right;" footerText="#{reportsStock.stockPurchaseValue}">
+                                            <f:facet name="footer" >
+                                                <h:outputLabel value="#{reportsStock.stockPurchaseValue}" >
+                                                    <f:convertNumber pattern="#,##0.00" />
+                                                </h:outputLabel>
+                                            </f:facet>
+                                        </p:column>
+
+                                        <p:column style="text-align: right;" footerText="#{reportsStock.stockSaleValue}">
+                                            <f:facet name="footer" >
+                                                <h:outputLabel value="#{reportsStock.stockSaleValue}" >
+                                                    <f:convertNumber pattern="#,##0.00" />
+                                                </h:outputLabel>
+                                            </f:facet>
+                                        </p:column>
+                                    </p:row>
+                                </p:columnGroup>
+                            </p:dataTable>
+                        </h:panelGroup>
+                    </p:panel>
+                </h:form>
+
+
+            </ui:define>
+
+
+        </ui:composition>
+
+    </h:body>
+</html>


### PR DESCRIPTION
## Summary
Fixes #23054 — adds a VMP Stock Report (aggregated across AMPs) and renames "Item Stock" to "Item (AMP) Stock" for clarity.

## Decisions made without approval
- **Reused the existing `PharmacyAnalyticsItemStock` privilege** to gate the new report rather than introducing a new privilege — per the hard limit on writing access-control changes unattended, reusing an existing, closely-related privilege (same report family, Stock Reports tab) was the safer substitute. A dedicated privilege can be split out later if wanted.
- **New config key** `'Pharmacy Analytics - Show VMP Stock Report'` (default `true`) — a display toggle following the exact existing pattern for every other report on this page, not an access-control mechanism, so treated as in-scope for an unattended change.
- **Reused `StockReportByItemDTO`** instead of adding a parallel `StockReportByVmpDTO` — identical shape (code/name/qty/purchaseValue/saleValue) at the VMP level.
- **Added a new `PharmacyReports.STOCK_REPORT_BY_VMP` enum constant** so the new report's execution-time tracking doesn't get conflated with Item Stock's — a small, low-risk addition to an existing enum.

## Changes
- `ReportsStock.java`: new `fillDepartmentVmpStocks()` (groups by `item.vmp.code/name`, same filter set as Item Stock, excludes items with no VMP link) + `navigateToVmpStockReport()`.
- New page `pharmacy_report_department_stock_by_vmp_dto.xhtml`, modeled on the Item Stock report, with the #23052 horizontal-scroll fix applied from the start.
- `pharmacy_analytics.xhtml`: renamed "Item Stock" → "Item (AMP) Stock" (label only — `reportKey` unchanged, so no existing user favorites are orphaned); added "VMP Stock Report" directly below it in both the home Stock Reports tab and the Favorites tab, with a new globally-unique `reportKey` confirmed via repo-wide grep first.
- `PharmacyReports.java`: new `STOCK_REPORT_BY_VMP` constant.

## Verification
Local Payara, Main Pharmacy department:
- Confirmed button rename and placement in the Stock Reports tab.
- Ran unfiltered: 920 aggregated VMP rows, grand totals (Purchase 96,113,672.78 / Sale 110,434,469.34) **exactly match** the Item (AMP) Stock report's totals — same stock pool, just re-grouped, a strong sanity check.
- Filtered to "Amoxicillin 250" → exactly one row, Quantity **2,396** — independently cross-checked via raw SQL (`STOCK` → `ITEMBATCH` → `ITEM` AMP → `ITEM` VMP, summed) which also returned 2,396.

See the issue comment for a screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
