### PR TITLE
hotfix(pharmacy): tendered/balance cash-only + Total Stock in retail sale autocomplete

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController.java
@@ -1135,7 +1135,9 @@ public class RetailSaleNativeSqlController implements Serializable, ControllerWi
         StringBuilder sql = new StringBuilder(
                 "SELECT NEW com.divudi.core.data.dto.StockDTO("
                 + "i.id, i.itemBatch.id, i.itemBatch.item.id, i.itemBatch.item.name, i.itemBatch.item.code, "
-                + "i.itemBatch.item.name, i.itemBatch.retailsaleRate, i.stock, i.itemBatch.dateOfExpire) "
+                + "i.itemBatch.item.name, i.itemBatch.retailsaleRate, i.stock, i.itemBatch.dateOfExpire, "
+                + "(SELECT COALESCE(SUM(s2.stock), 0.0) FROM Stock s2 "
+                + "WHERE s2.itemBatch.item = i.itemBatch.item AND s2.department = i.department AND s2.stock > :stockMin)) "
                 + "FROM Stock i "
                 + "WHERE i.stock > :stockMin "
                 + "AND i.department = :department "

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController.java
@@ -1154,8 +1154,16 @@ public class RetailSaleNativeSqlController implements Serializable, ControllerWi
         }
         sql.append(") ORDER BY i.itemBatch.item.name, i.itemBatch.dateOfExpire");
 
+        int maxResults = 20; // fallback default
+        try {
+            maxResults = configOptionApplicationController.getIntegerValueByKey(
+                    "RetailSaleStockAutocompleteMaxResults", 20);
+        } catch (Exception e) {
+            // Use fallback default
+        }
+
         lastAutocompleteResults = (List<StockDTO>) stockFacade.findLightsByJpql(
-                sql.toString(), parameters, TemporalType.TIMESTAMP, 30);
+                sql.toString(), parameters, TemporalType.TIMESTAMP, maxResults);
         return lastAutocompleteResults != null ? lastAutocompleteResults : new ArrayList<>();
     }
 

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController.java
@@ -1157,7 +1157,7 @@ public class RetailSaleNativeSqlController implements Serializable, ControllerWi
         int maxResults = 20; // fallback default
         try {
             maxResults = configOptionApplicationController.getIntegerValueByKey(
-                    "RetailSaleStockAutocompleteMaxResults", 20);
+                    "Pharmacy Retail Sale - Medicine Autocomplete Max Results", 20);
         } catch (Exception e) {
             // Use fallback default
         }

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController.java
@@ -1155,7 +1155,7 @@ public class RetailSaleNativeSqlController implements Serializable, ControllerWi
         sql.append(") ORDER BY i.itemBatch.item.name, i.itemBatch.dateOfExpire");
 
         lastAutocompleteResults = (List<StockDTO>) stockFacade.findLightsByJpql(
-                sql.toString(), parameters, TemporalType.TIMESTAMP, 20);
+                sql.toString(), parameters, TemporalType.TIMESTAMP, 30);
         return lastAutocompleteResults != null ? lastAutocompleteResults : new ArrayList<>();
     }
 

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController1.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController1.java
@@ -1146,7 +1146,7 @@ public class RetailSaleNativeSqlController1 implements Serializable, ControllerW
         sql.append(") ORDER BY i.itemBatch.item.name, i.itemBatch.dateOfExpire");
 
         lastAutocompleteResults = (List<StockDTO>) stockFacade.findLightsByJpql(
-                sql.toString(), parameters, TemporalType.TIMESTAMP, 20);
+                sql.toString(), parameters, TemporalType.TIMESTAMP, 30);
         return lastAutocompleteResults != null ? lastAutocompleteResults : new ArrayList<>();
     }
 

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController1.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController1.java
@@ -1148,7 +1148,7 @@ public class RetailSaleNativeSqlController1 implements Serializable, ControllerW
         int maxResults = 20; // fallback default
         try {
             maxResults = configOptionApplicationController.getIntegerValueByKey(
-                    "RetailSaleStockAutocompleteMaxResults", 20);
+                    "Pharmacy Retail Sale - Medicine Autocomplete Max Results", 20);
         } catch (Exception e) {
             // Use fallback default
         }

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController1.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController1.java
@@ -1126,7 +1126,9 @@ public class RetailSaleNativeSqlController1 implements Serializable, ControllerW
         StringBuilder sql = new StringBuilder(
                 "SELECT NEW com.divudi.core.data.dto.StockDTO("
                 + "i.id, i.itemBatch.id, i.itemBatch.item.id, i.itemBatch.item.name, i.itemBatch.item.code, "
-                + "i.itemBatch.item.name, i.itemBatch.retailsaleRate, i.stock, i.itemBatch.dateOfExpire) "
+                + "i.itemBatch.item.name, i.itemBatch.retailsaleRate, i.stock, i.itemBatch.dateOfExpire, "
+                + "(SELECT COALESCE(SUM(s2.stock), 0.0) FROM Stock s2 "
+                + "WHERE s2.itemBatch.item = i.itemBatch.item AND s2.department = i.department AND s2.stock > :stockMin)) "
                 + "FROM Stock i "
                 + "WHERE i.stock > :stockMin "
                 + "AND i.department = :department "

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController1.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController1.java
@@ -1145,8 +1145,16 @@ public class RetailSaleNativeSqlController1 implements Serializable, ControllerW
         }
         sql.append(") ORDER BY i.itemBatch.item.name, i.itemBatch.dateOfExpire");
 
