### PR TITLE
fix(reports): use backward-looking date range for Slow/Fast/None Movement Report

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -1888,6 +1888,24 @@ the general `p:calendar` guidance in §3). Don't assume `dd/mm/yyyy` just
 because that's the most common pattern elsewhere in the app. Verified while
 testing issue #23005.
 
+## 73. `asadmin deploy --contextroot /` from Git Bash gets mangled by MSYS path conversion — set `MSYS_NO_PATHCONV=1`
+
+Running `asadmin.bat deploy --contextroot / --name rh <war>` from the Bash
+tool (Git Bash/MSYS) fails with a `ConfigurationException` complaining it
+can't parse `jndi:/server/D:/Program%20Files/Git//WEB-INF/faces-config.xml`.
+MSYS auto-converts any bare leading `/` argument (like `--contextroot /`) into
+an absolute Windows path rooted at the Git install dir before the argument
+ever reaches `asadmin`, corrupting the context root and breaking the app's own
+path resolution. `--port <n>` and named paths are unaffected — only a
+standalone `/` argument triggers it.
+
+**Fix**: prefix the command with `MSYS_NO_PATHCONV=1` to disable MSYS's
+argument path-mangling for that call:
+```bash
+MSYS_NO_PATHCONV=1 "D:/Payara/bin/asadmin.bat" deploy --contextroot / --name rh "<path>/target/rh-3.0.0.war"
+```
+Verified while testing issue #22993.
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.

