### PR TITLE
fix(inward): enable Continue button on Edit Admission search page

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtEditController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtEditController.java
@@ -122,6 +122,16 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
     private Admission current;
     private Patient patient;
     private boolean patientDetailsEditable;
+    /**
+     * Distinguishes "a patient was tentatively picked in the search
+     * autocomplete" from "Continue was clicked and
+     * navigateToEditAdmissionDetails() finished loading the admission for
+     * editing". Both states leave `current.bhtNo` non-null, so the
+     * search-vs-edit panel toggle and the Continue button's enabled state
+     * cannot be driven off `current.bhtNo` alone (issue #22977). This flag
+     * only flips true once the edit form is actually ready to show.
+     */
+    private boolean admissionEditFormReady;
     String selectText = "";
     String comment;
 
@@ -476,6 +486,7 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
 
     public void onInstitutionChange() {
         current = null;
+        admissionEditFormReady = false;
     }
 
     public Institution getInstitution() {
@@ -550,6 +561,7 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
         items = null;
         patientList = null;
         current = null;
+        admissionEditFormReady = false;
         selectText = "";
         yearMonthDay = new YearMonthDay();
         institution = sessionController.getInstitution();
@@ -721,6 +733,7 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
         createPatientRoom();
         fillCreditCompaniesByPatient();
         fillCurrentPatientAllergies(current.getPatient());
+        admissionEditFormReady = true;
         return "/inward/inward_edit_bht?faces-redirect=true";
     }
 
@@ -806,6 +819,10 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
 
     public void setComment(String comment) {
         this.comment = comment;
+    }
+
+    public boolean isAdmissionEditFormReady() {
+        return admissionEditFormReady;
     }
 
     public void setCurrent(Admission current) {

--- a/src/main/webapp/inward/inward_edit_bht.xhtml
+++ b/src/main/webapp/inward/inward_edit_bht.xhtml
@@ -17,7 +17,7 @@
     <ui:define name="content">
         <h:panelGroup id="panSearch2">
             <h:form>
-                <h:panelGroup class="row" rendered="#{bhtEditController.current.bhtNo eq null}">
+                <h:panelGroup class="row" rendered="#{not bhtEditController.admissionEditFormReady}">
                     <div class="col-12">
                         <p:panel styleClass="shadow-sm">
                             <f:facet name="header">
@@ -68,7 +68,7 @@
                                                                        var="ins"
                                                                        itemLabel="#{ins.name}"
                                                                        itemValue="#{ins}" />
-                                                        <p:ajax listener="#{bhtEditController.onInstitutionChange}" update="acPt pnlPatientPreview" />
+                                                        <p:ajax listener="#{bhtEditController.onInstitutionChange}" update="acPt pnlPatientPreview btnSelect" />
                                                     </p:selectOneMenu>
                                                 </div>
                                             </div>
@@ -92,7 +92,7 @@
                                                         minQueryLength="2"
                                                         style="width: 100%;"
                                                         inputStyleClass="form-control form-control-lg">
-                                                        <p:ajax event="itemSelect" update="pnlPatientPreview" />
+                                                        <p:ajax event="itemSelect" update="pnlPatientPreview btnSelect" />
                                                         <p:column headerText="PHN" style="padding: 8px; min-width: 100px;">
                                                             <div class="d-flex align-items-center">
                                                                 <i class="fa-solid fa-id-card me-2 text-info"></i>
@@ -197,7 +197,7 @@
                     </div>
                 </h:panelGroup>
 
-                <h:panelGroup  rendered="#{bhtEditController.current.bhtNo ne null}"> 
+                <h:panelGroup  rendered="#{bhtEditController.admissionEditFormReady}">
                     <p:panel>
                         <f:facet name="header">
                             <div class="d-flex justify-content-between align-items-center">


### PR DESCRIPTION
## Summary
Fixes #22977 — the **Continue** button on the Edit Admission search page (`inward/inward_edit_bht.xhtml`) stayed disabled forever after entering a valid BHT No, blocking users from reaching Edit Admission Details.

## Decisions made without approval
(Run unattended per `/dev-issue-unattended`; documenting per that skill's requirements.)

- **Root cause investigation went deeper than the surface symptom.** The obvious fix (add the button to the `itemSelect` AJAX `update` target) was insufficient — I verified this live via Playwright network inspection before committing to a fix. The real issue: the button's enclosing `panelGroup` and the button's own `disabled` condition are both gated on `bhtEditController.current.bhtNo`, which becomes non-null the instant a patient is *tentatively* picked in the search autocomplete — not when Continue is actually clicked. Since a non-rendered ancestor produces no AJAX partial-response content for its children, the button's stale `disabled` attribute from initial page load could never be cleared.
- **Chose to add a new controller-side boolean (`admissionEditFormReady`)** rather than widening the AJAX update to the whole search panel, because `navigateToEditAdmissionDetails()` does essential setup (re-fetches a fresh `Admission`, loads patient room / credit companies / allergies) that must run before the edit panel is shown. Toggling the panel directly off `current.bhtNo` (via a wider AJAX update) would have skipped that setup and shown an under-initialized edit form.
- This is the only design choice involved; it's a self-contained UI-state fix with no schema, security, or cross-module implications.

## Root cause
- `current` is bound directly to the patient-search `p:autoComplete`'s `value`.
- On `itemSelect`, `current` becomes an existing (DB-backed) `Admission`, so `current.bhtNo` is immediately non-null.
- The button (and the whole search panel) lived inside a `panelGroup rendered="#{bhtEditController.current.bhtNo eq null}"`.
- The instant a patient was selected, that ancestor's render condition flipped to `false`. JSF cannot produce a partial-response `<update>` for a component whose ancestor isn't rendered, so the button's disabled state (set at initial page render, before a patient was picked) was never cleared client-side.
- Net effect: the browser's `disabled` HTML attribute on Continue was permanently stuck, so clicks did nothing — matching the reported bug exactly.

## Fix
- Added `admissionEditFormReady` (boolean) to `BhtEditController`:
  - Set `true` only at the end of `navigateToEditAdmissionDetails()`, after the fresh re-fetch and room/allergy/credit-company setup complete.
  - Reset to `false` in `prepereForNew()` and `onInstitutionChange()` — the existing "go back to search" reset points.
- Changed the two top-level panel `rendered` conditions in `inward_edit_bht.xhtml` to use `admissionEditFormReady` instead of `current.bhtNo`, so the search panel (and Continue button) now stays mounted and updatable until Continue's full setup actually completes.
- Kept the button's `disabled="#{empty bhtEditController.current.bhtNo}"` condition as-is, and added `btnSelect` (and the institution-change handler) to the relevant `p:ajax update` targets, so it now correctly re-renders enabled once a patient is picked.

## Testing
Verified end-to-end locally with Playwright against a full rebuild + redeploy:
1. Navigated to Edit Admission search page — Continue correctly disabled (no patient picked).
2. Searched `BHT/56756`, selected from autocomplete — "Selected Patient" preview appeared **and** Continue became enabled.
3. Clicked Continue — landed on a fully populated Edit Admission Details page: patient/admission/hospital details, Credit Company panel, Room Details, Guardian Details, and Bill Print preview all rendered correctly (confirming `navigateToEditAdmissionDetails()`'s setup still runs).
4. Checked server log — no exceptions during the flow.

Screenshot: https://github.com/hmislk/hmis.wiki/raw/master/images/issue_22977_edit_admission_continue_fixed.png

Closes #22977

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved admission editing so patient-selection controls remain available while details load.
  * The admission-edit form now appears only after all required details are ready.
  * Continue button status updates correctly when changing institutions or selecting a patient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->