+        int maxResults = 20; // fallback default
+        try {
+            maxResults = configOptionApplicationController.getIntegerValueByKey(
+                    "RetailSaleStockAutocompleteMaxResults", 20);
+        } catch (Exception e) {
+            // Use fallback default
+        }
+
         lastAutocompleteResults = (List<StockDTO>) stockFacade.findLightsByJpql(
-                sql.toString(), parameters, TemporalType.TIMESTAMP, 30);
+                sql.toString(), parameters, TemporalType.TIMESTAMP, maxResults);
         return lastAutocompleteResults != null ? lastAutocompleteResults : new ArrayList<>();
     }
 

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController2.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController2.java
@@ -1148,7 +1148,7 @@ public class RetailSaleNativeSqlController2 implements Serializable, ControllerW
         int maxResults = 20; // fallback default
         try {
             maxResults = configOptionApplicationController.getIntegerValueByKey(
-                    "RetailSaleStockAutocompleteMaxResults", 20);
+                    "Pharmacy Retail Sale - Medicine Autocomplete Max Results", 20);
         } catch (Exception e) {
             // Use fallback default
         }

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController2.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController2.java
@@ -1145,8 +1145,16 @@ public class RetailSaleNativeSqlController2 implements Serializable, ControllerW
         }
         sql.append(") ORDER BY i.itemBatch.item.name, i.itemBatch.dateOfExpire");
 
