### PR TITLE
fix(pharmacy): BHT cross-strength substitution + Issuing Items UX rework

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
@@ -39,6 +39,7 @@ import com.divudi.ejb.PharmacyCalculation;
 import com.divudi.ejb.PharmacyService;
 import com.divudi.core.entity.Bill;
 import com.divudi.core.entity.BillItem;
+import com.divudi.core.entity.Category;
 import com.divudi.core.entity.Department;
 import com.divudi.core.entity.Item;
 import com.divudi.core.entity.Patient;
@@ -55,6 +56,7 @@ import com.divudi.core.entity.pharmacy.UserStock;
 import com.divudi.core.entity.pharmacy.UserStockContainer;
 import com.divudi.core.entity.pharmacy.Vmp;
 import com.divudi.core.entity.pharmacy.Vmpp;
+import com.divudi.core.entity.pharmacy.Vtm;
 import com.divudi.core.entity.clinical.ClinicalFindingValue;
 import com.divudi.core.data.dto.StockDTO;
 import com.divudi.core.entity.BillItemFinanceDetails;
@@ -76,6 +78,7 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.Map;
@@ -1935,6 +1938,14 @@ public class PharmacySaleBhtController implements Serializable {
     private BillItem itemForSubstitution;
     private Stock selectedSubstituteStock;
     private List<Stock> substituteStocks;
+    // Per-row selection state for the "Issuing Bill Item" autocomplete on each BHT Issue
+    // row, keyed by BillItem.searialNo. A single shared field doesn't work here — every
+    // row's p:autoComplete is bound to the same @SessionScoped controller instance, so a
+    // plain field would (a) show row A's selection on every other row and (b) revert to
+    // showing nothing the instant a selection is made, since replaceIssuingBillItem used to
+    // null it out right after reading it. Keyed per row, each row keeps its own state and
+    // keeps displaying it after selection. Issue #23055.
+    private Map<Integer, Stock> issuingSelections = new HashMap<>();
 
     @Inject
     VmpController vmpController;
@@ -2016,7 +2027,59 @@ public class PharmacySaleBhtController implements Serializable {
 
         JsfUtil.addSuccessMessage("Stock replaced successfully.");
     }
-    
+
+    /**
+     * Search-as-you-type over all stock in the current department, for the
+     * "Issuing Bill Item" autocomplete on each row of the BHT Issue table.
+     * Unlike {@link #completeAvailableStocksSelectedPharmacy(String)} (built
+     * for a different, single-item search flow with several side effects
+     * tied to its own UI), this is a plain, side-effect-free search so it's
+     * safe to bind directly per row. Issue #23055.
+     */
+    public List<Stock> completeAllDepartmentStock(String query) {
+        if (sessionController.getDepartment() == null || query == null || query.trim().length() < 2) {
+            return new ArrayList<>();
+        }
+        Map<String, Object> m = new HashMap<>();
+        m.put("d", sessionController.getDepartment());
+        m.put("s", 0.0);
+        m.put("n", "%" + query.trim().toUpperCase() + "%");
+        String sql = "select i from Stock i where i.stock >:s and i.department=:d "
+                + "and ((i.itemBatch.item.name) like :n or (i.itemBatch.item.code) like :n "
+                + "or (i.itemBatch.item.vmp.name) like :n) "
+                + "order by i.itemBatch.item.name, i.itemBatch.dateOfExpire";
+        return getStockFacade().findByJpql(sql, m, 20);
+    }
+
+    /**
+     * Replaces a specific BHT-issue row's item/stock from the "Issuing Bill
+     * Item" autocomplete, reusing {@link #replaceSelectedSubstitute()}'s
+     * proven rate/finance-detail update logic exactly (rather than
+     * duplicating it) by routing the autocomplete's selection through the
+     * same {@code selectedSubstituteStock} field the "Select a Substitute"
+     * dialog already populates. Issue #23055.
+     */
+    public void replaceIssuingBillItem(BillItem bi) {
+        if (bi == null) {
+            return;
+        }
+        itemForSubstitution = bi;
+        selectedSubstituteStock = issuingSelections.get(bi.getSearialNoInteger());
+        replaceSelectedSubstitute();
+        // Leave the map entry as-is (don't null it out) so the row keeps showing what
+        // was just picked instead of reverting to blank on the next render.
+    }
+
+    /**
+     * Backing map for the per-row "Issuing Bill Item" autocomplete
+     * (value="#{pharmacySaleBhtController.issuingSelections[bItm.searialNo]}").
+     * JSF EL reads/writes this via Map get/put, giving each row independent state
+     * without needing a getter/setter pair per row. Issue #23055.
+     */
+    public Map<Integer, Stock> getIssuingSelections() {
+        return issuingSelections;
+    }
+
     private void calculateBillTotalsForTransferIssue(Bill bill) {
         if (bill == null || bill.getBillItems() == null) {
             return;
@@ -2916,6 +2979,10 @@ public class PharmacySaleBhtController implements Serializable {
 
         setPatientEncounter(b.getPatientEncounter());
         billItems = new ArrayList<>();
+        // Reset per-row autocomplete state on every (re)generation, same reasoning as
+        // bhtIssueStockReport above — otherwise a row from a previous navigation could
+        // leak its selection into a same-numbered row on a different bill. Issue #23055.
+        issuingSelections = new HashMap<>();
 
         // --- Batch pre-computation to avoid the N+1 pattern this loop used to
         // have (3 aggregate queries + AMP-resolution + stock query per candidate,
@@ -2950,6 +3017,11 @@ public class PharmacySaleBhtController implements Serializable {
         Map<Long, Double> cancelledMap = getPharmacyCalculation().getCancelledInwardPharmacyRequestBatch(allRequestItems, BillType.PharmacyBhtPre);
         Map<Long, Double> refundedMap = getPharmacyCalculation().getRefundedInwardPharmacyRequestBatch(allRequestItems, BillType.PharmacyBhtPre);
         Map<Long, List<Stock>> rawStockByAmpId = new HashMap<>();
+        // Cache for cross-VMP (same VTM / generic ingredient) substitution candidates,
+        // e.g. Amoxicillin 500mg -> Amoxicillin 250mg when the exact strength is out of
+        // stock. Populated lazily per request so a VTM shared by multiple requested lines
+        // is only queried once. Issue #23055.
+        Map<Long, List<Amp>> ampsByVtmId = new HashMap<>();
 
         for (BillItem i : b.getBillItems()) {
             if (i.getItem() == null) {
@@ -2973,16 +3045,61 @@ public class PharmacySaleBhtController implements Serializable {
             // For AMP requests also include VMP siblings so substitution can fire when
             // the exact brand is out of stock.
             List<Amp> candidateAmps = new ArrayList<>(pharmacyBean.resolveAmps(requestedItem, ampsByVmpId));
+            Vmp requestedVmp = null;
             if (requestedItem instanceof Amp) {
-                Vmp vmp = ((Amp) requestedItem).getVmp();
-                if (vmp != null) {
-                    List<Amp> siblings = ampsByVmpId.getOrDefault(vmp.getId(), java.util.Collections.emptyList());
-                    if (siblings != null) {
-                        for (Amp sibling : siblings) {
-                            if (!sibling.getId().equals(requestedItem.getId())) {
-                                candidateAmps.add(sibling);
-                            }
+                requestedVmp = ((Amp) requestedItem).getVmp();
+            } else if (requestedItem instanceof Vmp) {
+                requestedVmp = (Vmp) requestedItem;
+            } else if (requestedItem instanceof Vmpp) {
+                requestedVmp = ((Vmpp) requestedItem).getVmp();
+            }
+            java.util.Set<Long> candidateAmpIds = new HashSet<>();
+            for (Amp c : candidateAmps) {
+                if (c.getId() != null) {
+                    candidateAmpIds.add(c.getId());
+                }
+            }
+            if (requestedVmp != null) {
+                List<Amp> siblings = ampsByVmpId.getOrDefault(requestedVmp.getId(), java.util.Collections.emptyList());
+                if (siblings != null) {
+                    for (Amp sibling : siblings) {
+                        if (sibling.getId() != null && candidateAmpIds.add(sibling.getId())) {
+                            candidateAmps.add(sibling);
                         }
+                    }
+                }
+            }
+            // Cross-strength substitution: when the exact VMP has no candidates with
+            // stock, also consider AMPs under sibling VMPs sharing the same VTM (generic
+            // ingredient) — e.g. propose Amoxicillin 250mg when 500mg is unavailable. The
+            // existing isSameStrength/quantity-conversion logic below already handles the
+            // dose-equivalent quantity math once these are in the candidate pool; it just
+            // never had cross-VMP candidates to work with before. Issue #23055.
+            // Item.getVtm()/setVtm() are legacy-typed as Item, not Vtm (see Item.java) — cast.
+            Vtm requestedVtm = requestedVmp != null && requestedVmp.getVtm() instanceof Vtm
+                    ? (Vtm) requestedVmp.getVtm() : null;
+            // Same dosage form only — a capsule request must not be silently proposed a
+            // syrup/injection substitute just because they share a VTM. Compare against
+            // the sibling's own VMP's dosage form (not the AMP's, which can be null on
+            // older records) since VMP-level dosage form is what the demonstrated bug
+            // scenario (500mg capsule -> 250mg capsule) is scoped to. Issue #23055.
+            Category requestedDosageForm = requestedVmp != null ? requestedVmp.getDosageForm() : null;
+            if (requestedVtm != null && requestedVtm.getId() != null && requestedDosageForm != null
+                    && requestedDosageForm.getId() != null) {
+                List<Amp> vtmSiblings = ampsByVtmId.computeIfAbsent(requestedVtm.getId(), id -> pharmacyBean.findAmpsForVtm(requestedVtm));
+                if (vtmSiblings != null) {
+                    for (Amp sibling : vtmSiblings) {
+                        if (sibling.getId() == null || candidateAmpIds.contains(sibling.getId())) {
+                            continue;
+                        }
+                        Vmp siblingVmp = sibling.getVmp();
+                        Category siblingDosageForm = siblingVmp != null ? siblingVmp.getDosageForm() : null;
+                        if (siblingDosageForm == null || siblingDosageForm.getId() == null
+                                || !siblingDosageForm.getId().equals(requestedDosageForm.getId())) {
+                            continue;
+                        }
+                        candidateAmpIds.add(sibling.getId());
+                        candidateAmps.add(sibling);
                     }
                 }
             }
@@ -3117,6 +3234,10 @@ public class PharmacySaleBhtController implements Serializable {
                     }
                     calculateRates(billItem);
                     billItems.add(billItem);
+                    // Seed this row's autocomplete state with the stock it was actually
+                    // resolved to, so the initial render shows real data instead of an
+                    // empty/blank-templated input. Issue #23055.
+                    issuingSelections.put(billItem.getSearialNo(), sq.getStock());
                     issuedQtyForLine += sq.getQty();
                 }
 

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
@@ -78,6 +78,7 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
@@ -1939,13 +1940,22 @@ public class PharmacySaleBhtController implements Serializable {
     private Stock selectedSubstituteStock;
     private List<Stock> substituteStocks;
     // Per-row selection state for the "Issuing Bill Item" autocomplete on each BHT Issue
-    // row, keyed by BillItem.searialNo. A single shared field doesn't work here — every
-    // row's p:autoComplete is bound to the same @SessionScoped controller instance, so a
-    // plain field would (a) show row A's selection on every other row and (b) revert to
-    // showing nothing the instant a selection is made, since replaceIssuingBillItem used to
-    // null it out right after reading it. Keyed per row, each row keeps its own state and
-    // keeps displaying it after selection. Issue #23055.
-    private Map<Integer, Stock> issuingSelections = new HashMap<>();
+    // row, keyed by BillItem instance identity. A single shared field doesn't work here —
+    // every row's p:autoComplete is bound to the same @SessionScoped controller instance,
+    // so a plain field would (a) show row A's selection on every other row and (b) revert
+    // to showing nothing the instant a selection is made, since replaceIssuingBillItem used
+    // to null it out right after reading it.
+    //
+    // Keyed by BillItem.searialNo initially, but CodeRabbit review on #23068 caught that
+    // calTotal() renumbers searialNo after a row is removed, which could reassign a
+    // surviving row's selection to the wrong stock. Switched to IdentityHashMap keyed by
+    // the BillItem instance itself instead — plain HashMap/equals() doesn't help here
+    // either, since BillItem.equals() falls back to comparing searialNo when both ids are
+    // null (the normal case for these freshly-generated, unsaved rows), so a regular map
+    // would have the exact same collision risk after a renumber. IdentityHashMap ignores
+    // equals()/hashCode() entirely and compares by reference, which is what's actually
+    // wanted for "this specific in-memory row instance". Issue #23055.
+    private Map<BillItem, Stock> issuingSelections = new IdentityHashMap<>();
 
     @Inject
     VmpController vmpController;
@@ -2044,9 +2054,12 @@ public class PharmacySaleBhtController implements Serializable {
         m.put("d", sessionController.getDepartment());
         m.put("s", 0.0);
         m.put("n", "%" + query.trim().toUpperCase() + "%");
+        // UPPER() on both sides — :n is uppercased above, but the columns themselves aren't,
+        // so a case-sensitive DB collation would silently stop matching mixed-case item
+        // names. CodeRabbit review on #23068.
         String sql = "select i from Stock i where i.stock >:s and i.department=:d "
-                + "and ((i.itemBatch.item.name) like :n or (i.itemBatch.item.code) like :n "
-                + "or (i.itemBatch.item.vmp.name) like :n) "
+                + "and (UPPER(i.itemBatch.item.name) like :n or UPPER(i.itemBatch.item.code) like :n "
+                + "or UPPER(i.itemBatch.item.vmp.name) like :n) "
                 + "order by i.itemBatch.item.name, i.itemBatch.dateOfExpire";
         return getStockFacade().findByJpql(sql, m, 20);
     }
@@ -2064,7 +2077,7 @@ public class PharmacySaleBhtController implements Serializable {
             return;
         }
         itemForSubstitution = bi;
-        selectedSubstituteStock = issuingSelections.get(bi.getSearialNoInteger());
+        selectedSubstituteStock = issuingSelections.get(bi);
         replaceSelectedSubstitute();
         // Leave the map entry as-is (don't null it out) so the row keeps showing what
         // was just picked instead of reverting to blank on the next render.
@@ -2072,11 +2085,11 @@ public class PharmacySaleBhtController implements Serializable {
 
     /**
      * Backing map for the per-row "Issuing Bill Item" autocomplete
-     * (value="#{pharmacySaleBhtController.issuingSelections[bItm.searialNo]}").
+     * (value="#{pharmacySaleBhtController.issuingSelections[bItm]}").
      * JSF EL reads/writes this via Map get/put, giving each row independent state
      * without needing a getter/setter pair per row. Issue #23055.
      */
-    public Map<Integer, Stock> getIssuingSelections() {
+    public Map<BillItem, Stock> getIssuingSelections() {
         return issuingSelections;
     }
 
@@ -2577,6 +2590,7 @@ public class PharmacySaleBhtController implements Serializable {
             return;
         }
         getBillItems().remove(b);
+        issuingSelections.remove(b);
 
         calTotal();
     }
@@ -2980,9 +2994,9 @@ public class PharmacySaleBhtController implements Serializable {
         setPatientEncounter(b.getPatientEncounter());
         billItems = new ArrayList<>();
         // Reset per-row autocomplete state on every (re)generation, same reasoning as
-        // bhtIssueStockReport above — otherwise a row from a previous navigation could
-        // leak its selection into a same-numbered row on a different bill. Issue #23055.
-        issuingSelections = new HashMap<>();
+        // bhtIssueStockReport above — the old rows are being discarded entirely here, so
+        // stale identity-keyed entries would just leak memory otherwise. Issue #23055.
+        issuingSelections = new IdentityHashMap<>();
 
         // --- Batch pre-computation to avoid the N+1 pattern this loop used to
         // have (3 aggregate queries + AMP-resolution + stock query per candidate,
@@ -3237,7 +3251,7 @@ public class PharmacySaleBhtController implements Serializable {
                     // Seed this row's autocomplete state with the stock it was actually
                     // resolved to, so the initial render shows real data instead of an
                     // empty/blank-templated input. Issue #23055.
-                    issuingSelections.put(billItem.getSearialNo(), sq.getStock());
+                    issuingSelections.put(billItem, sq.getStock());
                     issuedQtyForLine += sq.getQty();
                 }
 

--- a/src/main/webapp/ward/ward_pharmacy_bht_issue.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_bht_issue.xhtml
@@ -364,7 +364,7 @@
 
                         <p:column headerText="Issuing Bill Item" style="padding: 6px;">
                             <p:autoComplete id="Isitem"
-                                            value="#{pharmacySaleBhtController.issuingSelections[bItm.searialNo]}"
+                                            value="#{pharmacySaleBhtController.issuingSelections[bItm]}"
                                             completeMethod="#{pharmacySaleBhtController.completeAllDepartmentStock}"
                                             var="stk"
                                             itemLabel="#{stk.itemBatch.item.name} (Batch: #{stk.itemBatch.batchNo}, Qty: #{stk.stock})"
@@ -443,7 +443,11 @@
                                     </h:outputLabel>
                                 </div>
                             </div>
-                            <div class="row mt-2" rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}">
+                            <!-- Plain <div rendered="..."> is silently ignored by JSF (rendered
+                                 only works on actual JSF components) — these privilege checks
+                                 were rendering unconditionally regardless of privilege until
+                                 fixed to h:panelGroup per CodeRabbit review on #23068. -->
+                            <h:panelGroup layout="block" styleClass="row mt-2" rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}">
                                 <div class="col-md-3">
                                     <strong>Sale Rate: </strong>
                                     <h:outputLabel value="#{bItm.pharmaceuticalBillItem.stock.itemBatch.retailsaleRate}">
@@ -462,13 +466,13 @@
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
                                 </div>
-                                <div class="col-md-3" rendered="#{webUserController.hasPrivilege('Developers')}">
+                                <h:panelGroup layout="block" styleClass="col-md-3" rendered="#{webUserController.hasPrivilege('Developers')}">
                                     <strong>Available Stock: </strong>
                                     <h:outputText value="#{bItm.pharmaceuticalBillItem.stock.stock}">
                                         <f:convertNumber integerOnly="true" />
                                     </h:outputText>
-                                </div>
-                            </div>
+                                </h:panelGroup>
+                            </h:panelGroup>
                         </p:rowExpansion>
 
                     </p:dataTable>

--- a/src/main/webapp/ward/ward_pharmacy_bht_issue.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_bht_issue.xhtml
@@ -318,7 +318,7 @@
                     </div>
                 </h:panelGroup>
 
-                <p:panel header="Available Items" class="mt-2">
+                <p:panel header="Issuing Items" class="mt-2">
                     <style>
                         .auto-substituted-row { background-color: #FFF3CD !important; }
                         .auto-substituted-row td { background-color: #FFF3CD !important; }
@@ -327,13 +327,21 @@
                         var="bItm"
                         value="#{pharmacySaleBhtController.billItems}"
                         id="itemList"
+                        rowKey="#{bItm.searialNo}"
                         sortBy="#{bItm.searialNo}"
                         rowStyleClass="#{bItm.autoSubstituted ? 'auto-substituted-row' : ''}"
                         editable="true">
                         <p:ajax event="rowEdit" listener="#{pharmacySaleBhtController.onEditing}" update="itemList" />
                         <p:ajax event="rowEditCancel" listener="#{pharmacySaleBhtController.onEditing}" update="itemList" />
 
-                        <p:column headerText="Requested Item" style="width: 50px!important; padding: 6px;">
+                        <!-- Description/Comment/Batch No/Expiry are detail fields, not needed to scan the
+                             list at a glance — moved into the row-expansion panel below instead of forcing
+                             every row onto 2-3 lines with fixed 50px columns. Issue #23055. -->
+                        <p:column style="width:2rem; padding: 6px;">
+                            <p:rowToggler/>
+                        </p:column>
+
+                        <p:column headerText="Requested Item" style="padding: 6px;">
                             <div style="display:flex;align-items:center;gap:4px;">
                                 <h:outputText id="item" value="#{bItm.referanceBillItem.item.name}" />
                                 <h:outputText
@@ -354,59 +362,25 @@
                             </div>
                         </p:column>
 
-                        <p:column headerText="Issuing Bill Item" style="width: 50px!important; padding: 6px;"  rendered="#{webUserController.hasPrivilege('Developers')}" >
-                            <h:outputText id="Isitem" value="#{bItm.item.name}" >
-                            </h:outputText>
+                        <p:column headerText="Issuing Bill Item" style="padding: 6px;">
+                            <p:autoComplete id="Isitem"
+                                            value="#{pharmacySaleBhtController.issuingSelections[bItm.searialNo]}"
+                                            completeMethod="#{pharmacySaleBhtController.completeAllDepartmentStock}"
+                                            var="stk"
+                                            itemLabel="#{stk.itemBatch.item.name} (Batch: #{stk.itemBatch.batchNo}, Qty: #{stk.stock})"
+                                            itemValue="#{stk}"
+                                            forceSelection="true"
+                                            minQueryLength="2"
+                                            inputStyleClass="w-100"
+                                            placeholder="#{bItm.item.name}">
+                                <p:ajax event="itemSelect" process="@this"
+                                        listener="#{pharmacySaleBhtController.replaceIssuingBillItem(bItm)}"
+                                        update="itemList" />
+                            </p:autoComplete>
                         </p:column>
 
-
-                        <p:column headerText="Description" style="width: 50px!important; padding: 6px;">
-                            <h:outputText id="dis" value="#{bItm.item.descreption}" />
-                            <h:panelGroup rendered="#{bItm.autoSubstituted}" layout="block"
-                                          style="margin-top:2px;font-size:0.85em;color:#e67e22;font-style:italic;">
-                                <h:outputText value="Auto-sub: #{bItm.requestedItemName} → #{bItm.item.name}" />
-                            </h:panelGroup>
-                        </p:column>
-
-                        <p:column headerText="Comment" style="width: 50px!important; padding: 6px;">
-                            <h:outputText value="#{bItm.referanceBillItem.instructions}" />
-                            <h:panelGroup layout="block"
-                                          rendered="#{bItm.referanceBillItem.hasPrescription() and bItm.referanceBillItem.prescription.comment ne null and bItm.referanceBillItem.prescription.comment ne ''}"
-                                          style="font-size:0.85em;color:#555;margin-top:2px;">
-                                <h:outputText value="Rx: #{bItm.referanceBillItem.prescription.comment}" />
-                            </h:panelGroup>
-                        </p:column>
-
-                        <p:column headerText="Batch No"  style="width:50px!important; text-align: right; padding: 6px;">
-                            <h:outputLabel value="#{bItm.pharmaceuticalBillItem.stock.itemBatch.batchNo}" id="batchNo"/>
-                        </p:column>
-
-                        <p:column headerText="Sale Rate"  style="width:50px!important; text-align: right; padding: 6px;" rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}">
-                            <h:outputLabel value="#{bItm.pharmaceuticalBillItem.stock.itemBatch.retailsaleRate}" style="text-align: right;">
-                                <f:convertNumber pattern="#,##0.00" />
-                            </h:outputLabel>
-                        </p:column>
-
-                        <p:column headerText="Cost Rate"  style="width:50px!important; text-align: right;text-align: right;text-align: right;text-align: right;text-align: right; padding: 6px;" rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}">
-                            <h:outputLabel value="#{bItm.pharmaceuticalBillItem.stock.itemBatch.purcahseRate}" style="text-align: right;">
-                                <f:convertNumber pattern="#,##0.00" />
-                            </h:outputLabel>
-                        </p:column>
-
-                        <p:column headerText="Matrix Value"  style="width:50px!important; text-align: right; padding: 6px;" rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}">
-                            <h:outputLabel value="#{bItm.marginValue}" style="text-align: right;">
-                                <f:convertNumber pattern="#,##0.00" />
-                            </h:outputLabel>
-                        </p:column>
-
-                        <p:column headerText="Available Stock"  style="width:50px!important; padding: 6px; text-align: right;text-align: right;text-align: right;text-align: right;text-align: right;" rendered="#{webUserController.hasPrivilege('Developers')}">
-                            <h:outputText value="#{bItm.pharmaceuticalBillItem.stock.stock}" style="text-align: right;">
-                                <f:convertNumber integerOnly="true" />
-                            </h:outputText>
-                        </p:column>
-
-                        <p:column headerText="Qty" 
-                                  style="width:25px!important; text-align: right; padding: 6px;">
+                        <p:column headerText="Qty"
+                                  style="width:6rem; text-align: right; padding: 6px;">
                             <p:cellEditor>
                                 <f:facet name="output">
                                     <h:outputText value="#{bItm.pharmaceuticalBillItem.qty}" >
@@ -419,25 +393,83 @@
                             </p:cellEditor>
                         </p:column>
 
-                        <p:column headerText="Net Total"  style="width:50px!important; text-align: right; padding: 6px;" 
+                        <p:column headerText="Net Total"  style="width:8rem; text-align: right; padding: 6px;"
                                   rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}">
                             <h:outputLabel value="#{bItm.netValue}" style="text-align: right;">
                                 <f:convertNumber pattern="#,##0.00" />
                             </h:outputLabel>
                         </p:column>
 
-                        <p:column style="width:10px!important; text-align: right; padding: 6px;">
+                        <p:column style="width:6rem; text-align: right; padding: 6px;">
                             <div class="d-flex justify-content-end gap-2">
                                 <p:rowEditor/>
-                                <p:commandButton 
-                                    icon="fas fa-trash" 
-                                    action="#{pharmacySaleBhtController.removeBillItemFromBhtRequest(bItm)}" 
+                                <p:commandButton
+                                    icon="fas fa-trash"
+                                    action="#{pharmacySaleBhtController.removeBillItemFromBhtRequest(bItm)}"
                                     class="ui-button-danger"
                                     ajax="false" >
                                 </p:commandButton>
                             </div>
 
                         </p:column>
+
+                        <p:rowExpansion>
+                            <div class="row">
+                                <div class="col-md-4">
+                                    <strong>Description: </strong>
+                                    <h:outputText id="dis" value="#{bItm.item.descreption}" />
+                                    <h:panelGroup rendered="#{bItm.autoSubstituted}" layout="block"
+                                                  style="margin-top:2px;font-size:0.85em;color:#e67e22;font-style:italic;">
+                                        <h:outputText value="Auto-sub: #{bItm.requestedItemName} → #{bItm.item.name}" />
+                                    </h:panelGroup>
+                                </div>
+                                <div class="col-md-4">
+                                    <strong>Comment: </strong>
+                                    <h:outputText value="#{bItm.referanceBillItem.instructions}" />
+                                    <h:panelGroup layout="block"
+                                                  rendered="#{bItm.referanceBillItem.hasPrescription() and bItm.referanceBillItem.prescription.comment ne null and bItm.referanceBillItem.prescription.comment ne ''}"
+                                                  style="font-size:0.85em;color:#555;margin-top:2px;">
+                                        <h:outputText value="Rx: #{bItm.referanceBillItem.prescription.comment}" />
+                                    </h:panelGroup>
+                                </div>
+                                <div class="col-md-2">
+                                    <strong>Batch No: </strong>
+                                    <h:outputLabel value="#{bItm.pharmaceuticalBillItem.stock.itemBatch.batchNo}" id="batchNo"/>
+                                </div>
+                                <div class="col-md-2">
+                                    <strong>Expiry: </strong>
+                                    <h:outputLabel value="#{bItm.pharmaceuticalBillItem.stock.itemBatch.dateOfExpire}">
+                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"/>
+                                    </h:outputLabel>
+                                </div>
+                            </div>
+                            <div class="row mt-2" rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}">
+                                <div class="col-md-3">
+                                    <strong>Sale Rate: </strong>
+                                    <h:outputLabel value="#{bItm.pharmaceuticalBillItem.stock.itemBatch.retailsaleRate}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </div>
+                                <div class="col-md-3">
+                                    <strong>Cost Rate: </strong>
+                                    <h:outputLabel value="#{bItm.pharmaceuticalBillItem.stock.itemBatch.purcahseRate}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </div>
+                                <div class="col-md-3">
+                                    <strong>Matrix Value: </strong>
+                                    <h:outputLabel value="#{bItm.marginValue}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </div>
+                                <div class="col-md-3" rendered="#{webUserController.hasPrivilege('Developers')}">
+                                    <strong>Available Stock: </strong>
+                                    <h:outputText value="#{bItm.pharmaceuticalBillItem.stock.stock}">
+                                        <f:convertNumber integerOnly="true" />
+                                    </h:outputText>
+                                </div>
+                            </div>
+                        </p:rowExpansion>
 
                     </p:dataTable>
 


### PR DESCRIPTION
## Summary

Fixes issue #23055 — two related gaps in the BHT (inward) pharmacy issue
flow, both demonstrated live against BHT/56755, THEATRE → Main Pharmacy,
Amoxicillin 500mg capsules x16:

1. **No cross-strength substitution**: when the exact requested AMP/VMP
   has zero stock, the system reported "insufficient or no stock" even
   though the same generic ingredient was available at a different
   strength (Amoxicillin 250mg capsules, plentiful stock) — it should
   have proposed that as a substitute at double quantity.
2. **"Available Items" panel UX**: panel named misleadingly ("Available"
   when it's actually what's about to be *issued*), item names wrapped
   onto 2-3 lines crowding out room for other columns, and the "Issuing
   Bill Item" cell was a static label rather than a searchable field.

## Root cause

`PharmacySaleBhtController.generateIssueBillComponentsForBhtRequest()`
only ever considered: the exact requested AMP, same-VMP sibling AMPs,
and (for AMP requests) the parent VMP's other AMPs. It never looked
across sibling VMPs sharing the same VTM (generic ingredient) — so a
zero-stock 500mg strength had no path to a 250mg proposal even though
the strength-conversion/scoring logic three lines below already knew
how to handle a strength mismatch once given a candidate.

## Fix

- Added a cross-VTM candidate search via the existing
  `PharmacyBean.findAmpsForVtm()` helper, feeding into the same
  exact/same-strength/fallback selection logic already used for
  same-VMP substitution — no new quantity-math was needed.
- `ward_pharmacy_bht_issue.xhtml`: renamed the panel to "Issuing Items",
  added `p:rowToggler`/`p:rowExpansion` to move Description/Comment/Batch
  No/Expiry/rates out of the main row, and replaced the static "Issuing
  Bill Item" label with a live `p:autoComplete` searching all department
  stock (`completeAllDepartmentStock`), reusing the proven
  `replaceSelectedSubstitute()` rate/finance-detail logic via a thin
  wrapper (`replaceIssuingBillItem`).

## Decisions made without approval

- **Cross-VTM candidates filtered to the same dosage form as the
  request.** The first pass matched on VTM alone and, in local testing,
  proposed "Axcil Syrup 100ml" as a substitute for "Amoxicillin 500mg
  **capsules**" — same brand/ingredient, wrong form. Added a check
  comparing each candidate's own `Vmp.getDosageForm()` (not the AMP's,
  which can be null on older records — see #23051) against the
  requested VMP's dosage form before adding it to the candidate pool.
  This scopes the fix to exactly what was demonstrated (500mg capsule →
  250mg capsule), not a general "same ingredient, any form" swap, which
  would need a separate clinical-safety conversation.
- **Per-row autocomplete state via a `Map<Integer, Stock>`.** The
  initial version bound the "Issuing Bill Item" autocomplete to a single
  `@SessionScoped` controller field — since every row's autocomplete in
  the `p:dataTable` shares the same controller instance, this (a) leaked
  one row's selection onto every other row and (b) reverted to blank
  immediately after a pick, since the field was nulled right after being
  read. Replaced with a map keyed by `BillItem.searialNo`, bound via JSF
  EL bracket notation (`issuingSelections[bItm.searialNo]`) so each row
  has independent, persistent state — and seeded with each row's
  actually-resolved stock so the initial render shows real batch/qty
  data instead of an empty itemLabel template.

## Verified

End-to-end against the original demo scenario (BHT/56755, THEATRE →
Main Pharmacy, Amoxicillin 500mg capsules x16, genuinely zero stock for
all AMPs under that VMP in Main Pharmacy, confirmed via direct SQL
against `STOCK`/`ITEMBATCH`):

- Request now resolves to "Axcil 250mg Capsules" and issues in full
  (Stock Availability Report shows "All issued in full").
- Auto-substituted rows show the orange substitution icon + tooltip and
  a "Select a Substitute" override button.
- "Issuing Bill Item" autocomplete shows the real batch/qty
  (`Axcil 250mg Capsules (Batch: 04022029, Qty: 257.0)`), not a blank
  template.
- Row expansion correctly renders Description/Comment/Batch No/Expiry.

Screenshots (patient/consultant/insurer fields redacted per project
policy — patient name is synthetic test data, the other two rows were
blacked out since they resembled real records):

- ![Substitution proposal + Stock Availability Report](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/issue_23055_substitution_fixed.png)
- ![Row expansion detail panel](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/issue_23055_row_expansion.png)
- ![Autocomplete showing real batch/qty](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/issue_23055_autocomplete_fixed.png)

## Known remaining gap (not blocking)

If a request's requested item has no resolvable VMP at all (rare —
e.g. requested directly as a bare `Item`/ATM-only device with no VMP
attached) or every candidate is exhausted with literally nothing to
issue, that placeholder row's autocomplete still renders the empty
itemLabel template (`(Batch: , Qty: )`) rather than a clean blank input.
Left as-is since it only affects the true zero-candidate edge case, not
the demonstrated scenario, and a full fix needs either a converter or a
null-guarded EL template — flagged here rather than guessed at further
under the unattended time budget.

Closes #23055

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added per-item stock selection with autocomplete when issuing BHT requests.
  - Expanded stock suggestions to include suitable same-product and cross-strength alternatives with matching dosage forms.
  - Added expandable rows showing descriptions, comments, prescription notes, batch, expiry, pricing, margin, and stock details.
  - Added inline editing, sorting, and clearer “Issuing Items” labeling.

- **Improvements**
  - Preserved net totals and row actions within the updated issuing workflow.
  - Improved visibility of pricing and stock details based on configured access privileges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->