### PR TITLE
fix(inward): show Outside Charge item name on outside-charge bill prints

### DIFF
--- a/src/main/webapp/resources/ezcomp/prints/A4_inward_outside.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/A4_inward_outside.xhtml
@@ -110,7 +110,7 @@
                         <tr>
                             <td style="text-align: center;">#{s.index + 1}</td>
                             <td style="text-transform: capitalize;">
-                                <h:outputLabel value="#{bip.inwardChargeType.label}" />
+                                <h:outputLabel value="#{not empty bip.item.name ? bip.item.name : bip.inwardChargeType.label}" />
                             </td>
                             <td style="text-align: right;">
                                 <h:outputLabel value="#{bip.netValue}">

--- a/src/main/webapp/resources/ezcomp/prints/five_five_inward_outside.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_inward_outside.xhtml
@@ -120,7 +120,7 @@
                         <tr>
                             <td style="text-align: left;">#{s.index + 1}</td>
                             <td style="text-align: left; text-transform: capitalize;">
-                                <h:outputLabel value="#{bip.inwardChargeType.label}" />
+                                <h:outputLabel value="#{not empty bip.item.name ? bip.item.name : bip.inwardChargeType.label}" />
                             </td>
                             <td style="text-align: right;">
                                 <h:outputLabel value="#{bip.netValue}">

--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings_inward_service.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings_inward_service.xhtml
@@ -285,7 +285,7 @@
                         <ui:repeat value="#{billBeanController.fetchBillItems(cc.attrs.bill)}" var="bip"   >
                             <tr>
                                 <td  style="overflow: visible;">
-                                    <h:outputLabel class="itemsBlockRightFiveFive" value="#{bip.item.printName}"  style="text-transform: capitalize!important;"  >
+                                    <h:outputLabel class="itemsBlockRightFiveFive" value="#{not empty bip.item.printName ? bip.item.printName : bip.item.name}"  style="text-transform: capitalize!important;"  >
                                     </h:outputLabel>
                                 </td>
                                 <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">

--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_without_headings_inward_service.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_without_headings_inward_service.xhtml
@@ -308,7 +308,7 @@
                                 <f:facet name="header">
                                     <h:outputText value="Description" />
                                 </f:facet>
-                                <h:outputLabel rendered="#{bip.item.department.id eq cc.attrs.bill.toDepartment.id}" value="#{bip.item.printName}" style="margin: 4px; font-size: 11px!important;" >
+                                <h:outputLabel rendered="#{bip.item.department.id eq cc.attrs.bill.toDepartment.id}" value="#{not empty bip.item.printName ? bip.item.printName : bip.item.name}" style="margin: 4px; font-size: 11px!important;" >
                                 </h:outputLabel>
                                 <h:panelGroup rendered="#{bip.item.department.id eq cc.attrs.bill.toDepartment.id and bip.billSession ne null }"  >
                                     <br/>

--- a/src/main/webapp/resources/ezcomp/prints/posBill_inward_outside.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/posBill_inward_outside.xhtml
@@ -86,7 +86,7 @@
                 <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
                     <tr>
                         <td style="text-align: left; text-transform: capitalize;">
-                            <h:outputLabel value="#{bip.inwardChargeType.label}" />
+                            <h:outputLabel value="#{not empty bip.item.name ? bip.item.name : bip.inwardChargeType.label}" />
                         </td>
                         <td style="text-align: right;">
                             <h:outputLabel value="#{bip.netValue}">

--- a/src/main/webapp/resources/ezcomp/prints/posOpdBill_inward_service.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/posOpdBill_inward_service.xhtml
@@ -351,7 +351,7 @@
 
                         <tr>
                             <td colspan="4" style="overflow: visible;">
-                                <h:outputLabel value="#{bip.item.printName}"  styleClass="itemsBlock" style="text-transform: capitalize!important;"  >
+                                <h:outputLabel value="#{not empty bip.item.printName ? bip.item.printName : bip.item.name}"  styleClass="itemsBlock" style="text-transform: capitalize!important;"  >
                                 </h:outputLabel>
                             </td>
                             <h:panelGroup rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">


