### PR TITLE
feat(pharmacy): config-gated Total AMP Stock column in retail sale autocomplete

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleForCashierNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleForCashierNativeSqlController.java
@@ -1785,8 +1785,9 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
         }
         qry = qry.replaceAll("[\\n\\r]", "").trim();
 
+        Department department = sessionController.getLoggedUser().getDepartment();
         Map<String, Object> parameters = new HashMap<>();
-        parameters.put("department", sessionController.getLoggedUser().getDepartment());
+        parameters.put("department", department);
         parameters.put("stockMin", 0.0);
         parameters.put("query", "%" + qry + "%");
 
@@ -1831,7 +1832,67 @@ public class RetailSaleForCashierNativeSqlController implements Serializable, Co
 
         lastAutocompleteResults = (List<StockDTO>) stockFacade.findLightsByJpql(
                 sql.toString(), parameters, TemporalType.TIMESTAMP, 20);
-        return lastAutocompleteResults != null ? lastAutocompleteResults : new ArrayList<>();
+        if (lastAutocompleteResults == null) {
+            lastAutocompleteResults = new ArrayList<>();
+        }
+        if (configOptionApplicationController.getBooleanValueByKey(
+                "Pharmacy Retail Sale - Show Total AMP Stock in Autocomplete", false)) {
+            populateTotalStockQty(lastAutocompleteResults, department);
+        }
+        return lastAutocompleteResults;
+    }
+
+    /**
+     * Populates the AMP-wide total stock quantity (summed across all batches
+     * of the item in the given department) onto each StockDTO's
+     * totalStockQty field. This is separate from the per-batch "Stocks"
+     * value already present on the DTO (dto.getStock()), which reflects only
+     * the single matched Stock row.
+     * <p>
+     * Gated behind the "Pharmacy Retail Sale - Show Total AMP Stock in
+     * Autocomplete" config key so it never runs unless explicitly enabled.
+     * Runs exactly one aggregate JPQL query regardless of list size (never a
+     * per-row subquery).
+     */
+    private void populateTotalStockQty(List<StockDTO> stocks, Department department) {
+        if (stocks == null || stocks.isEmpty()) {
+            return;
+        }
+        List<Long> itemIds = new ArrayList<>();
+        for (StockDTO dto : stocks) {
+            Long itemId = dto.getItemId();
+            if (itemId != null && !itemIds.contains(itemId)) {
+                itemIds.add(itemId);
+            }
+        }
+        if (itemIds.isEmpty()) {
+            return;
+        }
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("itemIds", itemIds);
+        params.put("department", department);
+        String jpql = "SELECT s.itemBatch.item.id, SUM(s.stock) FROM Stock s "
+                + "WHERE s.itemBatch.item.id IN :itemIds AND s.department = :department "
+                + "GROUP BY s.itemBatch.item.id";
+        List<Object[]> rows = stockFacade.findAggregates(jpql, params);
+        if (rows == null || rows.isEmpty()) {
+            return;
+        }
+
+        Map<Long, Double> totals = new HashMap<>();
+        for (Object[] row : rows) {
+            if (row == null || row.length < 2 || row[0] == null || row[1] == null) {
+                continue;
+            }
+            Long itemId = ((Number) row[0]).longValue();
+            Double totalStock = ((Number) row[1]).doubleValue();
+            totals.put(itemId, totalStock);
+        }
+
+        for (StockDTO dto : stocks) {
+            dto.setTotalStockQty(totals.get(dto.getItemId()));
+        }
     }
 
     public void handleSelect(SelectEvent<StockDTO> event) {

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController.java
@@ -1211,8 +1211,9 @@ public class RetailSaleNativeSqlController implements Serializable, ControllerWi
         }
         qry = qry.replaceAll("[\\n\\r]", "").trim();
 
+        Department department = sessionController.getLoggedUser().getDepartment();
         Map<String, Object> parameters = new HashMap<>();
-        parameters.put("department", sessionController.getLoggedUser().getDepartment());
+        parameters.put("department", department);
         parameters.put("stockMin", 0.0);
         parameters.put("query", "%" + qry + "%");
 