--- a/src/main/java/com/divudi/bean/report/PharmacyReportController.java
+++ b/src/main/java/com/divudi/bean/report/PharmacyReportController.java
@@ -350,6 +350,13 @@ public class PharmacyReportController implements Serializable {
 
     private String dateRange;
 
+    // Separate date-range selector for the Slow/Fast/None Movement Report.
+    // Kept independent from `dateRange` (used by the Expiry Item Report, see
+    // updateDateRange()) because the two reports need opposite "within N
+    // months" semantics: expiry looks forward from today, movement history
+    // looks backward from today. Issue #22993.
+    private String movementDateRange;
+
     private List<PharmacyRow> rows;
     BillType[] billTypes;
     List<MovementReportDto> movementRecords;
@@ -15340,6 +15347,29 @@ public class PharmacyReportController implements Serializable {
         // System.out.println("Updated To Date: " + toDate);
     }
 
+    // Method for updating dates when a date range is selected on the
+    // Slow/Fast/None Movement Report. Unlike updateDateRange() (used by the
+    // Expiry Item Report), "Within N Months" here means looking backward
+    // over the last N months of movement history, ending today. Issue #22993.
+    public void updateMovementDateRange() {
+        LocalDate today = LocalDate.now();
+
+        switch (movementDateRange) {
+            case "within3months":
+                fromDate = CommonFunctions.getStartOfDay(convertToDate(today.minusMonths(3)));
+                toDate = CommonFunctions.getEndOfDay(convertToDate(today));
+                break;
+            case "within6months":
+                fromDate = CommonFunctions.getStartOfDay(convertToDate(today.minusMonths(6)));
+                toDate = CommonFunctions.getEndOfDay(convertToDate(today));
+                break;
+            case "within12months":
+                fromDate = CommonFunctions.getStartOfDay(convertToDate(today.minusMonths(12)));
+                toDate = CommonFunctions.getEndOfDay(convertToDate(today));
+                break;
+        }
+    }
+
     // Utility to convert LocalDate to Date
     private Date convertToDate(LocalDate localDate) {
         return Date.from(localDate.atStartOfDay(ZoneId.systemDefault()).toInstant());
@@ -17147,6 +17177,14 @@ public class PharmacyReportController implements Serializable {
         this.dateRange = dateRange;
     }
 
+    public String getMovementDateRange() {
+        return movementDateRange;
+    }
+
+    public void setMovementDateRange(String movementDateRange) {
+        this.movementDateRange = movementDateRange;
+    }
+
     public Double getStockQty() {
         return stockQty;
     }
@@ -17757,6 +17795,24 @@ public class PharmacyReportController implements Serializable {
                 return "Within 12 Months";
             case "shortexpiry":
                 return "Expired Items";
+            default:
+                return "-";
+        }
+    }
+
+    // MovementDateRange to Label (Slow/Fast/None Movement Report)
+    public String getMovementDateRangeAsString() {
+        if (movementDateRange == null) {
+            return "-";
+        }
+
+        switch (movementDateRange) {
+            case "within3months":
+                return "Within 3 Months";
+            case "within6months":
+                return "Within 6 Months";
+            case "within12months":
+                return "Within 12 Months";
             default:
                 return "-";
         }

--- a/src/main/webapp/reports/inventoryReports/slow_fast_none_movement.xhtml
+++ b/src/main/webapp/reports/inventoryReports/slow_fast_none_movement.xhtml
@@ -57,14 +57,14 @@
                         <p:selectOneMenu
                                 id="phmDateRange"
                                 styleClass="w-100"
-                                value="#{pharmacyReportController.dateRange}">
+                                value="#{pharmacyReportController.movementDateRange}">
                             <f:selectItem itemLabel="Select" itemValue=""/>
                             <f:selectItem itemLabel="Within 3 Months" itemValue="within3months"/>
                             <f:selectItem itemLabel="Within 6 Months" itemValue="within6months"/>
                             <f:selectItem itemLabel="Within 12 Months" itemValue="within12months"/>
                             <p:ajax
                                     event="change"
-                                    listener="#{pharmacyReportController.updateDateRange}"
+                                    listener="#{pharmacyReportController.updateMovementDateRange}"
                                     update="fromDate toDate"/>
                         </p:selectOneMenu>
 
@@ -367,7 +367,7 @@
                                     <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"/>
                                 </h:outputText>
                                 <h:outputText value="Date Range:"/>
-                                <h:outputText value="#{pharmacyReportController.dateRangeAsString}"/>
+                                <h:outputText value="#{pharmacyReportController.movementDateRangeAsString}"/>
                                 <h:outputText value="Institution:"/>
                                 <h:outputText value="#{pharmacyReportController.institution != null ? pharmacyReportController.institution.name : 'All'}"/>
                                 <h:outputText value="Site:"/>
@@ -499,7 +499,7 @@
                                     <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"/>
                                 </h:outputText>
                                 <h:outputText value="Date Range:"/>
-                                <h:outputText value="#{pharmacyReportController.dateRangeAsString}"/>
+                                <h:outputText value="#{pharmacyReportController.movementDateRangeAsString}"/>
                                 <h:outputText value="Institution:"/>
                                 <h:outputText value="#{pharmacyReportController.institution != null ? pharmacyReportController.institution.name : 'All'}"/>
                                 <h:outputText value="Site:"/>
@@ -633,7 +633,7 @@
                                     <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"/>
                                 </h:outputText>
                                 <h:outputText value="Date Range:"/>
-                                <h:outputText value="#{pharmacyReportController.dateRangeAsString}"/>
+                                <h:outputText value="#{pharmacyReportController.movementDateRangeAsString}"/>
                                 <h:outputText value="Institution:"/>
                                 <h:outputText value="#{pharmacyReportController.institution != null ? pharmacyReportController.institution.name : 'All'}"/>
                                 <h:outputText value="Site:"/>

--- a/src/main/webapp/reports/inventoryReports/slow_fast_none_movement_print.xhtml
+++ b/src/main/webapp/reports/inventoryReports/slow_fast_none_movement_print.xhtml
@@ -61,7 +61,7 @@
                                                 </h:outputText>
 
                                                 <h:outputText value="Date Range:" styleClass="label"/>
-                                                <h:outputText value="#{pharmacyReportController.getDateRangeAsString()}"/>
+                                                <h:outputText value="#{pharmacyReportController.getMovementDateRangeAsString()}"/>
 
 
                                                 <!-- Row 2 -->
@@ -220,7 +220,7 @@
                                                 </h:outputText>
 
                                                 <h:outputText value="Date Range:" styleClass="label"/>
-                                                <h:outputText value="#{pharmacyReportController.getDateRangeAsString()}"/>
+                                                <h:outputText value="#{pharmacyReportController.getMovementDateRangeAsString()}"/>
 
 
                                                 <!-- Row 2 -->
@@ -379,7 +379,7 @@
                                                 </h:outputText>
 
                                                 <h:outputText value="Date Range:" styleClass="label"/>
-                                                <h:outputText value="#{pharmacyReportController.getDateRangeAsString()}"/>
+                                                <h:outputText value="#{pharmacyReportController.getMovementDateRangeAsString()}"/>
 
 
                                                 <!-- Row 2 -->


### PR DESCRIPTION
## Summary

Fixes the Date Range dropdown ("Within 3/6/12 Months") on the Slow/Fast/None
Movement Report so From Date/To Date auto-fill correctly.

## Root cause

The dropdown shared a single `dateRange` field and `updateDateRange()`
method on `PharmacyReportController` with the Expiry Item Report
(`expiry_item.xhtml`). The two reports need opposite "Within N Months"
semantics — Expiry looks *forward* from today, movement history needs to
look *backward* from today. A prior fix for the Expiry Item Report (closing
#17842) flipped the shared method to forward-looking, which correctly fixed
Expiry but broke this report's date auto-fill as a side effect.

## Fix

Added a dedicated `movementDateRange` field, `updateMovementDateRange()`
method, and `movementDateRangeAsString` label getter scoped only to the
Slow/Fast/None Movement Report, restoring the original backward-looking
"last N months, ending today" logic — without touching the Expiry Item
Report's `dateRange`/`updateDateRange()`, so #17842 stays intact.

## Decisions made without approval

- **Kept the two date-range concepts fully separate** (new field/method)
  rather than adding a mode flag to the shared method. The shared method
  already has in-code comments recording the deliberate forward-looking
  intent for Expiry (#17842); reusing it risked silently regressing that
  fix again for the next report that touches it.

## Verification

Verified end-to-end via Playwright against local dev data:
- Selecting "Within 3 Months" on 18 Aug 2026 auto-fills From Date = 18 May
  2026, To Date = 18 Aug 2026 (matches the example in #22993 exactly).
- "Within 6 Months" and "Within 12 Months" verified with the same logic.
- Process still generates the report correctly with the auto-filled range
  (2246 real records for a 12-month window on local dev data).

![Within 3 Months auto-fills the date range](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/22993-01-within-3-months-dates-autofilled.png)

Closes #22993

🤖 Generated with [Claude Code](https://claude.com/claude-code)
