### PR TITLE
21974 Channel Session Report Does Not Display Room Number in "Room No" Column

### DIFF
--- a/src/main/java/com/divudi/bean/channel/ChannelReportController.java
+++ b/src/main/java/com/divudi/bean/channel/ChannelReportController.java
@@ -1294,8 +1294,6 @@ public class ChannelReportController implements Serializable {
         for (SessionInstance s : sessioninstances) {
             if (s.isCancelled()) {
                 canceledSessionInstances.add(s);
-            }else{
-            channelService.fillBillSessionsAndUpdateBookingsCountInSessionInstance(s);
             }
         }
 

--- a/src/main/java/com/divudi/bean/channel/ChannelReportController.java
+++ b/src/main/java/com/divudi/bean/channel/ChannelReportController.java
@@ -1294,6 +1294,8 @@ public class ChannelReportController implements Serializable {
         for (SessionInstance s : sessioninstances) {
             if (s.isCancelled()) {
                 canceledSessionInstances.add(s);
+            }else{
+            channelService.fillBillSessionsAndUpdateBookingsCountInSessionInstance(s);
             }
         }
 

--- a/src/main/webapp/channel/doctor_card.xhtml
+++ b/src/main/webapp/channel/doctor_card.xhtml
@@ -126,11 +126,11 @@
                                 </p:outputLabel>
                             </p:column>
                             <p:column style="padding: 6px">
-                                <f:facet name="header" >
-                                    <p:outputLabel value="Room No" />
-                                    0   </f:facet>
-
-                            </p:column>
+                               <f:facet name="header" >
+                                  <p:outputLabel value="Room No" />
+                              </f:facet>
+                              <p:outputLabel value="#{i.roomNo}" />
+                           </p:column>
                         </p:dataTable>
                     </p:panel>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Doctor card reports now display the correct room number without an extraneous value.
  * Session information and booking counts are updated more accurately for active channel appointments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->