@@ -1246,7 +1247,67 @@ public class RetailSaleNativeSqlController implements Serializable, ControllerWi
 
         lastAutocompleteResults = (List<StockDTO>) stockFacade.findLightsByJpql(
                 sql.toString(), parameters, TemporalType.TIMESTAMP, 20);
-        return lastAutocompleteResults != null ? lastAutocompleteResults : new ArrayList<>();
+        if (lastAutocompleteResults == null) {
+            lastAutocompleteResults = new ArrayList<>();
+        }
+        if (configOptionApplicationController.getBooleanValueByKey(
+                "Pharmacy Retail Sale - Show Total AMP Stock in Autocomplete", false)) {
+            populateTotalStockQty(lastAutocompleteResults, department);
+        }
+        return lastAutocompleteResults;
+    }
+
+    /**
+     * Populates the AMP-wide total stock quantity (summed across all batches
+     * of the item in the given department) onto each StockDTO's
+     * totalStockQty field. This is separate from the per-batch "Stocks"
+     * value already present on the DTO (dto.getStock()), which reflects only
+     * the single matched Stock row.
+     * <p>
+     * Gated behind the "Pharmacy Retail Sale - Show Total AMP Stock in
+     * Autocomplete" config key so it never runs unless explicitly enabled.
+     * Runs exactly one aggregate JPQL query regardless of list size (never a
+     * per-row subquery).
+     */
+    private void populateTotalStockQty(List<StockDTO> stocks, Department department) {
+        if (stocks == null || stocks.isEmpty()) {
+            return;
+        }
+        List<Long> itemIds = new ArrayList<>();
+        for (StockDTO dto : stocks) {
+            Long itemId = dto.getItemId();
+            if (itemId != null && !itemIds.contains(itemId)) {
+                itemIds.add(itemId);
+            }
+        }
+        if (itemIds.isEmpty()) {
+            return;
+        }
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("itemIds", itemIds);
+        params.put("department", department);
+        String jpql = "SELECT s.itemBatch.item.id, SUM(s.stock) FROM Stock s "
+                + "WHERE s.itemBatch.item.id IN :itemIds AND s.department = :department "
+                + "GROUP BY s.itemBatch.item.id";
+        List<Object[]> rows = stockFacade.findAggregates(jpql, params);
+        if (rows == null || rows.isEmpty()) {
+            return;
+        }
+
+        Map<Long, Double> totals = new HashMap<>();
+        for (Object[] row : rows) {
+            if (row == null || row.length < 2 || row[0] == null || row[1] == null) {
+                continue;
+            }
+            Long itemId = ((Number) row[0]).longValue();
+            Double totalStock = ((Number) row[1]).doubleValue();
+            totals.put(itemId, totalStock);
+        }
+
+        for (StockDTO dto : stocks) {
+            dto.setTotalStockQty(totals.get(dto.getItemId()));
+        }
     }
 
     public void handleSelect(SelectEvent<StockDTO> event) {

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController1.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController1.java
@@ -1202,8 +1202,9 @@ public class RetailSaleNativeSqlController1 implements Serializable, ControllerW
         }
         qry = qry.replaceAll("[\\n\\r]", "").trim();
 
+        Department department = sessionController.getLoggedUser().getDepartment();
         Map<String, Object> parameters = new HashMap<>();
-        parameters.put("department", sessionController.getLoggedUser().getDepartment());
+        parameters.put("department", department);
         parameters.put("stockMin", 0.0);
         parameters.put("query", "%" + qry + "%");
 
@@ -1237,7 +1238,67 @@ public class RetailSaleNativeSqlController1 implements Serializable, ControllerW
 
         lastAutocompleteResults = (List<StockDTO>) stockFacade.findLightsByJpql(
                 sql.toString(), parameters, TemporalType.TIMESTAMP, 20);
