### PR TITLE
fix(pharmacy): Detailed Transfer Listing nets cancellations to zero regardless of stored sign

### DIFF
--- a/src/main/java/com/divudi/core/data/dto/PharmacyTransferIssueBillItemDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/PharmacyTransferIssueBillItemDTO.java
@@ -80,21 +80,22 @@ public class PharmacyTransferIssueBillItemDTO implements Serializable {
                                             Double purchaseRate, java.math.BigDecimal purchaseValue,
                                             java.math.BigDecimal transferRate, java.math.BigDecimal transferValue) {
         this.billClassSimpleName = extractSimpleClassName(billClass);
+        boolean isCancellation = "CancelledBill".equals(this.billClassSimpleName);
         this.deptId = deptId;
         this.createdAt = createdAt;
         this.itemName = itemName;
         this.itemCode = itemCode;
         this.qty = qty;
         this.costRate = costRate;
-        this.costValue = costValue != null ? costValue.doubleValue() : null;
+        this.costValue = normalizeStockValuationSign(costValue, isCancellation);
         this.retailRate = retailRate;
-        this.retailValue = retailValue != null ? retailValue.doubleValue() : null;
+        this.retailValue = normalizeStockValuationSign(retailValue, isCancellation);
         this.purchaseRate = purchaseRate;
-        this.purchaseValue = purchaseValue != null ? purchaseValue.doubleValue() : null;
+        this.purchaseValue = normalizeStockValuationSign(purchaseValue, isCancellation);
         this.transferRate = transferRate != null ? transferRate.doubleValue() : null;
         this.transferValue = transferValue != null ? transferValue.doubleValue() : null;
     }