### PR DESCRIPTION
## Summary
Partial fix for #22989 — the Outside Charge Item Name was not displayed in billing documents. Fixes the safely-resolvable parts; flags a structural gap that needs a maintainer decision rather than guessing at a redesign.

## Decisions made without approval
(Run unattended per `/dev-issue-unattended`; documenting per that skill's requirements.)

- **Investigated three candidate "documents" before fixing anything**, since the issue names "Interim Bill", "Service Bill Print", and "Service Bill Reprint" but the codebase's actual bill-type routing doesn't map 1:1 onto those names for Outside Charge bills (`BillType.InwardOutSideBill` is explicitly excluded from the `BillType.InwardBill`-only query backing `inward_bill_service.xhtml`'s "Service Bill" search). I traced the code to find where Outside Charge items actually appear in print output, rather than guessing from the issue's document names alone.
- **Found and fixed two independent, low-risk root causes** (see PR body below) that are safe, mechanical, and match an existing precedent already in the codebase (`inpatient_lab_investigation_item_list.xhtml`'s printName-fallback pattern) — applied consistently rather than inventing a new convention.
- **Deliberately did NOT touch the Interim Bill's core aggregation** (`ChargeItemTotal`/`BhtSummeryController#createTables()`), even though it's the clearest match for the issue's literal "Interim Bill" repro step. That aggregation is grouped by `InwardChargeType` category (not by item) for **every** charge type, confirmed via the local DB (e.g. "Theater Consumables & Drugs" already merges several differently-named items with no per-item link retained). Restructuring it to carry item-level detail is read in 20+ places controlling bill totals, discounts, and validation checks in `BhtSummeryController` — a genuine architecture question (e.g. should Outside Charge rows be exploded per-item while other categories stay aggregated?) that I flagged on the issue instead of silently redesigning core billing logic unattended, per this project's hard limits on ambiguous/high-blast-radius changes.

## Root causes & fixes

**1. Outside Charge bill's own print templates** (`posBill_inward_outside.xhtml`, `five_five_inward_outside.xhtml`, `A4_inward_outside.xhtml` — used by the "Add Outside Charges" page's own Print/Settle preview): only rendered `bip.inwardChargeType.label` (the shared category, e.g. "Instrument Charges"), never the specific item charged. Since each row here maps to exactly one real item (no aggregation), this was a safe direct fix: `#{not empty bip.item.name ? bip.item.name : bip.inwardChargeType.label}`.

**2. Blank item names on generic inward-service print composites** (`five_five_paper_with_headings_inward_service.xhtml`, `five_five_paper_without_headings_inward_service.xhtml`, `posOpdBill_inward_service.xhtml`): render `item.printName`, an optional field with no fallback. Confirmed via the local DB: 3 of 19 active `InwardService` items have `PRINTNAME IS NULL`, so their name silently disappeared. Added the same `#{not empty item.printName ? item.printName : item.name}` fallback already established elsewhere in the codebase.

**3. Formal Interim Bill (`resources/inward/bill/intrimBill.xhtml`, used by both the Interim Bill print and reprint pages) — NOT fixed, flagged on the issue.** See "Decisions made without approval" above.

## Testing
Verified end-to-end locally with Playwright (JSF-only change, hot-copied composites for verification per project convention):
1. Added an Outside Charge using "Harmonic Machine" — an item with `PRINTNAME IS NULL`, confirmed via direct DB query beforehand.
2. Settled the bill, viewed the print preview — confirmed "Harmonic Machine" now shows in the "Charge" column, where it previously would have shown only the generic "Instrument Charges" category label.
3. Checked server log — no exceptions during the flow.

Screenshot: https://github.com/hmislk/hmis.wiki/raw/master/images/issue_22989_outside_charge_item_name_fixed.png

Refs #22989 (partial — Interim Bill gap documented as a follow-up on the issue, left open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)