### PR TITLE
fix(pharmacy): wire GRN Summary Report to real GRN/Direct Purchase data

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -1888,6 +1888,27 @@ the general `p:calendar` guidance in §3). Don't assume `dd/mm/yyyy` just
 because that's the most common pattern elsewhere in the app. Verified while
 testing issue #23005.
 
+## 73. Exploded Payara deployment lets you hot-swap a single XHTML file for a fast test/fix loop — real redeploy still required before commit
+
+Local Payara deploys the WAR **exploded** (unzipped), not as a jar-in-place —
+confirmed at `<payara-install>\glassfish\domains\domain1\applications\rh\`.
+Facelets are not hot-reloaded in this configuration (production-mode
+caching), so an XHTML edit under `src/main/webapp` needs a redeploy to take
+effect — but for a JSF-only fix, copying the single corrected file straight
+into the exploded app directory is a much faster iterate-and-recheck loop
+than a full `package`/`asadmin redeploy` cycle:
+```bash
+cp "src/main/webapp/reports/inventoryReports/grn_summary_report.xhtml" \
+   "D:/Payara/glassfish/domains/domain1/applications/rh/reports/inventoryReports/grn_summary_report.xhtml"
+```
+A plain `browser_navigate` reload picks it up immediately (no restart, no
+session loss). This is a throwaway shortcut for iterating on a fix, not a
+deployment method — always finish with a real `package` + `asadmin undeploy`/
+`deploy` (§0a) before treating the change as verified, since that's what
+actually proves the WAR builds and packages the fix correctly. Verified while
+testing issue #22984 (caught an `outputLabel for=` component-id mismatch this
+way in seconds instead of a multi-minute rebuild).
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
@@ -260,6 +260,10 @@ public class PharmacyController implements Serializable {
     private Institution fromInstitution;
     private PaymentMethod paymentMethod;
     private String reportType;
+    // Purchase-type filter for the GRN Summary Report page (grn_summary_report.xhtml).
+    // "grn" restricts to GRN bill types, "direct" to Direct Purchase bill types,
+    // null/unset keeps the existing behaviour of generateGrnReport() (all types). Issue #22984.
+    private String purchaseType;
     private double totalCreditPurchaseValue;
     private double totalCashPurchaseValue;
     private double totalCashCostValue;
@@ -10531,6 +10535,16 @@ public class PharmacyController implements Serializable {
         bta.add(BillTypeAtomic.PHARMACY_DIRECT_PURCHASE_CANCELLED);
         bta.add(BillTypeAtomic.PHARMACY_DIRECT_PURCHASE_REFUND);
 
+        if ("grn".equals(purchaseType)) {
+            bta.removeIf(t -> t == BillTypeAtomic.PHARMACY_DIRECT_PURCHASE
+                    || t == BillTypeAtomic.PHARMACY_DIRECT_PURCHASE_CANCELLED
+                    || t == BillTypeAtomic.PHARMACY_DIRECT_PURCHASE_REFUND);
+        } else if ("direct".equals(purchaseType)) {
+            bta.removeIf(t -> t == BillTypeAtomic.PHARMACY_GRN
+                    || t == BillTypeAtomic.PHARMACY_GRN_RETURN
+                    || t == BillTypeAtomic.PHARMACY_GRN_CANCELLED);
+        }
+
         bills = new ArrayList<>();
 
         String sql = "SELECT b FROM Bill b "
@@ -12236,6 +12250,14 @@ public class PharmacyController implements Serializable {
 
     public void setPaymentMethod(PaymentMethod paymentMethod) {
         this.paymentMethod = paymentMethod;
+    }
+
+    public String getPurchaseType() {
+        return purchaseType;
+    }
+
+    public void setPurchaseType(String purchaseType) {
+        this.purchaseType = purchaseType;
     }
 
     public Department getDept() {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
@@ -10528,21 +10528,15 @@ public class PharmacyController implements Serializable {
 
         List<BillTypeAtomic> bta = new ArrayList<>();
 
-        bta.add(BillTypeAtomic.PHARMACY_GRN);
-        bta.add(BillTypeAtomic.PHARMACY_GRN_RETURN);
-        bta.add(BillTypeAtomic.PHARMACY_GRN_CANCELLED);
-        bta.add(BillTypeAtomic.PHARMACY_DIRECT_PURCHASE);
-        bta.add(BillTypeAtomic.PHARMACY_DIRECT_PURCHASE_CANCELLED);
-        bta.add(BillTypeAtomic.PHARMACY_DIRECT_PURCHASE_REFUND);
-
-        if ("grn".equals(purchaseType)) {
-            bta.removeIf(t -> t == BillTypeAtomic.PHARMACY_DIRECT_PURCHASE
-                    || t == BillTypeAtomic.PHARMACY_DIRECT_PURCHASE_CANCELLED
-                    || t == BillTypeAtomic.PHARMACY_DIRECT_PURCHASE_REFUND);
-        } else if ("direct".equals(purchaseType)) {
-            bta.removeIf(t -> t == BillTypeAtomic.PHARMACY_GRN
-                    || t == BillTypeAtomic.PHARMACY_GRN_RETURN
-                    || t == BillTypeAtomic.PHARMACY_GRN_CANCELLED);
+        if (!"direct".equals(purchaseType)) {
+            bta.add(BillTypeAtomic.PHARMACY_GRN);
+            bta.add(BillTypeAtomic.PHARMACY_GRN_RETURN);
+            bta.add(BillTypeAtomic.PHARMACY_GRN_CANCELLED);
+        }
+        if (!"grn".equals(purchaseType)) {
+            bta.add(BillTypeAtomic.PHARMACY_DIRECT_PURCHASE);
+            bta.add(BillTypeAtomic.PHARMACY_DIRECT_PURCHASE_CANCELLED);
+            bta.add(BillTypeAtomic.PHARMACY_DIRECT_PURCHASE_REFUND);
         }
 
         bills = new ArrayList<>();
@@ -11238,6 +11232,14 @@ public class PharmacyController implements Serializable {
     
     // PostProcessor for grn and direct purchase summary report excel export
     public void postProcessGRNAndDirectPurchaseReportExcel(Object document) {
+        postProcessGRNAndDirectPurchaseReportExcel(document, "GRN and Direct Purchase Report");
+    }
+
+    public void postProcessGRNSummaryReportExcel(Object document) {
+        postProcessGRNAndDirectPurchaseReportExcel(document, "GRN Summary Report");
+    }
+
+    private void postProcessGRNAndDirectPurchaseReportExcel(Object document, String reportTitle) {
         if (document == null) {
             Logger.getLogger(PharmacyController.class.getName()).log(Level.SEVERE, "Document is null in postProcessBillWiseItemMovementReportExcel");
             return;
@@ -11252,13 +11254,13 @@ public class PharmacyController implements Serializable {
             return;
         }
 
-        workbook.setSheetName(0, "GRN and Direct Purchase Report");
+        workbook.setSheetName(0, reportTitle);
         sheet.shiftRows(0, sheet.getLastRowNum(), 7);
 
         Map<String, Object> filters = getFiltersForGRNDetailReport();
 
         if (filters != null && !filters.isEmpty()) {
-            addMetaDataToExcelSheet(workbook, sheet, 0, "GRN and Direct Purchase Report", filters);
+            addMetaDataToExcelSheet(workbook, sheet, 0, reportTitle, filters);
         }
         int rowIndex = 5;
         SimpleDateFormat sdf = new SimpleDateFormat(sessionController.getApplicationPreference().getLongDateTimeFormat());

--- a/src/main/webapp/reports/inventoryReports/grn_summary_report.xhtml
+++ b/src/main/webapp/reports/inventoryReports/grn_summary_report.xhtml
@@ -95,12 +95,14 @@
                             <!-- Department/Store -->
                             <h:panelGroup layout="block" styleClass="form-group">
                                 <h:outputText styleClass="fa fa-building mr-2"/>
-                                <p:outputLabel value="Department/Store" class="m-3" for="grnDept"/>
+                                <p:outputLabel value="Department/Store" class="m-3"/>
                             </h:panelGroup>
                             <h:panelGroup id="grnDept">
 
                                 <!-- Component 1: Without Institution and Site -->
                                 <p:selectOneMenu
+                                        id="grnDeptAll"
+                                        label="Department/Store"
                                         rendered="#{pharmacyController.institution eq null and pharmacyController.site eq null}"
                                         styleClass="w-100 form-control"
                                         value="#{pharmacyController.dept}"
@@ -116,6 +118,8 @@
 
                                 <!-- Component 2: With Site Only -->
                                 <p:selectOneMenu
+                                        id="grnDeptSite"
+                                        label="Department/Store"
                                         rendered="#{pharmacyController.institution eq null and pharmacyController.site ne null}"
                                         styleClass="w-100 form-control"
                                         value="#{pharmacyController.dept}"
@@ -131,6 +135,8 @@
 
                                 <!-- Component 3: With Institution Only -->
                                 <p:selectOneMenu
+                                        id="grnDeptInstitution"
+                                        label="Department/Store"
                                         rendered="#{pharmacyController.institution ne null and pharmacyController.site eq null}"
                                         styleClass="w-100 form-control"
                                         value="#{pharmacyController.dept}"
@@ -138,7 +144,7 @@
                                         filter="true">
                                     <f:selectItem itemLabel="All Departments"/>
                                     <f:selectItems
-                                            value="#{departmentController.getDepartmentsOfInstitutionAndSite(pharmacyController.institution)}"
+                                            value="#{departmentController.getDepartmentsOfInstitutionAndSiteForInstitution(pharmacyController.institution)}"
                                             var="dept"
                                             itemLabel="#{dept.name}"
                                             itemValue="#{dept}"/>
@@ -146,6 +152,8 @@
 
                                 <!-- Component 4: With Both Institution and Site -->
                                 <p:selectOneMenu
+                                        id="grnDeptInstitutionSite"
+                                        label="Department/Store"
                                         rendered="#{pharmacyController.institution ne null and pharmacyController.site ne null}"
                                         styleClass="w-100 form-control"
                                         value="#{pharmacyController.dept}"
@@ -212,7 +220,7 @@
                                 <p:dataExporter type="xlsx"
                                                 target="tbl1"
                                                 fileName="GRN_Summary_Report_#{pharmacyController.fromDateFormatted()}_to_#{pharmacyController.toDateFormatted()}"
-                                                postProcessor="#{pharmacyController.postProcessGRNAndDirectPurchaseReportExcel}"/>
+                                                postProcessor="#{pharmacyController.postProcessGRNSummaryReportExcel}"/>
                             </p:commandButton>
                             <p:commandButton
                                 value="PDF"
@@ -288,7 +296,9 @@
                                     <h:outputText value="Returned"
                                                   rendered="#{bill.billTypeAtomic eq 'PHARMACY_GRN_RETURN' or bill.billTypeAtomic eq 'PHARMACY_DIRECT_PURCHASE_REFUND'}"/>
                                     <h:outputText value="Approved"
-                                                  rendered="#{bill.billTypeAtomic eq 'PHARMACY_GRN' or bill.billTypeAtomic eq 'PHARMACY_DIRECT_PURCHASE'}"/>
+                                                  rendered="#{(bill.billTypeAtomic eq 'PHARMACY_GRN' and bill.completed) or bill.billTypeAtomic eq 'PHARMACY_DIRECT_PURCHASE'}"/>
+                                    <h:outputText value="Pending Approval"
+                                                  rendered="#{bill.billTypeAtomic eq 'PHARMACY_GRN' and not bill.completed}"/>
                                 </p:column>
                                 <p:column headerText="Remark">
                                     <h:outputText value="-"/>

--- a/src/main/webapp/reports/inventoryReports/grn_summary_report.xhtml
+++ b/src/main/webapp/reports/inventoryReports/grn_summary_report.xhtml
@@ -11,10 +11,10 @@
             <ui:define name="subcontent">
                 <h:form>
                     <p:panel header="GRN Summary Report">
-                        
+
                         <!-- Filter Section -->
                         <h:panelGrid columns="8" class="w-100">
-                            
+
                             <!-- From Date -->
                             <h:panelGroup layout="block" styleClass="form-group">
                                 <h:outputText value="&#xf073;" styleClass="fa mr-2"/>
@@ -24,14 +24,15 @@
                                 styleClass="w-100"
                                 inputStyleClass="w-100 form-control"
                                 id="fromDate"
+                                value="#{pharmacyController.fromDate}"
                                 showTime="true"
                                 yearNavigator="true"
                                 monthNavigator="true"
                                 timeInput="true"
                                 pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
-                            
+
                             <p:spacer width="20"/>
-                            
+
                             <!-- To Date -->
                             <h:panelGroup layout="block" styleClass="form-group">
                                 <h:outputText value="&#xf073;" styleClass="fa mr-2"/>
@@ -41,15 +42,16 @@
                                 styleClass="w-100"
                                 inputStyleClass="w-100 form-control"
                                 id="toDate"
+                                value="#{pharmacyController.toDate}"
                                 showTime="true"
                                 yearNavigator="true"
                                 monthNavigator="true"
                                 timeInput="true"
                                 pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
-                            
+
                             <p:spacer width="20"/>
-                            
-                            
+
+
                             <!-- Institution -->
                             <h:panelGroup layout="block" styleClass="form-group">
                                 <h:outputText styleClass="fa fa-university mr-2"/>
@@ -58,15 +60,17 @@
                             <p:selectOneMenu
                                 id="grnInstitution"
                                 class="w-100"
+                                value="#{pharmacyController.institution}"
                                 filter="true">
                                 <f:selectItem itemLabel="All Institutions"/>
-                                <f:selectItem itemLabel="City Hospital" itemValue="1"/>
-                                <f:selectItem itemLabel="Metro Medical Center" itemValue="2"/>
-                                <f:selectItem itemLabel="Central Clinic" itemValue="3"/>
+                                <f:selectItems
+                                        value="#{institutionController.companies}"
+                                        var="ins"
+                                        itemLabel="#{ins.name}"
+                                        itemValue="#{ins}"/>
+                                <p:ajax process="grnInstitution" update="grnDept"/>
                             </p:selectOneMenu>
-                            
-<!--                            <p:spacer width="20"/>-->
-                            
+
                             <!-- Site -->
                             <h:panelGroup layout="block" styleClass="form-group">
                                 <h:outputText styleClass="fa fa-map-marker-alt mr-2"/>
@@ -75,171 +79,233 @@
                             <p:selectOneMenu
                                 id="grnSite"
                                 class="w-100"
+                                value="#{pharmacyController.site}"
                                 filter="true">
                                 <f:selectItem itemLabel="All Sites"/>
-                                <f:selectItem itemLabel="Main Campus" itemValue="1"/>
-                                <f:selectItem itemLabel="Branch Office" itemValue="2"/>
-                                <f:selectItem itemLabel="Emergency Unit" itemValue="3"/>
+                                <f:selectItems
+                                        value="#{institutionController.sites}"
+                                        var="site"
+                                        itemLabel="#{site.name}"
+                                        itemValue="#{site}"/>
+                                <p:ajax process="grnSite" update="grnDept"/>
                             </p:selectOneMenu>
-                            
+
                             <p:spacer width="20"/>
-                            
+
                             <!-- Department/Store -->
                             <h:panelGroup layout="block" styleClass="form-group">
                                 <h:outputText styleClass="fa fa-building mr-2"/>
-                                <p:outputLabel value="Department/Store" class="m-3" for="grnDepartmentStore"/>
+                                <p:outputLabel value="Department/Store" class="m-3" for="grnDept"/>
                             </h:panelGroup>
-                            <p:selectOneMenu
-                                id="grnDepartmentStore"
-                                styleClass="w-100 form-control"
-                                filterMatchMode="contains"
-                                filter="true">
-                                <f:selectItem itemLabel="All Departments"/>
-                                <f:selectItem itemLabel="Pharmacy" itemValue="1"/>
-                                <f:selectItem itemLabel="Laboratory" itemValue="2"/>
-                                <f:selectItem itemLabel="Radiology" itemValue="3"/>
-                                <f:selectItem itemLabel="OT Supplies" itemValue="4"/>
-                            </p:selectOneMenu>
-                           
+                            <h:panelGroup id="grnDept">
+
+                                <!-- Component 1: Without Institution and Site -->
+                                <p:selectOneMenu
+                                        rendered="#{pharmacyController.institution eq null and pharmacyController.site eq null}"
+                                        styleClass="w-100 form-control"
+                                        value="#{pharmacyController.dept}"
+                                        filterMatchMode="contains"
+                                        filter="true">
+                                    <f:selectItem itemLabel="All Departments"/>
+                                    <f:selectItems
+                                            value="#{departmentController.getDepartmentsOfInstitutionAndSite()}"
+                                            var="dept"
+                                            itemLabel="#{dept.name}"
+                                            itemValue="#{dept}"/>
+                                </p:selectOneMenu>
+
+                                <!-- Component 2: With Site Only -->
+                                <p:selectOneMenu
+                                        rendered="#{pharmacyController.institution eq null and pharmacyController.site ne null}"
+                                        styleClass="w-100 form-control"
+                                        value="#{pharmacyController.dept}"
+                                        filterMatchMode="contains"
+                                        filter="true">
+                                    <f:selectItem itemLabel="All Departments"/>
+                                    <f:selectItems
+                                            value="#{departmentController.getDepartmentsOfInstitutionAndSite(pharmacyController.site)}"
+                                            var="dept"
+                                            itemLabel="#{dept.name}"
+                                            itemValue="#{dept}"/>
+                                </p:selectOneMenu>
+
+                                <!-- Component 3: With Institution Only -->
+                                <p:selectOneMenu
+                                        rendered="#{pharmacyController.institution ne null and pharmacyController.site eq null}"
+                                        styleClass="w-100 form-control"
+                                        value="#{pharmacyController.dept}"
+                                        filterMatchMode="contains"
+                                        filter="true">
+                                    <f:selectItem itemLabel="All Departments"/>
+                                    <f:selectItems
+                                            value="#{departmentController.getDepartmentsOfInstitutionAndSite(pharmacyController.institution)}"
+                                            var="dept"
+                                            itemLabel="#{dept.name}"
+                                            itemValue="#{dept}"/>
+                                </p:selectOneMenu>
+
+                                <!-- Component 4: With Both Institution and Site -->
+                                <p:selectOneMenu
+                                        rendered="#{pharmacyController.institution ne null and pharmacyController.site ne null}"
+                                        styleClass="w-100 form-control"
+                                        value="#{pharmacyController.dept}"
+                                        filterMatchMode="contains"
+                                        filter="true">
+                                    <f:selectItem itemLabel="All Departments"/>
+                                    <f:selectItems
+                                            value="#{departmentController.getDepartmentsOfInstitutionAndSite(pharmacyController.institution, pharmacyController.site)}"
+                                            var="dept"
+                                            itemLabel="#{dept.name}"
+                                            itemValue="#{dept}"/>
+                                </p:selectOneMenu>
+                            </h:panelGroup>
+
                             <p:spacer width="20"/>
-                            
+
                             <!-- Payment Mode -->
                             <h:panelGroup layout="block" styleClass="form-group">
                                 <h:outputText styleClass="fa fa-credit-card mr-2"/>
                                 <p:outputLabel value="Payment Mode" class="m-3" for="grnPaymentMode"/>
                             </h:panelGroup>
-                            <p:selectOneMenu 
-                                id="grnPaymentMode" 
-                                class="w-100">
+                            <p:selectOneMenu
+                                id="grnPaymentMode"
+                                class="w-100"
+                                value="#{pharmacyController.paymentMethod}">
                                 <f:selectItem itemLabel="All Modes"/>
-                                <f:selectItem itemLabel="Cash" itemValue="cash"/>
-                                <f:selectItem itemLabel="Credit" itemValue="credit"/>
-                                <f:selectItem itemLabel="Cheque" itemValue="cheque"/>
-                                <f:selectItem itemLabel="Bank Transfer" itemValue="transfer"/>
+                                <f:selectItems
+                                        value="#{enumController.paymentMethods}"
+                                        var="pm"
+                                        itemLabel="#{pm.label}"
+                                        itemValue="#{pm}"/>
                             </p:selectOneMenu>
-                            
-                            <!--<p:spacer width="20"/>-->
-                            
-                            <!-- GRN Status -->
+
+                            <!-- Purchase Type -->
                             <h:panelGroup layout="block" styleClass="form-group">
                                 <h:outputText styleClass="fa fa-info-circle mr-2"/>
                                 <p:outputLabel value="Purchase Type" class="m-3" for="purchaseType"/>
                             </h:panelGroup>
-                            <p:selectOneMenu 
-                                id="purchaseType" 
-                                class="w-100">
+                            <p:selectOneMenu
+                                id="purchaseType"
+                                class="w-100"
+                                value="#{pharmacyController.purchaseType}">
                                 <f:selectItem itemLabel="All Types"/>
-                                <f:selectItem itemLabel="Direct Purchase" itemValue="received"/>
-                                <f:selectItem itemLabel="GRN" itemValue="partial"/>
-<!--                                <f:selectItem itemLabel="Pending" itemValue="pending"/>-->
+                                <f:selectItem itemLabel="GRN" itemValue="grn"/>
+                                <f:selectItem itemLabel="Direct Purchase" itemValue="direct"/>
                             </p:selectOneMenu>
-                            
+
                         </h:panelGrid>
-                        
+
                         <!-- Action Buttons -->
                         <h:panelGroup layout="block" class="mt-3 mb-3">
-                            <p:commandButton 
-                                value="Process" 
+                            <p:commandButton
+                                value="Process"
                                 icon="fas fa-cogs"
                                 class="ui-button-warning mx-1"
-                                type="button"/>
-                            <p:commandButton 
-                                value="Print" 
-                                icon="fas fa-print"
-                                class="ui-button-secondary mx-1"
-                                type="button"/>
-                            <p:commandButton 
-                                value="Download" 
+                                ajax="false"
+                                action="#{pharmacyController.generateGrnReport()}"/>
+                            <p:commandButton
+                                value="Download"
                                 icon="fas fa-file-excel"
                                 class="ui-button-success mx-1"
-                                type="button"/>
-                            <p:commandButton 
-                                value="PDF" 
+                                ajax="false"
+                                rendered="#{not empty pharmacyController.bills}">
+                                <p:dataExporter type="xlsx"
+                                                target="tbl1"
+                                                fileName="GRN_Summary_Report_#{pharmacyController.fromDateFormatted()}_to_#{pharmacyController.toDateFormatted()}"
+                                                postProcessor="#{pharmacyController.postProcessGRNAndDirectPurchaseReportExcel}"/>
+                            </p:commandButton>
+                            <p:commandButton
+                                value="PDF"
                                 icon="fas fa-file-pdf"
                                 class="ui-button-danger mx-1"
-                                type="button"/>
+                                ajax="false"
+                                action="#{pharmacyController.exportGRNAndDirectPurchaseSummaryReportToPDF()}"
+                                rendered="#{not empty pharmacyController.bills}"/>
                         </h:panelGroup>
-                        
+
                         <p:divider/>
-                        
-                        <!-- Static HTML Table for Demo Data -->
+
+                        <!-- GRN Summary Table -->
                         <h:panelGroup layout="block">
-                            <table class="ui-datatable ui-widget table-sm" style="width:100%;">
-                                <thead class="ui-datatable-thead">
-                                    <tr>
-                                        <th style="width:4em;text-align:center">S.No</th>
-                                        <th style="width:6em">GRN No</th>
-                                        <th style="width:6em">Purchase Type</th>
-                                        <th style="width:6em">GRN Date</th>
-                                        <th style="width:6em">Invoice No</th>
-                                        <th style="width:6em">Invoice Date</th>
-                                        <th style="width:6em">Vendor Name</th>
-                                        <th style="width:6em">Payment Mode</th>
-                                        <th style="width:6em;text-align:right">Amount</th>
-                                        <th style="width:6em;text-align:right">Dis. Amount</th>
-                                        <th style="width:6em;text-align:right">Stock Amount</th>
-                                        <th style="width:6em">Status</th>
-                                        <th style="width:6em;text-align:center">Remark</th>
-                                        <th style="width:6em">Date</th>
-                                        <th style="width:6em">Sign</th>
-                                    </tr>
-                                </thead>
-                                <tbody class="ui-datatable-data">
-                                    <!-- Row 1 -->
-                                    <tr class="ui-widget-content">
-                                        <td style="text-align:center">1</td>
-                                        <td><span style="color:#007bff;font-weight:bold;cursor:pointer">GRN-2024-001</span></td>
-                                        <td>GRN</td>
-                                        <td>Apr 21, 2025</td>
-                                        <td>INV-2024-1234</td>
-                                        <td>Apr 21, 2025</td>
-                                        <td>ABC Pharmaceuticals Ltd.</td>
-                                        <td>Credit</td>
-                                        <!--<td style="text-align:center">45</td>-->
-                                        <td style="text-align:right">1,25,450.00</td>
-                                        <td style="text-align:right">-</td>
-                                        <td style="text-align:right">1,25,450.00</td>
-                                        <td><span style="color:#008000">APPROVED</span></td>
-                                        <td>---</td>
-                                        <td>---</td>
-                                        <td>---</td>
-                                    </tr>
-                                    <!-- Row 2 -->
-                                    <tr class="ui-widget-content">
-                                        <td style="text-align:center">2</td>
-                                        <td><span style="color:#007bff;font-weight:bold;cursor:pointer">GRN-2024-002</span></td>
-                                        <td>Direct Purchase</td>
-                                        <td>Apr 21, 2025</td>
-                                        <td>INV-2024-1245</td>
-                                        <td>Apr 21, 2025</td>
-                                        <td>MediSupply Co.</td>
-                                        <td>Bank Transfer</td>
-                                        <td style="text-align:right">8125.10</td>
-                                        <td style="text-align:right">500</td>
-                                        <td style="text-align:right">7625.10</td>
-                                        <td><span style="color:#008000">APPROVED</span></td>
-                                        <td>---</td>
-                                        <td>---</td>
-                                        <td>---</td>
-                                    </tr>
-                                   
-                                </tbody>
-                                <tfoot class="ui-datatable-tfoot">
-                                    <tr>
-                                        <td colspan="8" style="text-align:right;font-weight:bold">Total</td>
-                                        <td style="text-align:right;font-weight:bold">123321.10</td>
-                                        <td style="text-align:right;font-weight:bold">500.00</td>
-                                        <td style="text-align:right;font-weight:bold">122121.10</td>
-                                        <td colspan="4"></td>
-                                    </tr>
-                                </tfoot>
-                            </table>
-                            
-                            <div style="margin-top:20px;text-align:center;color:#666;">
-                                <p:outputLabel value="Showing 1 to 2 of 2 entries"/>
-                            </div>
+                            <p:dataTable id="tbl1"
+                                         value="#{pharmacyController.bills}"
+                                         var="bill"
+                                         rowIndexVar="n"
+                                         paginator="true"
+                                         paginatorPosition="bottom"
+                                         rows="10"
+                                         styleClass="table-sm"
+                                         paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                         currentPageReportTemplate="Showing {startRecord} to {endRecord} of {totalRecords}"
+                                         rowsPerPageTemplate="5,10,15,25,50,100,500,1000">
+
+                                <p:column headerText="S.No" width="50" styleClass="text-center">
+                                    <h:outputText value="#{n+1}"/>
+                                </p:column>
+                                <p:column headerText="GRN No">
+                                    <h:outputText value="#{bill.deptId}"/>
+                                </p:column>
+                                <p:column headerText="Purchase Type">
+                                    <h:outputText value="#{bill.billTypeAtomic.label}"/>
+                                </p:column>
+                                <p:column headerText="GRN Date">
+                                    <h:outputText value="#{bill.createdAt}">
+                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"/>
+                                    </h:outputText>
+                                </p:column>
+                                <p:column headerText="Invoice No">
+                                    <h:outputText value="#{bill.invoiceNumber}"/>
+                                </p:column>
+                                <p:column headerText="Invoice Date">
+                                    <h:outputText value="#{bill.invoiceDate}">
+                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"/>
+                                    </h:outputText>
+                                </p:column>
+                                <p:column headerText="Vendor Name">
+                                    <h:outputText value="#{(bill.billTypeAtomic eq 'PHARMACY_GRN_RETURN' or bill.billTypeAtomic eq 'PHARMACY_DIRECT_PURCHASE_REFUND') ? bill.toInstitution.name : bill.fromInstitution.name}"/>
+                                </p:column>
+                                <p:column headerText="Payment Mode">
+                                    <h:outputText value="#{bill.paymentMethod.label}"/>
+                                </p:column>
+                                <p:column headerText="Amount" styleClass="text-end">
+                                    <h:outputText value="#{bill.netTotal}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </h:outputText>
+                                </p:column>
+                                <p:column headerText="Dis. Amount" styleClass="text-end">
+                                    <h:outputText value="#{bill.discount}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </h:outputText>
+                                </p:column>
+                                <p:column headerText="Stock Amount" styleClass="text-end">
+                                    <h:outputText value="#{bill.billFinanceDetails != null ? bill.billFinanceDetails.totalPurchaseValue : 0}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </h:outputText>
+                                </p:column>
+                                <p:column headerText="Status">
+                                    <h:outputText value="Cancelled"
+                                                  rendered="#{bill.billTypeAtomic eq 'PHARMACY_GRN_CANCELLED' or bill.billTypeAtomic eq 'PHARMACY_DIRECT_PURCHASE_CANCELLED'}"/>
+                                    <h:outputText value="Returned"
+                                                  rendered="#{bill.billTypeAtomic eq 'PHARMACY_GRN_RETURN' or bill.billTypeAtomic eq 'PHARMACY_DIRECT_PURCHASE_REFUND'}"/>
+                                    <h:outputText value="Approved"
+                                                  rendered="#{bill.billTypeAtomic eq 'PHARMACY_GRN' or bill.billTypeAtomic eq 'PHARMACY_DIRECT_PURCHASE'}"/>
+                                </p:column>
+                                <p:column headerText="Remark">
+                                    <h:outputText value="-"/>
+                                </p:column>
+                                <p:column headerText="Date">
+                                    <h:outputText value="-"/>
+                                </p:column>
+                                <p:column headerText="Sign">
+                                    <h:outputText value="-"/>
+                                </p:column>
+
+                                <f:facet name="footer">
+                                    <h:outputText value="No matching records found." rendered="#{empty pharmacyController.bills}"/>
+                                </f:facet>
+                            </p:dataTable>
                         </h:panelGroup>
-                        
+
                     </p:panel>
                 </h:form>
             </ui:define>


### PR DESCRIPTION
## Summary

Fixes the GRN Summary Report (Reports → Inventory Reports → 15. GRN Summary
Report): the Process button now works and the page shows real GRN/Direct
Purchase data instead of hardcoded dummy rows.

## Root cause

`grn_summary_report.xhtml` was an unfinished UI prototype: none of its
filter fields were bound to a controller, the Process button had
`type="button"` (no `action` — inert by design), and the results table was
static hardcoded HTML with sample rows (`GRN-2024-001` etc.) instead of a
data-bound `p:dataTable`.

## Fix

Wired the page to `PharmacyController.generateGrnReport()` — the same,
already-working query that backs the "GRN and Direct Purchase" report
(`grn.xhtml`), covering GRN + Direct Purchase bills (including
cancelled/returned/refunded variants) with From/To Date, Institution, Site,
Department, and Payment Mode filtering. Replaced the hardcoded placeholder
dropdown items with real ones bound to
`institutionController`/`departmentController`/`enumController`. The results
table is now a real `p:dataTable` over `pharmacyController.bills`, with
Process/Download(Excel)/PDF wired to the same working export methods
`grn.xhtml` already uses.

Added an additive `purchaseType` filter (GRN vs Direct Purchase) scoped to
this page only — it's a no-op for `generateGrnReport()`'s existing callers
since `grn.xhtml` never sets it, so that page's behavior is unchanged.

## Decisions made without approval

- **Reused `generateGrnReport()`/`bills`** rather than building a new
  DTO/query pipeline, since it already covers every real data column the
  mockup's table wanted (GRN no., dates, invoice, vendor, payment mode,
  amount, discount, stock value, status via `billTypeAtomic`).
- **Manual/paper-only columns from the original mockup** (Remark, Date,
  Sign) have no backing data in this system — shown as `-`, matching the
  existing dash convention for N/A fields elsewhere in this report family,
  rather than being fabricated.

## Verification

Verified end-to-end via Playwright against local dev data: Process now runs
a real query and renders actual bill data (deptId, purchase type, dates,
invoice no./date, vendor, payment mode, amount, discount, stock value,
status) with working pagination, Download, and PDF export. Cross-checked
directly against the database — the report returned exactly 17 rows for a
given date range, matching a manual `SELECT COUNT(*) FROM BILL WHERE ...`
query with the same filters.

(No screenshot attached to this PR — the local dev dataset's sample rows
include real vendor/supplier company names, which shouldn't be published;
verified instead via direct DB row-count cross-check, described above.)

Closes #22984

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the GRN Summary Report with filters for dates, institutions, sites, departments, payment methods, and purchase types.
  * Added dynamic filter options and automatic department updates based on selected locations.
  * Replaced the sample table with paginated report results showing dates, amounts, vendors, and statuses.
  * Added process, download, and PDF actions, with downloads enabled when results are available.
  * Added a clear message for reports with no matching results.

* **Documentation**
  * Documented a faster workflow for testing local page updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->