-        return lastAutocompleteResults != null ? lastAutocompleteResults : new ArrayList<>();
+        if (lastAutocompleteResults == null) {
+            lastAutocompleteResults = new ArrayList<>();
+        }
+        if (configOptionApplicationController.getBooleanValueByKey(
+                "Pharmacy Retail Sale - Show Total AMP Stock in Autocomplete", false)) {
+            populateTotalStockQty(lastAutocompleteResults, department);
+        }
+        return lastAutocompleteResults;
+    }
+
+    /**
+     * Populates the AMP-wide total stock quantity (summed across all batches
+     * of the item in the given department) onto each StockDTO's
+     * totalStockQty field. This is separate from the per-batch "Stocks"
+     * value already present on the DTO (dto.getStock()), which reflects only
+     * the single matched Stock row.
+     * <p>
+     * Gated behind the "Pharmacy Retail Sale - Show Total AMP Stock in
+     * Autocomplete" config key so it never runs unless explicitly enabled.
+     * Runs exactly one aggregate JPQL query regardless of list size (never a
+     * per-row subquery).
+     */
+    private void populateTotalStockQty(List<StockDTO> stocks, Department department) {
+        if (stocks == null || stocks.isEmpty()) {
+            return;
+        }
+        List<Long> itemIds = new ArrayList<>();
+        for (StockDTO dto : stocks) {
+            Long itemId = dto.getItemId();
+            if (itemId != null && !itemIds.contains(itemId)) {
+                itemIds.add(itemId);
+            }
+        }
+        if (itemIds.isEmpty()) {
+            return;
+        }
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("itemIds", itemIds);
+        params.put("department", department);
+        String jpql = "SELECT s.itemBatch.item.id, SUM(s.stock) FROM Stock s "
+                + "WHERE s.itemBatch.item.id IN :itemIds AND s.department = :department "
+                + "GROUP BY s.itemBatch.item.id";
+        List<Object[]> rows = stockFacade.findAggregates(jpql, params);
+        if (rows == null || rows.isEmpty()) {
+            return;
+        }
+
+        Map<Long, Double> totals = new HashMap<>();
+        for (Object[] row : rows) {
+            if (row == null || row.length < 2 || row[0] == null || row[1] == null) {
+                continue;
+            }
+            Long itemId = ((Number) row[0]).longValue();
+            Double totalStock = ((Number) row[1]).doubleValue();
+            totals.put(itemId, totalStock);
+        }
+
+        for (StockDTO dto : stocks) {
+            dto.setTotalStockQty(totals.get(dto.getItemId()));
+        }
     }
 
     public void handleSelect(SelectEvent<StockDTO> event) {

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController2.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController2.java
@@ -1202,8 +1202,9 @@ public class RetailSaleNativeSqlController2 implements Serializable, ControllerW
         }
         qry = qry.replaceAll("[\\n\\r]", "").trim();
 
+        Department department = sessionController.getLoggedUser().getDepartment();
         Map<String, Object> parameters = new HashMap<>();
-        parameters.put("department", sessionController.getLoggedUser().getDepartment());
+        parameters.put("department", department);
         parameters.put("stockMin", 0.0);
         parameters.put("query", "%" + qry + "%");
 
@@ -1237,7 +1238,67 @@ public class RetailSaleNativeSqlController2 implements Serializable, ControllerW
 
         lastAutocompleteResults = (List<StockDTO>) stockFacade.findLightsByJpql(
                 sql.toString(), parameters, TemporalType.TIMESTAMP, 20);