+        int maxResults = 20; // fallback default
+        try {
+            maxResults = configOptionApplicationController.getIntegerValueByKey(
+                    "RetailSaleStockAutocompleteMaxResults", 20);
+        } catch (Exception e) {
+            // Use fallback default
+        }
+
         lastAutocompleteResults = (List<StockDTO>) stockFacade.findLightsByJpql(
-                sql.toString(), parameters, TemporalType.TIMESTAMP, 30);
+                sql.toString(), parameters, TemporalType.TIMESTAMP, maxResults);
         return lastAutocompleteResults != null ? lastAutocompleteResults : new ArrayList<>();
     }
 

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController2.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController2.java
@@ -1126,7 +1126,9 @@ public class RetailSaleNativeSqlController2 implements Serializable, ControllerW
         StringBuilder sql = new StringBuilder(
                 "SELECT NEW com.divudi.core.data.dto.StockDTO("
                 + "i.id, i.itemBatch.id, i.itemBatch.item.id, i.itemBatch.item.name, i.itemBatch.item.code, "
-                + "i.itemBatch.item.name, i.itemBatch.retailsaleRate, i.stock, i.itemBatch.dateOfExpire) "
+                + "i.itemBatch.item.name, i.itemBatch.retailsaleRate, i.stock, i.itemBatch.dateOfExpire, "
+                + "(SELECT COALESCE(SUM(s2.stock), 0.0) FROM Stock s2 "
+                + "WHERE s2.itemBatch.item = i.itemBatch.item AND s2.department = i.department AND s2.stock > :stockMin)) "
                 + "FROM Stock i "
                 + "WHERE i.stock > :stockMin "
                 + "AND i.department = :department "

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController2.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController2.java
@@ -1146,7 +1146,7 @@ public class RetailSaleNativeSqlController2 implements Serializable, ControllerW
         sql.append(") ORDER BY i.itemBatch.item.name, i.itemBatch.dateOfExpire");
 
         lastAutocompleteResults = (List<StockDTO>) stockFacade.findLightsByJpql(
-                sql.toString(), parameters, TemporalType.TIMESTAMP, 20);
+                sql.toString(), parameters, TemporalType.TIMESTAMP, 30);
         return lastAutocompleteResults != null ? lastAutocompleteResults : new ArrayList<>();
     }
 

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController3.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController3.java
@@ -1146,7 +1146,7 @@ public class RetailSaleNativeSqlController3 implements Serializable, ControllerW
         sql.append(") ORDER BY i.itemBatch.item.name, i.itemBatch.dateOfExpire");
 
         lastAutocompleteResults = (List<StockDTO>) stockFacade.findLightsByJpql(
-                sql.toString(), parameters, TemporalType.TIMESTAMP, 20);
+                sql.toString(), parameters, TemporalType.TIMESTAMP, 30);
         return lastAutocompleteResults != null ? lastAutocompleteResults : new ArrayList<>();
     }
 

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController3.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController3.java
@@ -1126,7 +1126,9 @@ public class RetailSaleNativeSqlController3 implements Serializable, ControllerW
         StringBuilder sql = new StringBuilder(
                 "SELECT NEW com.divudi.core.data.dto.StockDTO("
                 + "i.id, i.itemBatch.id, i.itemBatch.item.id, i.itemBatch.item.name, i.itemBatch.item.code, "
-                + "i.itemBatch.item.name, i.itemBatch.retailsaleRate, i.stock, i.itemBatch.dateOfExpire) "
+                + "i.itemBatch.item.name, i.itemBatch.retailsaleRate, i.stock, i.itemBatch.dateOfExpire, "
+                + "(SELECT COALESCE(SUM(s2.stock), 0.0) FROM Stock s2 "
+                + "WHERE s2.itemBatch.item = i.itemBatch.item AND s2.department = i.department AND s2.stock > :stockMin)) "
                 + "FROM Stock i "
                 + "WHERE i.stock > :stockMin "
                 + "AND i.department = :department "

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController3.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController3.java
@@ -1145,8 +1145,16 @@ public class RetailSaleNativeSqlController3 implements Serializable, ControllerW
         }
         sql.append(") ORDER BY i.itemBatch.item.name, i.itemBatch.dateOfExpire");
 
+        int maxResults = 20; // fallback default
+        try {
+            maxResults = configOptionApplicationController.getIntegerValueByKey(
+                    "RetailSaleStockAutocompleteMaxResults", 20);
+        } catch (Exception e) {
+            // Use fallback default
+        }
+
         lastAutocompleteResults = (List<StockDTO>) stockFacade.findLightsByJpql(
-                sql.toString(), parameters, TemporalType.TIMESTAMP, 30);
+                sql.toString(), parameters, TemporalType.TIMESTAMP, maxResults);
         return lastAutocompleteResults != null ? lastAutocompleteResults : new ArrayList<>();
     }
 

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController3.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController3.java
@@ -1148,7 +1148,7 @@ public class RetailSaleNativeSqlController3 implements Serializable, ControllerW
         int maxResults = 20; // fallback default
         try {
             maxResults = configOptionApplicationController.getIntegerValueByKey(
-                    "RetailSaleStockAutocompleteMaxResults", 20);
+                    "Pharmacy Retail Sale - Medicine Autocomplete Max Results", 20);
         } catch (Exception e) {
             // Use fallback default
         }

--- a/src/main/java/com/divudi/core/data/dto/StockDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/StockDTO.java
@@ -379,6 +379,15 @@ public class StockDTO implements Serializable {
         this.costRate = costRate;
     }
 
