### PR TITLE
feat(theater): allow entering a comment for Surgery Timed Services

### DIFF
--- a/src/main/webapp/theater/inward_timed_service_consume_surgery.xhtml
+++ b/src/main/webapp/theater/inward_timed_service_consume_surgery.xhtml
@@ -225,6 +225,18 @@
                                     </div>
                                 </div>
                                 <div class="row m-1">
+                                    <div class="col-4">
+                                        <p:outputLabel value="Comment"/>
+                                    </div>
+                                    <div class="col-8">
+                                        <p:inputTextarea
+                                            id="comment"
+                                            rows="2"
+                                            class="w-100"
+                                            value="#{inwardTimedItemController.timedEncounterComponent.billFee.patientItem.comment}"/>
+                                    </div>
+                                </div>
+                                <div class="row m-1">
                                     <div class="col-12">
                                         <p:commandButton
                                             id="btnAddService"
@@ -271,6 +283,12 @@
                                 </h:outputLabel>
                             </p:column>
                             <p:column headerText="Comments">
+                                <p:inputTextarea
+                                    id="rowComment"
+                                    rows="2"
+                                    class="w-100"
+                                    value="#{ti.billFee.patientItem.comment}"
+                                    disabled="#{ti.billFee.id eq null or ti.billFee.retired or inwardTimedItemController.batchBill.patientEncounter.paymentFinalized}"/>
                                 <h:outputLabel value="Added by #{ti.billFee.creater.webUserPerson.name}"/>
                                 <br/>
                                 <h:panelGroup rendered="#{ti.billFee.retired}">

--- a/src/main/webapp/theater/inward_timed_service_consume_surgery.xhtml
+++ b/src/main/webapp/theater/inward_timed_service_consume_surgery.xhtml
@@ -9,7 +9,7 @@
                 xmlns:in="http://xmlns.jcp.org/jsf/composite/inward">
     <ui:define name="content">
 
-        <h:form id="form" onkeypress="if (event.keyCode === 13) { event.preventDefault(); return false; }">
+        <h:form id="form" onkeypress="if (event.keyCode === 13 &amp;&amp; event.target.tagName !== 'TEXTAREA') { event.preventDefault(); return false; }">
 
             <!-- Search panel: shown when no surgery bill is selected -->
             <h:panelGroup rendered="#{inwardTimedItemController.batchBill eq null}">


### PR DESCRIPTION
## Summary
Fixes #22994 — users had no way to enter a comment when adding a Surgery Timed Service on `theater/inward_timed_service_consume_surgery.xhtml`.

## Decisions made without approval
(Run unattended per `/dev-issue-unattended`; documenting per that skill's requirements.)

- **Discovered `PatientItem.comment` already exists and is already persisted** (confirmed via entity inspection and a direct schema check — `PATIENTITEM.COMMENT` column exists in the local DB) but was never wired to any page's UI. This made the fix purely additive (JSF-only, no entity/migration changes), rather than requiring new schema — I verified this before starting so as not to design an unnecessary migration.
- **Chose to make the comment editable in-place in the "Consumed Timed Services" table**, not just at creation time, mirroring the existing pattern for Start/End Time in that same table (both are already in-place-editable `p:datePicker`s saved via the row's "Update" button). This was a judgment call to satisfy the issue's third acceptance criterion ("View the saved comment when reviewing the relevant service") consistently with the page's existing UX rather than only supporting comment-on-create.
- No Java changes were needed: `addTimedService()` and `updateTimedService()` already persist the entire `PatientItem` entity, so wiring the field in XHTML was sufficient.

## Fix
- Added a Comment `p:inputTextarea` to the "Add Timed Service" form, bound to `inwardTimedItemController.timedEncounterComponent.billFee.patientItem.comment`.
- Enriched the "Comments" column in the "Consumed Timed Services" table with an in-place editable Comment textarea (bound to `ti.billFee.patientItem.comment`) above the existing "Added by X" / "Deleted by Y" audit line, disabled once the fee is retired or payment is finalized — consistent with the other editable columns in that row.

## Testing
Verified end-to-end locally with Playwright (JSF-only change, hot-copied for verification per project convention):
1. Searched surgery bill BHT/56755, selected it.
2. Added a new Timed Service with a comment ("Test comment for issue 22994 verification") — saved successfully, comment appeared in the Consumed Timed Services row.
3. Confirmed in the database: `PATIENTITEM.COMMENT` held the entered text.
4. Edited the comment in-place via the row's Update button — confirmed the DB value changed accordingly.
5. Removed the test row via the app's own "Remove" action (soft-retire via `removeTimedEncFromDbase`), confirmed `RETIRED=1` in the DB — no raw DB writes used for test data.
6. Checked server log — no exceptions during the flow.

Screenshot: https://github.com/hmislk/hmis.wiki/raw/master/images/issue_22994_timed_service_comment_field.png

Closes #22994

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comment entry for newly added timed services.
  * Added comment editing for existing consumed timed services.

* **Bug Fixes**
  * Prevented comments from being edited when services are unsaved, retired, or payment-finalized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->