-        return lastAutocompleteResults != null ? lastAutocompleteResults : new ArrayList<>();
+        if (lastAutocompleteResults == null) {
+            lastAutocompleteResults = new ArrayList<>();
+        }
+        if (configOptionApplicationController.getBooleanValueByKey(
+                "Pharmacy Retail Sale - Show Total AMP Stock in Autocomplete", false)) {
+            populateTotalStockQty(lastAutocompleteResults, department);
+        }
+        return lastAutocompleteResults;
+    }
+
+    /**
+     * Populates the AMP-wide total stock quantity (summed across all batches
+     * of the item in the given department) onto each StockDTO's
+     * totalStockQty field. This is separate from the per-batch "Stocks"
+     * value already present on the DTO (dto.getStock()), which reflects only
+     * the single matched Stock row.
+     * <p>
+     * Gated behind the "Pharmacy Retail Sale - Show Total AMP Stock in
+     * Autocomplete" config key so it never runs unless explicitly enabled.
+     * Runs exactly one aggregate JPQL query regardless of list size (never a
+     * per-row subquery).
+     */
+    private void populateTotalStockQty(List<StockDTO> stocks, Department department) {
+        if (stocks == null || stocks.isEmpty()) {
+            return;
+        }
+        List<Long> itemIds = new ArrayList<>();
+        for (StockDTO dto : stocks) {
+            Long itemId = dto.getItemId();
+            if (itemId != null && !itemIds.contains(itemId)) {
+                itemIds.add(itemId);
+            }
+        }
+        if (itemIds.isEmpty()) {
+            return;
+        }
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("itemIds", itemIds);
+        params.put("department", department);
+        String jpql = "SELECT s.itemBatch.item.id, SUM(s.stock) FROM Stock s "
+                + "WHERE s.itemBatch.item.id IN :itemIds AND s.department = :department "
+                + "GROUP BY s.itemBatch.item.id";
+        List<Object[]> rows = stockFacade.findAggregates(jpql, params);
+        if (rows == null || rows.isEmpty()) {
+            return;
+        }
+
+        Map<Long, Double> totals = new HashMap<>();
+        for (Object[] row : rows) {
+            if (row == null || row.length < 2 || row[0] == null || row[1] == null) {
+                continue;
+            }
+            Long itemId = ((Number) row[0]).longValue();
+            Double totalStock = ((Number) row[1]).doubleValue();
+            totals.put(itemId, totalStock);
+        }
+
+        for (StockDTO dto : stocks) {
+            dto.setTotalStockQty(totals.get(dto.getItemId()));
+        }
     }
 
     public void handleSelect(SelectEvent<StockDTO> event) {

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController3.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController3.java
@@ -1202,8 +1202,9 @@ public class RetailSaleNativeSqlController3 implements Serializable, ControllerW
         }
         qry = qry.replaceAll("[\\n\\r]", "").trim();
 
+        Department department = sessionController.getLoggedUser().getDepartment();
         Map<String, Object> parameters = new HashMap<>();
-        parameters.put("department", sessionController.getLoggedUser().getDepartment());
+        parameters.put("department", department);
         parameters.put("stockMin", 0.0);
         parameters.put("query", "%" + qry + "%");
 
@@ -1237,7 +1238,67 @@ public class RetailSaleNativeSqlController3 implements Serializable, ControllerW
 
         lastAutocompleteResults = (List<StockDTO>) stockFacade.findLightsByJpql(
                 sql.toString(), parameters, TemporalType.TIMESTAMP, 20);