+    // Constructor for optimized retail sale autocomplete with total stock qty across all batches
+    // of the item within the same department (Total Stock column)
+    public StockDTO(Long stockId, Long itemBatchId, Long itemId, String itemName, String code,
+                    String genericName, Double retailRate, Double stockQty, Date dateOfExpire,
+                    Double totalStockQty) {
+        this(stockId, itemBatchId, itemId, itemName, code, genericName, retailRate, stockQty, dateOfExpire);
+        this.totalStockQty = totalStockQty;
+    }
+
     // Constructor for optimized retail sale autocomplete with departmentType (for department type filtering)
     public StockDTO(Long id, Long itemBatchId, Long itemId, String itemName, String code,
                     String genericName, String batchNo, Double retailRate, Double stockQty,

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native.xhtml
@@ -177,18 +177,20 @@
                                                         accesskey="i"
                                                         inputStyleClass="w-100"
                                                         minQueryLength="3"
-                                                        maxResults="10"
+                                                        maxResults="30"
                                                         styleClass="w-100"
+                                                        scrollHeight="450"
                                                         forceSelection="true"
                                                         value="#{retailSaleNativeSqlController.stockDto}"
-                                                        queryDelay="300" completeMethod="#{retailSaleNativeSqlController.completeAvailableStockOptimizedDto}"
+                                                        queryDelay="300" 
+                                                        completeMethod="#{retailSaleNativeSqlController.completeAvailableStockOptimizedDto}"
                                                         converter="#{retailSaleNativeSqlController.stockDtoConverter}"
                                                         var="i"
                                                         itemLabel="#{i.itemName}"
                                                         itemValue="#{i}">
                                                         <p:column
                                                             headerText="Item"
-                                                            width="400"
+                                                            style="padding: 6px; width: 650px;"
                                                             styleClass="#{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
                                                             <h:outputText value="#{i.itemName}" />
                                                             &#160;<p:tag
@@ -197,7 +199,7 @@
                                                                 severity="#{commonFunctionsProxy.currentDateTime > i.dateOfExpire ? 'danger' : commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.dateOfExpire ? 'warning' : ''}" />
                                                         </p:column>
                                                         <p:column
-                                                            width="20em"
+                                                            style="padding: 6px; width: 100px;"
                                                             rendered="#{configOptionApplicationController.getBooleanValueByKey('Medicine Identification Codes Used', true)}"
                                                             headerText="Code"
                                                             styleClass="#{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
@@ -206,6 +208,7 @@
                                                         <p:column
                                                             width="20em"
                                                             headerText="Rate"
+                                                            style="padding: 6px; width: 100px;"
                                                             styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
                                                             <h:outputLabel value="#{i.retailRate}">
                                                                 <f:convertNumber pattern="#,##0.00" />
@@ -214,14 +217,17 @@
                                                         <p:column
                                                             width="20em"
                                                             headerText="Stocks"
+                                                            style="padding: 6px; width: 100px;"
                                                             styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
                                                             <h:outputLabel value="#{i.stockQty}">
                                                                 <f:convertNumber pattern="#,###" />
                                                             </h:outputLabel>
                                                         </p:column>
+                                                        
                                                         <p:column
                                                             width="20em"
                                                             headerText="Expiry"
+                                                            style="padding: 6px; width: 150px;"
                                                             styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
                                                             <h:outputLabel value="#{i.dateOfExpire}">
                                                                 <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" />

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native.xhtml
@@ -223,7 +223,15 @@
                                                                 <f:convertNumber pattern="#,###" />
                                                             </h:outputLabel>
                                                         </p:column>
-                                                        
+                                                        <p:column
+                                                            width="20em"
+                                                            headerText="Total Stock"
+                                                            style="padding: 6px; width: 100px;"
+                                                            styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
+                                                            <h:outputLabel value="#{i.totalStockQty}">
+                                                                <f:convertNumber pattern="#,###" />
+                                                            </h:outputLabel>
+                                                        </p:column>
                                                         <p:column
                                                             width="20em"
                                                             headerText="Expiry"

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native_1.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native_1.xhtml
@@ -177,18 +177,20 @@
                                                         accesskey="i"
                                                         inputStyleClass="w-100"
                                                         minQueryLength="3"
-                                                        maxResults="10"
+                                                        maxResults="30"
                                                         styleClass="w-100"
+                                                        scrollHeight="450"
                                                         forceSelection="true"
                                                         value="#{retailSaleNativeSqlController1.stockDto}"
-                                                        queryDelay="300" completeMethod="#{retailSaleNativeSqlController1.completeAvailableStockOptimizedDto}"
+                                                        queryDelay="300"
+                                                        completeMethod="#{retailSaleNativeSqlController1.completeAvailableStockOptimizedDto}"
                                                         converter="#{retailSaleNativeSqlController1.stockDtoConverter}"
                                                         var="i"
                                                         itemLabel="#{i.itemName}"
                                                         itemValue="#{i}">
                                                         <p:column
                                                             headerText="Item"
-                                                            width="400"
+                                                            style="padding: 6px; width: 650px;"
                                                             styleClass="#{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
                                                             <h:outputText value="#{i.itemName}" />
                                                             &#160;<p:tag
@@ -197,7 +199,7 @@
                                                                 severity="#{commonFunctionsProxy.currentDateTime > i.dateOfExpire ? 'danger' : commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.dateOfExpire ? 'warning' : ''}" />
                                                         </p:column>
                                                         <p:column
-                                                            width="20em"
+                                                            style="padding: 6px; width: 100px;"
                                                             rendered="#{configOptionApplicationController.getBooleanValueByKey('Medicine Identification Codes Used', true)}"
                                                             headerText="Code"
                                                             styleClass="#{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
@@ -206,6 +208,7 @@
                                                         <p:column
                                                             width="20em"
                                                             headerText="Rate"
+                                                            style="padding: 6px; width: 100px;"
                                                             styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
                                                             <h:outputLabel value="#{i.retailRate}">
                                                                 <f:convertNumber pattern="#,##0.00" />
@@ -214,6 +217,7 @@
                                                         <p:column
                                                             width="20em"
                                                             headerText="Stocks"
+                                                            style="padding: 6px; width: 100px;"
                                                             styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
                                                             <h:outputLabel value="#{i.stockQty}">
                                                                 <f:convertNumber pattern="#,###" />
@@ -221,7 +225,17 @@
                                                         </p:column>
                                                         <p:column
                                                             width="20em"
+                                                            headerText="Total Stock"
+                                                            style="padding: 6px; width: 100px;"
+                                                            styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
+                                                            <h:outputLabel value="#{i.totalStockQty}">
+                                                                <f:convertNumber pattern="#,###" />
+                                                            </h:outputLabel>
+                                                        </p:column>
+                                                        <p:column
+                                                            width="20em"
                                                             headerText="Expiry"
+                                                            style="padding: 6px; width: 150px;"
                                                             styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
                                                             <h:outputLabel value="#{i.dateOfExpire}">
                                                                 <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" />

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native_2.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native_2.xhtml
@@ -177,18 +177,20 @@
                                                         accesskey="i"
                                                         inputStyleClass="w-100"
                                                         minQueryLength="3"
-                                                        maxResults="10"
+                                                        maxResults="30"
                                                         styleClass="w-100"
+                                                        scrollHeight="450"
                                                         forceSelection="true"
                                                         value="#{retailSaleNativeSqlController2.stockDto}"
-                                                        queryDelay="300" completeMethod="#{retailSaleNativeSqlController2.completeAvailableStockOptimizedDto}"
+                                                        queryDelay="300"
+                                                        completeMethod="#{retailSaleNativeSqlController2.completeAvailableStockOptimizedDto}"
                                                         converter="#{retailSaleNativeSqlController2.stockDtoConverter}"
                                                         var="i"
                                                         itemLabel="#{i.itemName}"
                                                         itemValue="#{i}">
                                                         <p:column
                                                             headerText="Item"
-                                                            width="400"
+                                                            style="padding: 6px; width: 650px;"
                                                             styleClass="#{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
                                                             <h:outputText value="#{i.itemName}" />
                                                             &#160;<p:tag
@@ -197,7 +199,7 @@
                                                                 severity="#{commonFunctionsProxy.currentDateTime > i.dateOfExpire ? 'danger' : commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.dateOfExpire ? 'warning' : ''}" />
                                                         </p:column>
                                                         <p:column
-                                                            width="20em"
+                                                            style="padding: 6px; width: 100px;"
                                                             rendered="#{configOptionApplicationController.getBooleanValueByKey('Medicine Identification Codes Used', true)}"
                                                             headerText="Code"
                                                             styleClass="#{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
@@ -206,6 +208,7 @@
                                                         <p:column
                                                             width="20em"
                                                             headerText="Rate"
+                                                            style="padding: 6px; width: 100px;"
                                                             styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
                                                             <h:outputLabel value="#{i.retailRate}">
                                                                 <f:convertNumber pattern="#,##0.00" />
@@ -214,6 +217,7 @@
                                                         <p:column
                                                             width="20em"
                                                             headerText="Stocks"
+                                                            style="padding: 6px; width: 100px;"
                                                             styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
                                                             <h:outputLabel value="#{i.stockQty}">
                                                                 <f:convertNumber pattern="#,###" />
@@ -221,7 +225,17 @@
                                                         </p:column>
                                                         <p:column
                                                             width="20em"
+                                                            headerText="Total Stock"
+                                                            style="padding: 6px; width: 100px;"
+                                                            styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
+                                                            <h:outputLabel value="#{i.totalStockQty}">
+                                                                <f:convertNumber pattern="#,###" />
+                                                            </h:outputLabel>
+                                                        </p:column>
+                                                        <p:column
+                                                            width="20em"
                                                             headerText="Expiry"
+                                                            style="padding: 6px; width: 150px;"
                                                             styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
                                                             <h:outputLabel value="#{i.dateOfExpire}">
                                                                 <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" />

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native_3.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native_3.xhtml
@@ -177,18 +177,20 @@
                                                         accesskey="i"
                                                         inputStyleClass="w-100"
                                                         minQueryLength="3"
-                                                        maxResults="10"
+                                                        maxResults="30"
                                                         styleClass="w-100"
+                                                        scrollHeight="450"
                                                         forceSelection="true"
                                                         value="#{retailSaleNativeSqlController3.stockDto}"
-                                                        queryDelay="300" completeMethod="#{retailSaleNativeSqlController3.completeAvailableStockOptimizedDto}"
+                                                        queryDelay="300"
+                                                        completeMethod="#{retailSaleNativeSqlController3.completeAvailableStockOptimizedDto}"
                                                         converter="#{retailSaleNativeSqlController3.stockDtoConverter}"
                                                         var="i"
                                                         itemLabel="#{i.itemName}"
                                                         itemValue="#{i}">
                                                         <p:column
                                                             headerText="Item"
-                                                            width="400"
+                                                            style="padding: 6px; width: 650px;"
                                                             styleClass="#{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
                                                             <h:outputText value="#{i.itemName}" />
                                                             &#160;<p:tag
@@ -197,7 +199,7 @@
                                                                 severity="#{commonFunctionsProxy.currentDateTime > i.dateOfExpire ? 'danger' : commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.dateOfExpire ? 'warning' : ''}" />
                                                         </p:column>
                                                         <p:column
-                                                            width="20em"
+                                                            style="padding: 6px; width: 100px;"
                                                             rendered="#{configOptionApplicationController.getBooleanValueByKey('Medicine Identification Codes Used', true)}"
                                                             headerText="Code"
                                                             styleClass="#{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
@@ -206,6 +208,7 @@
                                                         <p:column
                                                             width="20em"
                                                             headerText="Rate"
+                                                            style="padding: 6px; width: 100px;"
                                                             styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
                                                             <h:outputLabel value="#{i.retailRate}">
                                                                 <f:convertNumber pattern="#,##0.00" />
@@ -214,6 +217,7 @@
                                                         <p:column
                                                             width="20em"
                                                             headerText="Stocks"
+                                                            style="padding: 6px; width: 100px;"
                                                             styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
                                                             <h:outputLabel value="#{i.stockQty}">
                                                                 <f:convertNumber pattern="#,###" />
@@ -221,7 +225,17 @@
                                                         </p:column>
                                                         <p:column
                                                             width="20em"
+                                                            headerText="Total Stock"
+                                                            style="padding: 6px; width: 100px;"
+                                                            styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
+                                                            <h:outputLabel value="#{i.totalStockQty}">
+                                                                <f:convertNumber pattern="#,###" />
+                                                            </h:outputLabel>
+                                                        </p:column>
+                                                        <p:column
+                                                            width="20em"
                                                             headerText="Expiry"
+                                                            style="padding: 6px; width: 150px;"
                                                             styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
                                                             <h:outputLabel value="#{i.dateOfExpire}">
                                                                 <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" />

--- a/src/main/webapp/resources/pharmacy/saleBill_Header_native.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBill_Header_native.xhtml
@@ -248,34 +248,36 @@
                         <td class="totalsBlock1" style="text-align: right!important; font-weight: bold;">
                             <div style="display: flex; float: right;">
                                 <h:outputLabel rendered="#{cc.attrs.bill.discountPercentPharmacy ne 0.0 and cc.attrs.bill.discount ne 0.0}" value="#{cc.attrs.bill.discountPercentPharmacy}">
-                                <f:convertNumber pattern="#,##0.00"/>
-                            </h:outputLabel>
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputLabel>
                                 <h:outputLabel rendered="#{cc.attrs.bill.discountPercentPharmacy ne 0.0 and cc.attrs.bill.discount ne 0.0}" value="%"></h:outputLabel>
                             </div>
                         </td>
                     </tr>
 
                     <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Allow Tendered Amount for pharmacy sale for cashier')}">
-                        <tr>
-                            <td class="totalsItemBlock1" style="text-align: left;">
-                                <h:outputLabel value="Tendered"/>
-                            </td>
-                            <td class="totalsItemBlock1" style="text-align: right;">
-                                <h:outputLabel value="#{cc.attrs.bill.cashPaid}">
-                                    <f:convertNumber pattern="#,##0.00"/>
-                                </h:outputLabel>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td class="totalsItemBlock1" style="text-align: left;">
-                                <h:outputLabel value="Balance"/>
-                            </td>
-                            <td class="totalsItemBlock1" style="text-align: right;">
-                                <h:outputLabel value="#{cc.attrs.bill.balance}">
-                                    <f:convertNumber pattern="#,##0.00"/>
-                                </h:outputLabel>
-                            </td>
-                        </tr>
+                        <h:panelGroup rendered="#{cc.attrs.bill.paymentMethodLabel eq 'Cash'}">
+                            <tr>
+                                <td class="totalsItemBlock1" style="text-align: left;">
+                                    <h:outputLabel value="Tendered"/>
+                                </td>
+                                <td class="totalsItemBlock1" style="text-align: right;">
+                                    <h:outputLabel value="#{cc.attrs.bill.cashPaid}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </h:outputLabel>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="totalsItemBlock1" style="text-align: left;">
+                                    <h:outputLabel value="Balance"/>
+                                </td>
+                                <td class="totalsItemBlock1" style="text-align: right;">
+                                    <h:outputLabel value="#{cc.attrs.bill.balance}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </h:outputLabel>
+                                </td>
+                            </tr>
+                        </h:panelGroup>
                     </h:panelGroup>
 
                     <tr>
@@ -347,7 +349,7 @@
                 // Wait for the popup (including the linked stylesheet) to finish loading
                 // before printing - printing immediately after document.close() races the
                 // browser's rendering of the popup and can produce a blank page.
-                printWindow.onload = function() {
+                printWindow.onload = function () {
                     printWindow.focus();
                     printWindow.print();
                 };


### PR DESCRIPTION
## Summary
- Native sale bill header: only show Tendered/Balance rows when the payment method is Cash.
- Retail sale native medicine autocomplete: widen result set/columns and add a "Total Stock" column showing stock summed across all batches of the item in the current department (single correlated-subquery JPQL, no N+1).
- New `StockDTO` constructor added (existing ones untouched) to carry `totalStockQty`.

## Test plan
- [ ] Open native "POS paper with header" sale bill, confirm Tendered/Balance only render for Cash payments.
- [ ] Search medicines in retail sale native autocomplete; confirm "Total Stock" reflects sum across batches for the item in the current department, distinct from the per-batch "Stocks" value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)