-    
+
     public PharmacyTransferIssueBillItemDTO(
             Object billClass,
             Long billId,
@@ -113,6 +114,7 @@ public class PharmacyTransferIssueBillItemDTO implements Serializable {
             java.math.BigDecimal transferValue) {
 
         this.billClassSimpleName = extractSimpleClassName(billClass);
+        boolean isCancellation = "CancelledBill".equals(this.billClassSimpleName);
         this.billId = billId;
         this.deptId = deptId;
         this.createdAt = createdAt;
@@ -120,13 +122,11 @@ public class PharmacyTransferIssueBillItemDTO implements Serializable {
         this.itemCode = itemCode;
         this.qty = qty;
         this.costRate = costRate;
-        this.costValue = costValue != null ? costValue.doubleValue() : null;
+        this.costValue = normalizeStockValuationSign(costValue, isCancellation);
         this.retailRate = retailRate;
-        this.retailValue = retailValue != null
-                ? retailValue.doubleValue() : null;
+        this.retailValue = normalizeStockValuationSign(retailValue, isCancellation);
         this.purchaseRate = purchaseRate;
-        this.purchaseValue = purchaseValue != null
-                ? purchaseValue.doubleValue() : null;
+        this.purchaseValue = normalizeStockValuationSign(purchaseValue, isCancellation);
         this.transferRate = transferRate != null
                 ? transferRate.doubleValue() : null;
         this.transferValue = transferValue != null
@@ -247,6 +247,24 @@ public class PharmacyTransferIssueBillItemDTO implements Serializable {
      
     public void setBillId(Long billId) {
         this.billId = billId;
+    }
+
+    /**
+     * Normalizes inventory-valuation sign for display regardless of what's actually
+     * persisted in BillItemFinanceDetails. Some historical data (issue #21438) has
+     * valueAtCostRate/valueAtPurchaseRate/valueAtRetailRate stored with the wrong sign
+     * for bills created via TransferIssueForRequestsController (~Dec 2025 onward);
+     * rather than trusting the stored sign or correcting historical data, this derives
+     * the correct sign from the documented convention at report time: original issues
+     * are NEGATIVE (stock-out reduces inventory value), cancellations are POSITIVE
+     * (stock returns). Magnitude is always preserved.
+     */
+    private static Double normalizeStockValuationSign(java.math.BigDecimal value, boolean isCancellation) {
+        if (value == null) {
+            return null;
+        }
+        double abs = Math.abs(value.doubleValue());
+        return isCancellation ? abs : -abs;
     }
 
     private String extractSimpleClassName(Object billClass) {


### PR DESCRIPTION
## What this fixes

Closes #21438. QA reported that after cancelling a Pharmacy Transfer Issue, the
**Detailed Transfer Listing** report (`pharmacy_report_transfer_issue_bill_item.xhtml`)
still *adds* the cancellation's Cost/Retail/Purchase Value instead of netting it to
zero, even though PR #22565 (merged 2026-07-30) already fixed this symptom for the
**Direct Issue** creation flow.

### Root cause

QA's repro actually went through a *second, different* creation flow — "Issue against
a Transfer Request" (`TransferIssueForRequestsController`, `BillTypeAtomic.PHARMACY_ISSUE`)
— not Direct Issue. That flow has been storing
`BillItemFinanceDetails.valueAtCostRate` / `valueAtPurchaseRate` / `valueAtRetailRate`
with the **wrong (positive) sign** since ~Dec 2025, in violation of the documented
negative-for-stock-out convention
(`developer_docs/pharmacy/cost-accounting-sign-conventions.md`). Because
`TransferIssueCancellationController` hardcodes the cancellation reversal assuming the
original is always negative, any bill from this flow gets a cancellation that's *also*
positive — so it adds instead of offsetting.

Confirmed via read-only queries against local `coop`, live coop-prod, and live
ruhunu-prod: this sign issue affects **every** "Issue against Request" bill created
since ~Dec 2025 (thousands of bill-items across at least two hospital deployments),
not just cancellations.

### Fix (deliberately scoped — see discussion below)

Rather than touching the write path or migrating historical data, this PR normalizes
the sign **at report-read time** in `PharmacyTransferIssueBillItemDTO`: original-issue
rows are forced negative, cancellation rows are forced positive, using the same
`TYPE(b)`-derived `billClassSimpleName` the report already selects for row styling
(`CancelledBill` vs everything else). Magnitude is always preserved.

- No-op for already-correctly-signed data (Direct Issue path) — negating a negative
  and re-abs'ing is idempotent.
- Fixes every wrongly-signed historical or future row immediately on deploy.
- Zero changes to any write path, any other table, or any other report.
- `PharmacyTransferIssueBillItemDTO` is used by exactly one query
  (`ReportsTransfer.fillDepartmentTransfersIssueByBillItemDto()`), so the change is
  fully scoped to this one report.

A follow-up issue will be filed separately for the creation-side regression in
`TransferIssueForRequestsController` (the actual source of the wrong-signed data) —
intentionally **not** addressed in this PR.

## Verification (local coop DB, Playwright)

1. Created a Transfer Request: OPD Pharmacy → Main Pharmacy (Amoxicillin 250mg, qty 10),
   finalized and approved (maker-checker, within OPD Pharmacy).
2. Issued against the request as Main Pharmacy: bill `TI/COOP/26/000401`
   (Cost Value 40.00, Retail Value 60.00) — via the request-based Issue flow, the one
   that was broken.
3. Report before cancellation: totals 154.54 / 212.80 (includes one unrelated
   pre-existing bill contributing 114.54 / 152.80).
4. Cancelled the issue via `pharmacy_reprint_transfer_isssue.xhtml` → `pharmacy_transfer_issue_cancel.xhtml`
   (cancellation bill `MPPHTICAN/4`).
5. Report after cancellation: totals dropped to **114.54 / 152.80** — exactly the
   unrelated bill's values. Our issue+cancellation pair netted to **zero**.
6. DB spot-check: `BILLITEMFINANCEDETAILS.VALUEATCOSTRATE` for both `TI/COOP/26/000401`
   and `MPPHTICAN/4` is still **positive** (unchanged) — confirming the fix is
   display-only, not a data mutation.

## Not in scope for this PR

- Correcting historical wrongly-signed data in any environment (discussed and
  explicitly deferred by the reporter).
- Fixing the creation-side regression in `TransferIssueForRequestsController` (tracked
  separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected valuation signs for pharmacy transfer issue and cancellation bills.
  * Preserved null values and valuation magnitudes while ensuring consistent cost, retail, and purchase amounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->