-        return lastAutocompleteResults != null ? lastAutocompleteResults : new ArrayList<>();
+        if (lastAutocompleteResults == null) {
+            lastAutocompleteResults = new ArrayList<>();
+        }
+        if (configOptionApplicationController.getBooleanValueByKey(
+                "Pharmacy Retail Sale - Show Total AMP Stock in Autocomplete", false)) {
+            populateTotalStockQty(lastAutocompleteResults, department);
+        }
+        return lastAutocompleteResults;
+    }
+
+    /**
+     * Populates the AMP-wide total stock quantity (summed across all batches
+     * of the item in the given department) onto each StockDTO's
+     * totalStockQty field. This is separate from the per-batch "Stocks"
+     * value already present on the DTO (dto.getStock()), which reflects only
+     * the single matched Stock row.
+     * <p>
+     * Gated behind the "Pharmacy Retail Sale - Show Total AMP Stock in
+     * Autocomplete" config key so it never runs unless explicitly enabled.
+     * Runs exactly one aggregate JPQL query regardless of list size (never a
+     * per-row subquery).
+     */
+    private void populateTotalStockQty(List<StockDTO> stocks, Department department) {
+        if (stocks == null || stocks.isEmpty()) {
+            return;
+        }
+        List<Long> itemIds = new ArrayList<>();
+        for (StockDTO dto : stocks) {
+            Long itemId = dto.getItemId();
+            if (itemId != null && !itemIds.contains(itemId)) {
+                itemIds.add(itemId);
+            }
+        }
+        if (itemIds.isEmpty()) {
+            return;
+        }
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("itemIds", itemIds);
+        params.put("department", department);
+        String jpql = "SELECT s.itemBatch.item.id, SUM(s.stock) FROM Stock s "
+                + "WHERE s.itemBatch.item.id IN :itemIds AND s.department = :department "
+                + "GROUP BY s.itemBatch.item.id";
+        List<Object[]> rows = stockFacade.findAggregates(jpql, params);
+        if (rows == null || rows.isEmpty()) {
+            return;
+        }
+
+        Map<Long, Double> totals = new HashMap<>();
+        for (Object[] row : rows) {
+            if (row == null || row.length < 2 || row[0] == null || row[1] == null) {
+                continue;
+            }
+            Long itemId = ((Number) row[0]).longValue();
+            Double totalStock = ((Number) row[1]).doubleValue();
+            totals.put(itemId, totalStock);
+        }
+
+        for (StockDTO dto : stocks) {
+            dto.setTotalStockQty(totals.get(dto.getItemId()));
+        }
     }
 
     public void handleSelect(SelectEvent<StockDTO> event) {

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_native.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_for_cashier_native.xhtml
@@ -199,6 +199,15 @@
                                                         </p:column>
                                                         <p:column
                                                             width="20em"
+                                                            headerText="Total Stock"
+                                                            rendered="#{configOptionApplicationController.getBooleanValueByKeyReadOnly('Pharmacy Retail Sale - Show Total AMP Stock in Autocomplete', false)}"
+                                                            styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
+                                                            <h:outputLabel value="#{i.totalStockQty}">
+                                                                <f:convertNumber pattern="#,###" />
+                                                            </h:outputLabel>
+                                                        </p:column>
+                                                        <p:column
+                                                            width="20em"
                                                             headerText="Expiry"
                                                             styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
                                                             <h:outputLabel value="#{i.dateOfExpire}">

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native.xhtml
@@ -221,6 +221,15 @@
                                                         </p:column>
                                                         <p:column
                                                             width="20em"
+                                                            headerText="Total Stock"
+                                                            rendered="#{configOptionApplicationController.getBooleanValueByKeyReadOnly('Pharmacy Retail Sale - Show Total AMP Stock in Autocomplete', false)}"
+                                                            styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
+                                                            <h:outputLabel value="#{i.totalStockQty}">
+                                                                <f:convertNumber pattern="#,###" />
+                                                            </h:outputLabel>
+                                                        </p:column>
+                                                        <p:column
+                                                            width="20em"
                                                             headerText="Expiry"
                                                             styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
                                                             <h:outputLabel value="#{i.dateOfExpire}">

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native_1.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native_1.xhtml
@@ -221,6 +221,15 @@
                                                         </p:column>
                                                         <p:column
                                                             width="20em"
+                                                            headerText="Total Stock"
+                                                            rendered="#{configOptionApplicationController.getBooleanValueByKeyReadOnly('Pharmacy Retail Sale - Show Total AMP Stock in Autocomplete', false)}"
+                                                            styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
+                                                            <h:outputLabel value="#{i.totalStockQty}">
+                                                                <f:convertNumber pattern="#,###" />
+                                                            </h:outputLabel>
+                                                        </p:column>
+                                                        <p:column
+                                                            width="20em"
                                                             headerText="Expiry"
                                                             styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
                                                             <h:outputLabel value="#{i.dateOfExpire}">

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native_2.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native_2.xhtml
@@ -221,6 +221,15 @@
                                                         </p:column>
                                                         <p:column
                                                             width="20em"
+                                                            headerText="Total Stock"
+                                                            rendered="#{configOptionApplicationController.getBooleanValueByKeyReadOnly('Pharmacy Retail Sale - Show Total AMP Stock in Autocomplete', false)}"
+                                                            styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
+                                                            <h:outputLabel value="#{i.totalStockQty}">
+                                                                <f:convertNumber pattern="#,###" />
+                                                            </h:outputLabel>
+                                                        </p:column>
+                                                        <p:column
+                                                            width="20em"
                                                             headerText="Expiry"
                                                             styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
                                                             <h:outputLabel value="#{i.dateOfExpire}">

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native_3.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native_3.xhtml
@@ -221,6 +221,15 @@
                                                         </p:column>
                                                         <p:column
                                                             width="20em"
+                                                            headerText="Total Stock"
+                                                            rendered="#{configOptionApplicationController.getBooleanValueByKeyReadOnly('Pharmacy Retail Sale - Show Total AMP Stock in Autocomplete', false)}"
+                                                            styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
+                                                            <h:outputLabel value="#{i.totalStockQty}">
+                                                                <f:convertNumber pattern="#,###" />
+                                                            </h:outputLabel>
+                                                        </p:column>
+                                                        <p:column
+                                                            width="20em"
                                                             headerText="Expiry"
                                                             styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
                                                             <h:outputLabel value="#{i.dateOfExpire}">


### PR DESCRIPTION
## Summary
Closes #14652. Adds an optional "Total Stock" column to the medicine-search autocomplete on the native-SQL **Retail Sale** and **Retail Sale for Cashier** pages, showing the AMP's stock summed across *all* its batches in the current department — distinct from the existing "Stocks" column, which shows only the one matched batch.

- New config option (default **off**): `Pharmacy Retail Sale - Show Total AMP Stock in Autocomplete`. Most hospitals didn't ask for this and don't want the extra query cost, so it's opt-in and gates both the extra query and the new UI column.
- Applied identically to all 5 relevant controllers/pages: `RetailSaleNativeSqlController` (+ windows 1/2/3) and `RetailSaleForCashierNativeSqlController`.
- Runs exactly **one** extra batched aggregate JPQL query per keystroke (`GROUP BY` over the item IDs already present in that keystroke's result set) — never a per-row/N+1 query.
- Reuses the existing, previously-unwired `StockDTO.totalStockQty` field/setter — no DTO changes.

### On a parallel hotfix PR (#23083)
While starting this, an independently-opened same-day PR (`pharmacy-native-sale-total-stock-hotfix` → `southernlanka-stg-migrated`) turned up that adds a similar-looking, always-on "Total Stock" column via a scalar subquery nested inside the `SELECT NEW StockDTO(...)` constructor projection. That pattern has no precedent elsewhere in this codebase and is effectively an N+1 query evaluated inside the DB engine. This PR deliberately does not reuse it — see the comment on #14652 for the full comparison.

## Test plan — verified locally (Payara + local `coop` DB, Main Pharmacy dept, item "Glycomet sr 500mg", 5 batches: 15 / 330 / 8,491 / 23 / 55)
- [x] Config **off** (default): autocomplete unchanged — no Total Stock column, no extra query.
- [x] Config **on**, Retail Sale (native): Total Stock shows **8,914** (sum of all 5 batches) on every row, cross-checked against a direct `SELECT SUM(stock) ...` in the DB.
- [x] Config **on**, Retail Sale for Cashier (native): same result.
- [x] Caught and fixed a real bug during verification: `IN (:itemIds)` is invalid JPQL for a collection-bind parameter under EclipseLink (throws `IllegalArgumentException`, silently breaking the autocomplete AJAX call) — corrected to `IN :itemIds`, matching this codebase's existing convention (e.g. `PharmacyBean.java:3141`).

### Evidence
**Config off (unchanged baseline):**
![Config off](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/14652-total-stock-column-config-off.png)

**Config on — Retail Sale (native):**
![Retail Sale on](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/14652-total-stock-column-retail-sale.png)

**Config on — Retail Sale for Cashier (native):**
![Cashier on](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/14652-total-stock-column-cashier.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional **Total Stock** column to pharmacy retail-sale item autocomplete results.
  * When enabled in configuration, the column shows the item’s combined stock across all batches in the current department.

* **Bug Fixes**
  * Improved autocomplete behavior when no matching results are found by returning an empty result list instead of displaying an unexpected blank state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->