### PR TITLE
fix(inward): block returning a lab investigation once its sample is received

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardServiceRefundController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardServiceRefundController.java
@@ -5,12 +5,19 @@
  * Inward service bill refund (issue #21247): return selected inward service
  * items from a bill without cancelling the whole bill. Kept separate from
  * OPD / Collecting-Centre refunds (BillSearch) because inpatient refunds have
- * different concerns - no drawer / cash-in-hand check, no lab-sampling guard,
- * credit-spend against the BHT encounter rather than a cash collection.
+ * different concerns - no drawer / cash-in-hand check, credit-spend against
+ * the BHT encounter rather than a cash collection. The lab-sampling guard
+ * (issue #22987) reuses the same PatientInvestigationStatus whitelist and
+ * dataEntered check already used by InwardSearch#checkCancelBill /
+ * #checkInvestigation for the sibling "Cancel whole bill" flow, so a
+ * laboratory investigation item can't be returned once its sample has been
+ * received (or its report already entered) - only before the lab has taken
+ * the sample, or again once the lab has retired/rejected it.
  */
 package com.divudi.bean.inward;
 
 import com.divudi.bean.common.BillController;
+import com.divudi.bean.common.EnumController;
 import com.divudi.bean.common.SessionController;
 import com.divudi.bean.common.WebUserController;
 import com.divudi.core.data.BillType;
@@ -21,9 +28,11 @@ import com.divudi.core.entity.BillFee;
 import com.divudi.core.entity.BillItem;
 import com.divudi.core.entity.RefundBill;
 import com.divudi.core.entity.inward.Admission;
+import com.divudi.core.entity.lab.PatientInvestigation;
 import com.divudi.core.facade.BillFacade;
 import com.divudi.core.facade.BillFeeFacade;
 import com.divudi.core.facade.BillItemFacade;
+import com.divudi.core.facade.PatientInvestigationFacade;
 import com.divudi.core.util.JsfUtil;
 import com.divudi.ejb.BillNumberGenerator;
 import java.io.Serializable;
@@ -53,6 +62,8 @@ public class InwardServiceRefundController implements Serializable {
     private BillFeeFacade billFeeFacade;
     @EJB
     private BillNumberGenerator billNumberBean;
+    @EJB
+    private PatientInvestigationFacade patientInvestigationFacade;
 
     @Inject
     private SessionController sessionController;
@@ -64,6 +75,8 @@ public class InwardServiceRefundController implements Serializable {
     private AdmissionController admissionController;
     @Inject
     private WebUserController webUserController;
+    @Inject
+    private EnumController enumController;
 
     private List<BillItem> refundingItems;
     private String comment;
@@ -166,6 +179,11 @@ public class InwardServiceRefundController implements Serializable {
             }
             if (itemAlreadyReturned(original)) {
                 JsfUtil.addErrorMessage("One or more selected items are already returned");
+                return null;
+            }
+            String labGuardError = checkLabSampleGuard(original);
+            if (labGuardError != null) {
+                JsfUtil.addErrorMessage(labGuardError);
                 return null;
             }
             for (BillFee bf : originalFeesOf(original)) {
@@ -350,6 +368,44 @@ public class InwardServiceRefundController implements Serializable {
         Map<String, Object> params = new HashMap<>();
         params.put("id", original.getId());
         return billItemFacade.findFirstByJpql(jpql, params) != null;
+    }
+
+    /**
+     * Lab-sampling guard for returning a laboratory investigation item
+     * (issue #22987). Not every BillItem on an inward service bill is a lab
+     * investigation (professional/other services have none), so a missing
+     * PatientInvestigation simply means this guard doesn't apply.
+     *
+     * Reuses the exact same status whitelist and dataEntered check already
+     * used by InwardSearch#checkCancelBill / #checkInvestigation for the
+     * sibling "Cancel whole bill" flow, so the two flows agree on when a lab
+     * item may be returned:
+     *  - before the lab has received the sample (status still in
+     *    EnumController#getAvailableStatusforCancel - Ordered / Barcode
+     *    Generated / Sample Collected / Sample Sent / Sample Rejected): OK.
+     *  - once the sample has been received/accepted and is being processed:
+     *    blocked.
+     *  - once a result has been entered (dataEntered): blocked, even if the
+     *    status itself would otherwise allow it.
+     *
+     * @return a user-facing error message if the return should be blocked,
+     * or null if it's allowed.
+     */
+    private String checkLabSampleGuard(BillItem original) {
+        String jpql = "SELECT p FROM PatientInvestigation p WHERE p.retired = false AND p.billItem = :bi";
+        Map<String, Object> params = new HashMap<>();
+        params.put("bi", original);
+        PatientInvestigation investigation = patientInvestigationFacade.findFirstByJpql(jpql, params);
+        if (investigation == null) {
+            return null;
+        }
+        if (Boolean.TRUE.equals(investigation.getDataEntered())) {
+            return "Cannot return \"" + original.getItem().getName() + "\" - the laboratory report has already been entered for this test.";
+        }
+        if (!enumController.getAvailableStatusforCancel().contains(investigation.getStatus())) {
+            return "Cannot return \"" + original.getItem().getName() + "\" - this test has already been received by the Laboratory.";
+        }
+        return null;
     }
 
     // Getters / Setters


### PR DESCRIPTION
## Summary
Fixes #22987 — an Inward user could return/cancel a laboratory investigation item from the Inward IP Bill even after the laboratory had received the sample, entered a result, or approved the report, with no validation message.

## Decisions made without approval
(Run unattended per `/dev-issue-unattended`; documenting per that skill's requirements.)

- **Traced two separate "Cancel"/"Return" code paths before concluding where the gap actually was.** `InwardSearch#cancelBillService()` (whole-bill "To Cancel") already had a lab-sampling guard (`checkCancelBill` + `checkInvestigation`). The per-item "Return" button (`InwardServiceRefundController`, from #21247) did not — and its own class-level Javadoc already documented this explicitly as a known simplification ("no lab-sampling guard"). This made the fix unambiguous: reuse the existing, already-proven guard logic rather than design new validation rules.
- **Reused the exact existing status whitelist** (`EnumController#getAvailableStatusforCancel()`) and `dataEntered` check instead of inventing a parallel one, so the two "Cancel" and "Return" flows can't drift out of sync on what counts as "safe to reverse." This directly maps onto the issue's four stated rules: `SAMPLE_REJECTED` (already in the whitelist) covers "sample retired by lab → allowed again"; everything from sample-received onward is excluded.
- Scoped narrowly to the one missing guard — did not touch `InwardSearch#cancelBillService()`'s existing (working) checks, and did not touch the config-gated `LabBillCancelSpecial` privilege bypass on that sibling flow, since that bypass is a separate, deliberate escape hatch already reviewed under different issues.

## Root cause
`InwardServiceRefundController.refundInwardServiceBill()` validated nursing-discharge, patient-discharge, bill-type, already-returned, and already-paid-to-staff conditions per item, but never checked the underlying `PatientInvestigation`'s lab workflow status at all.

## Fix
Added `checkLabSampleGuard(BillItem)`:
- No `PatientInvestigation` for this item (non-lab charge) → guard is a no-op.
- `dataEntered == true` → blocked: "Cannot return "X" - the laboratory report has already been entered for this test."
- `investigation.getStatus()` not in `EnumController#getAvailableStatusforCancel()` (i.e. sample already accepted/being processed and beyond) → blocked: "Cannot return "X" - this test has already been received by the Laboratory."
- Otherwise → allowed, same as before.

Called inside the existing per-item validation loop, alongside the already-returned / already-refunded-fee / already-paid-to-staff checks.

## Testing
Verified end-to-end locally with Playwright + DB checks, against **real existing local data** (no fabricated test data — both required states already existed):

1. **Blocked case**: BHT/56736, "FULL BLOOD COUNT (FBC)" (status `REPORT_APPROVED`, `dataEntered=true`). Attempted Return via the actual "Inward IP Bill → Service Reprint → Return" flow → blocked with the new message. Confirmed via direct DB query the `BILLITEM` row stayed `REFUNDED=0` (no mutation happened).
2. **Regression check**: BHT/56731, "Dengue Antigen" (status `ORDERED`, sample not yet sent). Return still succeeds exactly as before → confirmed `REFUNDED=1` in the DB and the refund receipt (negative-value line item) printed correctly.
3. Checked server log — no exceptions during either flow.

Note: step 2 performed a real return against existing local/dev data to verify no regression; this is the local development database, not production.

Screenshot: https://github.com/hmislk/hmis.wiki/raw/master/images/issue_22987_lab_sample_guard_blocked.png

Closes #22987

🤖 Generated with [Claude Code](https://claude.com/claude-code)