### PR TITLE
fix(collecting-centre): charge CC settlement amount from itemized bills, not ledger delta

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "permissions": {
+    "additionalDirectories": [
+      "C:\\Development\\hmis.wiki"
+    ],
+    "allow": [
+      "Bash(mysql *)",
+      "Bash(curl -s *)",
+      "Bash(curl -sS *)",
+      "Bash(curl -s\"*)",
+      "Bash(ping -c *)",
+      "Bash(ss -tnlp*)",
+      "Bash(/home/buddhika/payara/bin/asadmin list*)",
+      "Bash(/home/buddhika/payara/bin/asadmin ping-connection-pool*)"
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,7 +7,6 @@
       "Bash(mysql *)",
       "Bash(curl -s *)",
       "Bash(curl -sS *)",
-      "Bash(curl -s\"*)",
       "Bash(ping -c *)",
       "Bash(ss -tnlp*)",
       "Bash(/home/buddhika/payara/bin/asadmin list*)",

--- a/developer_docs/database/dual-version-id-allocator-separation.md
+++ b/developer_docs/database/dual-version-id-allocator-separation.md
@@ -1,0 +1,134 @@
+# Dual-Version ID Allocator Separation (Temporary)
+
+**Status:** TEMPORARY measure — remove once every production deployment that shares a
+database with a newer build has been upgraded to `GenerationType.IDENTITY`.
+
+**Added for:** Ruhunu, June 2026. The Ruhunu production build and the development
+build run side by side against the same main and audit databases.
+
+## Symptom
+
+```
+Internal Exception: java.sql.SQLIntegrityConstraintViolationException:
+Duplicate entry '18251' for key 'REPORTLOG.PRIMARY'
+Error Code: 1062
+Call: INSERT INTO REPORTLOG (ID, CREATEDAT, ...) VALUES (?, ?, ...)
+```
+
+The INSERT lists the `ID` column explicitly — that identifies the **old build**
+(`GenerationType.AUTO`) as the failing side. `REPORTLOG` lives in the **audit
+database** (`ReportLogFacade` uses `hmisAuditPU` on both branches), so both
+databases are affected, not just the main one.
+
+## Root cause: two independent ID allocators on one table
+
+| Build | Strategy | Allocator |
+|---|---|---|
+| Old production (e.g. `ruhunu-prod`, 189 entities) | `GenerationType.AUTO` | EclipseLink table sequencing: one global `SEQ_GEN` row in the `SEQUENCE` table, preallocated in blocks of 50, ID sent explicitly on INSERT |
+| Development build (198 entities) | `GenerationType.IDENTITY` | MySQL `AUTO_INCREMENT` on each table |
+
+Neither allocator sees the other's reservations. InnoDB's auto_increment counter
+always chases the highest inserted ID, which makes the collision *immediate*, not
+occasional:
+
+1. Old build preallocates sequence block `[18251..18300]`, inserts `18251`.
+2. The table's auto_increment counter jumps to `18252`.
+3. New build inserts → takes `18252`.
+4. Old build inserts its next preallocated value → `18252` → **duplicate key**.
+
+## Why a plain sequence bump cannot fix it
+
+Bumping `SEQ_COUNT` to any value N just moves the same race to N: as soon as the
+old build inserts at the new range, the auto_increment counter follows it, and the
+new build's next insert lands exactly on the old build's next preallocated value.
+The gap size is irrelevant.
+
+## The fix: disjoint ranges
+
+`IdAllocatorSeparation.separate(Connection)` (package
+`com.divudi.core.facade`) runs per schema:
+
+1. **Inventory** every table with a `BIGINT` primary key named `ID` (case detected
+   via `INFORMATION_SCHEMA`, per the cross-deployment case-sensitivity rule) and
+   find the **global max ID** across all of them.
+2. **Raise every `SEQUENCE` row** to `globalMax + 10,000`
+   (`SEQUENCE_SAFETY_MARGIN`). The old build stops re-issuing IDs the new build
+   has already used. The margin absorbs new-build inserts that happen between the
+   scan and step 3.
+3. **Push every table's `AUTO_INCREMENT` counter** to `globalMax + 1,000,000,000`
+   (`AUTO_INCREMENT_OFFSET`). The new build now allocates in a band the old
+   build's sequence would need a billion allocations to reach.
+
+The bands stay disjoint because InnoDB only moves an auto_increment counter
+*upward*, and only when an insert is **at or above** it — the old build's explicit
+low-range IDs never touch the high counters.
+
+```
+IDs:  [1 .. globalMax]   (globalMax+10k ...→]            [globalMax+1e9 ...→
+       existing rows      old build (SEQUENCE, explicit)   new build (AUTO_INCREMENT)
+```
+
+Both builds may still share the `SEQUENCE` table itself (the dev build's one
+remaining `AUTO` entity, `ShiftStaffRequirement`, also draws from `SEQ_GEN`) —
+that is safe: table sequencing uses row-locked `UPDATE`s, so concurrent processes
+get disjoint blocks.
+
+## Where the code lives
+
+| Piece | Location |
+|---|---|
+| Core logic (shared) | `src/main/java/com/divudi/core/facade/IdAllocatorSeparation.java` |
+| Main DB entry point | `DatabaseMigrationFacade.separateIdAllocatorsForDualVersionOperation()` |
+| Audit DB entry point | `AuditDatabaseFacade.separateIdAllocatorsForDualVersionOperation()` |
+| Controller action | `DataAdministrationController.separateIdAllocatorsForDualVersionOperation()` |
+| UI | `admin_functions.xhtml` → tab **"ID Generation — Dual Version Operation"** |
+
+The facade methods run on a raw JDBC connection outside JTA
+(`TransactionAttributeType.NOT_SUPPORTED`, `autoCommit=true`) because
+`ALTER TABLE` triggers MySQL implicit commits that desync the JTA transaction
+manager — same pattern as `executeDdlNative` / `applyAutoIncrementToAllEntityTables`.
+
+## Runbook
+
+1. Deploy the development build containing this function.
+2. Log in as a user with the **Admin** privilege.
+3. Admin → Data Administration → **Admin Functions** → tab
+   **"ID Generation — Dual Version Operation"** → **Separate ID Allocators**
+   (confirm dialog). The output column reports, per database: tables scanned,
+   global max ID, old sequence values, the new sequence target, and how many
+   tables had their counters moved.
+4. **Immediately restart the old-version Payara.** It still holds a preallocated
+   sequence block in memory and keeps colliding until it re-reads the bumped
+   `SEQUENCE` row. The new build needs no restart.
+
+### Verification (read-only, either DB)
+
+```sql
+SELECT SEQ_NAME, SEQ_COUNT FROM SEQUENCE;            -- ≈ global max + 10,000
+SELECT MAX(ID) FROM REPORTLOG;                        -- old-build rows: low range
+SELECT AUTO_INCREMENT FROM INFORMATION_SCHEMA.TABLES
+ WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'REPORTLOG';  -- ≈ global max + 1e9
+```
+
+After the restart, old-build inserts continue in the low range and new-build rows
+appear above one billion.
+
+## Side effects & safety
+
+- New-build rows get IDs above ~1,000,000,000. Harmless: every ID is `BIGINT`,
+  and IDs are surrogate keys (bill numbers etc. are generated separately).
+- Re-running is safe (idempotent in effect): max IDs only grow, `SEQUENCE` rows
+  below the target are raised, `ALTER ... AUTO_INCREMENT` to a value below a
+  counter that is already higher is ignored by InnoDB.
+- Empty tables are included deliberately — the new build must allocate high
+  everywhere, including tables it has not written yet.
+- No row data is modified; only the `SEQUENCE` counters and table metadata.
+
+## Permanent fix / removal
+
+Upgrade the old production branch to `GenerationType.IDENTITY` for all entities
+(as already done for Coop), with migration `v2.9.0` restoring `AUTO_INCREMENT`
+on any ID primary key missing it. IDENTITY then simply continues from wherever
+the counters stand — the billion-offset rows need no cleanup. After that
+upgrade, remove the admin tab, the controller method, the two facade methods,
+and `IdAllocatorSeparation`.

--- a/src/main/java/com/divudi/bean/common/BillBeanController.java
+++ b/src/main/java/com/divudi/bean/common/BillBeanController.java
@@ -1754,14 +1754,24 @@ public class BillBeanController implements Serializable {
     public List<Object[]> fetchDepartmentSale(Date fromDate, Date toDate, Institution institution, BillType billType) {
         PaymentMethod[] pms = new PaymentMethod[]{PaymentMethod.Cash, PaymentMethod.Card, PaymentMethod.Cheque, PaymentMethod.Slip};
 
+        // Sum from the child Payment rows (p.paidValue) instead of filtering whole bills by the
+        // bill-level paymentMethod. A bill settled with more than one method has
+        // bill.paymentMethod = MultiplePaymentMethods; filtering on the bill-level method dropped
+        // such bills entirely, even though their actual payments were Cash/Card/Cheque/Slip. The
+        // Daily Return report sums child payments and therefore counts them, which caused the QB
+        // Import figure to fall short. Filtering on p.paymentMethod captures the individual
+        // components of split-payment bills while still excluding credit/deposit portions.
+        // See hmislk/hmis#21639.
         String sql = "Select b.referenceBill.department,"
-                + " sum(b.netTotal) "
-                + " from Bill b "
+                + " sum(p.paidValue) "
+                + " from Payment p "
+                + " join p.bill b "
                 + " where b.retired=false"
+                + " and p.retired=false"
                 + " and  b.billType=:bType"
                 + " and b.referenceBill.department.institution=:ins "
                 + " and b.createdAt between :fromDate and :toDate "
-                + " and b.paymentMethod in :pm"
+                + " and p.paymentMethod in :pm"
                 + " and type(b)!=:cl "
                 + " group by b.referenceBill.department"
                 + " order by b.referenceBill.department.name";

--- a/src/main/java/com/divudi/bean/common/CollectingCentrePaymentController.java
+++ b/src/main/java/com/divudi/bean/common/CollectingCentrePaymentController.java
@@ -9,6 +9,7 @@ import com.divudi.core.entity.Bill;
 import com.divudi.core.entity.BillItem;
 import com.divudi.core.entity.Institution;
 import com.divudi.core.entity.Payment;
+import com.divudi.core.data.dto.CollectingCentrePaymentBillDTO;
 import com.divudi.core.facade.AgentHistoryFacade;
 import com.divudi.core.facade.BillFacade;
 import com.divudi.core.facade.BillItemFacade;
@@ -92,7 +93,7 @@ public class CollectingCentrePaymentController implements Serializable {
     private double payingBalanceAcodingToCCBalabce = 0.0;
     private Bill currentPaymentBill;
 
-    private List<Bill> paymentBills;
+    private List<CollectingCentrePaymentBillDTO> paymentBills;
 
     private String billNumber;
     private String comment;
@@ -106,8 +107,12 @@ public class CollectingCentrePaymentController implements Serializable {
         return "/collecting_centre/collecting_centre_repayment_bill_search?faces-redirect=true";
     }
 
-    public String navigateToViewCCPaymentBill(Bill bill) {
-        setCurrentPaymentBill(bill);
+    public String navigateToViewCCPaymentBill(Long billId) {
+        if (billId == null) {
+            JsfUtil.addErrorMessage("Payment Bill is Missing");
+            return "";
+        }
+        setCurrentPaymentBill(billFacade.find(billId));
         return "/collecting_centre/cc_repayment_bill_reprint?faces-redirect=true";
     }
 
@@ -699,7 +704,16 @@ public class CollectingCentrePaymentController implements Serializable {
         String jpql;
         Map temMap = new HashMap();
 
-        jpql = "select b from Bill b "
+        jpql = "select new com.divudi.core.data.dto.CollectingCentrePaymentBillDTO("
+                + " b.id, b.deptId, b.fromDate, b.toDate, b.createdAt, b.cancelled, cb.createdAt,"
+                + " cwup.name, ccrwup.name, ti.institutionCode, ti.name, b.netTotal) "
+                + " from Bill b "
+                + " left join b.cancelledBill cb "
+                + " left join b.creater c "
+                + " left join c.webUserPerson cwup "
+                + " left join cb.creater ccr "
+                + " left join ccr.webUserPerson ccrwup "
+                + " left join b.toInstitution ti "
                 + " where b.billTypeAtomic =:atomic "
                 + " and b.createdAt between :fromDate and :toDate "
                 + " and b.retired=false ";
@@ -720,7 +734,7 @@ public class CollectingCentrePaymentController implements Serializable {
         temMap.put("toDate", getToDate());
         temMap.put("fromDate", getFromDate());
 
-        paymentBills = billFacade.findByJpql(jpql, temMap, TemporalType.TIMESTAMP);
+        paymentBills = (List<CollectingCentrePaymentBillDTO>) billFacade.findLightsByJpqlWithoutCache(jpql, temMap, TemporalType.TIMESTAMP);
 
     }
 
@@ -858,8 +872,10 @@ public class CollectingCentrePaymentController implements Serializable {
 
             XSSFCellStyle amountStyle = workbook.createCellStyle();
 
+            SimpleDateFormat sdfDate = new SimpleDateFormat("dd-MM-yyyy");
+
             Row headerRow = sheet.createRow(rowIndex++);
-            String[] headers = {"No", "Bill No", "Bill At", "Billed By", "CC Code", "CC Name", "Status", "Cancelled At", "Cancelled By", "Net Total"};
+            String[] headers = {"No", "Bill No", "From", "To", "Bill At", "Billed By", "CC Code", "CC Name", "Status", "Cancelled At", "Cancelled By", "Net Total"};
 
             for (int i = 0; i < headers.length; i++) {
                 Cell cell = headerRow.createCell(i);
@@ -868,35 +884,46 @@ public class CollectingCentrePaymentController implements Serializable {
             }
 
             int no = 1;
-            for (Bill bill : paymentBills) {
+            for (CollectingCentrePaymentBillDTO bill : paymentBills) {
                 Row row = sheet.createRow(rowIndex++);
 
                 row.createCell(0).setCellValue(no++);
                 row.createCell(1).setCellValue(defaultIfNullOrEmpty(bill.getDeptId(), ""));
 
-                Cell billAtCell = row.createCell(2);
+                Cell fromDateCell = row.createCell(2);
+                if (bill.getFromDate() != null) {
+                    fromDateCell.setCellValue(sdfDate.format(bill.getFromDate()));
+                }
+
+                Cell toDateCell = row.createCell(3);
+                if (bill.getToDate() != null) {
+                    toDateCell.setCellValue(sdfDate.format(bill.getToDate()));
+                }
+
+                Cell billAtCell = row.createCell(4);
                 if (bill.getCreatedAt() != null) {
                     billAtCell.setCellValue(sdf.format(bill.getCreatedAt()));
                 }
 
-                row.createCell(3).setCellValue(defaultIfNullOrEmpty(getUserNameWithTitle(bill.getCreater()), ""));
+                row.createCell(5).setCellValue(defaultIfNullOrEmpty(bill.getCreatedByName(), ""));
 
-                row.createCell(4).setCellValue(bill.getToInstitution() != null ? defaultIfNullOrEmpty(bill.getToInstitution().getInstitutionCode(), "") : "");
-                row.createCell(5).setCellValue(bill.getToInstitution() != null ? defaultIfNullOrEmpty(bill.getToInstitution().getName(), "") : "");
+                row.createCell(6).setCellValue(defaultIfNullOrEmpty(bill.getToInstitutionCode(), ""));
+                row.createCell(7).setCellValue(defaultIfNullOrEmpty(bill.getToInstitutionName(), ""));
 
-                row.createCell(6).setCellValue(bill.isCancelled() ? "Cancelled" : "");
+                boolean cancelled = Boolean.TRUE.equals(bill.getCancelled());
+                row.createCell(8).setCellValue(cancelled ? "Cancelled" : "");
 
-                Cell cancelAtCell = row.createCell(7);
-                Cell cancelByCell = row.createCell(8);
-                if (bill.isCancelled() && bill.getCancelledBill() != null) {
-                    if (bill.getCancelledBill().getCreatedAt() != null) {
-                        cancelAtCell.setCellValue(sdf.format(bill.getCancelledBill().getCreatedAt()));
+                Cell cancelAtCell = row.createCell(9);
+                Cell cancelByCell = row.createCell(10);
+                if (cancelled) {
+                    if (bill.getCancelledAt() != null) {
+                        cancelAtCell.setCellValue(sdf.format(bill.getCancelledAt()));
                     }
-                    cancelByCell.setCellValue(defaultIfNullOrEmpty(getUserNameWithTitle(bill.getCancelledBill().getCreater()), ""));
+                    cancelByCell.setCellValue(defaultIfNullOrEmpty(bill.getCancelledByName(), ""));
                 }
 
-                Cell netTotalCell = row.createCell(9);
-                netTotalCell.setCellValue(bill.getNetTotal());
+                Cell netTotalCell = row.createCell(11);
+                netTotalCell.setCellValue(bill.getNetTotal() != null ? bill.getNetTotal() : 0.0);
                 netTotalCell.setCellStyle(amountStyle);
             }
 
@@ -911,13 +938,6 @@ public class CollectingCentrePaymentController implements Serializable {
 
         } catch (Exception e) {
         }
-    }
-
-    private String getUserNameWithTitle(com.divudi.core.entity.WebUser user) {
-        if (user == null || user.getWebUserPerson() == null) {
-            return "";
-        }
-        return user.getWebUserPerson().getNameWithTitle();
     }
 
     public void cancelPaymentBill() {
@@ -1166,11 +1186,11 @@ public class CollectingCentrePaymentController implements Serializable {
         this.currentPaymentBill = currentPaymentBill;
     }
 
-    public List<Bill> getPaymentBills() {
+    public List<CollectingCentrePaymentBillDTO> getPaymentBills() {
         return paymentBills;
     }
 
-    public void setPaymentBills(List<Bill> paymentBills) {
+    public void setPaymentBills(List<CollectingCentrePaymentBillDTO> paymentBills) {
         this.paymentBills = paymentBills;
     }
 

--- a/src/main/java/com/divudi/bean/common/CollectingCentrePaymentController.java
+++ b/src/main/java/com/divudi/bean/common/CollectingCentrePaymentController.java
@@ -159,15 +159,21 @@ public class CollectingCentrePaymentController implements Serializable {
             return;
         }
 
-        double paymentDone = getAllAgentHistory(currentCollectingCentre, true);
+        findPendingCCBills();
 
-        if (paymentDone > 0.0) {
-            JsfUtil.addErrorMessage("There is a bill that was taken within this range.");
+        if (selectedCCpaymentBills == null || selectedCCpaymentBills.isEmpty()) {
+            JsfUtil.addErrorMessage("There are no unpaid bills for this Collecting Centre within this range.");
             setCurrentCollectingCentre(null);
             return;
         }
 
-        findPendingCCBills();
+        long unpaidBillsBeforeRange = countUnpaidCCBillsBefore(currentCollectingCentre, fromDate);
+        if (unpaidBillsBeforeRange > 0) {
+            JsfUtil.addErrorMessage("There are " + unpaidBillsBeforeRange + " unpaid bill(s) for this Collecting Centre dated before the selected From Date. "
+                    + "Extend the range to include them before settling, otherwise they will be left unpaid.");
+            setCurrentCollectingCentre(null);
+            return;
+        }
 
         allHistorys = getAllAgentHistory(currentCollectingCentre);
 
@@ -180,12 +186,34 @@ public class CollectingCentrePaymentController implements Serializable {
         if (endingHistory != null) {
             finalEndingBalanseInCC = endingHistory.getBalanceAfterTransaction();
         }
-        
+
         periodPaidAmount = getPaidAgentPaymentsDuringThisPeriod(currentCollectingCentre);
 
-        calculaPayingBalanceAcodingToCCBalabce(startingHistory, endingHistory,periodPaidAmount);
+        // Ledger balance-delta is retained only for display/reconciliation (startingBalanseInCC /
+        // finalEndingBalanseInCC) - it must not drive the amount actually charged, since it can
+        // silently include activity that was already settled outside the selected date range.
+        calculaPayingBalanceAcodingToCCBalabce(startingHistory, endingHistory, periodPaidAmount);
+
+        // The amount charged is always the value of the itemized bills being marked paid.
+        payingBalanceAcodingToCCBalabce = totalCCAmount;
 
         calculateTotalOfPaymentReceive();
+    }
+
+    public long countUnpaidCCBillsBefore(Institution collectingCentre, Date beforeDate) {
+        String jpql = "select count(bill.id) "
+                + " from Bill bill "
+                + " where bill.collectingCentre=:cc "
+                + " and bill.createdAt < :beforeDate "
+                + " and bill.paid =:paid"
+                + " and bill.retired=false ";
+
+        Map<String, Object> m = new HashMap<>();
+        m.put("cc", collectingCentre);
+        m.put("beforeDate", beforeDate);
+        m.put("paid", false);
+
+        return billFacade.findLongByJpql(jpql, m, TemporalType.TIMESTAMP);
     }
     
     public List<AgentHistory> getAllHistoryFromPaymentBill(Bill ccPaymentBill) {

--- a/src/main/java/com/divudi/bean/common/CollectingCentrePaymentController.java
+++ b/src/main/java/com/divudi/bean/common/CollectingCentrePaymentController.java
@@ -242,12 +242,50 @@ public class CollectingCentrePaymentController implements Serializable {
         m.put("ret", false);
         m.put("cc", ccPaymentBill.getCollectingCentre());
         m.put("types", types);
-        m.put("fromDate", ccPaymentBill.getFromDate());
-        m.put("toDate", ccPaymentBill.getToDate());
+
+        Date rangeFromDate = ccPaymentBill.getFromDate();
+        Date rangeToDate = ccPaymentBill.getToDate();
+
+        if (rangeFromDate == null || rangeToDate == null) {
+            // Legacy payment bills created before fromDate/toDate were persisted on the Bill itself.
+            // Fall back to the date span of the bills it actually settled so a BETWEEN NULL AND NULL
+            // does not silently match zero rows and skip clearing paymentDone on cancellation.
+            Date[] derivedRange = deriveDateRangeFromBillItems(ccPaymentBill);
+            rangeFromDate = derivedRange[0];
+            rangeToDate = derivedRange[1];
+        }
+
+        m.put("fromDate", rangeFromDate);
+        m.put("toDate", rangeToDate);
+
+        if (rangeFromDate == null || rangeToDate == null) {
+            return new ArrayList<>();
+        }
 
         List<AgentHistory> listCount = agentHistoryFacade.findByJpql(jpql, m, TemporalType.TIMESTAMP);
 
         return listCount;
+    }
+
+    private Date[] deriveDateRangeFromBillItems(Bill ccPaymentBill) {
+        Date min = null;
+        Date max = null;
+        if (ccPaymentBill.getBillItems() != null) {
+            for (BillItem bi : ccPaymentBill.getBillItems()) {
+                Bill referenced = bi.getReferenceBill();
+                if (referenced == null || referenced.getCreatedAt() == null) {
+                    continue;
+                }
+                Date createdAt = referenced.getCreatedAt();
+                if (min == null || createdAt.before(min)) {
+                    min = createdAt;
+                }
+                if (max == null || createdAt.after(max)) {
+                    max = createdAt;
+                }
+            }
+        }
+        return new Date[]{min, max};
     }
 
     public double calculaPayingBalanceAcodingToCCBalabce(AgentHistory startingHistory, AgentHistory endingHistory, double paidCCAmount) {

--- a/src/main/java/com/divudi/bean/common/CollectingCentrePaymentController.java
+++ b/src/main/java/com/divudi/bean/common/CollectingCentrePaymentController.java
@@ -765,6 +765,95 @@ public class CollectingCentrePaymentController implements Serializable {
         return (value == null || value.trim().isEmpty()) ? defaultValue : value;
     }
 
+    public void exportPaymentBillsToExcel() throws IOException {
+        if (paymentBills == null || paymentBills.isEmpty()) {
+            JsfUtil.addErrorMessage("No Bills to Export");
+            return;
+        }
+
+        FacesContext context = FacesContext.getCurrentInstance();
+        HttpServletResponse response = (HttpServletResponse) context.getExternalContext().getResponse();
+
+        response.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+        response.setHeader("Content-Disposition", "attachment; filename=CC_Payment_Bills.xlsx");
+
+        try (XSSFWorkbook workbook = new XSSFWorkbook(); OutputStream out = response.getOutputStream()) {
+
+            XSSFSheet sheet = workbook.createSheet("CC Payment Bills");
+            int rowIndex = 0;
+
+            XSSFFont boldFont = workbook.createFont();
+            boldFont.setBold(true);
+
+            SimpleDateFormat sdf = new SimpleDateFormat("dd-MM-yyyy hh:mm a");
+
+            XSSFCellStyle boldStyle = workbook.createCellStyle();
+            boldStyle.setFont(boldFont);
+
+            XSSFCellStyle amountStyle = workbook.createCellStyle();
+
+            Row headerRow = sheet.createRow(rowIndex++);
+            String[] headers = {"No", "Bill No", "Bill At", "Billed By", "CC Code", "CC Name", "Status", "Cancelled At", "Cancelled By", "Net Total"};
+
+            for (int i = 0; i < headers.length; i++) {
+                Cell cell = headerRow.createCell(i);
+                cell.setCellValue(headers[i]);
+                cell.setCellStyle(boldStyle);
+            }
+
+            int no = 1;
+            for (Bill bill : paymentBills) {
+                Row row = sheet.createRow(rowIndex++);
+
+                row.createCell(0).setCellValue(no++);
+                row.createCell(1).setCellValue(defaultIfNullOrEmpty(bill.getDeptId(), ""));
+
+                Cell billAtCell = row.createCell(2);
+                if (bill.getCreatedAt() != null) {
+                    billAtCell.setCellValue(sdf.format(bill.getCreatedAt()));
+                }
+
+                row.createCell(3).setCellValue(defaultIfNullOrEmpty(getUserNameWithTitle(bill.getCreater()), ""));
+
+                row.createCell(4).setCellValue(bill.getToInstitution() != null ? defaultIfNullOrEmpty(bill.getToInstitution().getInstitutionCode(), "") : "");
+                row.createCell(5).setCellValue(bill.getToInstitution() != null ? defaultIfNullOrEmpty(bill.getToInstitution().getName(), "") : "");
+
+                row.createCell(6).setCellValue(bill.isCancelled() ? "Cancelled" : "");
+
+                Cell cancelAtCell = row.createCell(7);
+                Cell cancelByCell = row.createCell(8);
+                if (bill.isCancelled() && bill.getCancelledBill() != null) {
+                    if (bill.getCancelledBill().getCreatedAt() != null) {
+                        cancelAtCell.setCellValue(sdf.format(bill.getCancelledBill().getCreatedAt()));
+                    }
+                    cancelByCell.setCellValue(defaultIfNullOrEmpty(getUserNameWithTitle(bill.getCancelledBill().getCreater()), ""));
+                }
+
+                Cell netTotalCell = row.createCell(9);
+                netTotalCell.setCellValue(bill.getNetTotal());
+                netTotalCell.setCellStyle(amountStyle);
+            }
+
+            for (int i = 0; i < headers.length; i++) {
+                sheet.autoSizeColumn(i);
+            }
+
+            workbook.write(out);
+            out.flush();
+
+            context.responseComplete();
+
+        } catch (Exception e) {
+        }
+    }
+
+    private String getUserNameWithTitle(com.divudi.core.entity.WebUser user) {
+        if (user == null || user.getWebUserPerson() == null) {
+            return "";
+        }
+        return user.getWebUserPerson().getNameWithTitle();
+    }
+
     public void cancelPaymentBill() {
         if (ccPaymentSettlingStarted) {
             JsfUtil.addErrorMessage("Already Started Process");

--- a/src/main/java/com/divudi/bean/common/DataAdministrationController.java
+++ b/src/main/java/com/divudi/bean/common/DataAdministrationController.java
@@ -31,6 +31,7 @@ import com.divudi.core.facade.BillItemFacade;
 import com.divudi.core.facade.BillNumberFacade;
 import com.divudi.core.facade.AuditDatabaseFacade;
 import com.divudi.core.facade.CategoryFacade;
+import com.divudi.core.facade.DatabaseMigrationFacade;
 import com.divudi.core.facade.DepartmentFacade;
 import com.divudi.core.facade.InstitutionFacade;
 import com.divudi.core.facade.ItemBatchFacade;
@@ -234,6 +235,8 @@ public class DataAdministrationController implements Serializable {
     @EJB
     AuditDatabaseFacade auditDatabaseFacade;
     @EJB
+    DatabaseMigrationFacade databaseMigrationFacade;
+    @EJB
     CategoryFacade categoryFacade;
     @EJB
     ItemBatchFacade itemBatchFacade;
@@ -363,6 +366,37 @@ public class DataAdministrationController implements Serializable {
             return "Unknown exception";
         }
         return throwable.getMessage() != null ? throwable.getMessage() : throwable.getClass().getName();
+    }
+
+    /**
+     * TEMPORARY admin function for dual-version operation at Ruhunu: this
+     * production build uses GenerationType.AUTO (EclipseLink SEQUENCE table)
+     * while the newer development build uses GenerationType.IDENTITY
+     * (AUTO_INCREMENT), and both write to the same main and audit databases,
+     * so their independent ID allocators collide (Duplicate entry ... for key
+     * 'REPORTLOG.PRIMARY'). This raises the SEQUENCE rows above every existing
+     * ID and pushes all AUTO_INCREMENT counters one billion higher, giving
+     * each build its own range. THIS application server must be restarted
+     * after running. Remove once this build is upgraded to IDENTITY ID
+     * generation. See developer_docs/database/dual-version-id-allocator-separation.md
+     */
+    public void separateIdAllocatorsForDualVersionOperation() {
+        StringBuilder feedback = new StringBuilder();
+        feedback.append("=== Main Database ===<br/>");
+        try {
+            feedback.append(String.join("<br/>", databaseMigrationFacade.separateIdAllocatorsForDualVersionOperation()));
+        } catch (Exception e) {
+            feedback.append("Error: ").append(getExceptionMessage(e));
+        }
+        feedback.append("<br/><br/>=== Audit Database ===<br/>");
+        try {
+            feedback.append(String.join("<br/>", auditDatabaseFacade.separateIdAllocatorsForDualVersionOperation()));
+        } catch (Exception e) {
+            feedback.append("Error: ").append(getExceptionMessage(e));
+        }
+        feedback.append("<br/><br/>IMPORTANT: Restart THIS application server now. ")
+                .append("It still holds a preallocated ID block in memory and will keep colliding until restarted.");
+        executionFeedback = feedback.toString();
     }
 
     public void refresh() {

--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -21110,6 +21110,10 @@ public class SearchController implements Serializable {
             //Start - Atomic Bill Type with Cash in and cash out added for 10088-all-cashier-summary-had-calculated-fund-bills
             List<BillTypeAtomic> btas = BillTypeAtomic.findByFinanceType(BillFinanceType.CASH_IN);
             btas.addAll(BillTypeAtomic.findByFinanceType(BillFinanceType.CASH_OUT));
+            // Collecting Centre Agent Payment / Cancellation are agent commission payouts, not cashier
+            // collections - exclude them (issue #21840)
+            btas.remove(BillTypeAtomic.CC_AGENT_PAYMENT);
+            btas.remove(BillTypeAtomic.CC_AGENT_PAYMENT_CANCELLATION);
             jpql += "AND bill.billTypeAtomic in :btas ";
             parameters.put("btas", btas);
             // End - Atomic Bill Type with Cash in and cash out added FOR 10088-all-cashier-summary-had-calculated-fund-bills

--- a/src/main/java/com/divudi/bean/common/SessionController.java
+++ b/src/main/java/com/divudi/bean/common/SessionController.java
@@ -1153,6 +1153,7 @@ public class SessionController implements Serializable, HttpSessionListener {
             String hashed = getSecurityController().hashAndCheck(password);
             user.setWebUserPassword(hashed);
             user.setNeedToResetPassword(false);
+            user.setLastPasswordResetAt(new Date());
             uFacade.editAndCommit(user);
             recordPasswordHistory(user, hashed);
 
@@ -1188,9 +1189,11 @@ public class SessionController implements Serializable, HttpSessionListener {
 
         String hashed = getSecurityController().hashAndCheck(newPassword);
         user.setWebUserPassword(hashed);
+        user.setNeedToResetPassword(false);
+        user.setLastPasswordResetAt(new Date());
         uFacade.editAndCommit(user);
         recordPasswordHistory(user, hashed);
-        
+
         // Purge old password history entries beyond the configured limit
         purgeOldPasswordHistory(user);
         JsfUtil.addSuccessMessage("Password changed");

--- a/src/main/java/com/divudi/bean/common/UserPrivilageController.java
+++ b/src/main/java/com/divudi/bean/common/UserPrivilageController.java
@@ -166,6 +166,9 @@ public class UserPrivilageController implements Serializable {
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardAdmissionsAdmission, "Admission"), admissionsNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardAdmissionsEditAdmission, "Edit Admission Details"), admissionsNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardAdmissionsInwardAppoinment, "Inward Appointment"), admissionsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardEditPatientDetailsFromAdmission, "Edit Patient Details From Admission"), admissionsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardEditPaymentDetails, "Edit Payment Details"), admissionsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardManageAllergies, "Manage Allergies"), admissionsNode);
 
         TreeNode appointmentNode = new DefaultTreeNode(new PrivilegeHolder(null, "Appointment"), inwardNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardAppointmentMenu, "Appointment Menu"), appointmentNode);
@@ -190,30 +193,98 @@ public class UserPrivilageController implements Serializable {
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardServicesAndItemsAddOutSideCharges, "Add Outside Charges"), servicesItemsNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardServicesAndItemsAddProfessionalFee, "Add Professional Fee"), servicesItemsNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardServicesAndItemsAddTimedServices, "Add Timed Services"), servicesItemsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardAddChargesAfterNursingDischarge, "Add Charges After Nursing Discharge"), servicesItemsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardHoldProfessionalPayments, "Hold Professional Payments"), servicesItemsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardPayProfessionalFeesWhileOnHold, "Pay Professional Fees While On Hold"), servicesItemsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardServiceItemRequestApproval, "Approve Service/Item Requests"), servicesItemsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardServiceItemRequestRejection, "Reject Service/Item Requests"), servicesItemsNode);
 
         TreeNode inwardBillingNode = new DefaultTreeNode(new PrivilegeHolder(null, "Billing"), inwardNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardBilling, "Billing Menu"), inwardBillingNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardBillingInterimBill, "Interim Bill"), inwardBillingNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardBillingInterimBillSearch, "Interim Bill Search"), inwardBillingNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardFinalBillReportEdit, "Edit Patient Name After Payment Finalized"), inwardBillingNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardDoctorPaymentAccess, "Doctor Payment Access"), inwardBillingNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardPostFinalPaymentAccess, "Post Final Payment Access"), inwardBillingNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardMakeDepositAccess, "Make Deposit Access"), inwardBillingNode);
+
+        TreeNode dashboardPanelsNode = new DefaultTreeNode(new PrivilegeHolder(null, "Inpatient Dashboard Panels"), inwardNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientDashboardPanelAdmission, "Admission Panel"), dashboardPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientDashboardPanelBilling, "Billing Panel"), dashboardPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientDashboardPanelServices, "Services Panel"), dashboardPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientDashboardPanelRoomManagement, "Room Management Panel"), dashboardPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientDashboardPanelOperationTheatre, "Operation Theatre Panel"), dashboardPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientDashboardPanelClinicalData, "Clinical Data Panel"), dashboardPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientDashboardPanelPharmaceuticals, "Pharmaceuticals Panel"), dashboardPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientDashboardPanelDocuments, "Documents Panel"), dashboardPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientDashboardPanelReports, "Reports Panel"), dashboardPanelsNode);
+
+        TreeNode inwardSurgeryNode = new DefaultTreeNode(new PrivilegeHolder(null, "Surgery"), inwardNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSurgeryAdd, "Add Surgery"), inwardSurgeryNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSurgeryManage, "Manage Surgery"), inwardSurgeryNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSurgeryValidate, "Validate Surgery"), inwardSurgeryNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSurgeryValidationRevert, "Revert Surgery Validation"), inwardSurgeryNode);
+
+        TreeNode clinicalDataViewNode = new DefaultTreeNode(new PrivilegeHolder(null, "Clinical Data Access"), inwardNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardPatientHistoryView, "Patient History View"), clinicalDataViewNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardClinicalNotesView, "Clinical Notes View"), clinicalDataViewNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardWardMedicationsView, "Ward Medications View"), clinicalDataViewNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardDischargeMedicationsView, "Discharge Medications View"), clinicalDataViewNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardInvestigationsView, "Investigations View"), clinicalDataViewNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardImagesView, "Images View"), clinicalDataViewNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardDiagnosisCardView, "Diagnosis Card View"), clinicalDataViewNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardEventHistoryView, "Event History View"), clinicalDataViewNode);
 
         TreeNode inwardPharmacyNode = new DefaultTreeNode(new PrivilegeHolder(null, "Pharmacy"), inwardNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardPharmacyMenu, "Pharmacy Menu"), inwardPharmacyNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardPharmacyIssueRequest, "Pharmacy Issue Request"), inwardPharmacyNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardPharmacyIssueRequestSearch, "Pharmacy Issue Request Search"), inwardPharmacyNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardPharmacyIssueRequestCancel, "Pharmacy Issue Request Cancel"), inwardPharmacyNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardPharmacyReturnCancel, "Pharmacy Return Cancel"), inwardPharmacyNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardPharmacyReturnSubmit, "Pharmacy Return Submit"), inwardPharmacyNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardPharmacyBhtReceive, "Pharmacy BHT Receive"), inwardPharmacyNode);
 
         TreeNode searchNode = new DefaultTreeNode(new PrivilegeHolder(null, "Search"), inwardNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSearch, "Search Menu"), searchNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSearchServiceBill, "Search Service Bill"), searchNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSearchAdmissionsGeneralSearch, "Search Admissions - General Search (Date Range)"), searchNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSearchProfessionalBill, "Search Professional Bill"), searchNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSearchFinalBill, "Search Final Bill"), searchNode);
 
+        TreeNode admissionSearchScopeNode = new DefaultTreeNode(new PrivilegeHolder(null, "Admission Search Scope"), searchNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSearchAdmissionsByAdmittedDepartmentAnyInstitute, "By Admitted Department - Any Institute"), admissionSearchScopeNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSearchAdmissionsByAdmittedDepartmentLoggedInstitute, "By Admitted Department - Logged Institute"), admissionSearchScopeNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSearchAdmissionsByAdmittedDepartmentLoggedDepartment, "By Admitted Department - Logged Department"), admissionSearchScopeNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSearchAdmissionsByCurrentDepartmentAnyInstitute, "By Current Department - Any Institute"), admissionSearchScopeNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSearchAdmissionsByCurrentDepartmentLoggedInstitute, "By Current Department - Logged Institute"), admissionSearchScopeNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSearchAdmissionsByCurrentDepartmentLoggedDepartment, "By Current Department - Logged Department"), admissionSearchScopeNode);
+
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardReport, "Inward Reports"), inwardNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardPostDischargeReports, "Inward Post-Discharge Reports"), inwardNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardAdministration, "Administration"), inwardNode);
+
+        TreeNode inwardLaboratoryNode = new DefaultTreeNode(new PrivilegeHolder(null, "Laboratory"), inwardNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardLaboratory, "Laboratory Dashboard Menu"), inwardLaboratoryNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardLaboratoryBarcodeGeneration, "Barcode Generation"), inwardLaboratoryNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardLaboratorySampleManagement, "Sample Management"), inwardLaboratoryNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardLaboratoryReportSearch, "Report Search"), inwardLaboratoryNode);
+
+        TreeNode inwardFormsNode = new DefaultTreeNode(new PrivilegeHolder(null, "Forms"), inwardNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardFormTemplateAdmin, "Form Template Admin"), inwardFormsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardFormFill, "Fill / Edit Forms"), inwardFormsNode);
 
         TreeNode inwardClinicalNode = new DefaultTreeNode(new PrivilegeHolder(null, "Clinical"), inwardNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientClinicalAssessment, "Clinical Notes / Assessments"), inwardClinicalNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientClinicalDischarge, "Clinical Discharge"), inwardClinicalNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardNursingDischarge, "Nursing Discharge"), inwardClinicalNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardPhysicalDischarge, "Physical Discharge"), inwardClinicalNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardDocumentUpload, "Document Upload"), inwardClinicalNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientLetter, "Generate Inpatient Letters"), inwardClinicalNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSendEmail, "Send Email"), inwardClinicalNode);
+
+        TreeNode inwardPackageNode = new DefaultTreeNode(new PrivilegeHolder(null, "Packages"), inwardNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardPackageAdministration, "Manage Inpatient Packages"), inwardPackageNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardPackageAdmission, "Package-Based Admission"), inwardPackageNode);
 
         TreeNode additionalPrivilegesNode = new DefaultTreeNode(new PrivilegeHolder(null, "Additional Privileges"), inwardNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardAdditionalPrivilages, "Additional Privilege Menu"), additionalPrivilegesNode);
@@ -232,12 +303,22 @@ public class UserPrivilageController implements Serializable {
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardBillSettleWithoutCheck, "Inward Bill Settle Without Check"), additionalPrivilegesNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSearchServiceBillUnrestrictedAccess, "Inward Bill Search Without Restriction"), additionalPrivilegesNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSettleFinalBillUnrestricted, "Inward Final Bill Settle Without Restriction"), additionalPrivilegesNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSettleFinalBill, "Inward Settle Final Bill"), additionalPrivilegesNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardFinalBillCreateVersion, "Inward Final Bill Create New Version"), additionalPrivilegesNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardFinalBillSetConfirmed, "Inward Final Bill Set As Confirmed"), additionalPrivilegesNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardFinalBillRetire, "Inward Final Bill Retire"), additionalPrivilegesNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardFinalBillEmail, "Inward Final Bill Email"), additionalPrivilegesNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSaveProvisionalFinalBill, "Inward Save Provisional Final Bill"), additionalPrivilegesNode);
 
         // Theatre Privileges
         TreeNode theatreNode = new DefaultTreeNode(new PrivilegeHolder(null, "Theatre"), allNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.Theatre, "Theatre Menu"), theatreNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.TheatreAddSurgery, "Add Surgery"), theatreNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.TheatreBilling, "Theatre Billing"), theatreNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.TheatreSendPatient, "Send Patient to Theatre"), theatreNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.TheatreAcceptPatient, "Accept Patient in Theatre"), theatreNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.TheatreReturnPatient, "Return Patient to Ward"), theatreNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.WardAcceptTheatreReturn, "Accept Patient Returning from Theatre"), theatreNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.TheaterTransfer, "Theatre Transfer Menu Item"), theatreNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.TheaterTransferRequest, "Theatre Transfer Request"), theatreNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.TheaterTransferIssue, "Theatre Transfer Issue"), theatreNode);
@@ -356,6 +437,7 @@ public class UserPrivilageController implements Serializable {
         TreeNode pharmacyNode = new DefaultTreeNode(new PrivilegeHolder(null, "Pharmacy"), allNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.Pharmacy, "Pharmacy Menu"), pharmacyNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyAdministration, "Pharmacy Administration"), pharmacyNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyItemNameEdit, "Pharmacy Item Name Edit"), pharmacyNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDonation, "Pharmacy Donation"), pharmacyNode);
 
         // Channelling Privileges
@@ -497,6 +579,8 @@ public class UserPrivilageController implements Serializable {
         new DefaultTreeNode(new PrivilegeHolder(Privileges.ClinicalPatientEdit, "Edit Patient"), clinicalsNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.ClinicalPatientNameChange, "Change Patient Name"), clinicalsNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.ClinicalPatientPhoneNumberEdit, "Edit Patient Phone Number"), clinicalsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.ClinicalPatientBlacklist, "Blacklist / Unblacklist Patient"), clinicalsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.ClinicalPatientPseudonymise, "Pseudonymise Patient"), clinicalsNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.ClinicalPatientCommentsView, "View Patient Comments"), clinicalsNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.ClinicalPatientCommentsEdit, "Edit Patient Comments"), clinicalsNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.ClinicalMembershipAdd, "Add Membership"), clinicalsNode);
@@ -511,6 +595,10 @@ public class UserPrivilageController implements Serializable {
         new DefaultTreeNode(new PrivilegeHolder(Privileges.AdminStaff, "Manage Staff"), adminNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.AdminItems, "Manage Items/Services"), adminNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.AdminPrices, "Manage Fees/Prices/Packages"), adminNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.AdminPatientRelationships, "Manage Patient Relationships"), adminNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.AdminInactivePatients, "Manage Inactive Patients"), adminNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.MergePatients, "Merge Patients"), adminNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.ClientPortalCreateAccount, "Create Client Portal Account"), adminNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.ManageCreditCompany, "Manage Credit Companies"), adminNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.AdminFilterWithoutDepartment, "Filter Without Department"), adminNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.SearchAll, "Search All"), adminNode);
@@ -664,12 +752,16 @@ public class UserPrivilageController implements Serializable {
 
         TreeNode handoverAcceptAsCashier = new DefaultTreeNode(new PrivilegeHolder(Privileges.ShiftHandoverAcceptAsCashier, "Shift Handover Accept As A Cashier"), cashTransactionNode);
         TreeNode handoverAcceptAsMainCashier = new DefaultTreeNode(new PrivilegeHolder(Privileges.ShiftHandoverAcceptAsMainCashier, "Shift Handover Accept As Main Cashier"), cashTransactionNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.SettleHandoverProofMissing, "Settle Handover Proof Missing"), cashTransactionNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.SettleNonCashPayments, "Settle Non-Cash Payments"), cashTransactionNode);
 
         TreeNode listToCashReceiveNode = new DefaultTreeNode(new PrivilegeHolder(Privileges.CashTransactionListToCashRecieve, "List To Cash Receive"), cashTransactionNode);
 
         TreeNode PettyCashBillApprove = new DefaultTreeNode(new PrivilegeHolder(Privileges.PettyCashBillApprove, "Petty Cash Bill Approval"), cashTransactionNode);
         TreeNode PettyCashBillCancellationApprove = new DefaultTreeNode(new PrivilegeHolder(Privileges.PettyCashBillCancellationApprove, "Petty Cash Bill Cancellation Approval"), cashTransactionNode);
+        TreeNode PettyCashEditFinancialYear = new DefaultTreeNode(new PrivilegeHolder(Privileges.PettyCashEditFinancialYear, "Petty Cash Edit Financial Year"), cashTransactionNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.AllCashierSummery, "All Cashier Summary"), cashTransactionNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.CashierHandoverStatusReport, "Cashier Handover Status Report"), cashTransactionNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.IncomeReport, "Income Report"), cashTransactionNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.DuesAndAccess, "Dues and Access"), cashTransactionNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.CheckEnteredData, "Check Entered Data"), cashTransactionNode);
@@ -712,8 +804,16 @@ public class UserPrivilageController implements Serializable {
         TreeNode disbursementFinalizeRequest = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDisbursementFinalizeRequest, "Finalize Transfer Request"), disbursementNode);
         TreeNode PharmacyDisbursementApproval = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDisbursementRequestApproval, "Pharmacy Disbursement Request Approval"), disbursementNode);
         TreeNode disbursementIssueForRequest = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDisbursementIssurForRequest, "Issue for Request"), disbursementNode);
+        TreeNode issueForRequestSave = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyIssueForRequestSave, "Issue for Request Save"), disbursementNode);
+        TreeNode issueForRequestFinalize = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyIssueForRequestFinalize, "Issue for Request Finalize"), disbursementNode);
+        TreeNode issueForRequestApprove = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyIssueForRequestApprove, "Issue for Request Approve"), disbursementNode);
         TreeNode disbursementDirectIssue = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDisbursementDirectIssue, "Direct Issue"), disbursementNode);
         TreeNode disbursementRecieve = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDisbursementRecieve, "Recieve"), disbursementNode);
+        TreeNode receiveSave = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyReceiveSave, "Receive Save"), disbursementNode);
+        TreeNode receiveFinalize = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyReceiveFinalize, "Receive Finalize"), disbursementNode);
+        TreeNode receiveApprove = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyReceiveApprove, "Receive Approve"), disbursementNode);
+        TreeNode transferIssueCancel = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyTransferIssueCancel, "Transfer Issue Cancel"), disbursementNode);
+        TreeNode transferReceiveCancel = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyTransferReceiveCancel, "Transfer Receive Cancel"), disbursementNode);
         TreeNode TransferReciveApproval = new DefaultTreeNode(new PrivilegeHolder(Privileges.TransferReciveApproval, "Recieve Approval"), disbursementNode);
         TreeNode PharmacyDisbursementReports = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDisbursementReports, "Pharmacy Disbursement Reports"), disbursementNode);
         TreeNode PharmacyTransferViewRates = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyTransferViewRates, "Pharmacy Transfer View Rates"), disbursementNode);
@@ -725,8 +825,11 @@ public class UserPrivilageController implements Serializable {
         TreeNode InpatientMedicationManagementNode = new DefaultTreeNode("Inpatient medication Management", pharmacyNode);
         TreeNode InpatientMedicationManagementMenue = new DefaultTreeNode(new PrivilegeHolder(Privileges.InpatientMedicationManagementMenue, "Procurement Menu"), InpatientMedicationManagementNode);
         TreeNode PharmacyDirectIssueToBht = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDirectIssueToBht, "Pharmacy Direct Issue To Bht"), InpatientMedicationManagementNode);
+        TreeNode PharmacyDischargeMedicineIssue = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDischargeMedicineIssue, "Pharmacy Discharge Medicine Issue"), InpatientMedicationManagementNode);
         TreeNode PharmacyDirectIssueToTheaterCases = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDirectIssueToTheaterCases, "Pharmacy Direct Issue To Theater Cases"), InpatientMedicationManagementNode);
         TreeNode PharmacyBhtIssueRequest = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyBhtIssueRequest, "Pharmacy Bht Issue Request"), InpatientMedicationManagementNode);
+        TreeNode PharmacyBhtRequestForceComplete = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyBhtRequestForceComplete, "Pharmacy Bht Request Force Complete"), InpatientMedicationManagementNode);
+        TreeNode PharmacyReturnFromWardForceComplete = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyReturnFromWardForceComplete, "Pharmacy Return From Ward Force Complete"), InpatientMedicationManagementNode);
         TreeNode PharmacySearchInpatientDirectIssuesbyBill = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacySearchInpatientDirectIssuesbyBill, "Pharmacy Search Inpatient Direct Issues by Bill"), InpatientMedicationManagementNode);
         TreeNode PharmacySearchInpatientDirectIssuesbyItem = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacySearchInpatientDirectIssuesbyItem, "Pharmacy Search Inpatient Direct Issues by Item"), InpatientMedicationManagementNode);
         TreeNode PharmacySearchInpatientDirectIssueReturnsbyBill = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacySearchInpatientDirectIssueReturnsbyBill, "Pharmacy Search Inpatient Direct Issue Returns by Bill"), InpatientMedicationManagementNode);
@@ -740,11 +843,18 @@ public class UserPrivilageController implements Serializable {
         TreeNode pharmacyAutoOrderPModel = new DefaultTreeNode(new PrivilegeHolder(Privileges.AutoOrderPModel, "Auto Order (P Model)"), ProcumentNode);
         TreeNode pharmacyAutoOrderQModel = new DefaultTreeNode(new PrivilegeHolder(Privileges.AutoOrderQModal, "Auto Order (Q Model)"), ProcumentNode);
         TreeNode pharmacyDirectPurchase = new DefaultTreeNode(new PrivilegeHolder(Privileges.DirectPurchase, "Direct Purchase"), ProcumentNode);
+        TreeNode pharmacyDirectPurchaseSave = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDirectPurchaseSave, "Pharmacy Direct Purchase Save"), ProcumentNode);
+        TreeNode pharmacyDirectPurchaseFinalize = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDirectPurchaseFinalize, "Pharmacy Direct Purchase Finalize"), ProcumentNode);
+        TreeNode pharmacyDirectPurchaseApprove = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDirectPurchaseApprove, "Pharmacy Direct Purchase Approve"), ProcumentNode);
         TreeNode pharmacyPurchaseOrderApprovel = new DefaultTreeNode(new PrivilegeHolder(Privileges.PurchaseOrdersApprovel, "Purchase Orders Approvel"), ProcumentNode);
+        TreeNode pharmacyPurchaseOrderSave = new DefaultTreeNode(new PrivilegeHolder(Privileges.PurchaseOrderSave, "Purchase Order Save"), ProcumentNode);
+        TreeNode pharmacyPurchaseOrderFinalize = new DefaultTreeNode(new PrivilegeHolder(Privileges.PurchaseOrderFinalize, "Purchase Order Finalize"), ProcumentNode);
         TreeNode pharmacyGoodRecipt = new DefaultTreeNode(new PrivilegeHolder(Privileges.GoodsRecipt, "Pharmacy Good Recipt"), ProcumentNode);
         TreeNode pharmacyGrnSave = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyGrnSave, "Pharmacy GRN Save"), ProcumentNode);
         TreeNode pharmacyGrnFinalize = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyGrnFinalize, "Pharmacy GRN Finalize"), ProcumentNode);
         TreeNode pharmacyGrnApprove = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyGrnApprove, "Pharmacy GRN Approve"), ProcumentNode);
+        TreeNode pharmacyGrnCancel = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyGrnCancel, "Pharmacy GRN Cancel"), ProcumentNode);
+        TreeNode pharmacyGrnReturnCancel = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyGrnReturnCancel, "Pharmacy GRN Return Cancel"), ProcumentNode);
         TreeNode pharmacyReturnReceviedGoods = new DefaultTreeNode(new PrivilegeHolder(Privileges.ReturnReceviedGoods, "Pharmacy Return Recevied Goods"), ProcumentNode);
         TreeNode pharmacyCreateGrnReturn = new DefaultTreeNode(new PrivilegeHolder(Privileges.CreateGrnReturn, "Create GRN Return"), ProcumentNode);
         TreeNode pharmacyFinalizeGrnReturn = new DefaultTreeNode(new PrivilegeHolder(Privileges.FinalizeGrnReturn, "Finalize GRN Return"), ProcumentNode);
@@ -786,10 +896,18 @@ public class UserPrivilageController implements Serializable {
         TreeNode PharmacyStockTakeApprove = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyStockTakeApprove, "Pharmacy Stock Take Approve"), PharmacyAdjustment);
         // Create New Batch privilege
         new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyAdjustmentCreateBatch, "Pharmacy Adjustment Create Batch"), PharmacyAdjustment);
+        // Archive Old StockHistory Records (issue #20726)
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.ArchiveOldStockHistory, "Archive Old StockHistory Records"), PharmacyAdjustment);
+        // Archive Old ItemBatch Records (issue #20724)
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.ArchiveOldItemBatch, "Archive Old ItemBatch Records"), PharmacyAdjustment);
 
         TreeNode pharmacyDisposalNode = new DefaultTreeNode(new PrivilegeHolder(null, "Pharmacy Disposal"), pharmacyNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDisposalMenue, "Pharmacy Disposal Menu"), pharmacyDisposalNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDisposalIssue, "Pharmacy Disposal Issue"), pharmacyDisposalNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDisposalIssueFinalize, "Pharmacy Disposal Issue Finalize"), pharmacyDisposalNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDisposalIssueApprove, "Pharmacy Disposal Issue Approve"), pharmacyDisposalNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDisposalIssueCancel, "Pharmacy Disposal Issue Cancel"), pharmacyDisposalNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDiscardCategoryManage, "Pharmacy Issue Category Manage"), pharmacyDisposalNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDisposalSearchIssueBill, "Pharmacy Disposal Search Issue Bill"), pharmacyDisposalNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDisposalSearchIssueBillItems, "Pharmacy Disposal Search Issue Bill Items"), pharmacyDisposalNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyDisposalSearchIssueReturnBill, "Pharmacy Disposal Search Issue Return Bill"), pharmacyDisposalNode);
@@ -861,15 +979,42 @@ public class UserPrivilageController implements Serializable {
 
         // Request Privileges
         TreeNode requestNode = new DefaultTreeNode(new PrivilegeHolder(null, "Request Manage"), allNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.RequestManager, "Request Manager"), requestNode);
         TreeNode billCancelRequestApproval = new DefaultTreeNode(new PrivilegeHolder(Privileges.BillCancelRequestApproval, "Bill Cancel Approval"), requestNode);
         TreeNode itemRefundRequestApproval = new DefaultTreeNode(new PrivilegeHolder(Privileges.ItemRefundRequestApproval, "Item Refund Approval"), requestNode);
         TreeNode drawerAdjustmentRequestApproval = new DefaultTreeNode(new PrivilegeHolder(Privileges.DrawerAdjustmentRequestApproval, "Drawer Adjustment Approval"), requestNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.DrawerAdjustmentDirect, "Drawer Adjustment Direct (No Approval)"), requestNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.PettyCashCancellationApproval, "Petty-Cash Cancellation Approval"), requestNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacyRetailSaleReturnApproval, "Pharmacy Retail Sale Return Approval"), requestNode);
+
+        // Float Transfer Privileges
+        TreeNode floatTransferNode = new DefaultTreeNode(new PrivilegeHolder(null, "Float Transfer"), allNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.IssueFundTransfer, "Issue Float Transfer"), floatTransferNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.ReceiveFundTransfer, "Receive Float Transfer"), floatTransferNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.DeclineFundTransfer, "Decline Float Transfer"), floatTransferNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.RequestFundTransfer, "Request Float Transfer"), floatTransferNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.ProcessFundTransferRequest, "Process Float Transfer Request"), floatTransferNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.CancelOwnFundTransfer, "Cancel Own Float Transfer"), floatTransferNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.CancelOthersFundTransfer, "Cancel Others Float Transfer"), floatTransferNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.ViewFundTransferReports, "View Float Transfer Reports"), floatTransferNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.ViewAllShiftShortageBills, "View All Shift Shortage Bills"), floatTransferNode);
 
         // Request Privileges
         TreeNode nurseNode = new DefaultTreeNode(new PrivilegeHolder(null, "Nursing Work Bench"), allNode);
         TreeNode nursingWorkBench = new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingWorkBench, "Nursing Work Bench"), nurseNode);
         TreeNode showDrugCharges = new DefaultTreeNode(new PrivilegeHolder(Privileges.ShowDrugCharges, "Show Drug Charges"), nurseNode);
+        TreeNode ShowServiceCharges = new DefaultTreeNode(new PrivilegeHolder(Privileges.ShowServiceCharges, "Show Service Charges"), nurseNode);
+        TreeNode ShowTimeServiceCharges = new DefaultTreeNode(new PrivilegeHolder(Privileges.ShowTimeServiceCharges, "Show Time Service Charges"), nurseNode);
+
+        TreeNode nursingWorkBenchPanelsNode = new DefaultTreeNode(new PrivilegeHolder(null, "Nursing Workbench Panels"), nurseNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingWorkBenchPanelEdit, "Edit Panel"), nursingWorkBenchPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingWorkBenchPanelClinicalData, "Clinical Data Panel"), nursingWorkBenchPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingWorkBenchPanelRoomManagement, "Room Management Panel"), nursingWorkBenchPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingWorkBenchPanelService, "Service Panel"), nursingWorkBenchPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingWorkBenchPanelOperationTheatre, "Operation Theatre Panel"), nursingWorkBenchPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingWorkBenchPanelPharmaceuticals, "Pharmaceuticals Panel"), nursingWorkBenchPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingWorkBenchPanelReports, "Reports Panel"), nursingWorkBenchPanelsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingWorkBenchPanelPayments, "Payments Panel"), nursingWorkBenchPanelsNode);
 
         // Admin Privileges
         TreeNode superAdminNode = new DefaultTreeNode(new PrivilegeHolder(Privileges.SuperAdmin, "Super Admin"), allNode);
@@ -896,7 +1041,7 @@ public class UserPrivilageController implements Serializable {
 
     public void saveUserRolePrivileges() {
         if (webUserRole == null) {
-            JsfUtil.addErrorMessage("Please select a user");
+            JsfUtil.addErrorMessage("Please select a User Role");
             return;
         }
         saveWebUserRolePrivileges();
@@ -1147,7 +1292,7 @@ public class UserPrivilageController implements Serializable {
         fillUserRolePrivileges();
         JsfUtil.addSuccessMessage("Updated");
     }
-
+    
     private static void checkNodes(TreeNode root, List<PrivilegeHolder> privilegesToCheck) {
         if (root == null || privilegesToCheck == null || privilegesToCheck.isEmpty()) {
             return;
@@ -1405,6 +1550,7 @@ public class UserPrivilageController implements Serializable {
         currentUserPrivilegeHolders = createRolePrivilegeHolders(currentWebUserRolePrivileges);
         unselectTreeNodes(rootTreeNode);
         checkNodes(rootTreeNode, currentUserPrivilegeHolders);
+        privilegesLoaded = true;
     }
 
     public List<WebUserRolePrivilege> fetchUserPrivileges(WebUserRole role) {

--- a/src/main/java/com/divudi/bean/common/UserSettingsController.java
+++ b/src/main/java/com/divudi/bean/common/UserSettingsController.java
@@ -12,6 +12,8 @@ import java.io.Serializable;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.ejb.EJB;
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Inject;
@@ -32,6 +34,7 @@ import org.json.JSONObject;
 public class UserSettingsController implements Serializable {
 
     private static final long serialVersionUID = 1L;
+    private static final Logger LOGGER = Logger.getLogger(UserSettingsController.class.getName());
 
     @EJB
     private ConfigOptionFacade configOptionFacade;
@@ -197,7 +200,7 @@ public class UserSettingsController implements Serializable {
             settingsCache.put(key, option);
 
         } catch (Exception e) {
-            JsfUtil.addErrorMessage("Failed to save your settings.");
+            LOGGER.log(Level.WARNING, "Failed to save user setting: {0} - {1}", new Object[]{key, e.getMessage()});
         }
     }
 
@@ -229,7 +232,7 @@ public class UserSettingsController implements Serializable {
             String jsonString = serializeToJson(value);
             saveUserSetting(key, jsonString, OptionValueType.LONG_TEXT);
         } catch (Exception e) {
-            JsfUtil.addErrorMessage("Failed to save your settings.");
+            LOGGER.log(Level.WARNING, "Failed to save user JSON setting: {0} - {1}", new Object[]{key, e.getMessage()});
         }
     }
 
@@ -530,6 +533,7 @@ public class UserSettingsController implements Serializable {
     }
 
     public void setPharmacyGrnReturnRequestSupplierVisible(boolean visible) {
+        if (visible == isPharmacyGrnReturnRequestSupplierVisible()) return;
         ColumnVisibilitySettings settings = getColumnVisibility("pharmacy_grn_return_request");
         settings.setColumnVisible("supplier", visible);
         saveColumnVisibility("pharmacy_grn_return_request", settings);
@@ -540,6 +544,7 @@ public class UserSettingsController implements Serializable {
     }
 
     public void setPharmacyGrnReturnRequestPoNoVisible(boolean visible) {
+        if (visible == isPharmacyGrnReturnRequestPoNoVisible()) return;
         ColumnVisibilitySettings settings = getColumnVisibility("pharmacy_grn_return_request");
         settings.setColumnVisible("poNo", visible);
         saveColumnVisibility("pharmacy_grn_return_request", settings);
@@ -550,6 +555,7 @@ public class UserSettingsController implements Serializable {
     }
 
     public void setPharmacyGrnReturnRequestGrnNoVisible(boolean visible) {
+        if (visible == isPharmacyGrnReturnRequestGrnNoVisible()) return;
         ColumnVisibilitySettings settings = getColumnVisibility("pharmacy_grn_return_request");
         settings.setColumnVisible("grnNo", visible);
         saveColumnVisibility("pharmacy_grn_return_request", settings);
@@ -560,6 +566,7 @@ public class UserSettingsController implements Serializable {
     }
 
     public void setPharmacyGrnReturnRequestInvoiceNoVisible(boolean visible) {
+        if (visible == isPharmacyGrnReturnRequestInvoiceNoVisible()) return;
         ColumnVisibilitySettings settings = getColumnVisibility("pharmacy_grn_return_request");
         settings.setColumnVisible("invoiceNo", visible);
         saveColumnVisibility("pharmacy_grn_return_request", settings);
@@ -570,6 +577,7 @@ public class UserSettingsController implements Serializable {
     }
 
     public void setPharmacyGrnReturnRequestPoDetailsVisible(boolean visible) {
+        if (visible == isPharmacyGrnReturnRequestPoDetailsVisible()) return;
         ColumnVisibilitySettings settings = getColumnVisibility("pharmacy_grn_return_request");
         settings.setColumnVisible("poDetails", visible);
         saveColumnVisibility("pharmacy_grn_return_request", settings);
@@ -580,6 +588,7 @@ public class UserSettingsController implements Serializable {
     }
 
     public void setPharmacyGrnReturnRequestGrnDetailsVisible(boolean visible) {
+        if (visible == isPharmacyGrnReturnRequestGrnDetailsVisible()) return;
         ColumnVisibilitySettings settings = getColumnVisibility("pharmacy_grn_return_request");
         settings.setColumnVisible("grnDetails", visible);
         saveColumnVisibility("pharmacy_grn_return_request", settings);
@@ -590,6 +599,7 @@ public class UserSettingsController implements Serializable {
     }
 
     public void setPharmacyGrnReturnRequestPoValueVisible(boolean visible) {
+        if (visible == isPharmacyGrnReturnRequestPoValueVisible()) return;
         ColumnVisibilitySettings settings = getColumnVisibility("pharmacy_grn_return_request");
         settings.setColumnVisible("poValue", visible);
         saveColumnVisibility("pharmacy_grn_return_request", settings);
@@ -600,6 +610,7 @@ public class UserSettingsController implements Serializable {
     }
 
     public void setPharmacyGrnReturnRequestGrnValueVisible(boolean visible) {
+        if (visible == isPharmacyGrnReturnRequestGrnValueVisible()) return;
         ColumnVisibilitySettings settings = getColumnVisibility("pharmacy_grn_return_request");
         settings.setColumnVisible("grnValue", visible);
         saveColumnVisibility("pharmacy_grn_return_request", settings);

--- a/src/main/java/com/divudi/bean/common/WebUserController.java
+++ b/src/main/java/com/divudi/bean/common/WebUserController.java
@@ -1312,6 +1312,8 @@ public class WebUserController implements Serializable {
         String hashedPassword;
         hashedPassword = getSecurityController().hashAndCheck(newPassword);
         current.setWebUserPassword(hashedPassword);
+        current.setNeedToResetPassword(false);
+        current.setLastPasswordResetAt(new Date());
         getFacade().editAndCommit(current);
         WebUserPasswordHistory wh = new WebUserPasswordHistory();
         wh.setWebUser(current);

--- a/src/main/java/com/divudi/bean/opd/OpdBillController.java
+++ b/src/main/java/com/divudi/bean/opd/OpdBillController.java
@@ -2288,6 +2288,24 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
         return bi != null && bi.getId() != null;
     }
 
+    private void retirePartialBillOnSettlementFailure(Bill bill, List<BillItem> persistedItems) {
+        if (bill == null) {
+            return;
+        }
+        for (BillItem bi : persistedItems) {
+            if (isPersistedBillItem(bi) && !bi.isRetired()) {
+                bi.setRetired(true);
+                bi.setRetiredAt(new Date());
+                getBillItemFacade().edit(bi);
+            }
+        }
+        if (bill.getId() != null && !bill.isRetired()) {
+            bill.setRetired(true);
+            bill.setRetiredAt(new Date());
+            getBillFacade().edit(bill);
+        }
+    }
+
     private boolean processBillsByDepartment() {
         Set<Department> billDepts = new HashSet<>();
         for (BillEntry e : lstBillEntries) {
@@ -2306,6 +2324,7 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
                 if (Objects.equals(prformingDept.getId(), d.getId())) {
                     BillItem bi = getBillBean().saveBillItemForOpdBill(myBill, e, getSessionController().getLoggedUser(), getBillFeeBundleEntrys());
                     if (!isPersistedBillItem(bi)) {
+                        retirePartialBillOnSettlementFailure(myBill, myBill.getBillItems());
                         JsfUtil.addErrorMessage("Failed to save bill items for department " + d.getName() + ". Please retry the bill settlement.");
                         return false;
                     }
@@ -2314,6 +2333,7 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
                 }
             }
             if (tmp.isEmpty()) {
+                retirePartialBillOnSettlementFailure(myBill, myBill.getBillItems());
                 JsfUtil.addErrorMessage("No bill items were found for department " + d.getName() + ". Please retry the bill settlement.");
                 return false;
             }
@@ -2366,6 +2386,7 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
                             && Objects.equals(billEntry.getBillItem().getItem().getCategory().getId(), c.getId())) {
                         BillItem bi = getBillBean().saveBillItem(newlyCreatedIndividualBill, billEntry, getSessionController().getLoggedUser());
                         if (!isPersistedBillItem(bi)) {
+                            retirePartialBillOnSettlementFailure(newlyCreatedIndividualBill, newlyCreatedIndividualBill.getBillItems());
                             JsfUtil.addErrorMessage("Failed to save bill items for department " + d.getName() + " and category " + c.getName() + ". Please retry the bill settlement.");
                             return false;
                         }
@@ -2374,6 +2395,7 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
                     }
                 }
                 if (tmp.isEmpty()) {
+                    retirePartialBillOnSettlementFailure(newlyCreatedIndividualBill, newlyCreatedIndividualBill.getBillItems());
                     JsfUtil.addErrorMessage("No bill items were found for department " + d.getName() + " and category " + c.getName() + ". Please retry the bill settlement.");
                     return false;
                 }
@@ -2516,6 +2538,7 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
             for (BillEntry billEntry : getLstBillEntries()) {
                 BillItem bi = getBillBean().saveBillItem(newSingleBill, billEntry, getSessionController().getLoggedUser());
                 if (!isPersistedBillItem(bi)) {
+                    retirePartialBillOnSettlementFailure(newSingleBill, list);
                     JsfUtil.addErrorMessage("Failed to save bill items. Please retry the bill settlement.");
                     return false;
                 }

--- a/src/main/java/com/divudi/bean/opd/OpdBillController.java
+++ b/src/main/java/com/divudi/bean/opd/OpdBillController.java
@@ -2284,6 +2284,10 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
         return false; // Fallback case, should not reach here.
     }
 
+    static boolean isPersistedBillItem(BillItem bi) {
+        return bi != null && bi.getId() != null;
+    }
+
     private boolean processBillsByDepartment() {
         Set<Department> billDepts = new HashSet<>();
         for (BillEntry e : lstBillEntries) {
@@ -2301,9 +2305,17 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
                 Department prformingDept = departmentResolver.resolvePerformingDepartment(sessionController.getDepartment(), e.getBillItem().getItem());
                 if (Objects.equals(prformingDept.getId(), d.getId())) {
                     BillItem bi = getBillBean().saveBillItemForOpdBill(myBill, e, getSessionController().getLoggedUser(), getBillFeeBundleEntrys());
+                    if (!isPersistedBillItem(bi)) {
+                        JsfUtil.addErrorMessage("Failed to save bill items for department " + d.getName() + ". Please retry the bill settlement.");
+                        return false;
+                    }
                     myBill.getBillItems().add(bi);
                     tmp.add(e);
                 }
+            }
+            if (tmp.isEmpty()) {
+                JsfUtil.addErrorMessage("No bill items were found for department " + d.getName() + ". Please retry the bill settlement.");
+                return false;
             }
             if (getSessionController().getApplicationPreference().isPartialPaymentOfOpdBillsAllowed()) {
                 myBill.setCashPaid(cashPaid);
@@ -2353,9 +2365,17 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
                     if (Objects.equals(dept.getId(), d.getId())
                             && Objects.equals(billEntry.getBillItem().getItem().getCategory().getId(), c.getId())) {
                         BillItem bi = getBillBean().saveBillItem(newlyCreatedIndividualBill, billEntry, getSessionController().getLoggedUser());
+                        if (!isPersistedBillItem(bi)) {
+                            JsfUtil.addErrorMessage("Failed to save bill items for department " + d.getName() + " and category " + c.getName() + ". Please retry the bill settlement.");
+                            return false;
+                        }
                         newlyCreatedIndividualBill.getBillItems().add(bi);
                         tmp.add(billEntry);
                     }
+                }
+                if (tmp.isEmpty()) {
+                    JsfUtil.addErrorMessage("No bill items were found for department " + d.getName() + " and category " + c.getName() + ". Please retry the bill settlement.");
+                    return false;
                 }
 
                 Priority highestPriority = Optional
@@ -2494,7 +2514,12 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
             }
             List<BillItem> list = new ArrayList<>();
             for (BillEntry billEntry : getLstBillEntries()) {
-                list.add(getBillBean().saveBillItem(newSingleBill, billEntry, getSessionController().getLoggedUser()));
+                BillItem bi = getBillBean().saveBillItem(newSingleBill, billEntry, getSessionController().getLoggedUser());
+                if (!isPersistedBillItem(bi)) {
+                    JsfUtil.addErrorMessage("Failed to save bill items. Please retry the bill settlement.");
+                    return false;
+                }
+                list.add(bi);
             }
             newSingleBill.setBillItems(list);
 
@@ -2535,9 +2560,13 @@ public class OpdBillController implements Serializable, ControllerWithPatient, C
             getBillBean().checkBillItemFeesInitiated(newSingleBill);
             getBills().add(newSingleBill);
         } else if (oneOpdBillForEachDepartmentAndCategoryCombination) {
-            processBillsByDepartmentAndCategory();
+            if (!processBillsByDepartmentAndCategory()) {
+                return false;
+            }
         } else if (oneOpdBillForEachDepartment) {
-            processBillsByDepartment();
+            if (!processBillsByDepartment()) {
+                return false;
+            }
         } else if (oneOpdBillForEachCategory) {
             JsfUtil.addErrorMessage("Still Under Development");
             return false;

--- a/src/main/java/com/divudi/bean/pharmacy/AmpController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/AmpController.java
@@ -474,6 +474,19 @@ public class AmpController implements Serializable {
         return suggestions;
     }
 
+    public List<Amp> completeAmpAny(String qry) {
+        List<Amp> suggestions;
+        if (qry == null || qry.trim().isEmpty()) {
+            suggestions = new ArrayList<>();
+        } else {
+            String jpql = "SELECT c FROM Amp c WHERE c.retired = false AND LOWER(c.name) LIKE :query ORDER BY c.name";
+            Map<String, Object> parameters = new HashMap<>();
+            parameters.put("query", "%" + qry.trim().toLowerCase() + "%");
+            suggestions = getFacade().findByJpqlWithoutCache(jpql, parameters);
+        }
+        return suggestions;
+    }
+
     public List<Amp> completeAmpWithRetired(String qry) {
         List<Amp> a = null;
         Map m = new HashMap();

--- a/src/main/java/com/divudi/bean/pharmacy/DirectPurchaseReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/DirectPurchaseReturnWorkflowController.java
@@ -235,9 +235,7 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
         // Load the bill with all its items using billService
         try {
             currentBill = billService.reloadBill(currentBill);
-            if (currentBill != null && currentBill.getBillItems() != null) {
-                // Ensure bill items are loaded for preview
-                ensureBillItemsForPreview();
+            if (currentBill != null) {
                 printPreview = true;
                 return "/pharmacy/pharmacy_reprint_direct_purchase_return?faces-redirect=true";
             } else {
@@ -339,8 +337,6 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
 //            return;
 //        }
         saveBill(false);
-        // Ensure bill items are properly associated for any subsequent operations
-        ensureBillItemsForPreview();
         JsfUtil.addSuccessMessage("Direct Purchase Return Request Saved Successfully");
     }
 
@@ -381,8 +377,6 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
             processZeroQuantityItems();
 
             saveBill(true);
-            // Ensure the bill items are properly associated with the current bill for print preview
-            ensureBillItemsForPreview();
             printPreview = true;
             JsfUtil.addSuccessMessage("Direct Purchase Return Request Finalized Successfully");
         }
@@ -538,8 +532,6 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
                 JsfUtil.addSuccessMessage("Original Direct Purchase has been fully returned and marked as complete.");
             }
 
-            // Ensure bill items are properly associated for print preview
-            ensureBillItemsForPreview();
             printPreview = true;
             JsfUtil.addSuccessMessage("Direct Purchase Return Approved Successfully");
         }
@@ -986,32 +978,6 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
         } catch (Exception e) {
             JsfUtil.addErrorMessage("Error removing item: " + e.getMessage());
             e.printStackTrace();
-        }
-    }
-
-    private void ensureBillItemsForPreview() {
-        if (currentBill != null) {
-            // Ensure the current bill has its billItems collection properly populated
-            // The print preview component expects bill.billItems to be available
-            try {
-                if (currentBill.getBillItems() == null) {
-                    // Initialize the collection if it's null
-                    currentBill.setBillItems(new ArrayList<>());
-                }
-
-                // Clear and repopulate with current bill items
-                currentBill.getBillItems().clear();
-
-                // Add all current bill items that are not retired
-                for (BillItem bi : billItems) {
-                    if (bi != null && !bi.isRetired()) {
-                        currentBill.getBillItems().add(bi);
-                    }
-                }
-            } catch (Exception e) {
-                // If there's an issue with the billItems collection, log it but don't fail
-                JsfUtil.addErrorMessage("Warning: Could not properly associate items for preview: " + e.getMessage());
-            }
         }
     }
 
@@ -1671,8 +1637,6 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
         // This will make item deletion much more reliable
         try {
             saveBill(false); // Save but don't finalize
-            // Ensure bill items are properly associated for any subsequent operations
-            ensureBillItemsForPreview();
             JsfUtil.addSuccessMessage("Direct Purchase Return created successfully. You can now modify quantities and remove items as needed.");
         } catch (Exception e) {
             JsfUtil.addErrorMessage("Error creating Direct Purchase Return: " + e.getMessage());

--- a/src/main/java/com/divudi/bean/pharmacy/DirectPurchaseReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/DirectPurchaseReturnWorkflowController.java
@@ -593,7 +593,6 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
                 bi.setRetired(true);
                 bi.setRetirer(sessionController.getLoggedUser());
                 bi.setRetiredAt(new Date());
-                bi.setBill(null); // Set bill reference to null as requested
 
                 // If the item already exists in database, update it
                 if (bi.getId() != null) {
@@ -980,7 +979,6 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
                 bi.setRetired(true);
                 bi.setRetirer(sessionController.getLoggedUser());
                 bi.setRetiredAt(new Date());
-                bi.setBill(null); // Set bill as null as requested
 
                 // Update the bill item in database
                 billItemFacade.edit(bi);

--- a/src/main/java/com/divudi/bean/pharmacy/DirectPurchaseReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/DirectPurchaseReturnWorkflowController.java
@@ -366,6 +366,12 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
             return;
         }
 
+        // Sync bifd.quantity / bi.qty / pbi.qty from the authoritative source before validating.
+        // bifd.QUANTITY may have been stored negative by calculateLineTotal while bi.qty and
+        // pbi.qty are kept positive — reconcile everything to the absolute value of bifd.QUANTITY,
+        // falling back to bi.qty if bifd is null or zero.
+        syncQuantitiesBeforeFinalize();
+
         // Validate stock availability before finalizing
         if (!validateAllItemsStockAvailability(true)) {
             JsfUtil.addErrorMessage("Cannot finalize: Stock validation failed. Please correct the quantities and try again.");
@@ -1934,6 +1940,67 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
         }
 
         return true;
+    }
+
+    /**
+     * Reconciles bi.qty, pbi.qty, and bifd.QUANTITY so they all reflect the
+     * same absolute return quantity before stock validation and finalization.
+     *
+     * bifd.QUANTITY is the form-bound field the user edits. bi.qty and pbi.qty
+     * are set positively at request creation and may diverge when calculateLineTotal
+     * negates bifd.QUANTITY for DB storage. This method drives from the absolute
+     * value of bifd.QUANTITY (or bi.qty as fallback) and calls
+     * syncQuantitiesAfterQuantityChange + calculateLineTotal to re-align all fields.
+     */
+    private void syncQuantitiesBeforeFinalize() {
+        if (billItems == null) {
+            return;
+        }
+        for (BillItem bi : billItems) {
+            if (bi == null || bi.isRetired()) {
+                continue;
+            }
+            BillItemFinanceDetails fd = bi.getBillItemFinanceDetails();
+            PharmaceuticalBillItem phi = bi.getPharmaceuticalBillItem();
+            if (fd == null || phi == null) {
+                continue;
+            }
+
+            // Determine the intended return quantity from the most reliable source.
+            // bifd.QUANTITY is what the user last edited (may be negative from calculateLineTotal).
+            // bi.qty is always stored positive by calculateLineTotal.
+            // Use abs(bifd.QUANTITY) if non-zero; otherwise fall back to abs(bi.qty).
+            BigDecimal rawBifd = fd.getQuantity();
+            double biQty = bi.getQty() != null ? bi.getQty() : 0.0;
+            double absReturnQty;
+            if (rawBifd != null && rawBifd.compareTo(BigDecimal.ZERO) != 0) {
+                absReturnQty = Math.abs(rawBifd.doubleValue());
+            } else {
+                absReturnQty = Math.abs(biQty);
+            }
+
+            BigDecimal rawBifdFree = fd.getFreeQuantity();
+            double absFreeQty = rawBifdFree != null ? Math.abs(rawBifdFree.doubleValue()) : 0.0;
+
+            boolean isAmpp = bi.getItem() instanceof Ampp;
+            BigDecimal upp = fd.getUnitsPerPack() != null && fd.getUnitsPerPack().compareTo(BigDecimal.ZERO) != 0
+                    ? fd.getUnitsPerPack() : BigDecimal.ONE;
+
+            // Normalise bifd.QUANTITY to the absolute value (positive) so validation
+            // and calculateLineTotal both see the same number regardless of prior negation.
+            fd.setQuantity(BigDecimal.valueOf(absReturnQty));
+            fd.setFreeQuantity(BigDecimal.valueOf(absFreeQty));
+
+            // Sync pbi.qty in units (for AMPP multiply packs × unitsPerPack).
+            double qtyInUnits = isAmpp ? absReturnQty * upp.doubleValue() : absReturnQty;
+            double freeQtyInUnits = isAmpp ? absFreeQty * upp.doubleValue() : absFreeQty;
+            phi.setQty(qtyInUnits);
+            phi.setFreeQty(freeQtyInUnits);
+
+            // calculateLineTotal will negate the quantities for storage but we need
+            // them positive going into validateAllItemsStockAvailability which calls abs().
+            calculateLineTotal(bi);
+        }
     }
 
     /**

--- a/src/main/java/com/divudi/bean/pharmacy/DirectPurchaseReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/DirectPurchaseReturnWorkflowController.java
@@ -388,6 +388,61 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
         }
     }
 
+    /**
+     * Compares every item's in-session return quantities (paid + free) against
+     * the quantities persisted at finalization, read fresh from the database
+     * (L2 bypass). Any difference blocks the approval with a per-item message.
+     *
+     * Finalize validated stock for the FINALIZED quantities; approving anything
+     * else would issue a return that no one finalized (#21266 RC4).
+     *
+     * @return true when every quantity matches the finalized bill.
+     */
+    private boolean approvalQuantitiesMatchFinalized() {
+        if (currentBill == null || currentBill.getId() == null) {
+            JsfUtil.addErrorMessage("No finalized bill found to compare quantities against");
+            return false;
+        }
+        if (billItems == null || billItems.isEmpty()) {
+            return true;
+        }
+        boolean allMatch = true;
+        for (BillItem bi : billItems) {
+            if (bi == null || bi.isRetired() || bi.getId() == null) {
+                continue;
+            }
+            BillItem finalizedItem = billItemFacade.findWithoutCache(bi.getId());
+            if (finalizedItem == null || finalizedItem.getBillItemFinanceDetails() == null) {
+                continue;
+            }
+            BillItemFinanceDetails sessionFd = bi.getBillItemFinanceDetails();
+            BillItemFinanceDetails finalizedFd = finalizedItem.getBillItemFinanceDetails();
+
+            double sessionQty = sessionFd != null && sessionFd.getQuantity() != null
+                    ? Math.abs(sessionFd.getQuantity().doubleValue()) : 0.0;
+            double sessionFreeQty = sessionFd != null && sessionFd.getFreeQuantity() != null
+                    ? Math.abs(sessionFd.getFreeQuantity().doubleValue()) : 0.0;
+            double finalizedQty = finalizedFd.getQuantity() != null
+                    ? Math.abs(finalizedFd.getQuantity().doubleValue()) : 0.0;
+            double finalizedFreeQty = finalizedFd.getFreeQuantity() != null
+                    ? Math.abs(finalizedFd.getFreeQuantity().doubleValue()) : 0.0;
+
+            if (Math.abs(sessionQty - finalizedQty) > 0.0001
+                    || Math.abs(sessionFreeQty - finalizedFreeQty) > 0.0001) {
+                String itemName = bi.getItem() != null ? bi.getItem().getName() : "Unknown";
+                JsfUtil.addErrorMessage("Cannot approve: quantity for \"" + itemName
+                        + "\" (" + String.format("%.2f", sessionQty)
+                        + (sessionFreeQty > 0 ? " + " + String.format("%.2f", sessionFreeQty) + " free" : "")
+                        + ") does not match the finalized quantity ("
+                        + String.format("%.2f", finalizedQty)
+                        + (finalizedFreeQty > 0 ? " + " + String.format("%.2f", finalizedFreeQty) + " free" : "")
+                        + "). The return must be corrected and re-finalized.");
+                allMatch = false;
+            }
+        }
+        return allMatch;
+    }
+
     public void approve() {
         if (!isAuthorized("APPROVE", "ApproveDirectPurchaseReturn")) {
             return;
@@ -413,9 +468,19 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
             return;
         }
 
-        // Validate stock availability before approving
-        if (!validateAllItemsStockAvailability(true)) {
-            JsfUtil.addErrorMessage("Cannot approve: Stock validation failed. Please correct the quantities and try again.");
+        // The quantities being approved must be exactly the quantities that were
+        // FINALIZED (persisted by finalizeRequest). If they differ - approver
+        // edits, or a failed earlier Approve that auto-reduced quantities - the
+        // return must be rejected and sent back for re-finalization, never
+        // approved with silently changed quantities (#21266 RC4).
+        if (!approvalQuantitiesMatchFinalized()) {
+            return;
+        }
+
+        // Validate stock availability before approving. allowAutoCorrect=false:
+        // at approval, validation must never mutate quantities.
+        if (!validateAllItemsStockAvailability(true, false)) {
+            JsfUtil.addErrorMessage("Cannot approve: insufficient stock for the finalized quantities. The return must be corrected and re-finalized.");
             return;
         }
 
@@ -1833,6 +1898,12 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
      * @return true if stock is sufficient, false otherwise
      */
     public boolean validateStockAvailability(BillItem billItem, boolean showMessages) {
+        // Default keeps the legacy draft-stage behaviour (auto-corrects the
+        // quantity down to available stock so the user can re-submit).
+        return validateStockAvailability(billItem, showMessages, true);
+    }
+
+    public boolean validateStockAvailability(BillItem billItem, boolean showMessages, boolean allowAutoCorrect) {
         if (billItem == null || billItem.getPharmaceuticalBillItem() == null
                 || billItem.getPharmaceuticalBillItem().getStock() == null) {
             if (showMessages) {
@@ -1877,8 +1948,13 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
                 JsfUtil.addErrorMessage("Insufficient stock for " + itemName + " (Batch: " + stockBatch + "). "
                         + "Current stock: " + String.format("%.2f", currentStock)
                         + ", Total return quantity (including other items): " + String.format("%.2f", totalStockUsageFromCurrentReturn));
-
-                // Reset quantity to available stock minus other usages
+            }
+            // Draft-stage convenience only: rewrite the quantity down to what is
+            // available so the user can review and re-submit. MUST never run at
+            // approval - a validator that mutates quantities let a failed Approve
+            // silently reduce the return, so a second click approved quantities
+            // that no longer matched the finalized bill (#21266 RC4).
+            if (allowAutoCorrect) {
                 double availableForThisItem = Math.max(0, currentStock - (totalStockUsageFromCurrentReturn - totalReturnQtyInUnits));
 
                 if (isAmppItem) {
@@ -1965,6 +2041,10 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
      * Finalize, and Approve operations
      */
     public boolean validateAllItemsStockAvailability(boolean showMessages) {
+        return validateAllItemsStockAvailability(showMessages, true);
+    }
+
+    public boolean validateAllItemsStockAvailability(boolean showMessages, boolean allowAutoCorrect) {
         if (billItems == null || billItems.isEmpty()) {
             return true;
         }
@@ -1989,7 +2069,7 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
                 continue;
             }
 
-            if (!validateStockAvailability(bi, showMessages)) {
+            if (!validateStockAvailability(bi, showMessages, allowAutoCorrect)) {
                 allValid = false;
             }
         }

--- a/src/main/java/com/divudi/bean/pharmacy/DirectPurchaseReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/DirectPurchaseReturnWorkflowController.java
@@ -287,18 +287,19 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
         }
 
         try {
-            // Mark the bill as cancelled in the database
-            currentBill.setCancelled(true);
-
-            // Set cancellation metadata if bill has been saved to database
-            if (currentBill.getCreatedAt() != null) {
-                currentBill.setEditedAt(new Date());
-                currentBill.setEditor(sessionController.getLoggedUser());
+            // Reload from DB to ensure EclipseLink sees the full persistent billItems
+            // collection — editing the session-scoped bill directly can trigger orphan-removal
+            // DELETEs on BillItem rows that are still referenced by PharmaceuticalBillItem.
+            Bill freshBill = billFacade.find(currentBill.getId());
+            if (freshBill == null) {
+                JsfUtil.addErrorMessage("Cannot cancel: Direct Purchase Return no longer exists.");
+                return "";
             }
-
-            // Save the cancelled bill to database
-            billFacade.edit(currentBill);
-
+            freshBill.setCancelled(true);
+            freshBill.setEditedAt(new Date());
+            freshBill.setEditor(sessionController.getLoggedUser());
+            billFacade.edit(freshBill);
+            currentBill = freshBill;
             JsfUtil.addSuccessMessage("Direct Purchase Return cancelled successfully.");
         } catch (Exception e) {
             JsfUtil.addErrorMessage("Error cancelling Direct Purchase Return: " + e.getMessage());
@@ -366,13 +367,7 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
             return;
         }
 
-        // Sync bifd.quantity / bi.qty / pbi.qty from the authoritative source before validating.
-        // bifd.QUANTITY may have been stored negative by calculateLineTotal while bi.qty and
-        // pbi.qty are kept positive — reconcile everything to the absolute value of bifd.QUANTITY,
-        // falling back to bi.qty if bifd is null or zero.
-        syncQuantitiesBeforeFinalize();
-
-        // Validate stock availability before finalizing
+        // Validate stock availability before finalizing.
         if (!validateAllItemsStockAvailability(true)) {
             JsfUtil.addErrorMessage("Cannot finalize: Stock validation failed. Please correct the quantities and try again.");
             return;
@@ -477,9 +472,8 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
             return;
         }
 
-        // Validate stock availability before approving. allowAutoCorrect=false:
-        // at approval, validation must never mutate quantities.
-        if (!validateAllItemsStockAvailability(true, false)) {
+        // Validate stock availability before approving.
+        if (!validateAllItemsStockAvailability(true)) {
             JsfUtil.addErrorMessage("Cannot approve: insufficient stock for the finalized quantities. The return must be corrected and re-finalized.");
             return;
         }
@@ -488,16 +482,22 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
             // Process zero quantity items before approval
             processZeroQuantityItems();
 
-            // Mark the current bill as completed (approved)
-            currentBill.setCompleted(true);
-            currentBill.setCompletedBy(sessionController.getLoggedUser());
-            currentBill.setCompletedAt(new Date());
-            currentBill.setApproveAt(new Date());
-            currentBill.setApproveUser(sessionController.getLoggedUser());
-
-            // Save the bill with completed status
+            // Reload from DB before editing to avoid orphan-removal FK violations:
+            // currentBill.billItems (JPA collection) is empty in the session bean,
+            // so merging it directly would trigger DELETE on all persisted BillItems.
+            Bill freshForApprove = billFacade.find(currentBill.getId());
+            if (freshForApprove == null) {
+                JsfUtil.addErrorMessage("Cannot approve: bill no longer exists.");
+                return;
+            }
+            freshForApprove.setCompleted(true);
+            freshForApprove.setCompletedBy(sessionController.getLoggedUser());
+            freshForApprove.setCompletedAt(new Date());
+            freshForApprove.setApproveAt(new Date());
+            freshForApprove.setApproveUser(sessionController.getLoggedUser());
             try {
-                billFacade.edit(currentBill);
+                billFacade.edit(freshForApprove);
+                currentBill = freshForApprove;
             } catch (Exception e) {
                 JsfUtil.addErrorMessage("Error saving bill: " + e.getMessage());
                 return;
@@ -662,7 +662,28 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
         if (currentBill.getId() == null) {
             billFacade.create(currentBill);
         } else {
-            billFacade.edit(currentBill);
+            // Reload from DB before editing to avoid orphan-removal FK violations on the
+            // billItems @OneToMany(orphanRemoval=true): the session bill's JPA collection
+            // is empty, so merging directly would DELETE all persisted BillItems.
+            Bill freshForSave = billFacade.find(currentBill.getId());
+            if (freshForSave != null) {
+                freshForSave.setChecked(currentBill.isChecked());
+                freshForSave.setCheckedBy(currentBill.getCheckedBy());
+                freshForSave.setCheckeAt(currentBill.getCheckeAt());
+                freshForSave.setComments(currentBill.getComments());
+                freshForSave.setPaymentMethod(currentBill.getPaymentMethod());
+                freshForSave.setNetTotal(currentBill.getNetTotal());
+                freshForSave.setTotal(currentBill.getTotal());
+                freshForSave.setEditedAt(new Date());
+                freshForSave.setEditor(sessionController.getLoggedUser());
+                if (currentBill.getBillFinanceDetails() != null) {
+                    freshForSave.setBillFinanceDetails(currentBill.getBillFinanceDetails());
+                }
+                billFacade.edit(freshForSave);
+                currentBill = freshForSave;
+            } else {
+                billFacade.edit(currentBill);
+            }
         }
 
         saveBillItems();
@@ -1788,7 +1809,7 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
         double remainingQty = getRemainingQtyToReturn(billItem.getReferanceBillItem());
         double remainingFreeQty = getRemainingFreeQtyToReturn(billItem.getReferanceBillItem());
 
-        // Validate stock availability - critical check
+        // Validate stock availability - critical check.
         if (!validateStockAvailability(billItem, true)) {
             isValid = false;
         }
@@ -1868,12 +1889,6 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
      * @return true if stock is sufficient, false otherwise
      */
     public boolean validateStockAvailability(BillItem billItem, boolean showMessages) {
-        // Default keeps the legacy draft-stage behaviour (auto-corrects the
-        // quantity down to available stock so the user can re-submit).
-        return validateStockAvailability(billItem, showMessages, true);
-    }
-
-    public boolean validateStockAvailability(BillItem billItem, boolean showMessages, boolean allowAutoCorrect) {
         if (billItem == null || billItem.getPharmaceuticalBillItem() == null
                 || billItem.getPharmaceuticalBillItem().getStock() == null) {
             if (showMessages) {
@@ -1891,19 +1906,6 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
         }
 
         double currentStock = phi.getStock().getStock();
-        double returnQty = fd.getQuantity() != null ? Math.abs(fd.getQuantity().doubleValue()) : 0.0;
-        double returnFreeQty = fd.getFreeQuantity() != null ? Math.abs(fd.getFreeQuantity().doubleValue()) : 0.0;
-
-        // Convert to units if AMPP item
-        boolean isAmppItem = billItem.getItem() instanceof Ampp;
-        double unitsPerPack = 1.0;
-        if (isAmppItem && fd.getUnitsPerPack() != null) {
-            unitsPerPack = fd.getUnitsPerPack().doubleValue();
-        }
-
-        double returnQtyInUnits = isAmppItem ? returnQty * unitsPerPack : returnQty;
-        double returnFreeQtyInUnits = isAmppItem ? returnFreeQty * unitsPerPack : returnFreeQty;
-        double totalReturnQtyInUnits = returnQtyInUnits + returnFreeQtyInUnits;
 
         // Calculate total stock usage by this item AND other items in the same return using the same stock
         double totalStockUsageFromCurrentReturn = calculateTotalStockUsageFromCurrentReturn(phi.getStock(), billItem);
@@ -1917,90 +1919,13 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
 
                 JsfUtil.addErrorMessage("Insufficient stock for " + itemName + " (Batch: " + stockBatch + "). "
                         + "Current stock: " + String.format("%.2f", currentStock)
-                        + ", Total return quantity (including other items): " + String.format("%.2f", totalStockUsageFromCurrentReturn));
-            }
-            // Draft-stage convenience only: rewrite the quantity down to what is
-            // available so the user can review and re-submit. MUST never run at
-            // approval - a validator that mutates quantities let a failed Approve
-            // silently reduce the return, so a second click approved quantities
-            // that no longer matched the finalized bill (#21266 RC4).
-            if (allowAutoCorrect) {
-                double availableForThisItem = Math.max(0, currentStock - (totalStockUsageFromCurrentReturn - totalReturnQtyInUnits));
-
-                if (isAmppItem) {
-                    double availableInPacks = availableForThisItem / unitsPerPack;
-                    fd.setQuantity(BigDecimal.valueOf(availableInPacks));
-                    fd.setFreeQuantity(BigDecimal.ZERO);
-                } else {
-                    fd.setQuantity(BigDecimal.valueOf(availableForThisItem));
-                    fd.setFreeQuantity(BigDecimal.ZERO);
-                }
+                        + ", Total return quantity (including other items): " + String.format("%.2f", totalStockUsageFromCurrentReturn)
+                        + ". Please correct the return quantity.");
             }
             return false;
         }
 
         return true;
-    }
-
-    /**
-     * Reconciles bi.qty, pbi.qty, and bifd.QUANTITY so they all reflect the
-     * same absolute return quantity before stock validation and finalization.
-     *
-     * bifd.QUANTITY is the form-bound field the user edits. bi.qty and pbi.qty
-     * are set positively at request creation and may diverge when calculateLineTotal
-     * negates bifd.QUANTITY for DB storage. This method drives from the absolute
-     * value of bifd.QUANTITY (or bi.qty as fallback) and calls
-     * syncQuantitiesAfterQuantityChange + calculateLineTotal to re-align all fields.
-     */
-    private void syncQuantitiesBeforeFinalize() {
-        if (billItems == null) {
-            return;
-        }
-        for (BillItem bi : billItems) {
-            if (bi == null || bi.isRetired()) {
-                continue;
-            }
-            BillItemFinanceDetails fd = bi.getBillItemFinanceDetails();
-            PharmaceuticalBillItem phi = bi.getPharmaceuticalBillItem();
-            if (fd == null || phi == null) {
-                continue;
-            }
-
-            // Determine the intended return quantity from the most reliable source.
-            // bifd.QUANTITY is what the user last edited (may be negative from calculateLineTotal).
-            // bi.qty is always stored positive by calculateLineTotal.
-            // Use abs(bifd.QUANTITY) if non-zero; otherwise fall back to abs(bi.qty).
-            BigDecimal rawBifd = fd.getQuantity();
-            double biQty = bi.getQty() != null ? bi.getQty() : 0.0;
-            double absReturnQty;
-            if (rawBifd != null && rawBifd.compareTo(BigDecimal.ZERO) != 0) {
-                absReturnQty = Math.abs(rawBifd.doubleValue());
-            } else {
-                absReturnQty = Math.abs(biQty);
-            }
-
-            BigDecimal rawBifdFree = fd.getFreeQuantity();
-            double absFreeQty = rawBifdFree != null ? Math.abs(rawBifdFree.doubleValue()) : 0.0;
-
-            boolean isAmpp = bi.getItem() instanceof Ampp;
-            BigDecimal upp = fd.getUnitsPerPack() != null && fd.getUnitsPerPack().compareTo(BigDecimal.ZERO) != 0
-                    ? fd.getUnitsPerPack() : BigDecimal.ONE;
-
-            // Normalise bifd.QUANTITY to the absolute value (positive) so validation
-            // and calculateLineTotal both see the same number regardless of prior negation.
-            fd.setQuantity(BigDecimal.valueOf(absReturnQty));
-            fd.setFreeQuantity(BigDecimal.valueOf(absFreeQty));
-
-            // Sync pbi.qty in units (for AMPP multiply packs × unitsPerPack).
-            double qtyInUnits = isAmpp ? absReturnQty * upp.doubleValue() : absReturnQty;
-            double freeQtyInUnits = isAmpp ? absFreeQty * upp.doubleValue() : absFreeQty;
-            phi.setQty(qtyInUnits);
-            phi.setFreeQty(freeQtyInUnits);
-
-            // calculateLineTotal will negate the quantities for storage but we need
-            // them positive going into validateAllItemsStockAvailability which calls abs().
-            calculateLineTotal(bi);
-        }
     }
 
     /**
@@ -2072,10 +1997,6 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
      * Finalize, and Approve operations
      */
     public boolean validateAllItemsStockAvailability(boolean showMessages) {
-        return validateAllItemsStockAvailability(showMessages, true);
-    }
-
-    public boolean validateAllItemsStockAvailability(boolean showMessages, boolean allowAutoCorrect) {
         if (billItems == null || billItems.isEmpty()) {
             return true;
         }
@@ -2100,7 +2021,7 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
                 continue;
             }
 
-            if (!validateStockAvailability(bi, showMessages, allowAutoCorrect)) {
+            if (!validateStockAvailability(bi, showMessages)) {
                 allValid = false;
             }
         }
@@ -2118,7 +2039,7 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
         boolean isValid = true;
         boolean hasItemsWithQuantities = false;
 
-        // Validate stock availability first - this is critical
+        // Validate stock availability first - this is critical.
         if (!validateAllItemsStockAvailability(true)) {
             JsfUtil.addErrorMessage("Stock validation failed during finalization");
             isValid = false;
@@ -2787,11 +2708,18 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
         }
 
         try {
-            // Mark the bill as cancelled
-            returnBillToClose.setCancelled(true);
+            // Reload from DB to avoid orphan-removal FK violations (same pattern as cancel).
+            Bill freshToClose = billFacade.find(returnBillToClose.getId());
+            if (freshToClose == null) {
+                JsfUtil.addErrorMessage("Cannot close: direct purchase return no longer exists.");
+                return;
+            }
+            freshToClose.setCancelled(true);
+            freshToClose.setEditedAt(new Date());
+            freshToClose.setEditor(sessionController.getLoggedUser());
 
             // Save the changes
-            billFacade.edit(returnBillToClose);
+            billFacade.edit(freshToClose);
 
             // Refresh the lists
             fillDirectPurchaseReturnsToFinalize();

--- a/src/main/java/com/divudi/bean/pharmacy/DirectPurchaseReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/DirectPurchaseReturnWorkflowController.java
@@ -414,8 +414,8 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
             BillItemFinanceDetails sessionFd = bi.getBillItemFinanceDetails();
             BillItemFinanceDetails finalizedFd = finalizedItem.getBillItemFinanceDetails();
 
-            double sessionQty = sessionFd != null && sessionFd.getQuantity() != null
-                    ? Math.abs(sessionFd.getQuantity().doubleValue()) : 0.0;
+            // bi.qty is always positive; compare against DB fd.quantity (negative convention)
+            double sessionQty = Math.abs(bi.getQty());
             double sessionFreeQty = sessionFd != null && sessionFd.getFreeQuantity() != null
                     ? Math.abs(sessionFd.getFreeQuantity().doubleValue()) : 0.0;
             double finalizedQty = finalizedFd.getQuantity() != null
@@ -570,17 +570,10 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
 
             double totalReturnQty = 0.0;
 
-            if (returnByTotalQuantity) {
-                // Total quantity mode - check combined qty + free qty
-                double qty = fd.getQuantity() != null ? Math.abs(fd.getQuantity().doubleValue()) : 0.0;
-                double freeQty = fd.getFreeQuantity() != null ? Math.abs(fd.getFreeQuantity().doubleValue()) : 0.0;
-                totalReturnQty = qty + freeQty;
-            } else {
-                // Separate quantity mode - check individual quantities
-                double qty = fd.getQuantity() != null ? Math.abs(fd.getQuantity().doubleValue()) : 0.0;
-                double freeQty = fd.getFreeQuantity() != null ? Math.abs(fd.getFreeQuantity().doubleValue()) : 0.0;
-                totalReturnQty = qty + freeQty;
-            }
+            // bi.qty is always the positive user-entered pack qty
+            double qty = Math.abs(bi.getQty());
+            double freeQty = fd.getFreeQuantity() != null ? Math.abs(fd.getFreeQuantity().doubleValue()) : 0.0;
+            totalReturnQty = qty + freeQty;
 
             // If no return quantity, mark for retirement (use == 0.0 since we use absolute values)
             if (totalReturnQty == 0.0) {
@@ -700,40 +693,27 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
                 continue;
             }
 
-            // Allow items with zero quantities - they may be intentionally set to zero
-            // Skip only if item is retired or invalid
             if (bi.isRetired()) {
                 continue;
             }
 
-            // Ensure bill reference is set
+            // Recalculate from bi.qty before persisting so phi.qty and fd.quantity are
+            // always derived from the user-entered value regardless of whether AJAX events fired.
+            calculateLineTotal(bi);
+
             bi.setBill(currentBill);
 
-            // DEBUG: Log referanceBillItem info
-            String itemName = bi.getItem() != null ? bi.getItem().getName() : "Unknown";
-            Long refBillItemId = bi.getReferanceBillItem() != null ? bi.getReferanceBillItem().getId() : null;
-
-            // DEBUG: Log all quantity fields BEFORE save
-            Double biQty = bi.getQty();
-            BigDecimal bifdQty = bi.getBillItemFinanceDetails() != null ? bi.getBillItemFinanceDetails().getQuantity() : null;
-            BigDecimal bifdQtyByUnits = bi.getBillItemFinanceDetails() != null ? bi.getBillItemFinanceDetails().getQuantityByUnits() : null;
-            Double phiQty = bi.getPharmaceuticalBillItem() != null ? bi.getPharmaceuticalBillItem().getQty() : null;
-
-            // Set up pharmaceutical bill item relationship
             PharmaceuticalBillItem phi = bi.getPharmaceuticalBillItem();
             if (phi != null) {
                 phi.setBillItem(bi);
             }
 
-            // Set up finance details relationship
             BillItemFinanceDetails fd = bi.getBillItemFinanceDetails();
             if (fd != null) {
                 fd.setBillItem(bi);
             }
 
-            // Save entities in correct order
             if (bi.getId() == null) {
-                // Set audit fields only for new records
                 bi.setCreatedAt(new Date());
                 bi.setCreater(sessionController.getLoggedUser());
                 billItemFacade.create(bi);
@@ -741,17 +721,13 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
                 billItemFacade.edit(bi);
             }
 
-            if (phi.getId() == null) {
-                pharmaceuticalBillItemFacade.create(phi);
-            } else {
-                pharmaceuticalBillItemFacade.edit(phi);
+            if (phi != null) {
+                if (phi.getId() == null) {
+                    pharmaceuticalBillItemFacade.create(phi);
+                } else {
+                    pharmaceuticalBillItemFacade.edit(phi);
+                }
             }
-
-            // DEBUG: Log all quantity fields AFTER save to see what was persisted
-            biQty = bi.getQty();
-            bifdQty = bi.getBillItemFinanceDetails() != null ? bi.getBillItemFinanceDetails().getQuantity() : null;
-            bifdQtyByUnits = bi.getBillItemFinanceDetails() != null ? bi.getBillItemFinanceDetails().getQuantityByUnits() : null;
-            phiQty = bi.getPharmaceuticalBillItem() != null ? bi.getPharmaceuticalBillItem().getQty() : null;
         }
     }
 
@@ -1186,6 +1162,9 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
                 // DEBUG: Log the rate setting
 
                 newBillItemFinanceDetailsInReturnBill.setLineGrossRate(lineGrossRateAsEntered);
+                // Seed bi.qty from fd.quantity (pack qty) before calculateLineTotal reads bi.qty
+                BigDecimal initialPackQty = newBillItemFinanceDetailsInReturnBill.getQuantity();
+                newBillItemInReturnBill.setQty(initialPackQty != null ? Math.abs(initialPackQty.doubleValue()) : 0.0);
                 calculateLineTotal(newBillItemInReturnBill);
                 getBillItems().add(newBillItemInReturnBill);
             } catch (Exception e) {
@@ -1491,6 +1470,10 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
 
             BigDecimal lineGrossRateAsEntered = lineGrossRateForAUnit.multiply(unitsPerPack);
             fd.setLineGrossRate(lineGrossRateAsEntered);
+
+            // Seed bi.qty from fd.quantity (pack qty) before calculateLineTotal reads bi.qty
+            BigDecimal initialPackQtyForReturn = fd.getQuantity();
+            returnBillItem.setQty(initialPackQtyForReturn != null ? Math.abs(initialPackQtyForReturn.doubleValue()) : 0.0);
 
             // Calculate line total
             calculateLineTotal(returnBillItem);
@@ -1826,42 +1809,33 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
         }
 
         if (returnByTotalQty) {
-            // Total quantity mode - qty + free qty combined
-            double currentTotalQty = (fd.getQuantity() != null ? Math.abs(fd.getQuantity().doubleValue()) : 0.0);
-
-            // Convert pack quantity to units for AMPP items
+            // bi.qty is the positive pack qty entered by user
+            double currentTotalQty = Math.abs(bi.getQty());
             double currentTotalQtyInUnits = isAmppItem ? currentTotalQty * unitsPerPack : currentTotalQty;
 
-            // Allow exact match (>=) instead of just (>)
             if (currentTotalQtyInUnits > remainingTotalQty) {
-                // Convert back to packs for AMPP items when setting the corrected value
                 double correctedQtyInPacks = isAmppItem ? Math.max(0, remainingTotalQty / unitsPerPack) : Math.max(0, remainingTotalQty);
-                fd.setQuantity(BigDecimal.valueOf(correctedQtyInPacks));
+                bi.setQty(correctedQtyInPacks);
                 fd.setFreeQuantity(BigDecimal.ZERO);
                 JsfUtil.addErrorMessage("Cannot return more than remaining quantity. Remaining: "
                         + (isAmppItem ? (remainingTotalQty / unitsPerPack) + " packs" : remainingTotalQty + " units"));
                 isValid = false;
             }
         } else if (returnByQtyAndFree) {
-            // Separate quantity and free quantity mode
-            double currentQty = (fd.getQuantity() != null ? Math.abs(fd.getQuantity().doubleValue()) : 0.0);
-            double currentFreeQty = (fd.getFreeQuantity() != null ? Math.abs(fd.getFreeQuantity().doubleValue()) : 0.0);
+            double currentQty = Math.abs(bi.getQty());
+            double currentFreeQty = fd.getFreeQuantity() != null ? Math.abs(fd.getFreeQuantity().doubleValue()) : 0.0;
 
-            // Convert pack quantities to units for AMPP items
             double currentQtyInUnits = isAmppItem ? currentQty * unitsPerPack : currentQty;
             double currentFreeQtyInUnits = isAmppItem ? currentFreeQty * unitsPerPack : currentFreeQty;
 
-            // Allow exact match (>=) instead of just (>)
             if (currentQtyInUnits > remainingQty) {
-                // Convert back to packs for AMPP items when setting the corrected value
                 double correctedQtyInPacks = isAmppItem ? Math.max(0, remainingQty / unitsPerPack) : Math.max(0, remainingQty);
-                fd.setQuantity(BigDecimal.valueOf(correctedQtyInPacks));
+                bi.setQty(correctedQtyInPacks);
                 JsfUtil.addErrorMessage("Cannot return more than remaining quantity. Remaining: "
                         + (isAmppItem ? (remainingQty / unitsPerPack) + " packs" : remainingQty + " units"));
                 isValid = false;
             }
             if (currentFreeQtyInUnits > remainingFreeQty) {
-                // Convert back to packs for AMPP items when setting the corrected value
                 double correctedFreeQtyInPacks = isAmppItem ? Math.max(0, remainingFreeQty / unitsPerPack) : Math.max(0, remainingFreeQty);
                 fd.setFreeQuantity(BigDecimal.valueOf(correctedFreeQtyInPacks));
                 JsfUtil.addErrorMessage("Cannot return more than remaining free quantity. Remaining: "
@@ -1955,10 +1929,10 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
                 continue;
             }
 
-            double returnQty = fd.getQuantity() != null ? Math.abs(fd.getQuantity().doubleValue()) : 0.0;
+            // bi.qty is always positive (user-entered pack qty)
+            double returnQty = Math.abs(bi.getQty());
             double returnFreeQty = fd.getFreeQuantity() != null ? Math.abs(fd.getFreeQuantity().doubleValue()) : 0.0;
 
-            // Convert to units if AMPP item
             boolean isAmppItem = bi.getItem() instanceof Ampp;
             double unitsPerPack = 1.0;
             if (isAmppItem && fd.getUnitsPerPack() != null) {
@@ -1972,14 +1946,14 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
         }
 
         // Add the current item's usage
-        if (excludeItem != null && excludeItem.getBillItemFinanceDetails() != null) {
+        if (excludeItem != null) {
             BillItemFinanceDetails fd = excludeItem.getBillItemFinanceDetails();
-            double returnQty = fd.getQuantity() != null ? Math.abs(fd.getQuantity().doubleValue()) : 0.0;
-            double returnFreeQty = fd.getFreeQuantity() != null ? Math.abs(fd.getFreeQuantity().doubleValue()) : 0.0;
+            double returnQty = Math.abs(excludeItem.getQty());
+            double returnFreeQty = fd != null && fd.getFreeQuantity() != null ? Math.abs(fd.getFreeQuantity().doubleValue()) : 0.0;
 
             boolean isAmppItem = excludeItem.getItem() instanceof Ampp;
             double unitsPerPack = 1.0;
-            if (isAmppItem && fd.getUnitsPerPack() != null) {
+            if (isAmppItem && fd != null && fd.getUnitsPerPack() != null) {
                 unitsPerPack = fd.getUnitsPerPack().doubleValue();
             }
 
@@ -2014,8 +1988,8 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
             }
 
             // Skip items with zero quantities
-            double returnQty = fd.getQuantity() != null ? fd.getQuantity().doubleValue() : 0.0;
-            double returnFreeQty = fd.getFreeQuantity() != null ? fd.getFreeQuantity().doubleValue() : 0.0;
+            double returnQty = Math.abs(bi.getQty());
+            double returnFreeQty = fd != null && fd.getFreeQuantity() != null ? Math.abs(fd.getFreeQuantity().doubleValue()) : 0.0;
 
             if (returnQty == 0 && returnFreeQty == 0) {
                 continue;
@@ -2058,14 +2032,10 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
 
             // Check if at least one item has some return quantity
             BillItemFinanceDetails fd = bi.getBillItemFinanceDetails();
-            if (fd != null) {
-                double qty = fd.getQuantity() != null ? Math.abs(fd.getQuantity().doubleValue()) : 0.0;
-                double freeQty = fd.getFreeQuantity() != null ? Math.abs(fd.getFreeQuantity().doubleValue()) : 0.0;
-
-                // Accept any positive return quantities (including exact remaining quantities)
-                if (qty > 0 || freeQty > 0) {
-                    hasItemsWithQuantities = true;
-                }
+            double qty = Math.abs(bi.getQty());
+            double freeQty = fd != null && fd.getFreeQuantity() != null ? Math.abs(fd.getFreeQuantity().doubleValue()) : 0.0;
+            if (qty > 0 || freeQty > 0) {
+                hasItemsWithQuantities = true;
             }
         }
 
@@ -2185,49 +2155,38 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
         String itemName = bi.getItem() != null ? bi.getItem().getName() : "Unknown";
         boolean isAmpp = bi.getItem() instanceof Ampp;
 
-        if (isAmpp) {
-            // For AMPP items: User entered rate is per pack, we need to sync unit-based calculations
-            BigDecimal quantity = fd.getQuantity() != null ? fd.getQuantity() : BigDecimal.ZERO;
-            BigDecimal freeQuantity = fd.getFreeQuantity() != null ? fd.getFreeQuantity() : BigDecimal.ZERO;
-            BigDecimal unitsPerPack = fd.getUnitsPerPack() != null ? fd.getUnitsPerPack() : BigDecimal.ONE;
+        // bi.qty is always positive (user-entered pack qty)
+        BigDecimal quantity = BigDecimal.valueOf(Math.abs(bi.getQty()));
+        BigDecimal freeQuantity = fd.getFreeQuantity() != null ? fd.getFreeQuantity().abs() : BigDecimal.ZERO;
+        BigDecimal unitsPerPack = fd.getUnitsPerPack() != null ? fd.getUnitsPerPack() : BigDecimal.ONE;
 
-            // Calculate unit-based quantities
+        if (isAmpp) {
             BigDecimal quantityByUnits = quantity.multiply(unitsPerPack);
             BigDecimal freeQuantityByUnits = freeQuantity.multiply(unitsPerPack);
 
-            // Set calculated unit quantities
             fd.setQuantityByUnits(quantityByUnits);
             fd.setFreeQuantityByUnits(freeQuantityByUnits);
 
-            // Calculate unit rate from pack rate
             BigDecimal ratePerUnit = unitsPerPack.compareTo(BigDecimal.ZERO) > 0
                     ? userEnteredRate.divide(unitsPerPack, 4, BigDecimal.ROUND_HALF_UP)
                     : BigDecimal.ZERO;
 
-            // Sync pharmaceutical bill item with calculated unit-based values
             phi.setQty(quantityByUnits.doubleValue());
             phi.setFreeQty(freeQuantityByUnits.doubleValue());
             phi.setPurchaseRateInUnit(ratePerUnit.doubleValue());
             phi.setPurchaseRatePack(userEnteredRate.doubleValue());
-            phi.setPurchaseRate(userEnteredRate.doubleValue()); // Pack rate for AMPP
+            phi.setPurchaseRate(ratePerUnit.doubleValue());
 
         } else {
-            // For AMP items: User entered rate is per unit
-            BigDecimal quantity = fd.getQuantity() != null ? fd.getQuantity() : BigDecimal.ZERO;
-            BigDecimal freeQuantity = fd.getFreeQuantity() != null ? fd.getFreeQuantity() : BigDecimal.ZERO;
-
-            // Set unit quantities (same as pack quantities for AMP)
             fd.setQuantityByUnits(quantity);
             fd.setFreeQuantityByUnits(freeQuantity);
 
-            // Sync pharmaceutical bill item with unit-based values
             phi.setQty(quantity.doubleValue());
             phi.setFreeQty(freeQuantity.doubleValue());
             phi.setPurchaseRateInUnit(userEnteredRate.doubleValue());
-            phi.setPurchaseRate(userEnteredRate.doubleValue()); // Same for AMP
+            phi.setPurchaseRate(userEnteredRate.doubleValue());
         }
 
-        // Always preserve the user-entered rate
         fd.setLineGrossRate(userEnteredRate);
     }
 
@@ -2291,50 +2250,33 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
         BillItemFinanceDetails fd = bi.getBillItemFinanceDetails();
         PharmaceuticalBillItem phi = bi.getPharmaceuticalBillItem();
 
-        // CRITICAL: Store the current rate BEFORE any processing
-        // This rate is set based on configuration in getReturnRateForUnits() and must be preserved
         BigDecimal existingRate = fd.getLineGrossRate();
-        String itemName = bi.getItem() != null ? bi.getItem().getName() : "Unknown";
         boolean isAmpp = bi.getItem() instanceof Ampp;
 
-        if (isAmpp) {
-            // For AMPP items: Rate should remain as pack rate
-            BigDecimal quantity = fd.getQuantity() != null ? fd.getQuantity() : BigDecimal.ZERO;
-            BigDecimal freeQuantity = fd.getFreeQuantity() != null ? fd.getFreeQuantity() : BigDecimal.ZERO;
-            BigDecimal unitsPerPack = fd.getUnitsPerPack() != null ? fd.getUnitsPerPack() : BigDecimal.ONE;
+        // bi.qty is the source of truth — it is always the positive pack qty decoded
+        // directly from the XHTML input (value="#{ph.qty}"), so it is never negated.
+        BigDecimal quantity = BigDecimal.valueOf(Math.abs(bi.getQty()));
+        BigDecimal freeQuantity = fd.getFreeQuantity() != null ? fd.getFreeQuantity().abs() : BigDecimal.ZERO;
+        BigDecimal unitsPerPack = fd.getUnitsPerPack() != null ? fd.getUnitsPerPack() : BigDecimal.ONE;
 
-            // Calculate unit-based quantities
+        if (isAmpp) {
             BigDecimal quantityByUnits = quantity.multiply(unitsPerPack);
             BigDecimal freeQuantityByUnits = freeQuantity.multiply(unitsPerPack);
 
-            // Update unit quantities but preserve the rate
             fd.setQuantityByUnits(quantityByUnits);
             fd.setFreeQuantityByUnits(freeQuantityByUnits);
 
-            // Sync pharmaceutical bill item with calculated values
-            // NOTE: DO NOT set rate fields in PharmaceuticalBillItem here
-            // The rates should come from the original purchase item, not the return configuration
             phi.setQty(quantityByUnits.doubleValue());
             phi.setFreeQty(freeQuantityByUnits.doubleValue());
 
         } else {
-            // For AMP items: Rate is per unit
-            BigDecimal quantity = fd.getQuantity() != null ? fd.getQuantity() : BigDecimal.ZERO;
-            BigDecimal freeQuantity = fd.getFreeQuantity() != null ? fd.getFreeQuantity() : BigDecimal.ZERO;
-
-            // Update unit quantities (same as pack quantities for AMP)
             fd.setQuantityByUnits(quantity);
             fd.setFreeQuantityByUnits(freeQuantity);
 
-            // Sync pharmaceutical bill item with values
-            // NOTE: DO NOT set rate fields in PharmaceuticalBillItem here
-            // The rates should come from the original purchase item, not the return configuration
             phi.setQty(quantity.doubleValue());
             phi.setFreeQty(freeQuantity.doubleValue());
         }
 
-        // CRITICAL: Restore the original rate to prevent external service interference
-        // This ensures the configuration-based rate is maintained throughout the workflow
         fd.setLineGrossRate(existingRate);
     }
 
@@ -2350,26 +2292,15 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
 
         BillItemFinanceDetails fd = bi.getBillItemFinanceDetails();
         PharmaceuticalBillItem phi = bi.getPharmaceuticalBillItem();
-        BigDecimal qty = fd.getQuantity();
-        BigDecimal freeQty = fd.getFreeQuantity();
-        BigDecimal rate = fd.getLineGrossRate();
 
-        String itemName = bi.getItem() != null ? bi.getItem().getName() : "Unknown";
         boolean isAmpp = bi.getItem() instanceof Ampp;
 
-        if (qty == null) {
-            qty = BigDecimal.ZERO;
-        }
-        if (freeQty == null) {
-            freeQty = BigDecimal.ZERO;
-        }
-        if (rate == null) {
-            rate = BigDecimal.ZERO;
-        }
-
-        // CRITICAL: Use absolute values for calculation (quantities might already be negative from previous saves)
-        qty = qty.abs();
-        freeQty = freeQty.abs();
+        // Read from bi.qty — always positive user-entered pack qty, never negated.
+        // Avoids the sign feedback loop where fd.getQuantity() is already negative
+        // from a previous calculateLineTotal call.
+        BigDecimal qty = BigDecimal.valueOf(Math.abs(bi.getQty()));
+        BigDecimal freeQty = fd.getFreeQuantity() != null ? fd.getFreeQuantity().abs() : BigDecimal.ZERO;
+        BigDecimal rate = fd.getLineGrossRate() != null ? fd.getLineGrossRate() : BigDecimal.ZERO;
 
         // For Direct Purchase returns, line total = quantity × rate (free items have no financial value)
         // Total quantity (qty + freeQty) is still tracked for stock movement purposes
@@ -2412,11 +2343,17 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
         BigDecimal totalReturningQtyByUnits = qtyByUnits.add(freeQtyByUnits);
 
         // Update BIFD quantities - make negative for returns (stock moving out)
-        fd.setQuantity(qty.abs().negate());
-        fd.setFreeQuantity(freeQty.abs().negate());
-        fd.setQuantityByUnits(qtyByUnits.abs().negate());
-        fd.setFreeQuantityByUnits(freeQtyByUnits.abs().negate());
-        fd.setTotalQuantityByUnits(totalReturningQtyByUnits.abs().negate());
+        fd.setQuantity(qty.negate());
+        fd.setFreeQuantity(freeQty.negate());
+        fd.setQuantityByUnits(qtyByUnits.negate());
+        fd.setFreeQuantityByUnits(freeQtyByUnits.negate());
+        fd.setTotalQuantityByUnits(totalReturningQtyByUnits.negate());
+
+        // Keep PBI quantities in sync (always positive units)
+        if (phi != null) {
+            phi.setQty(qtyByUnits.doubleValue());
+            phi.setFreeQty(freeQtyByUnits.doubleValue());
+        }
 
         // Calculate and set quantity-related fields only
         // CRITICAL: DO NOT modify rates - they were set at bill creation time based on configuration

--- a/src/main/java/com/divudi/bean/pharmacy/DirectPurchaseReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/DirectPurchaseReturnWorkflowController.java
@@ -378,6 +378,7 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
             processZeroQuantityItems();
 
             saveBill(true);
+            currentBill = billService.reloadBill(currentBill);
             printPreview = true;
             JsfUtil.addSuccessMessage("Direct Purchase Return Request Finalized Successfully");
         }
@@ -538,6 +539,7 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
                 JsfUtil.addSuccessMessage("Original Direct Purchase has been fully returned and marked as complete.");
             }
 
+            currentBill = billService.reloadBill(currentBill);
             printPreview = true;
             JsfUtil.addSuccessMessage("Direct Purchase Return Approved Successfully");
         }

--- a/src/main/java/com/divudi/bean/pharmacy/DirectPurchaseReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/DirectPurchaseReturnWorkflowController.java
@@ -1809,20 +1809,19 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
         }
 
         if (returnByTotalQty) {
-            // bi.qty is the positive pack qty entered by user
-            double currentTotalQty = Math.abs(bi.getQty());
+            double currentTotalQty = Math.abs(billItem.getQty());
             double currentTotalQtyInUnits = isAmppItem ? currentTotalQty * unitsPerPack : currentTotalQty;
 
             if (currentTotalQtyInUnits > remainingTotalQty) {
                 double correctedQtyInPacks = isAmppItem ? Math.max(0, remainingTotalQty / unitsPerPack) : Math.max(0, remainingTotalQty);
-                bi.setQty(correctedQtyInPacks);
+                billItem.setQty(correctedQtyInPacks);
                 fd.setFreeQuantity(BigDecimal.ZERO);
                 JsfUtil.addErrorMessage("Cannot return more than remaining quantity. Remaining: "
                         + (isAmppItem ? (remainingTotalQty / unitsPerPack) + " packs" : remainingTotalQty + " units"));
                 isValid = false;
             }
         } else if (returnByQtyAndFree) {
-            double currentQty = Math.abs(bi.getQty());
+            double currentQty = Math.abs(billItem.getQty());
             double currentFreeQty = fd.getFreeQuantity() != null ? Math.abs(fd.getFreeQuantity().doubleValue()) : 0.0;
 
             double currentQtyInUnits = isAmppItem ? currentQty * unitsPerPack : currentQty;
@@ -1830,7 +1829,7 @@ public class DirectPurchaseReturnWorkflowController implements Serializable {
 
             if (currentQtyInUnits > remainingQty) {
                 double correctedQtyInPacks = isAmppItem ? Math.max(0, remainingQty / unitsPerPack) : Math.max(0, remainingQty);
-                bi.setQty(correctedQtyInPacks);
+                billItem.setQty(correctedQtyInPacks);
                 JsfUtil.addErrorMessage("Cannot return more than remaining quantity. Remaining: "
                         + (isAmppItem ? (remainingQty / unitsPerPack) + " packs" : remainingQty + " units"));
                 isValid = false;

--- a/src/main/java/com/divudi/bean/pharmacy/DisposalReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/DisposalReturnWorkflowController.java
@@ -341,29 +341,47 @@ public class DisposalReturnWorkflowController implements Serializable {
      * @param returnBillToClose The return bill to close
      */
     public void closeDisposalReturn(Bill returnBillToClose) {
-        if (returnBillToClose == null) {
+        if (returnBillToClose == null || returnBillToClose.getId() == null) {
             JsfUtil.addErrorMessage("No disposal return selected to close");
             return;
         }
 
+        // The row passed in comes from a list loaded earlier in the session and can
+        // be STALE - the return may have been settled after the list was loaded.
+        // Validating and merging the stale entity reverted settled bills back to
+        // drafts (completed/completedAt/deptId/insId cleared) while their items and
+        // stock movements remained - the #21266 RC5 orphan-return corruption
+        // (Ruhunu bills 4336218 / 4337297, 2026-03-25). Always validate and edit
+        // the CURRENT row, bypassing the L2 cache (another app server may have
+        // written it under dual-version operation).
+        Bill freshBill = billFacade.findWithoutCache(returnBillToClose.getId());
+        if (freshBill == null) {
+            JsfUtil.addErrorMessage("Disposal return not found");
+            return;
+        }
+
         // Verify the bill is not already completed
-        if (returnBillToClose.isCompleted()) {
+        if (freshBill.isCompleted()) {
             JsfUtil.addErrorMessage("Cannot close a completed disposal return");
+            fillDisposalReturnsToFinalize();
+            fillDisposalReturnsToApprove();
             return;
         }
 
         // Verify the bill is not already closed
-        if (returnBillToClose.isBillClosed()) {
+        if (freshBill.isBillClosed()) {
             JsfUtil.addErrorMessage("This disposal return is already closed");
+            fillDisposalReturnsToFinalize();
+            fillDisposalReturnsToApprove();
             return;
         }
 
         try {
             // Mark the bill as closed
-            returnBillToClose.setBillClosed(true);
+            freshBill.setBillClosed(true);
 
             // Save the changes
-            billFacade.edit(returnBillToClose);
+            billFacade.edit(freshBill);
 
             // Refresh the lists
             fillDisposalReturnsToFinalize();

--- a/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
@@ -652,6 +652,7 @@ public class GrnReturnWorkflowController implements Serializable {
             processZeroQuantityItems();
 
             saveBill(true);
+            currentBill = billService.reloadBill(currentBill);
             printPreview = true;
             JsfUtil.addSuccessMessage("GRN Return Request Finalized Successfully");
         }
@@ -825,6 +826,7 @@ public class GrnReturnWorkflowController implements Serializable {
                 JsfUtil.addSuccessMessage("Original GRN has been fully returned and marked as complete.");
             }
 
+            currentBill = billService.reloadBill(currentBill);
             printPreview = true;
             JsfUtil.addSuccessMessage("GRN Return Approved Successfully");
         }

--- a/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
@@ -30,6 +30,8 @@ import com.divudi.core.facade.BillFacade;
 import com.divudi.core.facade.BillItemFacade;
 import com.divudi.core.facade.ItemFacade;
 import com.divudi.core.facade.PharmaceuticalBillItemFacade;
+import com.divudi.core.facade.StockFacade;
+import com.divudi.core.entity.pharmacy.Stock;
 import com.divudi.core.util.JsfUtil;
 import com.divudi.service.BillService;
 import com.divudi.core.data.PaymentMethod;
@@ -83,6 +85,8 @@ public class GrnReturnWorkflowController implements Serializable {
     private BillItemFacade billItemFacade;
     @EJB
     private PharmaceuticalBillItemFacade pharmaceuticalBillItemFacade;
+    @EJB
+    private StockFacade stockFacade;
     @EJB
     private PharmacyBean pharmacyBean;
     @EJB
@@ -968,6 +972,52 @@ public class GrnReturnWorkflowController implements Serializable {
 
     // Stock handling - only at approval stage. Returns false (and shows an error) if any item fails.
     private boolean updateStock() {
+        // Phase 1: pre-deduction availability check — reads fresh DB stock for every
+        // item and accumulates total requested qty per stock record.  No mutations are
+        // made here, so a failure leaves the database completely unchanged.
+        Map<Long, Double> requestedByStockId = new HashMap<>();
+        Map<Long, String> itemNameByStockId = new HashMap<>();
+        for (BillItem bi : billItems) {
+            if (bi.isRetired()) {
+                continue;
+            }
+            PharmaceuticalBillItem phi = bi.getPharmaceuticalBillItem();
+            if (phi == null || phi.getStock() == null || phi.getStock().getId() == null) {
+                continue;
+            }
+            double absQty = Math.abs(phi.getQty()) + Math.abs(phi.getFreeQty());
+            if (absQty == 0) {
+                continue;
+            }
+            Long stockId = phi.getStock().getId();
+            requestedByStockId.merge(stockId, absQty, Double::sum);
+            itemNameByStockId.putIfAbsent(stockId,
+                    bi.getItem() != null ? bi.getItem().getName() : "Unknown");
+        }
+
+        boolean preCheckPassed = true;
+        for (Map.Entry<Long, Double> entry : requestedByStockId.entrySet()) {
+            Long stockId = entry.getKey();
+            double totalRequested = entry.getValue();
+            Stock freshStock = stockFacade.find(stockId);
+            double available = (freshStock != null && freshStock.getStock() != null)
+                    ? freshStock.getStock() : 0.0;
+            if (available < totalRequested) {
+                String itemName = itemNameByStockId.getOrDefault(stockId, "Unknown");
+                LOGGER.log(Level.WARNING,
+                        "Pre-deduction stock check failed for item: {0}, available: {1}, requested: {2}",
+                        new Object[]{itemName, available, totalRequested});
+                JsfUtil.addErrorMessage("Cannot approve: insufficient stock for \""
+                        + itemName + "\". Available: " + String.format("%.2f", available)
+                        + ", Requested: " + String.format("%.2f", totalRequested) + ".");
+                preCheckPassed = false;
+            }
+        }
+        if (!preCheckPassed) {
+            return false;
+        }
+
+        // Phase 2: all items passed the pre-check — proceed with deductions.
         for (BillItem bi : billItems) {
             if (bi.isRetired()) {
                 continue;
@@ -992,9 +1042,12 @@ public class GrnReturnWorkflowController implements Serializable {
             );
 
             if (!returnFlag) {
+                // Pre-check passed but deductFromStock still failed — concurrent transaction
+                // drained the stock between our check and this deduction.
                 String itemName = bi.getItem() != null ? bi.getItem().getName() : "Unknown";
                 double available = phi.getStock() != null ? phi.getStock().getStock() : 0;
-                LOGGER.log(Level.WARNING, "Stock deduction failed for item: {0}, available: {1}, requested: {2}",
+                LOGGER.log(Level.WARNING,
+                        "Stock deduction failed after pre-check for item: {0}, available: {1}, requested: {2}",
                         new Object[]{itemName, available, absQty});
                 phi.setQty(Math.abs(phi.getQty()));
                 phi.setFreeQty(Math.abs(phi.getFreeQty()));
@@ -1009,7 +1062,6 @@ public class GrnReturnWorkflowController implements Serializable {
         if (currentBill != null && currentBill.getBillFinanceDetails() != null) {
             BillFinanceDetails bfd = currentBill.getBillFinanceDetails();
 
-            // Negate the purchase, cost, and retail values at bill level
             if (bfd.getTotalPurchaseValue() != null) {
                 bfd.setTotalPurchaseValue(bfd.getTotalPurchaseValue().abs().negate());
             }
@@ -1020,7 +1072,6 @@ public class GrnReturnWorkflowController implements Serializable {
                 bfd.setTotalRetailSaleValue(bfd.getTotalRetailSaleValue().abs().negate());
             }
 
-            // Save the updated bill with corrected finance details
             billFacade.edit(currentBill);
         }
         return true;

--- a/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
@@ -688,8 +688,7 @@ public class GrnReturnWorkflowController implements Serializable {
             BillItemFinanceDetails sessionFd = bi.getBillItemFinanceDetails();
             BillItemFinanceDetails finalizedFd = finalizedItem.getBillItemFinanceDetails();
 
-            double sessionQty = sessionFd != null && sessionFd.getQuantity() != null
-                    ? Math.abs(sessionFd.getQuantity().doubleValue()) : 0.0;
+            double sessionQty = Math.abs(bi.getQty());
             double sessionFreeQty = sessionFd != null && sessionFd.getFreeQuantity() != null
                     ? Math.abs(sessionFd.getFreeQuantity().doubleValue()) : 0.0;
             double finalizedQty = finalizedFd.getQuantity() != null
@@ -855,19 +854,8 @@ public class GrnReturnWorkflowController implements Serializable {
                 continue;
             }
 
-            double totalReturnQty = 0.0;
-
-            if (returnByTotalQuantity) {
-                // Total quantity mode - check combined qty + free qty
-                double qty = fd.getQuantity() != null ? Math.abs(fd.getQuantity().doubleValue()) : 0.0;
-                double freeQty = fd.getFreeQuantity() != null ? Math.abs(fd.getFreeQuantity().doubleValue()) : 0.0;
-                totalReturnQty = qty + freeQty;
-            } else {
-                // Separate quantity mode - check individual quantities
-                double qty = fd.getQuantity() != null ? Math.abs(fd.getQuantity().doubleValue()) : 0.0;
-                double freeQty = fd.getFreeQuantity() != null ? Math.abs(fd.getFreeQuantity().doubleValue()) : 0.0;
-                totalReturnQty = qty + freeQty;
-            }
+            double freeQty = fd.getFreeQuantity() != null ? Math.abs(fd.getFreeQuantity().doubleValue()) : 0.0;
+            double totalReturnQty = Math.abs(bi.getQty()) + freeQty;
 
             // If no return quantity, mark for retirement (use == 0.0 since we use absolute values)
             if (totalReturnQty == 0.0) {
@@ -1147,22 +1135,6 @@ public class GrnReturnWorkflowController implements Serializable {
             }
         }
 
-        // After stock update, negate the bill-level finance details for returns (stock moving out)
-        if (currentBill != null && currentBill.getBillFinanceDetails() != null) {
-            BillFinanceDetails bfd = currentBill.getBillFinanceDetails();
-
-            if (bfd.getTotalPurchaseValue() != null) {
-                bfd.setTotalPurchaseValue(bfd.getTotalPurchaseValue().abs().negate());
-            }
-            if (bfd.getTotalCostValue() != null) {
-                bfd.setTotalCostValue(bfd.getTotalCostValue().abs().negate());
-            }
-            if (bfd.getTotalRetailSaleValue() != null) {
-                bfd.setTotalRetailSaleValue(bfd.getTotalRetailSaleValue().abs().negate());
-            }
-
-            billFacade.edit(currentBill);
-        }
         return true;
     }
 
@@ -1441,10 +1413,11 @@ public class GrnReturnWorkflowController implements Serializable {
         currentBill.getBillFinanceDetails().setNetTotal(returnTotal);
         currentBill.getBillFinanceDetails().setGrossTotal(returnTotal);
 
-        // Set purchase, cost, and retail sale values
-        currentBill.getBillFinanceDetails().setTotalPurchaseValue(totalPurchaseValue);
-        currentBill.getBillFinanceDetails().setTotalCostValue(totalCostValue);
-        currentBill.getBillFinanceDetails().setTotalRetailSaleValue(totalRetailValue);
+        // BFD convention: purchase/cost/retail values are negative for returns (stock leaving pharmacy)
+        // PBI stores them positive; negate here to match the established sign convention in the DB
+        currentBill.getBillFinanceDetails().setTotalPurchaseValue(totalPurchaseValue.negate());
+        currentBill.getBillFinanceDetails().setTotalCostValue(totalCostValue.negate());
+        currentBill.getBillFinanceDetails().setTotalRetailSaleValue(totalRetailValue.negate());
 
         // Also set the legacy total fields for backward compatibility
         currentBill.setTotal(returnTotal.doubleValue());
@@ -1466,12 +1439,12 @@ public class GrnReturnWorkflowController implements Serializable {
                 return;
             }
 
-            BigDecimal qty = bi.getBillItemFinanceDetails().getQuantity();
+            BigDecimal qty = BigDecimal.valueOf(bi.getQty());
             BigDecimal freeQty = bi.getBillItemFinanceDetails().getFreeQuantity();
 
             // Check quantity for decimal values
-            if (qty != null && qty.remainder(BigDecimal.ONE).compareTo(BigDecimal.ZERO) != 0) {
-                bi.getBillItemFinanceDetails().setQuantity(BigDecimal.ZERO);
+            if (qty.remainder(BigDecimal.ONE).compareTo(BigDecimal.ZERO) != 0) {
+                bi.setQty(0.0);
                 calculateLineTotal(bi);
                 calculateTotal();
                 JsfUtil.addErrorMessage("Please enter only whole numbers (integers) for quantity. Decimal values are not allowed.");
@@ -2195,42 +2168,32 @@ public class GrnReturnWorkflowController implements Serializable {
         }
 
         if (returnByTotalQty) {
-            // Total quantity mode - qty + free qty combined
-            double currentTotalQty = (fd.getQuantity() != null ? Math.abs(fd.getQuantity().doubleValue()) : 0.0);
-
-            // Convert pack quantity to units for AMPP items
+            double currentTotalQty = Math.abs(billItem.getQty());
             double currentTotalQtyInUnits = isAmppItem ? currentTotalQty * unitsPerPack : currentTotalQty;
 
-            // Allow exact match (>=) instead of just (>)
             if (currentTotalQtyInUnits > remainingTotalQty) {
-                // Convert back to packs for AMPP items when setting the corrected value
                 double correctedQtyInPacks = isAmppItem ? Math.max(0, remainingTotalQty / unitsPerPack) : Math.max(0, remainingTotalQty);
-                fd.setQuantity(BigDecimal.valueOf(correctedQtyInPacks));
+                billItem.setQty(correctedQtyInPacks);
                 fd.setFreeQuantity(BigDecimal.ZERO);
                 JsfUtil.addErrorMessage("Cannot return more than remaining quantity. Remaining: "
                         + (isAmppItem ? (remainingTotalQty / unitsPerPack) + " packs" : remainingTotalQty + " units"));
                 isValid = false;
             }
         } else if (returnByQtyAndFree) {
-            // Separate quantity and free quantity mode
-            double currentQty = (fd.getQuantity() != null ? Math.abs(fd.getQuantity().doubleValue()) : 0.0);
-            double currentFreeQty = (fd.getFreeQuantity() != null ? Math.abs(fd.getFreeQuantity().doubleValue()) : 0.0);
+            double currentQty = Math.abs(billItem.getQty());
+            double currentFreeQty = fd.getFreeQuantity() != null ? Math.abs(fd.getFreeQuantity().doubleValue()) : 0.0;
 
-            // Convert pack quantities to units for AMPP items
             double currentQtyInUnits = isAmppItem ? currentQty * unitsPerPack : currentQty;
             double currentFreeQtyInUnits = isAmppItem ? currentFreeQty * unitsPerPack : currentFreeQty;
 
-            // Allow exact match (>=) instead of just (>)
             if (currentQtyInUnits > remainingQty) {
-                // Convert back to packs for AMPP items when setting the corrected value
                 double correctedQtyInPacks = isAmppItem ? Math.max(0, remainingQty / unitsPerPack) : Math.max(0, remainingQty);
-                fd.setQuantity(BigDecimal.valueOf(correctedQtyInPacks));
+                billItem.setQty(correctedQtyInPacks);
                 JsfUtil.addErrorMessage("Cannot return more than remaining quantity. Remaining: "
                         + (isAmppItem ? (remainingQty / unitsPerPack) + " packs" : remainingQty + " units"));
                 isValid = false;
             }
             if (currentFreeQtyInUnits > remainingFreeQty) {
-                // Convert back to packs for AMPP items when setting the corrected value
                 double correctedFreeQtyInPacks = isAmppItem ? Math.max(0, remainingFreeQty / unitsPerPack) : Math.max(0, remainingFreeQty);
                 fd.setFreeQuantity(BigDecimal.valueOf(correctedFreeQtyInPacks));
                 JsfUtil.addErrorMessage("Cannot return more than remaining free quantity. Remaining: "
@@ -2271,7 +2234,10 @@ public class GrnReturnWorkflowController implements Serializable {
             return true; // No quantities to validate
         }
 
-        double currentStock = phi.getStock().getStock();
+        // Always read fresh stock from DB — session-cached value may be stale if
+        // another transaction (sale, issue, transfer) reduced stock after this return was opened.
+        Stock freshStock = stockFacade.findWithoutCache(phi.getStock().getId());
+        double currentStock = freshStock != null ? freshStock.getStock() : phi.getStock().getStock();
 
         // Calculate total stock usage by this item AND other items in the same return using the same stock
         double totalStockUsageFromCurrentReturn = calculateTotalStockUsageFromCurrentReturn(phi.getStock(), billItem);
@@ -2374,17 +2340,14 @@ public class GrnReturnWorkflowController implements Serializable {
                 continue;
             }
 
-            BillItemFinanceDetails fd = bi.getBillItemFinanceDetails();
-            if (fd == null) {
-                continue;
-            }
-
-            // Skip items with zero quantities
-            double returnQty = fd.getQuantity() != null ? fd.getQuantity().doubleValue() : 0.0;
-            double returnFreeQty = fd.getFreeQuantity() != null ? fd.getFreeQuantity().doubleValue() : 0.0;
-
-            if (returnQty <= 0 && returnFreeQty <= 0) {
-                continue;
+            // Skip items with zero quantities — read from BillItem.qty (always positive, user-facing)
+            if (Math.abs(bi.getQty()) <= 0) {
+                BillItemFinanceDetails fd = bi.getBillItemFinanceDetails();
+                double returnFreeQty = fd != null && fd.getFreeQuantity() != null
+                        ? fd.getFreeQuantity().doubleValue() : 0.0;
+                if (Math.abs(returnFreeQty) <= 0) {
+                    continue;
+                }
             }
 
             if (!validateStockAvailability(bi, showMessages)) {
@@ -2424,14 +2387,9 @@ public class GrnReturnWorkflowController implements Serializable {
 
             // Check if at least one item has some return quantity
             BillItemFinanceDetails fd = bi.getBillItemFinanceDetails();
-            if (fd != null) {
-                double qty = fd.getQuantity() != null ? Math.abs(fd.getQuantity().doubleValue()) : 0.0;
-                double freeQty = fd.getFreeQuantity() != null ? Math.abs(fd.getFreeQuantity().doubleValue()) : 0.0;
-
-                // Accept any positive return quantities (including exact remaining quantities)
-                if (qty > 0 || freeQty > 0) {
-                    hasItemsWithQuantities = true;
-                }
+            double freeQty = fd != null && fd.getFreeQuantity() != null ? Math.abs(fd.getFreeQuantity().doubleValue()) : 0.0;
+            if (Math.abs(bi.getQty()) > 0 || freeQty > 0) {
+                hasItemsWithQuantities = true;
             }
         }
 
@@ -2537,47 +2495,37 @@ public class GrnReturnWorkflowController implements Serializable {
         String itemName = bi.getItem() != null ? bi.getItem().getName() : "Unknown";
         boolean isAmpp = bi.getItem() instanceof Ampp;
 
-        if (isAmpp) {
-            // For AMPP items: User entered rate is per pack, we need to sync unit-based calculations
-            BigDecimal quantity = fd.getQuantity() != null ? fd.getQuantity() : BigDecimal.ZERO;
-            BigDecimal freeQuantity = fd.getFreeQuantity() != null ? fd.getFreeQuantity() : BigDecimal.ZERO;
-            BigDecimal unitsPerPack = fd.getUnitsPerPack() != null ? fd.getUnitsPerPack() : BigDecimal.ONE;
+        // Use bi.qty as source of truth — always positive pack quantity
+        BigDecimal quantity = BigDecimal.valueOf(Math.abs(bi.getQty()));
+        BigDecimal freeQuantity = fd.getFreeQuantity() != null ? fd.getFreeQuantity().abs() : BigDecimal.ZERO;
+        BigDecimal unitsPerPack = fd.getUnitsPerPack() != null ? fd.getUnitsPerPack() : BigDecimal.ONE;
 
-            // Calculate unit-based quantities
+        if (isAmpp) {
             BigDecimal quantityByUnits = quantity.multiply(unitsPerPack);
             BigDecimal freeQuantityByUnits = freeQuantity.multiply(unitsPerPack);
 
-            // Set calculated unit quantities
             fd.setQuantityByUnits(quantityByUnits);
             fd.setFreeQuantityByUnits(freeQuantityByUnits);
 
-            // Calculate unit rate from pack rate (HMIS STANDARD: PBI rates ALWAYS per unit)
             BigDecimal ratePerUnit = unitsPerPack.compareTo(BigDecimal.ZERO) > 0
                     ? userEnteredRate.divide(unitsPerPack, 4, RoundingMode.HALF_UP)
                     : BigDecimal.ZERO;
 
-            // Sync pharmaceutical bill item with calculated unit-based values
-            phi.setQty(quantityByUnits.doubleValue());        // ALWAYS in units
-            phi.setFreeQty(freeQuantityByUnits.doubleValue()); // ALWAYS in units
+            phi.setQty(quantityByUnits.doubleValue());
+            phi.setFreeQty(freeQuantityByUnits.doubleValue());
             phi.setPurchaseRateInUnit(ratePerUnit.doubleValue());
             phi.setPurchaseRatePack(userEnteredRate.doubleValue());
-            phi.setPurchaseRate(ratePerUnit.doubleValue());    // CRITICAL: ALWAYS per unit, not pack rate!
+            phi.setPurchaseRate(ratePerUnit.doubleValue());
 
         } else {
-            // For AMP items: User entered rate is per unit
-            BigDecimal quantity = fd.getQuantity() != null ? fd.getQuantity() : BigDecimal.ZERO;
-            BigDecimal freeQuantity = fd.getFreeQuantity() != null ? fd.getFreeQuantity() : BigDecimal.ZERO;
-
-            // Set unit quantities (same as pack quantities for AMP)
             fd.setQuantityByUnits(quantity);
             fd.setFreeQuantityByUnits(freeQuantity);
 
-            // Sync pharmaceutical bill item with unit-based values
-            phi.setQty(quantity.doubleValue());               // In units (same as packs for AMP)
-            phi.setFreeQty(freeQuantity.doubleValue());       // In units (same as packs for AMP)
+            phi.setQty(quantity.doubleValue());
+            phi.setFreeQty(freeQuantity.doubleValue());
             phi.setPurchaseRateInUnit(userEnteredRate.doubleValue());
-            phi.setPurchaseRate(userEnteredRate.doubleValue()); // Per unit
-            phi.setPurchaseRatePack(userEnteredRate.doubleValue()); // Same as unit for AMP
+            phi.setPurchaseRate(userEnteredRate.doubleValue());
+            phi.setPurchaseRatePack(userEnteredRate.doubleValue());
         }
 
         // Always preserve the user-entered rate
@@ -2649,47 +2597,37 @@ public class GrnReturnWorkflowController implements Serializable {
         String itemName = bi.getItem() != null ? bi.getItem().getName() : "Unknown";
         boolean isAmpp = bi.getItem() instanceof Ampp;
 
-        if (isAmpp) {
-            // For AMPP items: Rate should remain as pack rate
-            BigDecimal quantity = fd.getQuantity() != null ? fd.getQuantity() : BigDecimal.ZERO;
-            BigDecimal freeQuantity = fd.getFreeQuantity() != null ? fd.getFreeQuantity() : BigDecimal.ZERO;
-            BigDecimal unitsPerPack = fd.getUnitsPerPack() != null ? fd.getUnitsPerPack() : BigDecimal.ONE;
+        // Use bi.qty as source of truth (always positive, user-entered pack qty)
+        BigDecimal quantity = BigDecimal.valueOf(Math.abs(bi.getQty()));
+        BigDecimal freeQuantity = fd.getFreeQuantity() != null ? fd.getFreeQuantity().abs() : BigDecimal.ZERO;
+        BigDecimal unitsPerPack = fd.getUnitsPerPack() != null ? fd.getUnitsPerPack() : BigDecimal.ONE;
 
-            // Calculate unit-based quantities
+        if (isAmpp) {
             BigDecimal quantityByUnits = quantity.multiply(unitsPerPack);
             BigDecimal freeQuantityByUnits = freeQuantity.multiply(unitsPerPack);
 
-            // Update unit quantities but preserve the rate
             fd.setQuantityByUnits(quantityByUnits);
             fd.setFreeQuantityByUnits(freeQuantityByUnits);
 
-            // Calculate unit rate from existing pack rate (HMIS STANDARD: PBI rates ALWAYS per unit)
             BigDecimal ratePerUnit = unitsPerPack.compareTo(BigDecimal.ZERO) > 0
                     ? existingRate.divide(unitsPerPack, 4, RoundingMode.HALF_UP)
                     : BigDecimal.ZERO;
 
-            // Sync pharmaceutical bill item with calculated values
-            phi.setQty(quantityByUnits.doubleValue());        // ALWAYS in units
-            phi.setFreeQty(freeQuantityByUnits.doubleValue()); // ALWAYS in units
+            phi.setQty(quantityByUnits.doubleValue());
+            phi.setFreeQty(freeQuantityByUnits.doubleValue());
             phi.setPurchaseRateInUnit(ratePerUnit.doubleValue());
             phi.setPurchaseRatePack(existingRate.doubleValue());
-            phi.setPurchaseRate(ratePerUnit.doubleValue());    // CRITICAL: ALWAYS per unit, not pack rate!
+            phi.setPurchaseRate(ratePerUnit.doubleValue());
 
         } else {
-            // For AMP items: Rate is per unit
-            BigDecimal quantity = fd.getQuantity() != null ? fd.getQuantity() : BigDecimal.ZERO;
-            BigDecimal freeQuantity = fd.getFreeQuantity() != null ? fd.getFreeQuantity() : BigDecimal.ZERO;
-
-            // Update unit quantities (same as pack quantities for AMP)
             fd.setQuantityByUnits(quantity);
             fd.setFreeQuantityByUnits(freeQuantity);
 
-            // Sync pharmaceutical bill item with values
-            phi.setQty(quantity.doubleValue());               // In units (same as packs for AMP)
-            phi.setFreeQty(freeQuantity.doubleValue());       // In units (same as packs for AMP)
+            phi.setQty(quantity.doubleValue());
+            phi.setFreeQty(freeQuantity.doubleValue());
             phi.setPurchaseRateInUnit(existingRate.doubleValue());
-            phi.setPurchaseRate(existingRate.doubleValue());  // Per unit
-            phi.setPurchaseRatePack(existingRate.doubleValue()); // Same as unit for AMP
+            phi.setPurchaseRate(existingRate.doubleValue());
+            phi.setPurchaseRatePack(existingRate.doubleValue());
         }
 
         // CRITICAL: Restore the original rate to prevent external service interference
@@ -2710,9 +2648,10 @@ public class GrnReturnWorkflowController implements Serializable {
         Item item = bi.getItem();
         boolean isAmpp = item instanceof Ampp;
 
-        // Null-safe BigDecimal values
-        BigDecimal qty = fd.getQuantity() != null ? fd.getQuantity() : BigDecimal.ZERO;
-        BigDecimal freeQty = fd.getFreeQuantity() != null ? fd.getFreeQuantity() : BigDecimal.ZERO;
+        // Read qty from BillItem (user-facing field) — always positive, avoids sign feedback loop
+        // from fd.getQuantity() which may already be negated from a previous calculateLineTotal call.
+        BigDecimal qty = BigDecimal.valueOf(Math.abs(bi.getQty()));
+        BigDecimal freeQty = fd.getFreeQuantity() != null ? fd.getFreeQuantity().abs() : BigDecimal.ZERO;
         BigDecimal rate = fd.getLineGrossRate() != null ? fd.getLineGrossRate() : BigDecimal.ZERO;
         BigDecimal unitsPerPack = fd.getUnitsPerPack() != null ? fd.getUnitsPerPack() : BigDecimal.ONE;
 

--- a/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
@@ -438,18 +438,19 @@ public class GrnReturnWorkflowController implements Serializable {
         }
 
         try {
-            // Mark the bill as cancelled in the database
-            currentBill.setCancelled(true);
-
-            // Set cancellation metadata if bill has been saved to database
-            if (currentBill.getCreatedAt() != null) {
-                currentBill.setEditedAt(new Date());
-                currentBill.setEditor(sessionController.getLoggedUser());
+            // Reload from DB to ensure EclipseLink sees the full persistent billItems
+            // collection — editing the session-scoped bill directly can trigger orphan-removal
+            // DELETEs on BillItem rows that are still referenced by PharmaceuticalBillItem.
+            Bill freshBill = billFacade.find(currentBill.getId());
+            if (freshBill == null) {
+                JsfUtil.addErrorMessage("Cannot cancel: GRN Return no longer exists.");
+                return "";
             }
-
-            // Save the cancelled bill to database
-            billFacade.edit(currentBill);
-
+            freshBill.setCancelled(true);
+            freshBill.setEditedAt(new Date());
+            freshBill.setEditor(sessionController.getLoggedUser());
+            billFacade.edit(freshBill);
+            currentBill = freshBill;
             JsfUtil.addSuccessMessage("GRN Return cancelled successfully.");
         } catch (Exception e) {
             JsfUtil.addErrorMessage("Error cancelling GRN Return: " + e.getMessage());
@@ -745,9 +746,8 @@ public class GrnReturnWorkflowController implements Serializable {
             return;
         }
 
-        // Validate stock availability before approving. allowAutoCorrect=false:
-        // at approval, validation must never mutate quantities.
-        if (!validateAllItemsStockAvailability(true, false)) {
+        // Validate stock availability before approving.
+        if (!validateAllItemsStockAvailability(true)) {
             JsfUtil.addErrorMessage("Cannot approve: insufficient stock for the finalized quantities. The return must be corrected and re-finalized.");
             return;
         }
@@ -756,16 +756,22 @@ public class GrnReturnWorkflowController implements Serializable {
             // Process zero quantity items before approval
             processZeroQuantityItems();
 
-            // Mark the current bill as completed (approved)
-            currentBill.setCompleted(true);
-            currentBill.setCompletedBy(sessionController.getLoggedUser());
-            currentBill.setCompletedAt(new Date());
-            currentBill.setApproveAt(new Date());
-            currentBill.setApproveUser(sessionController.getLoggedUser());
-
-            // Save the bill with completed status
+            // Reload from DB before editing to avoid orphan-removal FK violations:
+            // currentBill.billItems (JPA collection) is empty in the session bean,
+            // so merging it directly would trigger DELETE on all persisted BillItems.
+            Bill freshForApprove = billFacade.find(currentBill.getId());
+            if (freshForApprove == null) {
+                JsfUtil.addErrorMessage("Cannot approve: bill no longer exists.");
+                return;
+            }
+            freshForApprove.setCompleted(true);
+            freshForApprove.setCompletedBy(sessionController.getLoggedUser());
+            freshForApprove.setCompletedAt(new Date());
+            freshForApprove.setApproveAt(new Date());
+            freshForApprove.setApproveUser(sessionController.getLoggedUser());
             try {
-                billFacade.edit(currentBill);
+                billFacade.edit(freshForApprove);
+                currentBill = freshForApprove;
             } catch (Exception e) {
                 JsfUtil.addErrorMessage("Error saving bill: " + e.getMessage());
                 return;
@@ -773,12 +779,16 @@ public class GrnReturnWorkflowController implements Serializable {
 
             if (!updateStock()) {
                 // Roll back completed status — stock deduction failed for one or more items
-                currentBill.setCompleted(false);
-                currentBill.setCompletedBy(null);
-                currentBill.setCompletedAt(null);
-                currentBill.setApproveAt(null);
-                currentBill.setApproveUser(null);
-                billFacade.edit(currentBill);
+                Bill freshForRollback = billFacade.find(currentBill.getId());
+                if (freshForRollback != null) {
+                    freshForRollback.setCompleted(false);
+                    freshForRollback.setCompletedBy(null);
+                    freshForRollback.setCompletedAt(null);
+                    freshForRollback.setApproveAt(null);
+                    freshForRollback.setApproveUser(null);
+                    billFacade.edit(freshForRollback);
+                    currentBill = freshForRollback;
+                }
                 return;
             }
 
@@ -972,7 +982,28 @@ public class GrnReturnWorkflowController implements Serializable {
         if (currentBill.getId() == null) {
             billFacade.create(currentBill);
         } else {
-            billFacade.edit(currentBill);
+            // Reload from DB before editing to avoid orphan-removal FK violations on the
+            // billItems @OneToMany(orphanRemoval=true): the session bill's JPA collection
+            // is empty, so merging directly would DELETE all persisted BillItems.
+            Bill freshForSave = billFacade.find(currentBill.getId());
+            if (freshForSave != null) {
+                freshForSave.setChecked(currentBill.isChecked());
+                freshForSave.setCheckedBy(currentBill.getCheckedBy());
+                freshForSave.setCheckeAt(currentBill.getCheckeAt());
+                freshForSave.setComments(currentBill.getComments());
+                freshForSave.setPaymentMethod(currentBill.getPaymentMethod());
+                freshForSave.setNetTotal(currentBill.getNetTotal());
+                freshForSave.setTotal(currentBill.getTotal());
+                freshForSave.setEditedAt(new Date());
+                freshForSave.setEditor(sessionController.getLoggedUser());
+                if (currentBill.getBillFinanceDetails() != null) {
+                    freshForSave.setBillFinanceDetails(currentBill.getBillFinanceDetails());
+                }
+                billFacade.edit(freshForSave);
+                currentBill = freshForSave;
+            } else {
+                billFacade.edit(currentBill);
+            }
         }
 
         saveBillItems();
@@ -2224,12 +2255,6 @@ public class GrnReturnWorkflowController implements Serializable {
      * @return true if stock is sufficient, false otherwise
      */
     public boolean validateStockAvailability(BillItem billItem, boolean showMessages) {
-        // Default keeps the legacy draft-stage behaviour (auto-corrects the
-        // quantity down to available stock so the user can re-submit).
-        return validateStockAvailability(billItem, showMessages, true);
-    }
-
-    public boolean validateStockAvailability(BillItem billItem, boolean showMessages, boolean allowAutoCorrect) {
         if (billItem == null || billItem.getPharmaceuticalBillItem() == null
                 || billItem.getPharmaceuticalBillItem().getStock() == null) {
             if (showMessages) {
@@ -2247,19 +2272,6 @@ public class GrnReturnWorkflowController implements Serializable {
         }
 
         double currentStock = phi.getStock().getStock();
-        double returnQty = fd.getQuantity() != null ? Math.abs(fd.getQuantity().doubleValue()) : 0.0;
-        double returnFreeQty = fd.getFreeQuantity() != null ? Math.abs(fd.getFreeQuantity().doubleValue()) : 0.0;
-
-        // Convert to units if AMPP item
-        boolean isAmppItem = billItem.getItem() instanceof Ampp;
-        double unitsPerPack = 1.0;
-        if (isAmppItem && fd.getUnitsPerPack() != null) {
-            unitsPerPack = fd.getUnitsPerPack().doubleValue();
-        }
-
-        double returnQtyInUnits = isAmppItem ? returnQty * unitsPerPack : returnQty;
-        double returnFreeQtyInUnits = isAmppItem ? returnFreeQty * unitsPerPack : returnFreeQty;
-        double totalReturnQtyInUnits = returnQtyInUnits + returnFreeQtyInUnits;
 
         // Calculate total stock usage by this item AND other items in the same return using the same stock
         double totalStockUsageFromCurrentReturn = calculateTotalStockUsageFromCurrentReturn(phi.getStock(), billItem);
@@ -2273,24 +2285,8 @@ public class GrnReturnWorkflowController implements Serializable {
 
                 JsfUtil.addErrorMessage("Insufficient stock for " + itemName + " (Batch: " + stockBatch + "). "
                         + "Current stock: " + String.format("%.2f", currentStock)
-                        + ", Total return quantity (including other items): " + String.format("%.2f", totalStockUsageFromCurrentReturn));
-            }
-            // Draft-stage convenience only: rewrite the quantity down to what is
-            // available so the user can review and re-submit. MUST never run at
-            // approval - a validator that mutates quantities let a failed Approve
-            // silently reduce the return, so a second click approved quantities
-            // that no longer matched the finalized bill (#21266 RC4).
-            if (allowAutoCorrect) {
-                double availableForThisItem = Math.max(0, currentStock - (totalStockUsageFromCurrentReturn - totalReturnQtyInUnits));
-
-                if (isAmppItem) {
-                    double availableInPacks = availableForThisItem / unitsPerPack;
-                    fd.setQuantity(BigDecimal.valueOf(availableInPacks));
-                    fd.setFreeQuantity(BigDecimal.ZERO);
-                } else {
-                    fd.setQuantity(BigDecimal.valueOf(availableForThisItem));
-                    fd.setFreeQuantity(BigDecimal.ZERO);
-                }
+                        + ", Total return quantity (including other items): " + String.format("%.2f", totalStockUsageFromCurrentReturn)
+                        + ". Please correct the return quantity.");
             }
             return false;
         }
@@ -2367,10 +2363,6 @@ public class GrnReturnWorkflowController implements Serializable {
      * Finalize, and Approve operations
      */
     public boolean validateAllItemsStockAvailability(boolean showMessages) {
-        return validateAllItemsStockAvailability(showMessages, true);
-    }
-
-    public boolean validateAllItemsStockAvailability(boolean showMessages, boolean allowAutoCorrect) {
         if (billItems == null || billItems.isEmpty()) {
             return true;
         }
@@ -2395,7 +2387,7 @@ public class GrnReturnWorkflowController implements Serializable {
                 continue;
             }
 
-            if (!validateStockAvailability(bi, showMessages, allowAutoCorrect)) {
+            if (!validateStockAvailability(bi, showMessages)) {
                 allValid = false;
             }
         }

--- a/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
@@ -708,7 +708,16 @@ public class GrnReturnWorkflowController implements Serializable {
                 return;
             }
 
-            updateStock();  // Stock handling happens only at approval stage
+            if (!updateStock()) {
+                // Roll back completed status — stock deduction failed for one or more items
+                currentBill.setCompleted(false);
+                currentBill.setCompletedBy(null);
+                currentBill.setCompletedAt(null);
+                currentBill.setApproveAt(null);
+                currentBill.setApproveUser(null);
+                billFacade.edit(currentBill);
+                return;
+            }
 
             // Create payment for the return - ALL payment methods require payment records for healthcare compliance
             // Payment validation was performed at method start, so we can proceed with confidence
@@ -847,6 +856,9 @@ public class GrnReturnWorkflowController implements Serializable {
             currentBill.setBillTypeAtomic(BillTypeAtomic.PHARMACY_GRN_RETURN);
             currentBill.setInstitution(sessionController.getInstitution());
             currentBill.setDepartment(sessionController.getDepartment());
+            if (sessionController.getDepartment() != null) {
+                currentBill.setDepartmentType(sessionController.getDepartment().getDepartmentType());
+            }
             currentBill.setCreater(sessionController.getLoggedUser());
             currentBill.setCreatedAt(new Date());
 
@@ -954,31 +966,24 @@ public class GrnReturnWorkflowController implements Serializable {
         }
     }
 
-    // Stock handling - only at approval stage
-    private void updateStock() {
+    // Stock handling - only at approval stage. Returns false (and shows an error) if any item fails.
+    private boolean updateStock() {
         for (BillItem bi : billItems) {
-            // Skip only retired items or items with truly zero quantities
             if (bi.isRetired()) {
                 continue;
             }
 
             PharmaceuticalBillItem phi = bi.getPharmaceuticalBillItem();
-            double totalQty = phi.getQty() + phi.getFreeQty();
+            double absQty = Math.abs(phi.getQty()) + Math.abs(phi.getFreeQty());
 
-            // Skip stock processing for zero quantity items (no stock impact)
-            if (totalQty == 0) {
+            if (absQty == 0) {
                 continue;
             }
 
-            // For returns: make quantities negative before saving, use absolute value for stock deduction
-            double absQty = Math.abs(totalQty);
             phi.setQty(-Math.abs(phi.getQty()));
             phi.setFreeQty(-Math.abs(phi.getFreeQty()));
-
-            // Save the pharmaceutical bill item with negative quantities
             pharmaceuticalBillItemFacade.edit(phi);
 
-            // Deduct from stock for return (use absolute value)
             boolean returnFlag = pharmacyBean.deductFromStock(
                     phi.getStock(),
                     absQty,
@@ -987,11 +992,16 @@ public class GrnReturnWorkflowController implements Serializable {
             );
 
             if (!returnFlag) {
-                LOGGER.log(Level.WARNING, "Unable to deduct stock for item: {0}", bi.getItem().getName());
-                // Reset quantities if stock deduction failed
-                phi.setQty(0);
-                phi.setFreeQty(0);
+                String itemName = bi.getItem() != null ? bi.getItem().getName() : "Unknown";
+                double available = phi.getStock() != null ? phi.getStock().getStock() : 0;
+                LOGGER.log(Level.WARNING, "Stock deduction failed for item: {0}, available: {1}, requested: {2}",
+                        new Object[]{itemName, available, absQty});
+                phi.setQty(Math.abs(phi.getQty()));
+                phi.setFreeQty(Math.abs(phi.getFreeQty()));
                 pharmaceuticalBillItemFacade.edit(phi);
+                JsfUtil.addErrorMessage("Cannot approve: insufficient stock for \"" + itemName
+                        + "\". Available: " + available + ", Requested: " + absQty + ".");
+                return false;
             }
         }
 
@@ -1013,6 +1023,7 @@ public class GrnReturnWorkflowController implements Serializable {
             // Save the updated bill with corrected finance details
             billFacade.edit(currentBill);
         }
+        return true;
     }
 
     // Validation methods
@@ -1921,6 +1932,9 @@ public class GrnReturnWorkflowController implements Serializable {
         currentBill.setCreater(sessionController.getLoggedUser());
         currentBill.setInstitution(sessionController.getInstitution());
         currentBill.setDepartment(sessionController.getDepartment());
+        if (sessionController.getDepartment() != null) {
+            currentBill.setDepartmentType(sessionController.getDepartment().getDepartmentType());
+        }
 
         //Copy Payment Method Details from GRN to GRN Return
         currentBill.setPaymentMethod(originalGrn.getPaymentMethod());

--- a/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
@@ -662,6 +662,61 @@ public class GrnReturnWorkflowController implements Serializable {
         }
     }
 
+    /**
+     * Compares every item's in-session return quantities (paid + free) against
+     * the quantities persisted at finalization, read fresh from the database
+     * (L2 bypass). Any difference blocks the approval with a per-item message.
+     *
+     * Finalize validated stock for the FINALIZED quantities; approving anything
+     * else would issue a return that no one finalized (#21266 RC4).
+     *
+     * @return true when every quantity matches the finalized bill.
+     */
+    private boolean approvalQuantitiesMatchFinalized() {
+        if (currentBill == null || currentBill.getId() == null) {
+            JsfUtil.addErrorMessage("No finalized bill found to compare quantities against");
+            return false;
+        }
+        if (billItems == null || billItems.isEmpty()) {
+            return true;
+        }
+        boolean allMatch = true;
+        for (BillItem bi : billItems) {
+            if (bi == null || bi.isRetired() || bi.getId() == null) {
+                continue;
+            }
+            BillItem finalizedItem = billItemFacade.findWithoutCache(bi.getId());
+            if (finalizedItem == null || finalizedItem.getBillItemFinanceDetails() == null) {
+                continue;
+            }
+            BillItemFinanceDetails sessionFd = bi.getBillItemFinanceDetails();
+            BillItemFinanceDetails finalizedFd = finalizedItem.getBillItemFinanceDetails();
+
+            double sessionQty = sessionFd != null && sessionFd.getQuantity() != null
+                    ? Math.abs(sessionFd.getQuantity().doubleValue()) : 0.0;
+            double sessionFreeQty = sessionFd != null && sessionFd.getFreeQuantity() != null
+                    ? Math.abs(sessionFd.getFreeQuantity().doubleValue()) : 0.0;
+            double finalizedQty = finalizedFd.getQuantity() != null
+                    ? Math.abs(finalizedFd.getQuantity().doubleValue()) : 0.0;
+            double finalizedFreeQty = finalizedFd.getFreeQuantity() != null
+                    ? Math.abs(finalizedFd.getFreeQuantity().doubleValue()) : 0.0;
+
+            if (Math.abs(sessionQty - finalizedQty) > 0.0001
+                    || Math.abs(sessionFreeQty - finalizedFreeQty) > 0.0001) {
+                String itemName = bi.getItem() != null ? bi.getItem().getName() : "Unknown";
+                JsfUtil.addErrorMessage("Cannot approve: quantity for \"" + itemName
+                        + "\" (" + String.format("%.2f", sessionQty)
+                        + (sessionFreeQty > 0 ? " + " + String.format("%.2f", sessionFreeQty) + " free" : "")
+                        + ") does not match the finalized quantity ("
+                        + String.format("%.2f", finalizedQty)
+                        + (finalizedFreeQty > 0 ? " + " + String.format("%.2f", finalizedFreeQty) + " free" : "")
+                        + "). The return must be corrected and re-finalized.");
+                allMatch = false;
+            }
+        }
+        return allMatch;
+    }
+
     public void approve() {
         if (!isAuthorized("APPROVE", "ApproveGrnReturn")) {
             return;
@@ -687,9 +742,19 @@ public class GrnReturnWorkflowController implements Serializable {
             return;
         }
 
-        // Validate stock availability before approving
-        if (!validateAllItemsStockAvailability(true)) {
-            JsfUtil.addErrorMessage("Cannot approve: Stock validation failed. Please correct the quantities and try again.");
+        // The quantities being approved must be exactly the quantities that were
+        // FINALIZED (persisted by finalizeRequest). If they differ - approver
+        // edits, or a failed earlier Approve that auto-reduced quantities - the
+        // return must be rejected and sent back for re-finalization, never
+        // approved with silently changed quantities (#21266 RC4).
+        if (!approvalQuantitiesMatchFinalized()) {
+            return;
+        }
+
+        // Validate stock availability before approving. allowAutoCorrect=false:
+        // at approval, validation must never mutate quantities.
+        if (!validateAllItemsStockAvailability(true, false)) {
+            JsfUtil.addErrorMessage("Cannot approve: insufficient stock for the finalized quantities. The return must be corrected and re-finalized.");
             return;
         }
 
@@ -2197,6 +2262,12 @@ public class GrnReturnWorkflowController implements Serializable {
      * @return true if stock is sufficient, false otherwise
      */
     public boolean validateStockAvailability(BillItem billItem, boolean showMessages) {
+        // Default keeps the legacy draft-stage behaviour (auto-corrects the
+        // quantity down to available stock so the user can re-submit).
+        return validateStockAvailability(billItem, showMessages, true);
+    }
+
+    public boolean validateStockAvailability(BillItem billItem, boolean showMessages, boolean allowAutoCorrect) {
         if (billItem == null || billItem.getPharmaceuticalBillItem() == null
                 || billItem.getPharmaceuticalBillItem().getStock() == null) {
             if (showMessages) {
@@ -2241,8 +2312,13 @@ public class GrnReturnWorkflowController implements Serializable {
                 JsfUtil.addErrorMessage("Insufficient stock for " + itemName + " (Batch: " + stockBatch + "). "
                         + "Current stock: " + String.format("%.2f", currentStock)
                         + ", Total return quantity (including other items): " + String.format("%.2f", totalStockUsageFromCurrentReturn));
-
-                // Reset quantity to available stock minus other usages
+            }
+            // Draft-stage convenience only: rewrite the quantity down to what is
+            // available so the user can review and re-submit. MUST never run at
+            // approval - a validator that mutates quantities let a failed Approve
+            // silently reduce the return, so a second click approved quantities
+            // that no longer matched the finalized bill (#21266 RC4).
+            if (allowAutoCorrect) {
                 double availableForThisItem = Math.max(0, currentStock - (totalStockUsageFromCurrentReturn - totalReturnQtyInUnits));
 
                 if (isAmppItem) {
@@ -2329,6 +2405,10 @@ public class GrnReturnWorkflowController implements Serializable {
      * Finalize, and Approve operations
      */
     public boolean validateAllItemsStockAvailability(boolean showMessages) {
+        return validateAllItemsStockAvailability(showMessages, true);
+    }
+
+    public boolean validateAllItemsStockAvailability(boolean showMessages, boolean allowAutoCorrect) {
         if (billItems == null || billItems.isEmpty()) {
             return true;
         }
@@ -2353,7 +2433,7 @@ public class GrnReturnWorkflowController implements Serializable {
                 continue;
             }
 
-            if (!validateStockAvailability(bi, showMessages)) {
+            if (!validateStockAvailability(bi, showMessages, allowAutoCorrect)) {
                 allValid = false;
             }
         }

--- a/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
@@ -1340,10 +1340,8 @@ public class GrnReturnWorkflowController implements Serializable {
                     pharmaceuticalBillItemFacade.edit(phi);
                 }
 
-                // Remove from current list to refresh the display
+                // Remove from current display list only; never touch the entity collection
                 billItems.remove(bi);
-                // Remove from Bill's bill item list
-                currentBill.getBillItems().remove(bi);
                 JsfUtil.addSuccessMessage("Item retired and removed from return: " + itemName);
             }
 

--- a/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
@@ -386,9 +386,7 @@ public class GrnReturnWorkflowController implements Serializable {
         // Load the bill with all its items using billService
         try {
             currentBill = billService.reloadBill(currentBill);
-            if (currentBill != null && currentBill.getBillItems() != null) {
-                // Ensure bill items are loaded for preview
-                ensureBillItemsForPreview();
+            if (currentBill != null) {
                 printPreview = true;
                 return "/pharmacy/pharmacy_reprint_grn_return?faces-redirect=true";
             } else {
@@ -613,8 +611,6 @@ public class GrnReturnWorkflowController implements Serializable {
 //            return;
 //        }
         saveBill(false);
-        // Ensure bill items are properly associated for any subsequent operations
-        ensureBillItemsForPreview();
         JsfUtil.addSuccessMessage("GRN Return Request Saved Successfully");
     }
 
@@ -655,8 +651,6 @@ public class GrnReturnWorkflowController implements Serializable {
             processZeroQuantityItems();
 
             saveBill(true);
-            // Ensure the bill items are properly associated with the current bill for print preview
-            ensureBillItemsForPreview();
             printPreview = true;
             JsfUtil.addSuccessMessage("GRN Return Request Finalized Successfully");
         }
@@ -821,8 +815,6 @@ public class GrnReturnWorkflowController implements Serializable {
                 JsfUtil.addSuccessMessage("Original GRN has been fully returned and marked as complete.");
             }
 
-            // Ensure bill items are properly associated for print preview
-            ensureBillItemsForPreview();
             printPreview = true;
             JsfUtil.addSuccessMessage("GRN Return Approved Successfully");
         }
@@ -1351,32 +1343,6 @@ public class GrnReturnWorkflowController implements Serializable {
         } catch (Exception e) {
             JsfUtil.addErrorMessage("Error removing item: " + e.getMessage());
             e.printStackTrace();
-        }
-    }
-
-    private void ensureBillItemsForPreview() {
-        if (currentBill != null) {
-            // Ensure the current bill has its billItems collection properly populated
-            // The print preview component expects bill.billItems to be available
-            try {
-                if (currentBill.getBillItems() == null) {
-                    // Initialize the collection if it's null
-                    currentBill.setBillItems(new ArrayList<>());
-                }
-
-                // Clear and repopulate with current bill items
-                currentBill.getBillItems().clear();
-
-                // Add all current bill items that are not retired
-                for (BillItem bi : billItems) {
-                    if (bi != null && !bi.isRetired()) {
-                        currentBill.getBillItems().add(bi);
-                    }
-                }
-            } catch (Exception e) {
-                // If there's an issue with the billItems collection, log it but don't fail
-                JsfUtil.addErrorMessage("Warning: Could not properly associate items for preview: " + e.getMessage());
-            }
         }
     }
 
@@ -2061,8 +2027,6 @@ public class GrnReturnWorkflowController implements Serializable {
         // This will make item deletion much more reliable
         try {
             saveBill(false); // Save but don't finalize
-            // Ensure bill items are properly associated for any subsequent operations
-            ensureBillItemsForPreview();
             JsfUtil.addSuccessMessage("GRN Return created successfully. You can now modify quantities and remove items as needed.");
         } catch (Exception e) {
             JsfUtil.addErrorMessage("Error creating GRN Return: " + e.getMessage());

--- a/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
@@ -1014,6 +1014,11 @@ public class GrnReturnWorkflowController implements Serializable {
                 continue;
             }
 
+            // Recalculate from bi.qty before persisting so phi.qty and fd.quantity are
+            // always derived from the user-entered pack qty regardless of whether AJAX
+            // blur events fired before the Finalize POST.
+            calculateLineTotal(bi);
+
             // Ensure bill reference is set
             bi.setBill(currentBill);
 
@@ -1555,6 +1560,16 @@ public class GrnReturnWorkflowController implements Serializable {
 
                 BigDecimal lineGrossRateAsEntered = lineGrossRateForAUnit.multiply(unitsPerPack);
                 newBillItemFinanceDetailsInReturnBill.setLineGrossRate(lineGrossRateAsEntered);
+                // Seed bi.qty (pack qty) from phi.qty (unit qty) before calculateLineTotal reads it.
+                // phi.qty was set to the available-to-return quantity in units above; bi.qty starts
+                // at 0.0 (line 1496) and calculateLineTotal reads bi.qty — without seeding, every
+                // initial line total would be calculated as zero.
+                boolean isAmppItem = newBillItemInReturnBill.getItem() instanceof Ampp;
+                BigDecimal phiQty = BigDecimal.valueOf(newPharmaceuticalBillItemInReturnBill.getQty());
+                BigDecimal initialPackQty = isAmppItem && unitsPerPack.compareTo(BigDecimal.ZERO) > 0
+                        ? phiQty.divide(unitsPerPack, 4, java.math.RoundingMode.HALF_UP)
+                        : phiQty;
+                newBillItemInReturnBill.setQty(initialPackQty.doubleValue());
                 calculateLineTotal(newBillItemInReturnBill);
                 getBillItems().add(newBillItemInReturnBill);
             } catch (Exception e) {

--- a/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnReturnWorkflowController.java
@@ -880,7 +880,6 @@ public class GrnReturnWorkflowController implements Serializable {
                 bi.setRetired(true);
                 bi.setRetirer(sessionController.getLoggedUser());
                 bi.setRetiredAt(new Date());
-                bi.setBill(null); // Set bill reference to null as requested
 
                 // If the item already exists in database, update it
                 if (bi.getId() != null) {
@@ -1342,14 +1341,13 @@ public class GrnReturnWorkflowController implements Serializable {
             // If the item is not saved (no ID), simply remove it from the list
             if (bi.getId() == null) {
                 billItems.remove(bi);
-                bi.setBill(null);
                 JsfUtil.addSuccessMessage("Item removed from return list: " + itemName);
             } else {
-                // If already saved, mark as retired and remove from database
+                // If already saved, mark as retired — keep bill reference intact so
+                // the FK stays valid and EclipseLink orphan-removal never fires.
                 bi.setRetired(true);
                 bi.setRetirer(sessionController.getLoggedUser());
                 bi.setRetiredAt(new Date());
-                bi.setBill(null); // Set bill as null as requested
 
                 // Update the bill item in database
                 billItemFacade.edit(bi);

--- a/src/main/java/com/divudi/bean/pharmacy/IssueReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/IssueReturnController.java
@@ -1119,7 +1119,7 @@ public class IssueReturnController implements Serializable {
 
     public List<BillItem> getReturnBillItems() {
         if (returnBillItems == null) {
-            return returnBillItems;
+            return java.util.Collections.emptyList();
         }
         return returnBillItems.stream()
                 .filter(bi -> bi != null && !bi.isRetired())
@@ -1356,10 +1356,10 @@ public class IssueReturnController implements Serializable {
     }
 
     public void calculateBillTotal() {
-        if (returnBillItems == null || returnBillItems.isEmpty()) {
+        List<BillItem> activeItems = getReturnBillItems();
+        if (activeItems.isEmpty()) {
             return;
         }
-        List<BillItem> activeItems = getReturnBillItems();
         calculateReturnBillTotalFromItems(activeItems);
     }
 

--- a/src/main/java/com/divudi/bean/pharmacy/IssueReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/IssueReturnController.java
@@ -275,15 +275,18 @@ public class IssueReturnController implements Serializable {
         }
 
         saveDisposalIssueReturnBill();
-        getReturnBill().setEditedAt(new Date());
-        getReturnBill().setEditor(sessionController.getLoggedUser());
-        getReturnBill().setChecked(true);
-        getReturnBill().setCheckeAt(new Date());
-        getReturnBill().setCheckedBy(sessionController.getLoggedUser());
-        getReturnBill().setBillItems(null);
-        getBillFacade().edit(getReturnBill());
+        // Reload from DB so we don't trigger orphan-removal on billItems
+        returnBill = billService.reloadBill(getReturnBill());
+        if (returnBill != null) {
+            returnBill.setEditedAt(new Date());
+            returnBill.setEditor(sessionController.getLoggedUser());
+            returnBill.setChecked(true);
+            returnBill.setCheckeAt(new Date());
+            returnBill.setCheckedBy(sessionController.getLoggedUser());
+            getBillFacade().edit(returnBill);
+        }
 
-        // Refresh the bill and reload bill items for print preview
+        // Refresh again and reload bill items for print preview
         returnBill = billService.reloadBill(getReturnBill());
         if (returnBill != null) {
             returnBillItems = billService.fetchBillItems(returnBill);
@@ -321,18 +324,24 @@ public class IssueReturnController implements Serializable {
         saveSettlingBill();
         saveSettlingBillComponents();
 
+        // Reload both bills so EclipseLink doesn't orphan-remove existing billItems
+        Bill freshReturn = billService.reloadBill(getReturnBill());
+        if (freshReturn != null) {
+            returnBill = freshReturn;
+        }
         getReturnBill().setReferenceBill(getOriginalBill());
         getReturnBill().setCompleted(true);
         getReturnBill().setCompletedAt(new Date());
         getReturnBill().setCompletedBy(getSessionController().getLoggedUser());
-        getReturnBill().setBillItems(null);
         getBillFacade().edit(getReturnBill());
 
+        Bill freshOriginal = billService.reloadBill(getOriginalBill());
+        if (freshOriginal != null) {
+            originalBill = freshOriginal;
+        }
         getOriginalBill().setRefundedBill(getReturnBill());
         getOriginalBill().setRefunded(true);
         getOriginalBill().getRefundBills().add(getReturnBill());
-
-        getOriginalBill().setBillItems(null);
         getBillFacade().edit(getOriginalBill());
 
         printPreview = true;
@@ -502,15 +511,29 @@ public class IssueReturnController implements Serializable {
             getReturnBill().setCreater(sessionController.getLoggedUser());
             getBillFacade().create(getReturnBill());
         } else {
-            // Null out the billItems collection before merge so EclipseLink does not treat
-            // the in-memory empty ArrayList as an authoritative orphan-removal signal.
-            // Bill items are managed independently by saveBillComponents() / billItemFacade.
-            getReturnBill().setBillItems(null);
-            getBillFacade().edit(getReturnBill());
+            // Reload from DB before merge so EclipseLink's managed entity carries the
+            // real billItems collection — setting null or an empty list here triggers
+            // orphan-removal deletes that violate the pharmaceuticalbillitem FK.
+            Bill fresh = billService.reloadBill(getReturnBill());
+            if (fresh != null) {
+                fresh.setReferenceBill(getReturnBill().getReferenceBill());
+                fresh.setComments(getReturnBill().getComments());
+                fresh.setEditedAt(new Date());
+                fresh.setEditor(sessionController.getLoggedUser());
+                getBillFacade().edit(fresh);
+                returnBill = fresh;
+            }
         }
     }
 
     private void saveSettlingBill() {
+        // Reload from DB first so EclipseLink's managed entity carries the real
+        // billItems collection — nulling it before edit triggers orphan-removal deletes
+        // that violate the pharmaceuticalbillitem FK (same fix as saveBill).
+        Bill fresh = billService.reloadBill(getReturnBill());
+        if (fresh != null) {
+            returnBill = fresh;
+        }
 
         getReturnBill().setBillType(BillType.PharmacyIssue);
         getReturnBill().setBillTypeAtomic(BillTypeAtomic.PHARMACY_DISPOSAL_ISSUE_RETURN);
@@ -568,7 +591,6 @@ public class IssueReturnController implements Serializable {
         }
         getReturnBill().setDeptId(deptId);
         getReturnBill().setInsId(insId);
-        getReturnBill().setBillItems(null);
         billFacade.edit(returnBill);
     }
 
@@ -804,10 +826,8 @@ public class IssueReturnController implements Serializable {
             getOriginalBill().setFullReturned(true);
             getOriginalBill().setFullReturnedAt(new Date());
             getOriginalBill().setFullReturnedBy(sessionController.getLoggedUser());
-            getOriginalBill().setBillItems(null);
             getBillFacade().edit(getOriginalBill());
         }
-        getReturnBill().setBillItems(null);
         getBillFacade().edit(getReturnBill());
 
     }

--- a/src/main/java/com/divudi/bean/pharmacy/IssueReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/IssueReturnController.java
@@ -95,6 +95,7 @@ public class IssueReturnController implements Serializable {
 
     private List<BillItem> originalBillItems;
     private List<BillItem> returnBillItems;
+    private List<BillItem> cachedFilteredReturnBillItems;
 
     private List<BillItem> selectedBillItems;
 
@@ -290,6 +291,7 @@ public class IssueReturnController implements Serializable {
         returnBill = billService.reloadBill(getReturnBill());
         if (returnBill != null) {
             returnBillItems = billService.fetchBillItems(returnBill);
+            invalidateReturnBillItemsCache();
         }
 
         printPreview = true;
@@ -428,6 +430,9 @@ public class IssueReturnController implements Serializable {
             JsfUtil.addErrorMessage("Programming Error");
             return null;
         }
+        // Save immediately so BillItems get database IDs for rowKey — required
+        // for PrimeFaces datatable checkbox selection to work correctly.
+        saveDisposalIssueReturnBill();
         return "/pharmacy/pharmacy_bill_return_issue?faces-redirect=true";
     }
 
@@ -535,7 +540,7 @@ public class IssueReturnController implements Serializable {
             returnBill = fresh;
         }
 
-        getReturnBill().setBillType(BillType.PharmacyIssue);
+        getReturnBill().setBillType(BillType.PharmacyDisposalIssue);
         getReturnBill().setBillTypeAtomic(BillTypeAtomic.PHARMACY_DISPOSAL_ISSUE_RETURN);
         getReturnBill().setBilledBill(getOriginalBill());
         getReturnBill().setCompleted(true);
@@ -926,6 +931,7 @@ public class IssueReturnController implements Serializable {
         returnBill.setInvoiceNumber(originalBill.getInvoiceNumber());
         originalBillItems = billService.fetchBillItems(originalBill);
         returnBillItems = new ArrayList<>();
+        invalidateReturnBillItemsCache();
         if (originalBillItems == null || originalBillItems.isEmpty()) {
             return false;
         }
@@ -1079,6 +1085,7 @@ public class IssueReturnController implements Serializable {
             returnBillItems.remove(selectedItem);
         }
         selectedBillItems.clear();
+        invalidateReturnBillItemsCache();
         calculateBillTotal();
         JsfUtil.addSuccessMessage("Selected items deleted successfully");
     }
@@ -1094,6 +1101,7 @@ public class IssueReturnController implements Serializable {
             billItemFacade.edit(itemToDelete);
         }
         returnBillItems.remove(itemToDelete);
+        invalidateReturnBillItemsCache();
         calculateBillTotal();
         JsfUtil.addSuccessMessage("Item deleted successfully");
     }
@@ -1138,16 +1146,25 @@ public class IssueReturnController implements Serializable {
     }
 
     public List<BillItem> getReturnBillItems() {
-        if (returnBillItems == null) {
-            return java.util.Collections.emptyList();
+        if (cachedFilteredReturnBillItems == null) {
+            if (returnBillItems == null) {
+                cachedFilteredReturnBillItems = java.util.Collections.emptyList();
+            } else {
+                cachedFilteredReturnBillItems = returnBillItems.stream()
+                        .filter(bi -> bi != null && !bi.isRetired())
+                        .collect(java.util.stream.Collectors.toList());
+            }
         }
-        return returnBillItems.stream()
-                .filter(bi -> bi != null && !bi.isRetired())
-                .collect(java.util.stream.Collectors.toList());
+        return cachedFilteredReturnBillItems;
+    }
+
+    private void invalidateReturnBillItemsCache() {
+        cachedFilteredReturnBillItems = null;
     }
 
     public void setReturnBillItems(List<BillItem> returnBillItems) {
         this.returnBillItems = returnBillItems;
+        invalidateReturnBillItemsCache();
     }
 
     /**
@@ -1386,7 +1403,7 @@ public class IssueReturnController implements Serializable {
      * with zero return quantity to ensure only items being returned are included in totals.
      */
     private void calculateReturnBillTotalFromItems(List<BillItem> billItems) {
-        // Initialize totals
+        // Initialize totals — positive accumulators; negated before writing to bill header
         double netTotal = 0.0;
         double grossTotal = 0.0;
         double totalDiscountValue = 0.0;

--- a/src/main/java/com/divudi/bean/pharmacy/IssueReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/IssueReturnController.java
@@ -280,6 +280,7 @@ public class IssueReturnController implements Serializable {
         getReturnBill().setChecked(true);
         getReturnBill().setCheckeAt(new Date());
         getReturnBill().setCheckedBy(sessionController.getLoggedUser());
+        getReturnBill().setBillItems(null);
         getBillFacade().edit(getReturnBill());
 
         // Refresh the bill and reload bill items for print preview
@@ -324,12 +325,14 @@ public class IssueReturnController implements Serializable {
         getReturnBill().setCompleted(true);
         getReturnBill().setCompletedAt(new Date());
         getReturnBill().setCompletedBy(getSessionController().getLoggedUser());
+        getReturnBill().setBillItems(null);
         getBillFacade().edit(getReturnBill());
 
         getOriginalBill().setRefundedBill(getReturnBill());
         getOriginalBill().setRefunded(true);
         getOriginalBill().getRefundBills().add(getReturnBill());
 
+        getOriginalBill().setBillItems(null);
         getBillFacade().edit(getOriginalBill());
 
         printPreview = true;
@@ -498,6 +501,10 @@ public class IssueReturnController implements Serializable {
             getReturnBill().setCreater(sessionController.getLoggedUser());
             getBillFacade().create(getReturnBill());
         } else {
+            // Null out the billItems collection before merge so EclipseLink does not treat
+            // the in-memory empty ArrayList as an authoritative orphan-removal signal.
+            // Bill items are managed independently by saveBillComponents() / billItemFacade.
+            getReturnBill().setBillItems(null);
             getBillFacade().edit(getReturnBill());
         }
     }
@@ -560,6 +567,7 @@ public class IssueReturnController implements Serializable {
         }
         getReturnBill().setDeptId(deptId);
         getReturnBill().setInsId(insId);
+        getReturnBill().setBillItems(null);
         billFacade.edit(returnBill);
     }
 
@@ -797,8 +805,10 @@ public class IssueReturnController implements Serializable {
             getOriginalBill().setFullReturned(true);
             getOriginalBill().setFullReturnedAt(new Date());
             getOriginalBill().setFullReturnedBy(sessionController.getLoggedUser());
+            getOriginalBill().setBillItems(null);
             getBillFacade().edit(getOriginalBill());
         }
+        getReturnBill().setBillItems(null);
         getBillFacade().edit(getReturnBill());
 
     }
@@ -846,6 +856,7 @@ public class IssueReturnController implements Serializable {
 
         bill.setTotal(total);
         bill.setNetTotal(netTotal);
+        bill.setBillItems(null);
         getBillFacade().edit(bill);
 
     }

--- a/src/main/java/com/divudi/bean/pharmacy/IssueReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/IssueReturnController.java
@@ -1234,11 +1234,8 @@ public class IssueReturnController implements Serializable {
         }
         double qty = bi.getQty();
 
-        // Comprehensive validation with auto-correction for user input
-        if (!validateItemReturnQuantity(bi, true)) {
-            // Validation failed, quantity has been auto-corrected
-            // Re-calculate with the corrected quantity
-            qty = bi.getQty();
+        if (!validateItemReturnQuantity(bi, false)) {
+            return;
         }
 
         // Get rates from item batch - these are always in units

--- a/src/main/java/com/divudi/bean/pharmacy/IssueReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/IssueReturnController.java
@@ -210,7 +210,49 @@ public class IssueReturnController implements Serializable {
         pageMetadataRegistry.registerPage(metadata);
     }
 
+    /**
+     * Guards every write entry point (save / finalize / settle) against acting
+     * on a bill whose CURRENT database state is already completed or closed.
+     *
+     * The @SessionScoped bean (and the browser page) can hold a STALE copy of
+     * the return bill - e.g. the bill was settled, then Save/Finalize/Settle is
+     * clicked again from an old screen or list row. Merging that stale copy
+     * reverts the settled bill to a draft (completed/deptId/insId cleared)
+     * while its items and stock movements remain - the #21266 RC5 orphan-return
+     * corruption (Ruhunu bills 4336218 / 4337297, 2026-03-25). Reads bypass the
+     * L2 cache because another app server may have written the bill under
+     * dual-version operation.
+     *
+     * @return true if processing must stop (with a user-facing message).
+     */
+    private boolean disposalReturnAlreadyProcessed() {
+        if (getReturnBill() == null || getReturnBill().getId() == null) {
+            return false; // new, never-persisted draft - nothing to clobber
+        }
+        Bill fresh = getBillFacade().findWithoutCache(getReturnBill().getId());
+        if (fresh == null) {
+            return false;
+        }
+        if (fresh.isCompleted()) {
+            JsfUtil.addErrorMessage("This disposal return (" + (fresh.getDeptId() != null ? fresh.getDeptId() : fresh.getId())
+                    + ") has already been settled. Reload the page before continuing.");
+            return true;
+        }
+        if (fresh.isBillClosed()) {
+            JsfUtil.addErrorMessage("This disposal return has been closed. Create a new return instead.");
+            return true;
+        }
+        if (fresh.isCancelled() || fresh.isRetired()) {
+            JsfUtil.addErrorMessage("This disposal return is cancelled or retired and can no longer be processed.");
+            return true;
+        }
+        return false;
+    }
+
     public void saveDisposalIssueReturnBill() {
+        if (disposalReturnAlreadyProcessed()) {
+            return;
+        }
         // No validation required for saving drafts - users can save incomplete data
         saveBill();
         saveBillComponents();
@@ -218,6 +260,9 @@ public class IssueReturnController implements Serializable {
     }
 
     public void finalizeDisposalIssueReturnBill() {
+        if (disposalReturnAlreadyProcessed()) {
+            return;
+        }
         // Validate return comment is provided
         if (returnBill.getComments() == null || returnBill.getComments().trim().isEmpty()) {
             JsfUtil.addErrorMessage("Return Comment is required. Please provide a reason for the return.");
@@ -248,6 +293,12 @@ public class IssueReturnController implements Serializable {
     }
 
     public void settleDisposalIssueReturnBill() {
+        // Re-settling an already-settled bill (double-click, stale screen, stale
+        // list row) would write a second set of items and stock movements and
+        // then clobber the bill header (#21266 RC5).
+        if (disposalReturnAlreadyProcessed()) {
+            return;
+        }
         if (getReturnBill().getCheckedBy() == null) {
             JsfUtil.addErrorMessage("Pleace Finalise Bill First. Can not Return");
             return;

--- a/src/main/java/com/divudi/bean/pharmacy/IssueReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/IssueReturnController.java
@@ -357,13 +357,14 @@ public class IssueReturnController implements Serializable {
      * @return true if all return quantities are valid, false otherwise
      */
     public boolean validateReturnQuantities() {
-        if (returnBillItems == null || returnBillItems.isEmpty()) {
+        List<BillItem> activeItems = getReturnBillItems();
+        if (activeItems == null || activeItems.isEmpty()) {
             JsfUtil.addErrorMessage("No items found to return");
             return false;
         }
 
         boolean hasErrors = false;
-        for (BillItem returnItem : returnBillItems) {
+        for (BillItem returnItem : activeItems) {
             if (returnItem == null || returnItem.getReferanceBillItem() == null) {
                 continue;
             }
@@ -604,8 +605,6 @@ public class IssueReturnController implements Serializable {
                 i.setBill(null);
                 i.setRetired(true);
                 billItemFacade.edit(i);
-                getReturnBill().getBillItems().remove(i);
-                returnBill = billService.reloadBill(returnBill);
                 continue;
             }
 
@@ -1119,7 +1118,12 @@ public class IssueReturnController implements Serializable {
     }
 
     public List<BillItem> getReturnBillItems() {
-        return returnBillItems;
+        if (returnBillItems == null) {
+            return returnBillItems;
+        }
+        return returnBillItems.stream()
+                .filter(bi -> bi != null && !bi.isRetired())
+                .collect(java.util.stream.Collectors.toList());
     }
 
     public void setReturnBillItems(List<BillItem> returnBillItems) {
@@ -1355,8 +1359,8 @@ public class IssueReturnController implements Serializable {
         if (returnBillItems == null || returnBillItems.isEmpty()) {
             return;
         }
-        // Always calculate from returnBillItems for issue returns
-        calculateReturnBillTotalFromItems(returnBillItems);
+        List<BillItem> activeItems = getReturnBillItems();
+        calculateReturnBillTotalFromItems(activeItems);
     }
 
     /**

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
@@ -3995,7 +3995,10 @@ public class PharmacyController implements Serializable {
 
         for (BillTypeAtomic billType : billTypeAtomics) {
             Map<String, Object> parameters = new HashMap<>();
+            // [0]=sourceDept [1]=consumptionDept [2]=category [3]=item
+            // [4]=purchaseVal [5]=costVal [6]=retailVal [7]=netTotal [8]=qty
             String jpql = "SELECT "
+                    + "b.department.name, "
                     + "b.toDepartment.name, "
                     + "bi.item.category.name, "
                     + "bi.item.name, "
@@ -4033,6 +4036,10 @@ public class PharmacyController implements Serializable {
                 jpql += "AND bi.item.category = :category ";
                 parameters.put("category", category);
             }
+            if (dosageForm != null) {
+                jpql += "AND bi.item.dosageForm = :df ";
+                parameters.put("df", dosageForm);
+            }
             if (item != null) {
                 jpql += "AND bi.item = :item ";
                 parameters.put("item", item);
@@ -4046,8 +4053,8 @@ public class PharmacyController implements Serializable {
                 parameters.put("departmentTypes", selectedDepartmentTypes);
             }
 
-            jpql += "GROUP BY b.toDepartment.name, bi.item.category.name, bi.item.name "
-                    + "ORDER BY b.toDepartment.name, bi.item.category.name, bi.item.name";
+            jpql += "GROUP BY b.department.name, b.toDepartment.name, bi.item.category.name, bi.item.name "
+                    + "ORDER BY b.department.name, b.toDepartment.name, bi.item.category.name, bi.item.name";
 
             try {
                 List<Object[]> results = getBillItemFacade().findObjectsArrayByJpql(jpql, parameters, TemporalType.TIMESTAMP);
@@ -4055,17 +4062,18 @@ public class PharmacyController implements Serializable {
                 double qtySign = consumptionQtySign(billType);
 
                 for (Object[] row : results) {
-                    String deptName = (String) row[0];
-                    String catName = (String) row[1];
-                    String iName = (String) row[2];
-                    Double purchase = row[3] != null ? valueSign * ((Number) row[3]).doubleValue() : 0.0;
-                    Double cost = row[4] != null ? valueSign * ((Number) row[4]).doubleValue() : 0.0;
-                    Double retail = row[5] != null ? valueSign * ((Number) row[5]).doubleValue() : 0.0;
-                    Double net = row[6] != null ? ((Number) row[6]).doubleValue() : 0.0;
-                    Double qty = row[7] != null ? qtySign * ((Number) row[7]).doubleValue() : 0.0;
+                    String sourceDeptName = (String) row[0];
+                    String deptName = (String) row[1];
+                    String catName = (String) row[2];
+                    String iName = (String) row[3];
+                    Double purchase = row[4] != null ? valueSign * ((Number) row[4]).doubleValue() : 0.0;
+                    Double cost = row[5] != null ? valueSign * ((Number) row[5]).doubleValue() : 0.0;
+                    Double retail = row[6] != null ? valueSign * ((Number) row[6]).doubleValue() : 0.0;
+                    Double net = row[7] != null ? ((Number) row[7]).doubleValue() : 0.0;
+                    Double qty = row[8] != null ? qtySign * ((Number) row[8]).doubleValue() : 0.0;
 
                     ConsumptionCategoryItemDto dto = new ConsumptionCategoryItemDto(
-                            deptName, catName, iName, qty, purchase, cost, retail, net);
+                            sourceDeptName, deptName, catName, iName, qty, purchase, cost, retail, net);
                     allItems.add(dto);
                 }
             } catch (Exception e) {
@@ -4073,14 +4081,14 @@ public class PharmacyController implements Serializable {
             }
         }
 
-        // Aggregate by dept + category + item
+        // Aggregate by sourceDept + consumptionDept + category + item
         Map<String, ConsumptionCategoryItemDto> aggregated = new LinkedHashMap<>();
         for (ConsumptionCategoryItemDto dto : allItems) {
-            String key = dto.getDepartmentName() + "||" + dto.getCategoryName() + "||" + dto.getItemName();
+            String key = dto.getSourceDepartmentName() + "||" + dto.getDepartmentName() + "||" + dto.getCategoryName() + "||" + dto.getItemName();
             ConsumptionCategoryItemDto existing = aggregated.get(key);
             if (existing == null) {
                 aggregated.put(key, new ConsumptionCategoryItemDto(
-                        dto.getDepartmentName(), dto.getCategoryName(), dto.getItemName(),
+                        dto.getSourceDepartmentName(), dto.getDepartmentName(), dto.getCategoryName(), dto.getItemName(),
                         dto.getQty(), dto.getTotalPurchaseValue(), dto.getTotalCostValue(),
                         dto.getTotalRetailValue(), dto.getNetTotal()));
             } else {
@@ -4094,26 +4102,37 @@ public class PharmacyController implements Serializable {
 
         List<ConsumptionCategoryItemDto> aggregatedList = new ArrayList<>(aggregated.values());
 
-        // Build category map for categoryWise view
+        // consumptionCategoryDtoMap: consumptionDept -> category -> items (for categoryWise view)
         Map<String, Map<String, List<ConsumptionCategoryItemDto>>> catMap = new TreeMap<>();
-        // Build department totals (scalar map) for summary view
+        // departmentTotals: sourceDept -> consumptionDept -> [purchase,cost,retail,net] (mirrors legacy summary)
         Map<String, Map<String, Double[]>> deptTotals = new TreeMap<>();
+        // pharmacyTotals: sourceDept -> [purchase,cost,retail,net] (for excel/pdf export)
+        Map<String, Double[]> pharmTotals = new TreeMap<>();
 
         for (ConsumptionCategoryItemDto dto : aggregatedList) {
+            String sourceDeptName = dto.getSourceDepartmentName();
             String deptName = dto.getDepartmentName();
             String catName = dto.getCategoryName();
             if (deptName == null || deptName.trim().isEmpty()) continue;
             if (catName == null || catName.trim().isEmpty()) continue;
             if (dto.getQty() == 0.0) continue;
 
+            // Category map: consumptionDept -> category -> items
             catMap.computeIfAbsent(deptName, k -> new TreeMap<>())
                     .computeIfAbsent(catName, k -> new ArrayList<>())
                     .add(dto);
 
-            deptTotals.computeIfAbsent(deptName, k -> new TreeMap<>())
-                    .merge(catName,
-                            new Double[]{dto.getTotalPurchaseValue(), dto.getTotalCostValue(), dto.getTotalRetailValue(), dto.getNetTotal()},
-                            (ex, nv) -> new Double[]{ex[0] + nv[0], ex[1] + nv[1], ex[2] + nv[2], ex[3] + nv[3]});
+            if (sourceDeptName != null && !sourceDeptName.trim().isEmpty()) {
+                // Summary map: sourceDept -> consumptionDept -> [values]
+                deptTotals.computeIfAbsent(sourceDeptName, k -> new TreeMap<>())
+                        .merge(deptName,
+                                new Double[]{dto.getTotalPurchaseValue(), dto.getTotalCostValue(), dto.getTotalRetailValue(), dto.getNetTotal()},
+                                (ex, nv) -> new Double[]{ex[0] + nv[0], ex[1] + nv[1], ex[2] + nv[2], ex[3] + nv[3]});
+                // Export totals: sourceDept -> [values]
+                pharmTotals.merge(sourceDeptName,
+                        new Double[]{dto.getTotalPurchaseValue(), dto.getTotalCostValue(), dto.getTotalRetailValue(), dto.getNetTotal()},
+                        (ex, nv) -> new Double[]{ex[0] + nv[0], ex[1] + nv[1], ex[2] + nv[2], ex[3] + nv[3]});
+            }
 
             totalPurchase += dto.getTotalPurchaseValue();
             totalCostValue += dto.getTotalCostValue();
@@ -4123,6 +4142,7 @@ public class PharmacyController implements Serializable {
 
         consumptionCategoryDtoMap = catMap;
         setDepartmentTotals(deptTotals);
+        setPharmacyTotals(pharmTotals);
     }
 
     private void resetFields() {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
@@ -3827,6 +3827,50 @@ public class PharmacyController implements Serializable {
         }
     }
 
+    /**
+     * Multiplier to convert a stored {@code valueAt*Rate} into consumption-direction value.
+     *
+     * <p>Stored {@code billItemFinanceDetails.valueAt*Rate} (and the matching
+     * {@code billFinanceDetails.total*Value}) use a stock-direction sign: negative when
+     * stock leaves the source department, positive when it comes back. Consumption
+     * accounting is the inverse — an issue adds to consumption, a return/cancel subtracts.
+     * For every disposal-issue bill in this convention the contribution to consumption
+     * value is therefore {@code -valueAt*Rate}.</p>
+     *
+     * <p>See {@code DataAdministrationController.isFinanceValueNegative} for the canonical
+     * sign rules.</p>
+     */
+    private static double consumptionValueSign(BillTypeAtomic bta) {
+        if (bta == null) {
+            return 1.0;
+        }
+        switch (bta) {
+            case PHARMACY_DISPOSAL_ISSUE:
+            case PHARMACY_DISPOSAL_ISSUE_RETURN:
+            case PHARMACY_DISPOSAL_ISSUE_CANCELLED:
+                return -1.0;
+            default:
+                return 1.0;
+        }
+    }
+
+    /**
+     * Multiplier to convert a stored {@code billItem.qty} into consumption-direction qty.
+     * Issues add to consumption (+1); returns and cancellations subtract (-1).
+     */
+    private static double consumptionQtySign(BillTypeAtomic bta) {
+        if (bta == null) {
+            return 1.0;
+        }
+        switch (bta) {
+            case PHARMACY_DISPOSAL_ISSUE_RETURN:
+            case PHARMACY_DISPOSAL_ISSUE_CANCELLED:
+                return -1.0;
+            default:
+                return 1.0;
+        }
+    }
+
     public void generateConsumptionReportTableByBill(List<BillTypeAtomic> billTypeAtomics) {
         try {
             bills = new ArrayList<>();
@@ -3897,10 +3941,26 @@ public class PharmacyController implements Serializable {
                 PharmacyRow row = new PharmacyRow();
                 row.setBill(b);
 
-                // Simply aggregate the values displayed in the columns without manipulation
-                totalPurchase += b.getBillFinanceDetails().getTotalPurchaseValue() != null ? b.getBillFinanceDetails().getTotalPurchaseValue().doubleValue() : 0.0;
-                totalCostValue += b.getBillFinanceDetails().getTotalCostValue() != null ? b.getBillFinanceDetails().getTotalCostValue().doubleValue() : 0.0;
-                totalRetailValue += b.getBillFinanceDetails().getTotalRetailSaleValue() != null ? b.getBillFinanceDetails().getTotalRetailSaleValue().doubleValue() : 0.0;
+                // Apply consumption-direction sign so returns/cancellations subtract
+                // from net consumption rather than adding (issue #21025).
+                if (b.getBillFinanceDetails() != null) {
+                    double sign = consumptionValueSign(b.getBillTypeAtomic());
+
+                    double rowPurchase = b.getBillFinanceDetails().getTotalPurchaseValue() != null
+                            ? sign * b.getBillFinanceDetails().getTotalPurchaseValue().doubleValue() : 0.0;
+                    double rowCost = b.getBillFinanceDetails().getTotalCostValue() != null
+                            ? sign * b.getBillFinanceDetails().getTotalCostValue().doubleValue() : 0.0;
+                    double rowRetail = b.getBillFinanceDetails().getTotalRetailSaleValue() != null
+                            ? sign * b.getBillFinanceDetails().getTotalRetailSaleValue().doubleValue() : 0.0;
+
+                    row.setConsumptionPurchaseValue(rowPurchase);
+                    row.setConsumptionCostValue(rowCost);
+                    row.setConsumptionRetailValue(rowRetail);
+
+                    totalPurchase += rowPurchase;
+                    totalCostValue += rowCost;
+                    totalRetailValue += rowRetail;
+                }
 
                 pharmacyRows.add(row);
 
@@ -4083,23 +4143,32 @@ public class PharmacyController implements Serializable {
             totalRetailValue = 0.0;
 
             for (PharmacyRow row : pharmacyRows) {
-                // Simply aggregate the values displayed in the columns without manipulation
+                // Apply consumption-direction sign so returns/cancellations subtract
+                // from net consumption rather than adding (issue #21025).
                 if (row.getBillItem() != null && row.getBillItem().getBillItemFinanceDetails() != null) {
                     BigDecimal valueAtPurchase = row.getBillItem().getBillItemFinanceDetails().getValueAtPurchaseRate();
                     BigDecimal valueAtCost = row.getBillItem().getBillItemFinanceDetails().getValueAtCostRate();
                     BigDecimal valueAtRetail = row.getBillItem().getBillItemFinanceDetails().getValueAtRetailRate();
 
-                    if (valueAtPurchase != null) {
-                        totalPurchase += valueAtPurchase.doubleValue();
-                    }
+                    BillTypeAtomic bta = row.getBillItem().getBill() != null
+                            ? row.getBillItem().getBill().getBillTypeAtomic()
+                            : null;
+                    double valueSign = consumptionValueSign(bta);
+                    double qtySign = consumptionQtySign(bta);
 
-                    if (valueAtCost != null) {
-                        totalCostValue += valueAtCost.doubleValue();
-                    }
+                    double rowPurchase = valueAtPurchase != null ? valueSign * valueAtPurchase.doubleValue() : 0.0;
+                    double rowCost = valueAtCost != null ? valueSign * valueAtCost.doubleValue() : 0.0;
+                    double rowRetail = valueAtRetail != null ? valueSign * valueAtRetail.doubleValue() : 0.0;
+                    double rowQty = qtySign * (row.getBillItem().getQty() != null ? row.getBillItem().getQty() : 0.0);
 
-                    if (valueAtRetail != null) {
-                        totalRetailValue += valueAtRetail.doubleValue();
-                    }
+                    row.setConsumptionPurchaseValue(rowPurchase);
+                    row.setConsumptionCostValue(rowCost);
+                    row.setConsumptionRetailValue(rowRetail);
+                    row.setConsumptionQty(rowQty);
+
+                    totalPurchase += rowPurchase;
+                    totalCostValue += rowCost;
+                    totalRetailValue += rowRetail;
                 }
             }
 
@@ -4489,17 +4558,23 @@ public class PharmacyController implements Serializable {
             try {
                 List<Object[]> results = getBillItemFacade().findObjectsArrayByJpql(jpql, parameters, TemporalType.TIMESTAMP);
 
+                // Apply consumption-direction sign so returns/cancellations subtract
+                // from net consumption rather than adding (issue #21025). netTotal is
+                // already stored with the correct sign, so it does not need flipping.
+                double valueSign = consumptionValueSign(billType);
+                double qtySign = consumptionQtySign(billType);
+
                 // Convert Object[] to DepartmentCategoryWiseItems
                 for (Object[] row : results) {
                     Department mainDept = (Department) row[0];
                     Department consumptionDept = (Department) row[1];
                     Item item = (Item) row[2];
                     Category category = (item != null) ? item.getCategory() : null;
-                    Double purchaseValue = row[3] != null ? ((Number) row[3]).doubleValue() : 0.0;
-                    Double costValue = row[4] != null ? ((Number) row[4]).doubleValue() : 0.0;
-                    Double retailValue = row[5] != null ? ((Number) row[5]).doubleValue() : 0.0;
+                    Double purchaseValue = row[3] != null ? valueSign * ((Number) row[3]).doubleValue() : 0.0;
+                    Double costValue = row[4] != null ? valueSign * ((Number) row[4]).doubleValue() : 0.0;
+                    Double retailValue = row[5] != null ? valueSign * ((Number) row[5]).doubleValue() : 0.0;
                     Double netTotal = row[6] != null ? ((Number) row[6]).doubleValue() : 0.0;
-                    Double qty = row[7] != null ? ((Number) row[7]).doubleValue() : 0.0;
+                    Double qty = row[7] != null ? qtySign * ((Number) row[7]).doubleValue() : 0.0;
 
                     DepartmentCategoryWiseItems dtoItem = new DepartmentCategoryWiseItems(
                             mainDept, consumptionDept, item, category,
@@ -12294,20 +12369,17 @@ public class PharmacyController implements Serializable {
                     table.addCell(new PdfPCell(new Phrase(bill.getInvoiceNumber() != null ? bill.getInvoiceNumber() : "", normalFont)));
 
                     PdfPCell purchaseCell = new PdfPCell(new Phrase(
-                            bill.getBillFinanceDetails() != null && bill.getBillFinanceDetails().getTotalPurchaseValue() != null
-                                    ? decimalFormat.format(bill.getBillFinanceDetails().getTotalPurchaseValue()) : "0.00", normalFont));
+                            decimalFormat.format(row.getConsumptionPurchaseValue()), normalFont));
                     purchaseCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
                     table.addCell(purchaseCell);
 
                     PdfPCell costCell = new PdfPCell(new Phrase(
-                            bill.getBillFinanceDetails() != null && bill.getBillFinanceDetails().getTotalCostValue() != null
-                                    ? decimalFormat.format(bill.getBillFinanceDetails().getTotalCostValue()) : "0.00", normalFont));
+                            decimalFormat.format(row.getConsumptionCostValue()), normalFont));
                     costCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
                     table.addCell(costCell);
 
                     PdfPCell retailCell = new PdfPCell(new Phrase(
-                            bill.getBillFinanceDetails() != null && bill.getBillFinanceDetails().getTotalRetailSaleValue() != null
-                                    ? decimalFormat.format(bill.getBillFinanceDetails().getTotalRetailSaleValue()) : "0.00", normalFont));
+                            decimalFormat.format(row.getConsumptionRetailValue()), normalFont));
                     retailCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
                     table.addCell(retailCell);
 

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
@@ -4164,7 +4164,34 @@ public class PharmacyController implements Serializable {
         billTableCostTotal = 0.0;
     }
 
-    public void generateConsumptionReportTableByBill(BillType billType) {
+    private static double consumptionValueSign(BillTypeAtomic bta) {
+        if (bta == null) {
+            return 1.0;
+        }
+        switch (bta) {
+            case PHARMACY_DISPOSAL_ISSUE:
+            case PHARMACY_DISPOSAL_ISSUE_RETURN:
+            case PHARMACY_DISPOSAL_ISSUE_CANCELLED:
+                return -1.0;
+            default:
+                return 1.0;
+        }
+    }
+
+    private static double consumptionQtySign(BillTypeAtomic bta) {
+        if (bta == null) {
+            return 1.0;
+        }
+        switch (bta) {
+            case PHARMACY_DISPOSAL_ISSUE_RETURN:
+            case PHARMACY_DISPOSAL_ISSUE_CANCELLED:
+                return -1.0;
+            default:
+                return 1.0;
+        }
+    }
+
+        public void generateConsumptionReportTableByBill(BillType billType) {
         try {
             bills = new ArrayList<>();
 
@@ -5175,6 +5202,64 @@ public class PharmacyController implements Serializable {
     private String formatNumber(double value) {
         DecimalFormat df = new DecimalFormat("#,##0.00");
         return df.format(value);
+    }
+
+    // DTO-aware helpers that read directly from consumptionCategoryDtoMap
+    // (outer key = consumptionDept, inner key = category)
+    public String getDtoDeptPurchaseTotalForConsumptionReport(final String deptName) {
+        double total = consumptionCategoryDtoMap.getOrDefault(deptName, Collections.emptyMap())
+                .values().stream().flatMap(List::stream)
+                .mapToDouble(dto -> dto.getTotalPurchaseValue() != null ? dto.getTotalPurchaseValue() : 0.0).sum();
+        return formatNumber(total);
+    }
+
+    public String getDtoDeptCostTotalForConsumptionReport(final String deptName) {
+        double total = consumptionCategoryDtoMap.getOrDefault(deptName, Collections.emptyMap())
+                .values().stream().flatMap(List::stream)
+                .mapToDouble(dto -> dto.getTotalCostValue() != null ? dto.getTotalCostValue() : 0.0).sum();
+        return formatNumber(total);
+    }
+
+    public String getDtoDeptRetailTotalForConsumptionReport(final String deptName) {
+        double total = consumptionCategoryDtoMap.getOrDefault(deptName, Collections.emptyMap())
+                .values().stream().flatMap(List::stream)
+                .mapToDouble(dto -> dto.getTotalRetailValue() != null ? dto.getTotalRetailValue() : 0.0).sum();
+        return formatNumber(total);
+    }
+
+    public String getDtoDeptNetTotalForConsumptionReport(final String deptName) {
+        double total = consumptionCategoryDtoMap.getOrDefault(deptName, Collections.emptyMap())
+                .values().stream().flatMap(List::stream)
+                .mapToDouble(dto -> dto.getNetTotal() != null ? dto.getNetTotal() : 0.0).sum();
+        return formatNumber(total);
+    }
+
+    public String getDtoCategoryPurchaseTotalForConsumptionReport(final String deptName, final String catName) {
+        double total = consumptionCategoryDtoMap.getOrDefault(deptName, Collections.emptyMap())
+                .getOrDefault(catName, Collections.emptyList()).stream()
+                .mapToDouble(dto -> dto.getTotalPurchaseValue() != null ? dto.getTotalPurchaseValue() : 0.0).sum();
+        return formatNumber(total);
+    }
+
+    public String getDtoCategoryCostTotalForConsumptionReport(final String deptName, final String catName) {
+        double total = consumptionCategoryDtoMap.getOrDefault(deptName, Collections.emptyMap())
+                .getOrDefault(catName, Collections.emptyList()).stream()
+                .mapToDouble(dto -> dto.getTotalCostValue() != null ? dto.getTotalCostValue() : 0.0).sum();
+        return formatNumber(total);
+    }
+
+    public String getDtoCategoryRetailTotalForConsumptionReport(final String deptName, final String catName) {
+        double total = consumptionCategoryDtoMap.getOrDefault(deptName, Collections.emptyMap())
+                .getOrDefault(catName, Collections.emptyList()).stream()
+                .mapToDouble(dto -> dto.getTotalRetailValue() != null ? dto.getTotalRetailValue() : 0.0).sum();
+        return formatNumber(total);
+    }
+
+    public String getDtoCategoryNetTotalForConsumptionReport(final String deptName, final String catName) {
+        double total = consumptionCategoryDtoMap.getOrDefault(deptName, Collections.emptyMap())
+                .getOrDefault(catName, Collections.emptyList()).stream()
+                .mapToDouble(dto -> dto.getNetTotal() != null ? dto.getNetTotal() : 0.0).sum();
+        return formatNumber(total);
     }
 
     public void generateConsumptionReportTableAsDepartmentSummary(final List<DepartmentCategoryWiseItems> list) {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
@@ -4164,33 +4164,6 @@ public class PharmacyController implements Serializable {
         billTableCostTotal = 0.0;
     }
 
-    private static double consumptionValueSign(BillTypeAtomic bta) {
-        if (bta == null) {
-            return 1.0;
-        }
-        switch (bta) {
-            case PHARMACY_DISPOSAL_ISSUE:
-            case PHARMACY_DISPOSAL_ISSUE_RETURN:
-            case PHARMACY_DISPOSAL_ISSUE_CANCELLED:
-                return -1.0;
-            default:
-                return 1.0;
-        }
-    }
-
-    private static double consumptionQtySign(BillTypeAtomic bta) {
-        if (bta == null) {
-            return 1.0;
-        }
-        switch (bta) {
-            case PHARMACY_DISPOSAL_ISSUE_RETURN:
-            case PHARMACY_DISPOSAL_ISSUE_CANCELLED:
-                return -1.0;
-            default:
-                return 1.0;
-        }
-    }
-
         public void generateConsumptionReportTableByBill(BillType billType) {
         try {
             bills = new ArrayList<>();

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
@@ -29,6 +29,9 @@ import com.divudi.core.util.JsfUtil;
 import com.divudi.core.data.dataStructure.CategoryWithItem;
 import com.divudi.core.data.dataStructure.PharmacySummery;
 import com.divudi.core.data.dto.AmpDto;
+import com.divudi.core.data.dto.ConsumptionBillDto;
+import com.divudi.core.data.dto.ConsumptionBillItemDto;
+import com.divudi.core.data.dto.ConsumptionCategoryItemDto;
 import com.divudi.core.data.dto.PharmacyGrnItemDTO;
 import com.divudi.core.data.dto.BeforeStockTakingDTO;
 import com.divudi.core.data.dto.PharmacyGrnReturnItemDTO;
@@ -3663,6 +3666,7 @@ public class PharmacyController implements Serializable {
         }
     }
 
+    @Deprecated
     public void createConsumptionReportTable() {
         reportTimerController.trackReportExecution(() -> {
             resetFields();
@@ -3697,6 +3701,428 @@ public class PharmacyController implements Serializable {
                     throw new IllegalArgumentException("Invalid report type: " + reportType);
             }
         }, InventoryReports.CONSUMPTION_REPORT, sessionController.getLoggedUser());
+    }
+
+    public void createConsumptionReportTableDto() {
+        reportTimerController.trackReportExecution(() -> {
+            resetConsumptionDtoFields();
+            List<BillTypeAtomic> disposalBillTypes = new ArrayList<>();
+            disposalBillTypes.add(BillTypeAtomic.PHARMACY_DISPOSAL_ISSUE);
+            disposalBillTypes.add(BillTypeAtomic.PHARMACY_DISPOSAL_ISSUE_RETURN);
+            disposalBillTypes.add(BillTypeAtomic.PHARMACY_DISPOSAL_ISSUE_CANCELLED);
+
+            switch (reportType) {
+                case "byBill":
+                    if (item != null) {
+                        JsfUtil.addErrorMessage("You can not use List By Bill when an item is selected");
+                        return;
+                    }
+                    if (category != null) {
+                        JsfUtil.addErrorMessage("You can not use List By Bill when a category is selected");
+                        return;
+                    }
+                    generateConsumptionByBillDto(disposalBillTypes);
+                    break;
+                case "byBillItem":
+                    generateConsumptionByBillItemDto(disposalBillTypes);
+                    break;
+                case "summeryReport":
+                case "categoryWise":
+                    generateConsumptionSummaryAndCategoryDto(disposalBillTypes);
+                    break;
+                default:
+                    throw new IllegalArgumentException("Invalid report type: " + reportType);
+            }
+        }, InventoryReports.CONSUMPTION_REPORT, sessionController.getLoggedUser());
+    }
+
+    private void resetConsumptionDtoFields() {
+        consumptionBillDtos = new ArrayList<>();
+        consumptionBillItemDtos = new ArrayList<>();
+        consumptionCategoryDtoMap = new HashMap<>();
+        totalPurchase = 0.0;
+        totalCostValue = 0.0;
+        totalRetailValue = 0.0;
+        totalSaleValue = 0.0;
+        departmentTotals = new HashMap<>();
+    }
+
+    public void generateConsumptionByBillDto(List<BillTypeAtomic> billTypeAtomics) {
+        try {
+            StringBuilder jpql = new StringBuilder();
+            jpql.append("SELECT b.id, b.deptId, b.invoiceNumber, ");
+            jpql.append("toDept.name, ");
+            jpql.append("b.cancelled, b.fullReturned, ");
+            jpql.append("cb.id, cb.deptId, ");
+            jpql.append("rb.id, rb.deptId, ");
+            jpql.append("obb.id, obb.deptId, ");
+            jpql.append("bfd.totalPurchaseValue, bfd.totalCostValue, bfd.totalRetailSaleValue, ");
+            jpql.append("b.createdAt, wu.name, b.comments, b.billTypeAtomic ");
+            jpql.append("FROM Bill b ");
+            jpql.append("LEFT JOIN b.toDepartment toDept ");
+            jpql.append("LEFT JOIN b.cancelledBill cb ");
+            jpql.append("LEFT JOIN b.refundedBill rb ");
+            jpql.append("LEFT JOIN b.billedBill obb ");
+            jpql.append("LEFT JOIN b.billFinanceDetails bfd ");
+            jpql.append("LEFT JOIN b.creater cr ");
+            jpql.append("LEFT JOIN cr.webUserPerson wu ");
+            jpql.append("WHERE (b.retired = false OR b.retired IS NULL) ");
+            jpql.append("AND b.completed = true ");
+            jpql.append("AND b.billTypeAtomic IN :billTypeAtomics ");
+            jpql.append("AND b.createdAt BETWEEN :fromDate AND :toDate ");
+
+            Map<String, Object> params = new HashMap<>();
+            params.put("billTypeAtomics", billTypeAtomics);
+            params.put("fromDate", fromDate);
+            params.put("toDate", toDate);
+
+            if (institution != null) {
+                jpql.append("AND b.institution = :institution ");
+                params.put("institution", institution);
+            }
+            if (site != null) {
+                jpql.append("AND b.department.site = :site ");
+                params.put("site", site);
+            }
+            if (dept != null) {
+                jpql.append("AND b.department = :dept ");
+                params.put("dept", dept);
+            }
+            if (dosageForm != null) {
+                jpql.append("AND EXISTS (SELECT bi2 FROM BillItem bi2 WHERE bi2.bill = b AND bi2.item.dosageForm = :df) ");
+                params.put("df", dosageForm);
+            }
+            if (toDepartment != null) {
+                jpql.append("AND b.toDepartment = :toDept2 ");
+                params.put("toDept2", toDepartment);
+            }
+            if (selectedDepartmentTypes != null && !selectedDepartmentTypes.isEmpty()) {
+                jpql.append("AND b.departmentType IN :departmentTypes ");
+                params.put("departmentTypes", selectedDepartmentTypes);
+            }
+            jpql.append("ORDER BY b.createdAt ASC");
+
+            List<Object[]> rows = getBillFacade().findObjectsArrayByJpql(jpql.toString(), params, TemporalType.TIMESTAMP);
+
+            consumptionBillDtos = new ArrayList<>();
+            totalPurchase = 0.0;
+            totalCostValue = 0.0;
+            totalRetailValue = 0.0;
+
+            for (Object[] row : rows) {
+                BillTypeAtomic bta = row[18] != null ? (BillTypeAtomic) row[18] : null;
+                double valueSign = consumptionValueSign(bta);
+
+                double rawPurchase = row[12] != null ? ((Number) row[12]).doubleValue() : 0.0;
+                double rawCost = row[13] != null ? ((Number) row[13]).doubleValue() : 0.0;
+                double rawRetail = row[14] != null ? ((Number) row[14]).doubleValue() : 0.0;
+
+                double purchase = valueSign * rawPurchase;
+                double cost = valueSign * rawCost;
+                double retail = valueSign * rawRetail;
+
+                ConsumptionBillDto dto = new ConsumptionBillDto(
+                        row[0] != null ? ((Number) row[0]).longValue() : null,
+                        (String) row[1],
+                        (String) row[2],
+                        (String) row[3],
+                        row[4] != null ? (Boolean) row[4] : false,
+                        row[5] != null ? (Boolean) row[5] : false,
+                        row[6] != null ? ((Number) row[6]).longValue() : null,
+                        (String) row[7],
+                        row[8] != null ? ((Number) row[8]).longValue() : null,
+                        (String) row[9],
+                        row[10] != null ? ((Number) row[10]).longValue() : null,
+                        (String) row[11],
+                        purchase, cost, retail,
+                        (java.util.Date) row[15],
+                        (String) row[16],
+                        (String) row[17]
+                );
+
+                consumptionBillDtos.add(dto);
+                totalPurchase += purchase;
+                totalCostValue += cost;
+                totalRetailValue += retail;
+            }
+        } catch (Exception e) {
+            Logger.getLogger(PharmacyController.class.getName()).log(Level.SEVERE, "Error generating consumption by bill DTO", e);
+            JsfUtil.addErrorMessage(e, "Failed to generate Consumption By Bill report.");
+        }
+    }
+
+    public void generateConsumptionByBillItemDto(List<BillTypeAtomic> billTypeAtomics) {
+        try {
+            StringBuilder jpql = new StringBuilder();
+            jpql.append("SELECT bi.id, b.id, b.deptId, b.invoiceNumber, ");
+            jpql.append("toDept.name, ");
+            jpql.append("i.name, cat.name, df.name, ");
+            jpql.append("bi.qty, ");
+            jpql.append("b.cancelled, b.fullReturned, ");
+            jpql.append("cb.id, cb.deptId, ");
+            jpql.append("rb.id, rb.deptId, ");
+            jpql.append("obb.id, obb.deptId, ");
+            jpql.append("bifd.purchaseRate, bifd.valueAtPurchaseRate, ");
+            jpql.append("bifd.retailSaleRate, bifd.valueAtRetailRate, ");
+            jpql.append("bifd.costRate, bifd.valueAtCostRate, ");
+            jpql.append("b.createdAt, wu.name, b.comments, b.billTypeAtomic ");
+            jpql.append("FROM BillItem bi ");
+            jpql.append("JOIN bi.bill b ");
+            jpql.append("LEFT JOIN b.toDepartment toDept ");
+            jpql.append("LEFT JOIN bi.item i ");
+            jpql.append("LEFT JOIN i.category cat ");
+            jpql.append("LEFT JOIN i.dosageForm df ");
+            jpql.append("LEFT JOIN b.cancelledBill cb ");
+            jpql.append("LEFT JOIN b.refundedBill rb ");
+            jpql.append("LEFT JOIN b.billedBill obb ");
+            jpql.append("LEFT JOIN bi.billItemFinanceDetails bifd ");
+            jpql.append("LEFT JOIN b.creater cr ");
+            jpql.append("LEFT JOIN cr.webUserPerson wu ");
+            jpql.append("WHERE (bi.retired = false OR bi.retired IS NULL) ");
+            jpql.append("AND (b.retired = false OR b.retired IS NULL) ");
+            jpql.append("AND b.completed = true ");
+            jpql.append("AND b.billTypeAtomic IN :billTypeAtomics ");
+            jpql.append("AND b.createdAt BETWEEN :fromDate AND :toDate ");
+
+            Map<String, Object> params = new HashMap<>();
+            params.put("billTypeAtomics", billTypeAtomics);
+            params.put("fromDate", fromDate);
+            params.put("toDate", toDate);
+
+            if (institution != null) {
+                jpql.append("AND b.institution = :institution ");
+                params.put("institution", institution);
+            }
+            if (site != null) {
+                jpql.append("AND b.department.site = :site ");
+                params.put("site", site);
+            }
+            if (dept != null) {
+                jpql.append("AND b.department = :department ");
+                params.put("department", dept);
+            }
+            if (category != null) {
+                jpql.append("AND i.category = :category ");
+                params.put("category", category);
+            }
+            if (dosageForm != null) {
+                jpql.append("AND i.dosageForm = :df ");
+                params.put("df", dosageForm);
+            }
+            if (item != null) {
+                jpql.append("AND bi.item = :item ");
+                params.put("item", item);
+            }
+            if (toDepartment != null) {
+                jpql.append("AND b.toDepartment = :toDepartment ");
+                params.put("toDepartment", toDepartment);
+            }
+            if (selectedDepartmentTypes != null && !selectedDepartmentTypes.isEmpty()) {
+                jpql.append("AND b.departmentType IN :departmentTypes ");
+                params.put("departmentTypes", selectedDepartmentTypes);
+            }
+            jpql.append("ORDER BY b.createdAt ASC");
+
+            List<Object[]> rows = getBillItemFacade().findObjectsArrayByJpql(jpql.toString(), params, TemporalType.TIMESTAMP);
+
+            consumptionBillItemDtos = new ArrayList<>();
+            totalPurchase = 0.0;
+            totalCostValue = 0.0;
+            totalRetailValue = 0.0;
+
+            for (Object[] row : rows) {
+                BillTypeAtomic bta = row[26] != null ? (BillTypeAtomic) row[26] : null;
+                double valueSign = consumptionValueSign(bta);
+                double qtySign = consumptionQtySign(bta);
+
+                double rawPurchaseVal = row[18] != null ? ((Number) row[18]).doubleValue() : 0.0;
+                double rawRetailVal = row[20] != null ? ((Number) row[20]).doubleValue() : 0.0;
+                double rawCostVal = row[22] != null ? ((Number) row[22]).doubleValue() : 0.0;
+                double rawQty = row[8] != null ? ((Number) row[8]).doubleValue() : 0.0;
+
+                double purchaseVal = valueSign * rawPurchaseVal;
+                double retailVal = valueSign * rawRetailVal;
+                double costVal = valueSign * rawCostVal;
+                double qty = qtySign * rawQty;
+
+                ConsumptionBillItemDto dto = new ConsumptionBillItemDto(
+                        row[0] != null ? ((Number) row[0]).longValue() : null,
+                        row[1] != null ? ((Number) row[1]).longValue() : null,
+                        (String) row[2],
+                        (String) row[3],
+                        (String) row[4],
+                        (String) row[5],
+                        (String) row[6],
+                        (String) row[7],
+                        qty,
+                        row[9] != null ? (Boolean) row[9] : false,
+                        row[10] != null ? (Boolean) row[10] : false,
+                        row[11] != null ? ((Number) row[11]).longValue() : null,
+                        (String) row[12],
+                        row[13] != null ? ((Number) row[13]).longValue() : null,
+                        (String) row[14],
+                        row[15] != null ? ((Number) row[15]).longValue() : null,
+                        (String) row[16],
+                        row[17] != null ? ((Number) row[17]).doubleValue() : 0.0,
+                        purchaseVal,
+                        row[19] != null ? ((Number) row[19]).doubleValue() : 0.0,
+                        retailVal,
+                        row[21] != null ? ((Number) row[21]).doubleValue() : 0.0,
+                        costVal,
+                        (java.util.Date) row[23],
+                        (String) row[24],
+                        (String) row[25]
+                );
+
+                consumptionBillItemDtos.add(dto);
+                totalPurchase += purchaseVal;
+                totalCostValue += costVal;
+                totalRetailValue += retailVal;
+            }
+        } catch (Exception e) {
+            Logger.getLogger(PharmacyController.class.getName()).log(Level.SEVERE, "Error generating consumption by bill item DTO", e);
+            JsfUtil.addErrorMessage(e, "Failed to generate Consumption By Bill Item report.");
+        }
+    }
+
+    public void generateConsumptionSummaryAndCategoryDto(List<BillTypeAtomic> billTypeAtomics) {
+        totalSaleValue = 0.0;
+        totalCostValue = 0.0;
+        totalPurchase = 0.0;
+        totalRetailValue = 0.0;
+
+        List<ConsumptionCategoryItemDto> allItems = new ArrayList<>();
+
+        for (BillTypeAtomic billType : billTypeAtomics) {
+            Map<String, Object> parameters = new HashMap<>();
+            String jpql = "SELECT "
+                    + "b.toDepartment.name, "
+                    + "bi.item.category.name, "
+                    + "bi.item.name, "
+                    + "SUM(COALESCE(bi.billItemFinanceDetails.valueAtPurchaseRate, 0.0)), "
+                    + "SUM(COALESCE(bi.billItemFinanceDetails.valueAtCostRate, 0.0)), "
+                    + "SUM(COALESCE(bi.billItemFinanceDetails.valueAtRetailRate, 0.0)), "
+                    + "SUM(COALESCE(bi.billItemFinanceDetails.netTotal, 0.0)), "
+                    + "SUM(bi.qty) "
+                    + "FROM BillItem bi "
+                    + "JOIN bi.bill b "
+                    + "WHERE (bi.retired = false OR bi.retired IS NULL) "
+                    + "AND (b.retired = false OR b.retired IS NULL) "
+                    + "AND b.completed = true "
+                    + "AND bi.billItemFinanceDetails IS NOT NULL "
+                    + "AND b.createdAt BETWEEN :fromDate AND :toDate "
+                    + "AND b.billTypeAtomic = :billTypeAtomic ";
+
+            parameters.put("fromDate", fromDate);
+            parameters.put("toDate", toDate);
+            parameters.put("billTypeAtomic", billType);
+
+            if (institution != null) {
+                jpql += "AND b.institution = :institution ";
+                parameters.put("institution", institution);
+            }
+            if (site != null) {
+                jpql += "AND b.department.site = :site ";
+                parameters.put("site", site);
+            }
+            if (dept != null) {
+                jpql += "AND b.department = :department ";
+                parameters.put("department", dept);
+            }
+            if (category != null) {
+                jpql += "AND bi.item.category = :category ";
+                parameters.put("category", category);
+            }
+            if (item != null) {
+                jpql += "AND bi.item = :item ";
+                parameters.put("item", item);
+            }
+            if (toDepartment != null) {
+                jpql += "AND b.toDepartment = :toDepartment ";
+                parameters.put("toDepartment", toDepartment);
+            }
+            if (selectedDepartmentTypes != null && !selectedDepartmentTypes.isEmpty()) {
+                jpql += "AND b.departmentType IN :departmentTypes ";
+                parameters.put("departmentTypes", selectedDepartmentTypes);
+            }
+
+            jpql += "GROUP BY b.toDepartment.name, bi.item.category.name, bi.item.name "
+                    + "ORDER BY b.toDepartment.name, bi.item.category.name, bi.item.name";
+
+            try {
+                List<Object[]> results = getBillItemFacade().findObjectsArrayByJpql(jpql, parameters, TemporalType.TIMESTAMP);
+                double valueSign = consumptionValueSign(billType);
+                double qtySign = consumptionQtySign(billType);
+
+                for (Object[] row : results) {
+                    String deptName = (String) row[0];
+                    String catName = (String) row[1];
+                    String iName = (String) row[2];
+                    Double purchase = row[3] != null ? valueSign * ((Number) row[3]).doubleValue() : 0.0;
+                    Double cost = row[4] != null ? valueSign * ((Number) row[4]).doubleValue() : 0.0;
+                    Double retail = row[5] != null ? valueSign * ((Number) row[5]).doubleValue() : 0.0;
+                    Double net = row[6] != null ? ((Number) row[6]).doubleValue() : 0.0;
+                    Double qty = row[7] != null ? qtySign * ((Number) row[7]).doubleValue() : 0.0;
+
+                    ConsumptionCategoryItemDto dto = new ConsumptionCategoryItemDto(
+                            deptName, catName, iName, qty, purchase, cost, retail, net);
+                    allItems.add(dto);
+                }
+            } catch (Exception e) {
+                Logger.getLogger(PharmacyController.class.getName()).log(Level.SEVERE, "Error generating consumption summary/category DTO for " + billType, e);
+            }
+        }
+
+        // Aggregate by dept + category + item
+        Map<String, ConsumptionCategoryItemDto> aggregated = new LinkedHashMap<>();
+        for (ConsumptionCategoryItemDto dto : allItems) {
+            String key = dto.getDepartmentName() + "||" + dto.getCategoryName() + "||" + dto.getItemName();
+            ConsumptionCategoryItemDto existing = aggregated.get(key);
+            if (existing == null) {
+                aggregated.put(key, new ConsumptionCategoryItemDto(
+                        dto.getDepartmentName(), dto.getCategoryName(), dto.getItemName(),
+                        dto.getQty(), dto.getTotalPurchaseValue(), dto.getTotalCostValue(),
+                        dto.getTotalRetailValue(), dto.getNetTotal()));
+            } else {
+                existing.setQty(existing.getQty() + dto.getQty());
+                existing.setTotalPurchaseValue(existing.getTotalPurchaseValue() + dto.getTotalPurchaseValue());
+                existing.setTotalCostValue(existing.getTotalCostValue() + dto.getTotalCostValue());
+                existing.setTotalRetailValue(existing.getTotalRetailValue() + dto.getTotalRetailValue());
+                existing.setNetTotal(existing.getNetTotal() + dto.getNetTotal());
+            }
+        }
+
+        List<ConsumptionCategoryItemDto> aggregatedList = new ArrayList<>(aggregated.values());
+
+        // Build category map for categoryWise view
+        Map<String, Map<String, List<ConsumptionCategoryItemDto>>> catMap = new TreeMap<>();
+        // Build department totals (scalar map) for summary view
+        Map<String, Map<String, Double[]>> deptTotals = new TreeMap<>();
+
+        for (ConsumptionCategoryItemDto dto : aggregatedList) {
+            String deptName = dto.getDepartmentName();
+            String catName = dto.getCategoryName();
+            if (deptName == null || deptName.trim().isEmpty()) continue;
+            if (catName == null || catName.trim().isEmpty()) continue;
+            if (dto.getQty() == 0.0) continue;
+
+            catMap.computeIfAbsent(deptName, k -> new TreeMap<>())
+                    .computeIfAbsent(catName, k -> new ArrayList<>())
+                    .add(dto);
+
+            deptTotals.computeIfAbsent(deptName, k -> new TreeMap<>())
+                    .merge(catName,
+                            new Double[]{dto.getTotalPurchaseValue(), dto.getTotalCostValue(), dto.getTotalRetailValue(), dto.getNetTotal()},
+                            (ex, nv) -> new Double[]{ex[0] + nv[0], ex[1] + nv[1], ex[2] + nv[2], ex[3] + nv[3]});
+
+            totalPurchase += dto.getTotalPurchaseValue();
+            totalCostValue += dto.getTotalCostValue();
+            totalRetailValue += dto.getTotalRetailValue();
+            totalSaleValue += dto.getNetTotal();
+        }
+
+        consumptionCategoryDtoMap = catMap;
+        setDepartmentTotals(deptTotals);
     }
 
     private void resetFields() {
@@ -8962,6 +9388,10 @@ public class PharmacyController implements Serializable {
     private List<com.divudi.core.data.dto.PharmacyTransferReceiveByDepartmentDTO> transferReceivesByDepartment;
     private List<com.divudi.core.data.dto.PharmacyDisposeIssueByDepartmentDTO> disposeIssuesByDepartment;
 
+    private List<ConsumptionBillDto> consumptionBillDtos;
+    private List<ConsumptionBillItemDto> consumptionBillItemDtos;
+    private Map<String, Map<String, List<ConsumptionCategoryItemDto>>> consumptionCategoryDtoMap = new HashMap<>();
+
     private List<InstitutionSale> institutionTransferIssue;
     private List<InstitutionSale> institutionIssue;
 
@@ -10497,6 +10927,30 @@ public class PharmacyController implements Serializable {
 
     public void setDisposeIssuesByDepartment(List<com.divudi.core.data.dto.PharmacyDisposeIssueByDepartmentDTO> disposeIssuesByDepartment) {
         this.disposeIssuesByDepartment = disposeIssuesByDepartment;
+    }
+
+    public List<ConsumptionBillDto> getConsumptionBillDtos() {
+        return consumptionBillDtos;
+    }
+
+    public void setConsumptionBillDtos(List<ConsumptionBillDto> consumptionBillDtos) {
+        this.consumptionBillDtos = consumptionBillDtos;
+    }
+
+    public List<ConsumptionBillItemDto> getConsumptionBillItemDtos() {
+        return consumptionBillItemDtos;
+    }
+
+    public void setConsumptionBillItemDtos(List<ConsumptionBillItemDto> consumptionBillItemDtos) {
+        this.consumptionBillItemDtos = consumptionBillItemDtos;
+    }
+
+    public Map<String, Map<String, List<ConsumptionCategoryItemDto>>> getConsumptionCategoryDtoMap() {
+        return consumptionCategoryDtoMap;
+    }
+
+    public void setConsumptionCategoryDtoMap(Map<String, Map<String, List<ConsumptionCategoryItemDto>>> consumptionCategoryDtoMap) {
+        this.consumptionCategoryDtoMap = consumptionCategoryDtoMap;
     }
 
     public Double getTotalDisposeIssuesByDepartmentQuantity() {

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderController.java
@@ -171,7 +171,15 @@ public class PurchaseOrderController implements Serializable {
         return "/pharmacy/pharmacy_purhcase_order_approving?faces-redirect=true";
     }
 
-    public String approve() {
+    // synchronized: a double-submit on the Approve button (slow ajax="false"
+    // postback re-clicked, or a resubmitted form) let two requests race through
+    // the same in-memory billItems list before either had persisted, so both
+    // saw BillItem.id == null and created every line twice. The "already
+    // approved" guard below only protects against a second call once the first
+    // has actually finished; synchronized serializes concurrent/racing calls
+    // on this session-scoped bean so the guard is effective (issue: GRN item
+    // duplication reported by Ruhunu, same pattern as #21417)
+    public synchronized String approve() {
         // Check if the requested bill is already approved to prevent double approving
         if (getRequestedBill() != null && getRequestedBill().getReferenceBill() != null) {
             JsfUtil.addErrorMessage("This purchase order is already approved");

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderController.java
@@ -152,7 +152,18 @@ public class PurchaseOrderController implements Serializable {
         return fromDate;
     }
 
-    public String navigateToPurchaseOrderApproval() {
+    // synchronized: the Approve button on the PO-list-to-approve page has no
+    // confirm() or double-click guard and posts here (not to approve()) before
+    // the review screen is even shown. A double-click raced two calls through
+    // clearList()+generateBillComponent() on this session-scoped bean: both
+    // nulled billItems, then both re-populated it from the same PO Request,
+    // leaving billItems holding every line twice. The (already synchronized)
+    // approve() then faithfully persisted the doubled list in a single call,
+    // producing one approved Bill with every item duplicated once - the GRN
+    // duplication reported by Ruhunu on PO/RH/GSK/26/01093, a recurrence of
+    // the same bug class as the approve() fix (PR #21815) one step earlier
+    // in the workflow.
+    public synchronized String navigateToPurchaseOrderApproval() {
         Bill temRequestedBill = requestedBill;
 
         // Check if the requested bill is already approved

--- a/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PurchaseOrderRequestController.java
@@ -722,6 +722,7 @@ public class PurchaseOrderRequestController implements Serializable {
     public void saveBillComponent() {
         for (BillItem b : getBillItems()) {
             b.setBill(getCurrentBill());
+            resyncPharmaceuticalBillItemIfEmpty(b);
             if (b.getId() == null) {
                 getBillItemFacade().create(b);
             } else {
@@ -730,10 +731,32 @@ public class PurchaseOrderRequestController implements Serializable {
         }
     }
 
+    // A duplicate-line removal can leave the surviving BillItem with a lazily
+    // created all-zero PharmaceuticalBillItem while its BillItemFinanceDetails
+    // still holds the real quantities; downstream approval/GRN reads the PBI,
+    // so rebuild it from the finance details before persisting (issue #21417)
+    private void resyncPharmaceuticalBillItemIfEmpty(BillItem b) {
+        if (b == null || b.isRetired() || b.getBillItemFinanceDetails() == null) {
+            return;
+        }
+        PharmaceuticalBillItem pbi = b.getPharmaceuticalBillItem();
+        if (pbi.getQty() != 0 || pbi.getFreeQty() != 0) {
+            return;
+        }
+        BigDecimal qtyByUnits = b.getBillItemFinanceDetails().getQuantityByUnits();
+        BigDecimal freeQtyByUnits = b.getBillItemFinanceDetails().getFreeQuantityByUnits();
+        boolean financeDetailsHaveQty = (qtyByUnits != null && qtyByUnits.compareTo(BigDecimal.ZERO) > 0)
+                || (freeQtyByUnits != null && freeQtyByUnits.compareTo(BigDecimal.ZERO) > 0);
+        if (financeDetailsHaveQty) {
+            calculateLineValues(b);
+        }
+    }
+
     public void finalizeBillComponent() {
         getBillItems().removeIf(BillItem::isRetired);
         for (BillItem b : getBillItems()) {
             b.setBill(getCurrentBill());
+            resyncPharmaceuticalBillItemIfEmpty(b);
             BigDecimal qUnits = (b.getBillItemFinanceDetails() != null && b.getBillItemFinanceDetails().getQuantityByUnits() != null)
                     ? b.getBillItemFinanceDetails().getQuantityByUnits() : BigDecimal.ZERO;
             BigDecimal fqUnits = (b.getBillItemFinanceDetails() != null && b.getBillItemFinanceDetails().getFreeQuantityByUnits() != null)
@@ -797,7 +820,11 @@ public class PurchaseOrderRequestController implements Serializable {
         }
     }
 
-    private boolean saveRequestWithoutMessage() {
+    // synchronized: concurrent saves from the same session (Enter-key defaultCommand
+    // racing a button click) both saw billItem.id == null and persisted the same
+    // in-memory BillItem twice, creating duplicate rows sharing one
+    // BillItemFinanceDetails (issue #21417)
+    private synchronized boolean saveRequestWithoutMessage() {
         if (getCurrentBill().isChecked()) {
             JsfUtil.addErrorMessage("Cannot save a finalized bill");
             return false;
@@ -866,7 +893,7 @@ public class PurchaseOrderRequestController implements Serializable {
         return allItems;
     }
 
-    public void finalizeRequest() {
+    public synchronized void finalizeRequest() {
         if (currentBill == null) {
             JsfUtil.addErrorMessage("No Bill");
             return;

--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueCancellationController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueCancellationController.java
@@ -10,6 +10,7 @@ import com.divudi.core.util.JsfUtil;
 import com.divudi.core.data.BillClassType;
 import com.divudi.core.data.BillNumberSuffix;
 import com.divudi.core.data.BillType;
+import com.divudi.core.data.DepartmentType;
 import com.divudi.core.data.BillTypeAtomic;
 import com.divudi.ejb.BillNumberGenerator;
 import com.divudi.ejb.PharmacyBean;
@@ -253,6 +254,13 @@ public class TransferIssueCancellationController implements Serializable {
         cancellationBill.setToDepartment(originalBill.getToDepartment());
         cancellationBill.setToInstitution(originalBill.getToInstitution());
         cancellationBill.setToStaff(originalBill.getToStaff());
+        cancellationBill.setDepartmentType(originalBill.getDepartmentType());
+        if (cancellationBill.getDepartmentType() == null) {
+            // Legacy issue bills predate departmentType stamping (#22056);
+            // derive from the original items so the cancellation stays visible
+            // in department-type-filtered reports.
+            cancellationBill.setDepartmentType(singleDepartmentTypeOfItems(originalBill.getBillItems()));
+        }
 
         // Set audit fields
         cancellationBill.setCreater(sessionController.getLoggedUser());
@@ -268,6 +276,26 @@ public class TransferIssueCancellationController implements Serializable {
         // Initialize collections
         cancellationBill.setBillItems(new ArrayList<>());
         cancellationBill.setBilledBill(originalBill);
+    }
+
+    // Returns the department type shared by all non-null item types, or null
+    // when items are mixed/untyped — never guess from a partial match (#22056).
+    private DepartmentType singleDepartmentTypeOfItems(List<BillItem> items) {
+        if (items == null) {
+            return null;
+        }
+        DepartmentType found = null;
+        for (BillItem bi : items) {
+            if (bi.isRetired() || bi.getItem() == null || bi.getItem().getDepartmentType() == null) {
+                continue;
+            }
+            if (found == null) {
+                found = bi.getItem().getDepartmentType();
+            } else if (!found.equals(bi.getItem().getDepartmentType())) {
+                return null;
+            }
+        }
+        return found;
     }
 
     /**

--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueController.java
@@ -12,6 +12,7 @@ import com.divudi.core.data.BillClassType;
 import com.divudi.core.data.BillNumberSuffix;
 import com.divudi.core.data.BillType;
 import com.divudi.core.data.BillTypeAtomic;
+import com.divudi.core.data.DepartmentType;
 import com.divudi.core.data.dto.StockDTO;
 import com.divudi.ejb.BillNumberGenerator;
 
@@ -1519,8 +1520,16 @@ public class TransferIssueController implements Serializable {
 
         billItem.setSearialNo(getBillItems().size() + 1);
 
-        if (getIssuedBill().getDepartmentType() == null && billItem.getItem() != null) {
-            getIssuedBill().setDepartmentType(billItem.getItem().getDepartmentType());
+        if (billItem.getItem() != null) {
+            DepartmentType itemDeptType = billItem.getItem().getDepartmentType();
+            if (getIssuedBill().getDepartmentType() == null) {
+                getIssuedBill().setDepartmentType(itemDeptType);
+            } else if (itemDeptType != null && !itemDeptType.equals(getIssuedBill().getDepartmentType())) {
+                JsfUtil.addErrorMessage("Cannot add items from different department types. "
+                        + "Bill is set for " + getIssuedBill().getDepartmentType().getLabel()
+                        + " items, but you are trying to add a " + itemDeptType.getLabel() + " item.");
+                return;
+            }
         }
 
         getBillItems().add(billItem);

--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueController.java
@@ -1518,6 +1518,11 @@ public class TransferIssueController implements Serializable {
         billItem.getBillItemFinanceDetails().setValueAtPurchaseRate(purchaseRate.multiply(billItem.getBillItemFinanceDetails().getQuantity()));
 
         billItem.setSearialNo(getBillItems().size() + 1);
+
+        if (getIssuedBill().getDepartmentType() == null && billItem.getItem() != null) {
+            getIssuedBill().setDepartmentType(billItem.getItem().getDepartmentType());
+        }
+
         getBillItems().add(billItem);
 
         qty = null;

--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueController.java
@@ -777,6 +777,11 @@ public class TransferIssueController implements Serializable {
             return;
         }
 
+        if (getIssuedBill().getDepartmentType() == null && getRequestedBill() != null) {
+            getIssuedBill().setDepartmentType(getRequestedBill().getDepartmentType());
+        }
+        stampDepartmentTypeFromItemsIfMissing();
+
         saveBill();
         for (BillItem billItemsInIssue : getBillItems()) {
             BillItem originalOrderItem = billItemsInIssue.getReferanceBillItem();
@@ -1782,6 +1787,30 @@ public class TransferIssueController implements Serializable {
             getBillFacade().create(getIssuedBill());
         } else {
             getBillFacade().edit(getIssuedBill());
+        }
+    }
+
+    // Fallback when neither the request bill nor addToBill stamped a
+    // departmentType: department-type-filtered reports drop NULL bills (#22056).
+    // Stamps only when all non-null item types agree; mixed legacy data is left
+    // unset rather than misclassifying the whole bill.
+    private void stampDepartmentTypeFromItemsIfMissing() {
+        if (getIssuedBill().getDepartmentType() != null) {
+            return;
+        }
+        DepartmentType found = null;
+        for (BillItem bi : getBillItems()) {
+            if (bi.getItem() == null || bi.getItem().getDepartmentType() == null) {
+                continue;
+            }
+            if (found == null) {
+                found = bi.getItem().getDepartmentType();
+            } else if (!found.equals(bi.getItem().getDepartmentType())) {
+                return;
+            }
+        }
+        if (found != null) {
+            getIssuedBill().setDepartmentType(found);
         }
     }
 

--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueDirectController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueDirectController.java
@@ -177,6 +177,10 @@ public class TransferIssueDirectController implements Serializable {
 
         billItem.setSearialNo(getBillItems().size());
 
+        if (issuedBill.getDepartmentType() == null && billItem.getItem() != null) {
+            issuedBill.setDepartmentType(billItem.getItem().getDepartmentType());
+        }
+
         // Set the transfer rate based on configuration
         BigDecimal itemTransferRate = determineTransferRate(getTmpStock().getItemBatch());
         BigDecimal lineGrossRate = itemTransferRate.multiply(billItem.getBillItemFinanceDetails().getUnitsPerPack());

--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueDirectController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueDirectController.java
@@ -177,8 +177,16 @@ public class TransferIssueDirectController implements Serializable {
 
         billItem.setSearialNo(getBillItems().size());
 
-        if (issuedBill.getDepartmentType() == null && billItem.getItem() != null) {
-            issuedBill.setDepartmentType(billItem.getItem().getDepartmentType());
+        if (billItem.getItem() != null) {
+            DepartmentType itemDeptType = billItem.getItem().getDepartmentType();
+            if (issuedBill.getDepartmentType() == null) {
+                issuedBill.setDepartmentType(itemDeptType);
+            } else if (itemDeptType != null && !itemDeptType.equals(issuedBill.getDepartmentType())) {
+                JsfUtil.addErrorMessage("Cannot add items from different department types. "
+                        + "Bill is set for " + issuedBill.getDepartmentType().getLabel()
+                        + " items, but you are trying to add a " + itemDeptType.getLabel() + " item.");
+                return;
+            }
         }
 
         // Set the transfer rate based on configuration

--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueForRequestsController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueForRequestsController.java
@@ -453,6 +453,11 @@ public class TransferIssueForRequestsController implements Serializable {
             return;
         }
 
+        if (getIssuedBill().getDepartmentType() == null && !getBillItems().isEmpty()
+                && getBillItems().get(0).getItem() != null) {
+            getIssuedBill().setDepartmentType(getBillItems().get(0).getItem().getDepartmentType());
+        }
+
         saveBill();
         for (BillItem billItemsInIssue : getBillItems()) {
             BillItem originalOrderItem = billItemsInIssue.getReferanceBillItem();

--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueForRequestsController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueForRequestsController.java
@@ -453,9 +453,8 @@ public class TransferIssueForRequestsController implements Serializable {
             return;
         }
 
-        if (getIssuedBill().getDepartmentType() == null && !getBillItems().isEmpty()
-                && getBillItems().get(0).getItem() != null) {
-            getIssuedBill().setDepartmentType(getBillItems().get(0).getItem().getDepartmentType());
+        if (getIssuedBill().getDepartmentType() == null && getRequestedBill() != null) {
+            getIssuedBill().setDepartmentType(getRequestedBill().getDepartmentType());
         }
 
         saveBill();

--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueForRequestsController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueForRequestsController.java
@@ -15,6 +15,7 @@ import com.divudi.core.util.JsfUtil;
 import com.divudi.core.data.BillClassType;
 import com.divudi.core.data.BillNumberSuffix;
 import com.divudi.core.data.BillType;
+import com.divudi.core.data.DepartmentType;
 import com.divudi.core.data.BillTypeAtomic;
 import com.divudi.ejb.BillNumberGenerator;
 import com.divudi.ejb.PharmacyBean;
@@ -466,6 +467,7 @@ public class TransferIssueForRequestsController implements Serializable {
         if (getIssuedBill().getDepartmentType() == null && getRequestedBill() != null) {
             getIssuedBill().setDepartmentType(getRequestedBill().getDepartmentType());
         }
+        stampDepartmentTypeFromItemsIfMissing();
 
         saveBill();
         for (BillItem billItemsInIssue : getBillItems()) {
@@ -1115,6 +1117,30 @@ public class TransferIssueForRequestsController implements Serializable {
             getBillFacade().create(getIssuedBill());
         } else {
             getBillFacade().edit(getIssuedBill());
+        }
+    }
+
+    // Fallback when the request bill carries no departmentType (e.g. legacy
+    // requests): department-type-filtered reports drop bills left NULL (#22056).
+    // Stamps only when all non-null item types agree; mixed legacy data is left
+    // unset rather than misclassifying the whole bill.
+    private void stampDepartmentTypeFromItemsIfMissing() {
+        if (getIssuedBill().getDepartmentType() != null) {
+            return;
+        }
+        DepartmentType found = null;
+        for (BillItem bi : getBillItems()) {
+            if (bi.getItem() == null || bi.getItem().getDepartmentType() == null) {
+                continue;
+            }
+            if (found == null) {
+                found = bi.getItem().getDepartmentType();
+            } else if (!found.equals(bi.getItem().getDepartmentType())) {
+                return;
+            }
+        }
+        if (found != null) {
+            getIssuedBill().setDepartmentType(found);
         }
     }
 

--- a/src/main/java/com/divudi/bean/pharmacy/TransferIssueForRequestsController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferIssueForRequestsController.java
@@ -417,6 +417,16 @@ public class TransferIssueForRequestsController implements Serializable {
             return;
         }
         for (BillItem bi : getBillItems()) {
+            // Single source of truth for the issued quantity (#21266 RC6): the
+            // user-entered qty lives in BillItemFinanceDetails.quantity, but the
+            // stock movement below uses pbi.qty - which still holds the REQUESTED
+            // qty from item generation if a UI edit did not sync it. Stock then
+            // moved by the requested qty while updateBillItemRateAndValue()
+            // rewrote the persisted line to the user-entered qty AFTER the stock
+            // ops (pbi 4912145, 2026-05-20: stock moved 2, line said 1). Sync
+            // pbi/billItem qty from the user-entered value BEFORE validating or
+            // moving any stock, keeping the positive pre-settle sign convention.
+            syncStockQtyFromUserEnteredQty(bi);
             if (bi.getPharmaceuticalBillItem().getItemBatch() != null) {
                 if (bi.getPharmaceuticalBillItem().getStock().getStock() < bi.getPharmaceuticalBillItem().getQty()) {
                     JsfUtil.addErrorMessage("Available quantity is less than issued quantity in " + bi.getPharmaceuticalBillItem().getItemBatch().getItem().getName());
@@ -637,6 +647,31 @@ public class TransferIssueForRequestsController implements Serializable {
 
     }
 
+    /**
+     * Copies the user-entered quantity (BillItemFinanceDetails.quantity, in
+     * packs) onto the fields the settle stock operations read - pbi.qty (units),
+     * pbi.qtyPacks and billItem.qty (packs) - so the quantity that moves stock
+     * is always the quantity that gets persisted (#21266 RC6). Values are set
+     * POSITIVE to match the pre-settle convention expected by the validation
+     * and zero-removal checks; settle() negates them later. Lines without
+     * finance details or a quantity are left untouched (conservative fallback).
+     */
+    private void syncStockQtyFromUserEnteredQty(BillItem bi) {
+        if (bi == null || bi.getPharmaceuticalBillItem() == null) {
+            return;
+        }
+        BillItemFinanceDetails f = bi.getBillItemFinanceDetails();
+        if (f == null || f.getQuantity() == null) {
+            return;
+        }
+        double packs = Math.abs(f.getQuantity().doubleValue());
+        double unitsPerPack = (f.getUnitsPerPack() != null && f.getUnitsPerPack().compareTo(BigDecimal.ZERO) > 0)
+                ? f.getUnitsPerPack().doubleValue() : 1.0;
+        bi.getPharmaceuticalBillItem().setQty(packs * unitsPerPack);
+        bi.getPharmaceuticalBillItem().setQtyPacks(packs);
+        bi.setQty(packs);
+    }
+
     private void updateBillItemRateAndValue(BillItem b) {
         BillItemFinanceDetails f = b.getBillItemFinanceDetails();
         double rate = b.getBillItemFinanceDetails().getLineGrossRate().doubleValue();
@@ -689,6 +724,14 @@ public class TransferIssueForRequestsController implements Serializable {
             if (f.getPurchaseRate() == null) {
                 f.setPurchaseRate(BigDecimal.valueOf(batch.getPurcahseRate()));
             }
+            // Recompute valuation fields from the user-entered quantity. They are
+            // set at item-generation time from the REQUESTED qty and were never
+            // updated when the user changed the issuing qty (#21266 RC6:
+            // valueAtPurchaseRate stayed 990 = 2 x 495 while the line qty became
+            // 1). Positive sign, matching the generation-time convention.
+            f.setValueAtPurchaseRate(BigDecimal.valueOf(batch.getPurcahseRate()).multiply(qtyInUnits));
+            f.setValueAtRetailRate(BigDecimal.valueOf(batch.getRetailsaleRate()).multiply(qtyInUnits));
+            f.setValueAtCostRate(costRate.multiply(qtyInUnits));
         } else {
             f.setLineCostRate(BigDecimal.ZERO);
             f.setLineCost(BigDecimal.ZERO);

--- a/src/main/java/com/divudi/bean/pharmacy/TransferReceiveCancellationController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferReceiveCancellationController.java
@@ -10,6 +10,7 @@ import com.divudi.core.util.JsfUtil;
 import com.divudi.core.data.BillClassType;
 import com.divudi.core.data.BillNumberSuffix;
 import com.divudi.core.data.BillType;
+import com.divudi.core.data.DepartmentType;
 import com.divudi.core.data.BillTypeAtomic;
 import com.divudi.ejb.BillNumberGenerator;
 import com.divudi.ejb.PharmacyBean;
@@ -240,6 +241,13 @@ public class TransferReceiveCancellationController implements Serializable {
         cancellationBill.setFromInstitution(originalReceiveBill.getFromInstitution());
         cancellationBill.setToDepartment(originalReceiveBill.getToDepartment());
         cancellationBill.setToInstitution(originalReceiveBill.getToInstitution());
+        cancellationBill.setDepartmentType(originalReceiveBill.getDepartmentType());
+        if (cancellationBill.getDepartmentType() == null) {
+            // Legacy receive bills predate departmentType stamping (#22056);
+            // derive from the original items so the cancellation stays visible
+            // in department-type-filtered reports.
+            cancellationBill.setDepartmentType(singleDepartmentTypeOfItems(originalReceiveBill.getBillItems()));
+        }
 
         // Set audit fields
         cancellationBill.setCreater(sessionController.getLoggedUser());
@@ -258,6 +266,26 @@ public class TransferReceiveCancellationController implements Serializable {
 
         // Initialize collections
         cancellationBill.setBillItems(new ArrayList<>());
+    }
+
+    // Returns the department type shared by all non-null item types, or null
+    // when items are mixed/untyped — never guess from a partial match (#22056).
+    private DepartmentType singleDepartmentTypeOfItems(List<BillItem> items) {
+        if (items == null) {
+            return null;
+        }
+        DepartmentType found = null;
+        for (BillItem bi : items) {
+            if (bi.isRetired() || bi.getItem() == null || bi.getItem().getDepartmentType() == null) {
+                continue;
+            }
+            if (found == null) {
+                found = bi.getItem().getDepartmentType();
+            } else if (!found.equals(bi.getItem().getDepartmentType())) {
+                return null;
+            }
+        }
+        return found;
     }
 
     /**

--- a/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
@@ -1082,7 +1082,8 @@ public class TransferReceiveController implements Serializable {
 
     public void onEdit(RowEditEvent event) {
         BillItem tmp = (BillItem) event.getObject();
-        if (tmp.getPharmaceuticalBillItem().getStaffStock().getStock() < tmp.getQty()) {
+        if (tmp.getPharmaceuticalBillItem().getStaffStock() == null
+                || tmp.getPharmaceuticalBillItem().getStaffStock().getStock() < tmp.getQty()) {
             tmp.setTmpQty(0.0);
             JsfUtil.addErrorMessage("You cant recieved over than Issued Qty setted Old Value");
         }
@@ -1090,7 +1091,18 @@ public class TransferReceiveController implements Serializable {
         //   getPharmacyController().setPharmacyItem(tmp.getItem());
     }
 
+    /**
+     * A null staffStock means the corresponding issue-side line never
+     * actually moved stock to the porter - treat that the same as
+     * insufficient stock rather than letting the missing reference NPE.
+     * porterStockCoversAllLines() already rejects this case up front for
+     * settle()/settleApprove(); this guard covers onEdit() and any other
+     * caller that reaches a single line's stock check directly (#22951).
+     */
     public boolean errorCheck(BillItem billItem) {
+        if (billItem.getPharmaceuticalBillItem().getStaffStock() == null) {
+            return true;
+        }
         if (billItem.getPharmaceuticalBillItem().getStaffStock().getStock() < billItem.getQty()) {
             return true;
         }

--- a/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
@@ -558,7 +558,6 @@ public class TransferReceiveController implements Serializable {
         getIssuedBill().getForwardReferenceBills().add(getReceivedBill());
         fillData(getReceivedBill());
         getBillFacade().edit(getIssuedBill());
-        getBillFacade().edit(getReceivedBill());
         
         // Check if Transfer Issue is fully received and update fullyIssued status
         if (getIssuedBill() != null && !getIssuedBill().isFullyIssued()) {
@@ -970,7 +969,12 @@ public class TransferReceiveController implements Serializable {
         if (getReceivedBill().getId() == null) {
             getReceivedBill().setCreatedAt(new Date());
             getReceivedBill().setCreater(sessionController.getLoggedUser());
+            // Detach billItems before create() to prevent CascadeType.ALL from inserting
+            // them here — settle() creates each BillItem explicitly after stock validation.
+            List<BillItem> items = getReceivedBill().getBillItems();
+            getReceivedBill().setBillItems(new ArrayList<>());
             getBillFacade().create(getReceivedBill());
+            getReceivedBill().setBillItems(items);
         } else {
             getBillFacade().edit(getReceivedBill());
         }

--- a/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
@@ -37,6 +37,7 @@ import com.divudi.core.entity.pharmacy.Vmp;
 import com.divudi.core.entity.pharmacy.Vmpp;
 import com.divudi.core.entity.pharmacy.Ampp;
 import com.divudi.core.entity.Item;
+import com.divudi.core.entity.Staff;
 import com.divudi.core.facade.BillFacade;
 import com.divudi.core.facade.BillItemFacade;
 import com.divudi.core.facade.PharmaceuticalBillItemFacade;
@@ -262,6 +263,14 @@ public class TransferReceiveController implements Serializable {
             newlyCreatedReceivedBillItem.invertValue();
             newlyCreatedReceivedBillItem.getPharmaceuticalBillItem().invertValue();
 
+            // The copy above inherits the ISSUE line's stock binding, which is the
+            // ISSUING department's stock row. A receive must only ever touch the
+            // porter's in-transit stock (deducted) and the receiving department's
+            // stock (added; bound after addToStock() in settle). A receive line that
+            // keeps the sender's stock reference and slips past the stock loop is
+            // recorded as received without moving any stock (#21266 phantom receives).
+            newlyCreatedReceivedBillItem.getPharmaceuticalBillItem().setStock(null);
+
             // Adjust quantity to remaining amount
             double unitsPerPack = 1.0;
             Item item = newlyCreatedReceivedBillItem.getItem();
@@ -449,6 +458,81 @@ public class TransferReceiveController implements Serializable {
         }
     }
 
+    /**
+     * Converts a bill item's user-entered receive quantity (packs) to units.
+     */
+    private double receiveQtyInUnits(BillItem i) {
+        double qtyInPacks = 0.0;
+        if (i.getBillItemFinanceDetails() != null && i.getBillItemFinanceDetails().getQuantity() != null) {
+            qtyInPacks = i.getBillItemFinanceDetails().getQuantity().doubleValue();
+        }
+        double unitsPerPack = 1.0;
+        Item item = i.getItem();
+        if (item instanceof Ampp || item instanceof Vmpp) {
+            unitsPerPack = item.getDblValue() > 0 ? item.getDblValue() : 1.0;
+        }
+        return qtyInPacks * unitsPerPack;
+    }
+
+    /**
+     * Validates that the porter (carrier) holds enough in-transit stock to cover
+     * EVERY line being received, before any data is written. Quantities are
+     * aggregated per item batch (several receive lines can draw from the same
+     * batch) and compared against the porter's live stock read fresh from the
+     * database.
+     *
+     * On a receive, stock must move porter -> receiving department. Previously,
+     * lines that could not be covered were silently skipped or zeroed mid-settle,
+     * and the skipped lines were later cascade-persisted still carrying the
+     * issuing department's stock binding with no stock movement — the #21266
+     * phantom-receive corruption. Failing the whole settle up front with explicit
+     * messages prevents both the corruption and the silent partial receive.
+     *
+     * @return true if every line is covered; false (with user-facing error
+     * messages) otherwise.
+     */
+    private boolean porterStockCoversAllLines() {
+        Staff porter = getIssuedBill() == null ? null : getIssuedBill().getToStaff();
+        if (porter == null) {
+            JsfUtil.addErrorMessage("This transfer issue has no carrying staff (porter) recorded - cannot receive. Please contact the issuing department.");
+            return false;
+        }
+        Map<Long, Double> requiredUnitsByBatch = new HashMap<>();
+        Map<Long, ItemBatch> batchById = new HashMap<>();
+        for (BillItem i : getReceivedBill().getBillItems()) {
+            double units = receiveQtyInUnits(i);
+            if (units <= 0.0) {
+                continue;
+            }
+            ItemBatch batch = i.getPharmaceuticalBillItem() == null ? null : i.getPharmaceuticalBillItem().getItemBatch();
+            if (batch == null || batch.getId() == null) {
+                JsfUtil.addErrorMessage("Item " + (i.getItem() != null ? i.getItem().getName() : "?") + " has no batch - cannot receive.");
+                return false;
+            }
+            requiredUnitsByBatch.merge(batch.getId(), units, Double::sum);
+            batchById.put(batch.getId(), batch);
+        }
+        boolean allCovered = true;
+        for (Map.Entry<Long, Double> e : requiredUnitsByBatch.entrySet()) {
+            ItemBatch batch = batchById.get(e.getKey());
+            HashMap<String, Object> params = new HashMap<>();
+            String jpql = "select s from Stock s where s.itemBatch=:bc and s.staff=:stf";
+            params.put("bc", batch);
+            params.put("stf", porter);
+            Stock porterStock = getStockFacade().findFirstByJpql(jpql, params, true);
+            double available = porterStock == null ? 0.0 : porterStock.getStock();
+            if (available + 0.0001 < e.getValue()) {
+                String itemName = (batch.getItem() != null && batch.getItem().getName() != null)
+                        ? batch.getItem().getName() : ("Batch " + batch.getId());
+                JsfUtil.addErrorMessage("Insufficient in-transit (porter) stock for " + itemName
+                        + ": receiving " + e.getValue() + " but porter holds " + available
+                        + ". Nothing was received.");
+                allCovered = false;
+            }
+        }
+        return allCovered;
+    }
+
     private void doSettle() {
         if (getReceivedBill().getBillItems() == null || getReceivedBill().getBillItems().isEmpty()) {
             JsfUtil.addErrorMessage("Nothing to Recive, Please check Recieved Quantity");
@@ -464,6 +548,12 @@ public class TransferReceiveController implements Serializable {
         // Validate that current receive quantities don't exceed remaining quantities
         if (wouldCauseOverReceiving()) {
             JsfUtil.addErrorMessage("Cannot receive - quantities exceed remaining amounts!");
+            return;
+        }
+
+        // All-or-nothing: every line must be coverable from the porter's in-transit
+        // stock BEFORE anything is written (#21266 phantom-receive guard).
+        if (!porterStockCoversAllLines()) {
             return;
         }
 
@@ -526,6 +616,13 @@ public class TransferReceiveController implements Serializable {
                 getBillItemFacade().edit(i);
             }
         }
+
+        // Drop lines that were never persisted (zero quantity or failed checks)
+        // from the in-memory bill. Bill.billItems cascades ALL, so the later
+        // edit(getReceivedBill()) merges would otherwise INSERT these skipped
+        // lines - still carrying the issue line's data with no stock movement -
+        // which is exactly the #21266 phantom-receive corruption.
+        getReceivedBill().getBillItems().removeIf(bi -> bi.getId() == null);
 
         // Handle Department ID generation (independent)
         String deptId;
@@ -864,6 +961,12 @@ public class TransferReceiveController implements Serializable {
             return;
         }
 
+        // All-or-nothing: every line must be coverable from the porter's in-transit
+        // stock BEFORE anything is written (#21266 phantom-receive guard).
+        if (!porterStockCoversAllLines()) {
+            return;
+        }
+
         getReceivedBill().setApproveAt(new Date());
         getReceivedBill().setApproveUser(getSessionController().getLoggedUser());
 
@@ -932,6 +1035,12 @@ public class TransferReceiveController implements Serializable {
                 Stock addedStock = getPharmacyBean().addToStock(tmpPh, Math.abs(qty), getSessionController().getDepartment());
                 tmpPh.setStock(addedStock);
             } else {
+                // No stock was moved - never leave the line bound to the stock
+                // reference inherited from the issue line (the issuing
+                // department's stock), or it records a phantom receive (#21266).
+                tmpPh.setStock(null);
+                tmpPh.setQty(0);
+                i.setQty(0.0);
                 i.setTmpQty(0);
                 getBillItemFacade().edit(i);
             }

--- a/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
@@ -19,6 +19,7 @@ import java.util.Objects;
 import javax.persistence.TemporalType;
 import com.divudi.core.data.BillNumberSuffix;
 import com.divudi.core.data.BillType;
+import com.divudi.core.data.DepartmentType;
 import com.divudi.core.data.BillTypeAtomic;
 import com.divudi.core.data.dataStructure.SearchKeyword;
 import com.divudi.ejb.BillNumberGenerator;
@@ -973,6 +974,10 @@ public class TransferReceiveController implements Serializable {
         getReceivedBill().setBillType(BillType.PharmacyTransferReceive);
         getReceivedBill().setBillTypeAtomic(BillTypeAtomic.PHARMACY_RECEIVE);
         getReceivedBill().setBackwardReferenceBill(getIssuedBill());
+        if (getIssuedBill().getDepartmentType() != null) {
+            getReceivedBill().setDepartmentType(getIssuedBill().getDepartmentType());
+        }
+        stampDepartmentTypeFromItemsIfMissing();
         List<BillItem> itemsToAdd = new ArrayList<>();
 
         for (BillItem i : getReceivedBill().getBillItems()) {
@@ -1097,6 +1102,10 @@ public class TransferReceiveController implements Serializable {
         getReceivedBill().setBillTypeAtomic(BillTypeAtomic.PHARMACY_RECEIVE);
         getReceivedBill().setBackwardReferenceBill(getIssuedBill());
         getReceivedBill().setFromStaff(getIssuedBill().getToStaff());
+        if (getIssuedBill().getDepartmentType() != null) {
+            getReceivedBill().setDepartmentType(getIssuedBill().getDepartmentType());
+        }
+        stampDepartmentTypeFromItemsIfMissing();
         if (getReceivedBill().getId() == null) {
             getReceivedBill().setCreatedAt(new Date());
             getReceivedBill().setCreater(sessionController.getLoggedUser());
@@ -1113,6 +1122,30 @@ public class TransferReceiveController implements Serializable {
             }
         } else {
             getBillFacade().edit(getReceivedBill());
+        }
+    }
+
+    // Fallback when the issued bill carries no departmentType (legacy issues):
+    // department-type-filtered reports drop bills left NULL (#22056).
+    // Stamps only when all non-null item types agree; mixed legacy data is left
+    // unset rather than misclassifying the whole bill.
+    private void stampDepartmentTypeFromItemsIfMissing() {
+        if (getReceivedBill().getDepartmentType() != null) {
+            return;
+        }
+        DepartmentType found = null;
+        for (BillItem bi : getReceivedBill().getBillItems()) {
+            if (bi.getItem() == null || bi.getItem().getDepartmentType() == null) {
+                continue;
+            }
+            if (found == null) {
+                found = bi.getItem().getDepartmentType();
+            } else if (!found.equals(bi.getItem().getDepartmentType())) {
+                return;
+            }
+        }
+        if (found != null) {
+            getReceivedBill().setDepartmentType(found);
         }
     }
 

--- a/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferReceiveController.java
@@ -112,6 +112,9 @@ public class TransferReceiveController implements Serializable {
     private List<Bill> bills;
     private SearchKeyword searchKeyword;
     private BillItem selectedBillItem;
+    // Re-entrancy guard: blocks a second settle() (e.g. rapid double-click on the
+    // non-AJAX Receive button) from processing the same transfer twice.
+    private boolean settling;
 
     public static class ConfigOptionInfo {
 
@@ -433,6 +436,20 @@ public class TransferReceiveController implements Serializable {
     }
 
     public void settle() {
+        // Re-entrancy guard: a second near-simultaneous submit (rapid double-click
+        // on the non-AJAX Receive button) is ignored until the first completes.
+        if (settling) {
+            return;
+        }
+        settling = true;
+        try {
+            doSettle();
+        } finally {
+            settling = false;
+        }
+    }
+
+    private void doSettle() {
         if (getReceivedBill().getBillItems() == null || getReceivedBill().getBillItems().isEmpty()) {
             JsfUtil.addErrorMessage("Nothing to Recive, Please check Recieved Quantity");
             return;
@@ -557,6 +574,11 @@ public class TransferReceiveController implements Serializable {
 
         getIssuedBill().getForwardReferenceBills().add(getReceivedBill());
         fillData(getReceivedBill());
+        // Persist the received bill again after fillData() recalculates its
+        // net/grand/total and BillFinanceDetails value fields. Safe here: the
+        // BillItems were already created (have IDs) in the settle() loop above,
+        // so this merge updates totals without re-inserting them.
+        getBillFacade().edit(getReceivedBill());
         getBillFacade().edit(getIssuedBill());
         
         // Check if Transfer Issue is fully received and update fullyIssued status
@@ -973,8 +995,13 @@ public class TransferReceiveController implements Serializable {
             // them here — settle() creates each BillItem explicitly after stock validation.
             List<BillItem> items = getReceivedBill().getBillItems();
             getReceivedBill().setBillItems(new ArrayList<>());
-            getBillFacade().create(getReceivedBill());
-            getReceivedBill().setBillItems(items);
+            try {
+                getBillFacade().create(getReceivedBill());
+            } finally {
+                // Always restore the in-memory items, even if create() throws,
+                // so the @SessionScoped bean does not lose the receive rows on retry.
+                getReceivedBill().setBillItems(items);
+            }
         } else {
             getBillFacade().edit(getReceivedBill());
         }
@@ -1477,6 +1504,10 @@ public class TransferReceiveController implements Serializable {
 
     public void setSelectedBillItem(BillItem selectedBillItem) {
         this.selectedBillItem = selectedBillItem;
+    }
+
+    public boolean isSettling() {
+        return settling;
     }
 
     @Deprecated

--- a/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
@@ -337,6 +337,13 @@ public class TransferRequestController implements Serializable {
     // the final persist step on this session-scoped bean so a racing double-submit
     // can't write the (already duplicated) billItems list twice.
     public synchronized void approveTransferRequestBill() {
+        // Check if the pre-bill is already approved to prevent a queued double-submit
+        // (blocked on the synchronized lock above) from creating a second approved bill
+        // once the first call has finished.
+        if (transferRequestBillPre != null && transferRequestBillPre.getReferenceBill() != null) {
+            JsfUtil.addErrorMessage("This transfer request is already approved");
+            return;
+        }
         if (billItems == null || billItems.isEmpty()) {
             JsfUtil.addErrorMessage("No Bill Items");
             return;

--- a/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
@@ -333,7 +333,10 @@ public class TransferRequestController implements Serializable {
 
     }
 
-    public void approveTransferRequestBill() {
+    // synchronized: defense in depth alongside navigateToApproveRequest() — serializes
+    // the final persist step on this session-scoped bean so a racing double-submit
+    // can't write the (already duplicated) billItems list twice.
+    public synchronized void approveTransferRequestBill() {
         if (billItems == null || billItems.isEmpty()) {
             JsfUtil.addErrorMessage("No Bill Items");
             return;
@@ -347,7 +350,9 @@ public class TransferRequestController implements Serializable {
         printPreview = true;
     }
 
-    public Bill createNewApprovedTransferRequestBill(Bill preBillToCreateApprovedBill, List<BillItem> transferRequestPreBillItems, Bill newApprovedBill) {
+    // synchronized: same re-entrancy guard as approveTransferRequestBill()/
+    // navigateToApproveRequest() above, applied at the actual persist step.
+    public synchronized Bill createNewApprovedTransferRequestBill(Bill preBillToCreateApprovedBill, List<BillItem> transferRequestPreBillItems, Bill newApprovedBill) {
         if (transferRequestPreBillItems == null || transferRequestPreBillItems.isEmpty()) {
             JsfUtil.addErrorMessage("No Bill Items");
             return null;
@@ -677,7 +682,13 @@ public class TransferRequestController implements Serializable {
     
     
 
-    public String navigateToApproveRequest() {
+    // synchronized: the Approve Request button on the transfer-request-list-to-approve
+    // page has no double-click guard. This method clears and repopulates the
+    // session-scoped billItems field from the pre-bill's items; a double-click raced
+    // two concurrent calls through this clear-then-repopulate step, leaving billItems
+    // holding every line twice (issue: duplicate items on TREQ/RH/GRO/26/00074, same
+    // bug class as #21417/#21815/PR #22101, tracked generically under #22102).
+    public synchronized String navigateToApproveRequest() {
         Bill transferRequestBillTemp = transferRequestBillPre;
         recreate();
         transferRequestBillPre = transferRequestBillTemp;

--- a/src/main/java/com/divudi/bean/report/PharmacyReportController.java
+++ b/src/main/java/com/divudi/bean/report/PharmacyReportController.java
@@ -18369,11 +18369,23 @@ public class PharmacyReportController implements Serializable {
         return dtoStockConsumptionPurchaseTotal;
     }
 
+    public void setDtoStockConsumptionPurchaseTotal(double dtoStockConsumptionPurchaseTotal) {
+        this.dtoStockConsumptionPurchaseTotal = dtoStockConsumptionPurchaseTotal;
+    }
+
     public double getDtoStockConsumptionCostTotal() {
         return dtoStockConsumptionCostTotal;
     }
 
+    public void setDtoStockConsumptionCostTotal(double dtoStockConsumptionCostTotal) {
+        this.dtoStockConsumptionCostTotal = dtoStockConsumptionCostTotal;
+    }
+
     public double getDtoStockConsumptionRetailTotal() {
         return dtoStockConsumptionRetailTotal;
+    }
+
+    public void setDtoStockConsumptionRetailTotal(double dtoStockConsumptionRetailTotal) {
+        this.dtoStockConsumptionRetailTotal = dtoStockConsumptionRetailTotal;
     }
 }

--- a/src/main/java/com/divudi/bean/report/PharmacyReportController.java
+++ b/src/main/java/com/divudi/bean/report/PharmacyReportController.java
@@ -6306,11 +6306,14 @@ public class PharmacyReportController implements Serializable {
 
                 double rawQty = row[9] != null ? ((Number) row[9]).doubleValue() : 0.0;
                 double rawPurchaseRate = row[10] != null ? ((Number) row[10]).doubleValue() : 0.0;
-                double rawPurchaseVal = row[11] != null ? ((Number) row[11]).doubleValue() : 0.0;
                 double rawCostRate = row[12] != null ? ((Number) row[12]).doubleValue() : 0.0;
-                double rawCostVal = row[13] != null ? ((Number) row[13]).doubleValue() : 0.0;
                 double rawRetailRate = row[14] != null ? ((Number) row[14]).doubleValue() : 0.0;
-                double rawRetailVal = row[15] != null ? ((Number) row[15]).doubleValue() : 0.0;
+                // RETURN stores bifd values as positive (inflow); ISSUE/CANCELLED as negative (outflow).
+                // When bifd row is absent fall back to qty*rate with matching sign.
+                double bifdSign = (bta == BillTypeAtomic.PHARMACY_DISPOSAL_ISSUE_RETURN) ? 1.0 : -1.0;
+                double rawPurchaseVal = row[11] != null ? ((Number) row[11]).doubleValue() : bifdSign * rawQty * rawPurchaseRate;
+                double rawCostVal     = row[13] != null ? ((Number) row[13]).doubleValue() : bifdSign * rawQty * rawCostRate;
+                double rawRetailVal   = row[15] != null ? ((Number) row[15]).doubleValue() : bifdSign * rawQty * rawRetailRate;
 
                 double qty = qtySign * rawQty;
                 double purchaseVal = valueSign * rawPurchaseVal;

--- a/src/main/java/com/divudi/bean/report/PharmacyReportController.java
+++ b/src/main/java/com/divudi/bean/report/PharmacyReportController.java
@@ -33,6 +33,7 @@ import com.divudi.core.data.dto.MovementReportDto;
 import com.divudi.core.data.dto.AmpDto;
 import com.divudi.core.data.dto.BillItemDTO;
 import com.divudi.core.data.dto.CostOfGoodSoldBillDTO;
+import com.divudi.core.data.dto.StockConsumptionItemDto;
 import com.divudi.core.data.dto.ExpiryItemListDto;
 import com.divudi.core.data.dto.ExpiryItemStockListDto;
 import com.divudi.core.data.dto.StockLedgerDTO;
@@ -386,6 +387,11 @@ public class PharmacyReportController implements Serializable {
     private double totalPurchaseValue;
     private double totalRetailValue;
     private double totalSaleValue;
+
+    private List<StockConsumptionItemDto> stockConsumptionItemDtos;
+    private double dtoStockConsumptionPurchaseTotal;
+    private double dtoStockConsumptionCostTotal;
+    private double dtoStockConsumptionRetailTotal;
 
     // Maps to store remaining quantities and values for Good In Transit report
     private Map<Long, Double> billItemRemainingQuantities = new HashMap<>();
@@ -6228,6 +6234,131 @@ public class PharmacyReportController implements Serializable {
         btasToGetBillItems.add(BillTypeAtomic.PHARMACY_DISPOSAL_ISSUE_RETURN);
         retrieveBillItemsCompleted(btasToGetBillItems, true);
         calculateStockConsumptionTotals(billItems);
+    }
+
+    public void processStockConsumptionDto() {
+        stockConsumptionItemDtos = new ArrayList<>();
+        dtoStockConsumptionPurchaseTotal = 0.0;
+        dtoStockConsumptionCostTotal = 0.0;
+        dtoStockConsumptionRetailTotal = 0.0;
+        try {
+            List<BillTypeAtomic> billTypeAtomics = new ArrayList<>();
+            billTypeAtomics.add(BillTypeAtomic.PHARMACY_DISPOSAL_ISSUE);
+            billTypeAtomics.add(BillTypeAtomic.PHARMACY_DISPOSAL_ISSUE_CANCELLED);
+            billTypeAtomics.add(BillTypeAtomic.PHARMACY_DISPOSAL_ISSUE_RETURN);
+
+            StringBuilder jpql = new StringBuilder();
+            jpql.append("SELECT bi.id, b.id, b.deptId, ");
+            jpql.append("refBill.id, refBill.deptId, ");
+            jpql.append("b.createdAt, ");
+            jpql.append("i.name, i.code, ");
+            jpql.append("ib.batchNo, ");
+            jpql.append("bi.qty, ");
+            jpql.append("pbi.purchaseRate, bifd.valueAtPurchaseRate, ");
+            jpql.append("ib.costRate, bifd.valueAtCostRate, ");
+            jpql.append("ib.retailsaleRate, bifd.valueAtRetailRate, ");
+            jpql.append("toDept.name, b.comments, mu.name, ");
+            jpql.append("b.billTypeAtomic ");
+            jpql.append("FROM BillItem bi ");
+            jpql.append("JOIN bi.bill b ");
+            jpql.append("LEFT JOIN b.referenceBill refBill ");
+            jpql.append("LEFT JOIN bi.item i ");
+            jpql.append("LEFT JOIN bi.pharmaceuticalBillItem pbi ");
+            jpql.append("LEFT JOIN pbi.itemBatch ib ");
+            jpql.append("LEFT JOIN bi.billItemFinanceDetails bifd ");
+            jpql.append("LEFT JOIN b.toDepartment toDept ");
+            jpql.append("LEFT JOIN i.issueUnit mu ");
+            jpql.append("WHERE (bi.retired = false OR bi.retired IS NULL) ");
+            jpql.append("AND (b.retired = false OR b.retired IS NULL) ");
+            jpql.append("AND b.completed = true ");
+            jpql.append("AND b.billTypeAtomic IN :billTypeAtomics ");
+            jpql.append("AND b.createdAt BETWEEN :fromDate AND :toDate ");
+
+            Map<String, Object> params = new HashMap<>();
+            params.put("billTypeAtomics", billTypeAtomics);
+            params.put("fromDate", fromDate);
+            params.put("toDate", toDate);
+
+            if (institution != null) {
+                jpql.append("AND b.institution = :institution ");
+                params.put("institution", institution);
+            }
+            if (site != null) {
+                jpql.append("AND b.department.site = :site ");
+                params.put("site", site);
+            }
+            if (department != null) {
+                jpql.append("AND b.department = :department ");
+                params.put("department", department);
+            }
+            if (selectedDepartmentTypes != null && !selectedDepartmentTypes.isEmpty()) {
+                jpql.append("AND b.departmentType IN :departmentTypes ");
+                params.put("departmentTypes", selectedDepartmentTypes);
+            }
+            jpql.append("ORDER BY b.createdAt ASC");
+
+            List<Object[]> rows = billItemFacade.findObjectsArrayByJpql(jpql.toString(), params, TemporalType.TIMESTAMP);
+
+            for (Object[] row : rows) {
+                BillTypeAtomic bta = row[19] != null ? (BillTypeAtomic) row[19] : null;
+                double valueSign = stockConsumptionValueSign(bta);
+                double qtySign = stockConsumptionQtySign(bta);
+
+                double rawQty = row[9] != null ? ((Number) row[9]).doubleValue() : 0.0;
+                double rawPurchaseRate = row[10] != null ? ((Number) row[10]).doubleValue() : 0.0;
+                double rawPurchaseVal = row[11] != null ? ((Number) row[11]).doubleValue() : 0.0;
+                double rawCostRate = row[12] != null ? ((Number) row[12]).doubleValue() : 0.0;
+                double rawCostVal = row[13] != null ? ((Number) row[13]).doubleValue() : 0.0;
+                double rawRetailRate = row[14] != null ? ((Number) row[14]).doubleValue() : 0.0;
+                double rawRetailVal = row[15] != null ? ((Number) row[15]).doubleValue() : 0.0;
+
+                double qty = qtySign * rawQty;
+                double purchaseVal = valueSign * rawPurchaseVal;
+                double costVal = valueSign * rawCostVal;
+                double retailVal = valueSign * rawRetailVal;
+
+                StockConsumptionItemDto dto = new StockConsumptionItemDto(
+                        row[0] != null ? ((Number) row[0]).longValue() : null,
+                        row[1] != null ? ((Number) row[1]).longValue() : null,
+                        (String) row[2],
+                        row[3] != null ? ((Number) row[3]).longValue() : null,
+                        (String) row[4],
+                        (java.util.Date) row[5],
+                        (String) row[6],
+                        (String) row[7],
+                        (String) row[8],
+                        qty,
+                        rawPurchaseRate,
+                        purchaseVal,
+                        rawCostRate,
+                        costVal,
+                        rawRetailRate,
+                        retailVal,
+                        (String) row[16],
+                        (String) row[17],
+                        (String) row[18]
+                );
+
+                stockConsumptionItemDtos.add(dto);
+                dtoStockConsumptionPurchaseTotal += purchaseVal;
+                dtoStockConsumptionCostTotal += costVal;
+                dtoStockConsumptionRetailTotal += retailVal;
+            }
+        } catch (Exception e) {
+            Logger.getLogger(PharmacyReportController.class.getName()).log(Level.SEVERE, "Error generating stock consumption DTO", e);
+            JsfUtil.addErrorMessage(e, "Failed to generate Stock Consumption DTO report.");
+        }
+    }
+
+    private static double stockConsumptionValueSign(BillTypeAtomic bta) {
+        return -1.0;
+    }
+
+    private static double stockConsumptionQtySign(BillTypeAtomic bta) {
+        if (bta == BillTypeAtomic.PHARMACY_DISPOSAL_ISSUE_RETURN) {
+            return -1.0;
+        }
+        return 1.0;
     }
 
     public void exportStockConsumptionToExcel() {
@@ -18224,5 +18355,25 @@ public class PharmacyReportController implements Serializable {
             filename += "_" + dates;
         }
         return filename;
+    }
+
+    public List<StockConsumptionItemDto> getStockConsumptionItemDtos() {
+        return stockConsumptionItemDtos;
+    }
+
+    public void setStockConsumptionItemDtos(List<StockConsumptionItemDto> stockConsumptionItemDtos) {
+        this.stockConsumptionItemDtos = stockConsumptionItemDtos;
+    }
+
+    public double getDtoStockConsumptionPurchaseTotal() {
+        return dtoStockConsumptionPurchaseTotal;
+    }
+
+    public double getDtoStockConsumptionCostTotal() {
+        return dtoStockConsumptionCostTotal;
+    }
+
+    public double getDtoStockConsumptionRetailTotal() {
+        return dtoStockConsumptionRetailTotal;
     }
 }

--- a/src/main/java/com/divudi/bean/report/PharmacyReportController.java
+++ b/src/main/java/com/divudi/bean/report/PharmacyReportController.java
@@ -13511,6 +13511,12 @@ public class PharmacyReportController implements Serializable {
             List<BillType> billTypes = new ArrayList<>();
             billTypes.add(BillType.PharmacyAdjustmentDepartmentSingleStock);
             billTypes.add(BillType.PharmacyAdjustmentDepartmentStock);
+            // Stock-take adjustment bills (PHARMACY_STOCK_ADJUSTMENT_BILL) move stock too;
+            // omitting them left their stock movements uncounted on the calculated side and
+            // produced a COGS variance equal to the adjustment value on every stock-take day.
+            // pbi.qty on these bills is the adjustment delta, so the existing qty<0/qty>0
+            // split places them in the Issue/Receive rows correctly. See issue #21266.
+            billTypes.add(BillType.PharmacyStockAdjustmentBill);
 
             // Query for Stock Adjustment Issues (negative quantities)
             Map<String, Object> paramsIssue = new HashMap<>();

--- a/src/main/java/com/divudi/bean/report/PharmacyReportController.java
+++ b/src/main/java/com/divudi/bean/report/PharmacyReportController.java
@@ -11832,7 +11832,21 @@ public class PharmacyReportController implements Serializable {
                     .append("FROM BillItem bi ")
                     .append("WHERE bi.retired = :ret ")
                     .append("AND bi.bill.billTypeAtomic IN :btas ")
-                    .append("AND bi.bill.createdAt BETWEEN :fd AND :td ");
+                    // Filter by the actual STOCK-MOVEMENT date, not bill creation, so the
+                    // movement rows align with the stock side (StockHistory is written when
+                    // stock physically moves). Stock moves on approval, but which timestamp
+                    // marks approval differs by workflow:
+                    //   - GRN / GRN-return / direct purchase: stock moves at completedAt.
+                    //   - Draft transfer issue: completedAt is set at draft *finalization*
+                    //     (finalizeDraftIssue), while stock is deducted later at *approval*
+                    //     (approveDraftIssue), which sets checkeAt.
+                    // GREATEST(createdAt, completedAt, checkeAt) picks the latest of the three,
+                    // which is the moment stock actually moved in every workflow, and falls
+                    // back to createdAt when the approval timestamps are null (non-approval
+                    // flows). Using createdAt alone mis-dated approval-gated movements (e.g. a
+                    // GRN return created one day, approved another) and produced a spurious COGS
+                    // variance. See issue #21266 (and Codex review on PR #21348 re: draft transfers).
+                    .append("AND FUNCTION('GREATEST', bi.bill.createdAt, COALESCE(bi.bill.completedAt, bi.bill.createdAt), COALESCE(bi.bill.checkeAt, bi.bill.createdAt)) BETWEEN :fd AND :td ");
 
             params.put("ret", false);
             params.put("btas", billTypeAtomics);
@@ -11879,13 +11893,22 @@ public class PharmacyReportController implements Serializable {
             List<BillTypeAtomic> billTypeAtomics = new ArrayList<>();
             billTypeAtomics.add(BillTypeAtomic.PHARMACY_GRN);
             billTypeAtomics.add(BillTypeAtomic.PHARMACY_DIRECT_PURCHASE);
-            billTypeAtomics.add(BillTypeAtomic.PHARMACY_GRN_CANCELLED);
-            billTypeAtomics.add(BillTypeAtomic.PHARMACY_DIRECT_PURCHASE_CANCELLED);
+            // FIX (variance double-count): GRN/Direct-Purchase CANCELLED bills must NOT be
+            // summed here. They are already counted (with their negative values) in the
+            // "Purchase Return" row via calculatePurchaseReturn(). Counting them again in the
+            // GRN Cash/Credit row subtracted the cancellation value twice on the calculated
+            // side while actual stock only dropped once, producing a variance equal to the
+            // cancelled bill's value (e.g. GSKGRNCAN/1 -> -1,350 variance in Ruhunu).
+            // These two lines were added on 2025-10-07 (commit 7ddc2781087) and duplicate the
+            // cancellation handling that has lived in calculatePurchaseReturn() since 2025-08-04.
+//            billTypeAtomics.add(BillTypeAtomic.PHARMACY_GRN_CANCELLED);
+//            billTypeAtomics.add(BillTypeAtomic.PHARMACY_DIRECT_PURCHASE_CANCELLED);
 
             StringBuilder jpql = new StringBuilder("SELECT bi.bill.paymentMethod, SUM(bi.billItemFinanceDetails.valueAtPurchaseRate), SUM(bi.billItemFinanceDetails.valueAtCostRate), SUM(bi.billItemFinanceDetails.valueAtRetailRate) FROM BillItem bi ")
                     .append("WHERE bi.retired = false ")
                     .append("AND bi.bill.billTypeAtomic IN :bType ")
-                    .append("AND bi.bill.createdAt BETWEEN :fd AND :td ")
+                    // Stock-movement date — see issue #21266 and the GREATEST note above.
+                    .append("AND FUNCTION('GREATEST', bi.bill.createdAt, COALESCE(bi.bill.completedAt, bi.bill.createdAt), COALESCE(bi.bill.checkeAt, bi.bill.createdAt)) BETWEEN :fd AND :td ")
                     .append("AND bi.bill.paymentMethod IN (:cash, :credit) ");
 
             Map<String, Object> params = new HashMap<>();
@@ -11972,7 +11995,11 @@ public class PharmacyReportController implements Serializable {
                     .append("FROM BillItem bi ")
                     .append("WHERE bi.retired = :ret ")
                     .append("AND bi.bill.billTypeAtomic IN :btas ")
-                    .append("AND bi.bill.createdAt BETWEEN :fd AND :td ");
+                    // Use stock-movement date (completedAt) when present, else createdAt.
+                    // Stock moves on approval (completedAt = StockHistory date); filtering by
+                    // createdAt mis-dates approval-gated movements (e.g. GRN returns created one
+                    // day, approved another) and produces a spurious COGS variance. See issue #21266.
+                    .append("AND FUNCTION('GREATEST', bi.bill.createdAt, COALESCE(bi.bill.completedAt, bi.bill.createdAt), COALESCE(bi.bill.checkeAt, bi.bill.createdAt)) BETWEEN :fd AND :td ");
 
             commonParams.put("ret", false);
             commonParams.put("btas", btas);
@@ -12030,7 +12057,11 @@ public class PharmacyReportController implements Serializable {
                     .append("FROM BillItem bi ")
                     .append("WHERE bi.retired = :ret ")
                     .append("AND " + billTypeField + " IN :billTypes ")
-                    .append("AND bi.bill.createdAt BETWEEN :fd AND :td ");
+                    // Use stock-movement date (completedAt) when present, else createdAt.
+                    // Stock moves on approval (completedAt = StockHistory date); filtering by
+                    // createdAt mis-dates approval-gated movements (e.g. GRN returns created one
+                    // day, approved another) and produces a spurious COGS variance. See issue #21266.
+                    .append("AND FUNCTION('GREATEST', bi.bill.createdAt, COALESCE(bi.bill.completedAt, bi.bill.createdAt), COALESCE(bi.bill.checkeAt, bi.bill.createdAt)) BETWEEN :fd AND :td ");
 
             commonParams.put("ret", false);
             commonParams.put("billTypes", billTypeValue);
@@ -12084,7 +12115,11 @@ public class PharmacyReportController implements Serializable {
                     .append("FROM BillItem bi ")
                     .append("WHERE bi.retired = :ret ")
                     .append("AND " + billTypeField + " IN :billTypes ")
-                    .append("AND bi.bill.createdAt BETWEEN :fd AND :td ");
+                    // Use stock-movement date (completedAt) when present, else createdAt.
+                    // Stock moves on approval (completedAt = StockHistory date); filtering by
+                    // createdAt mis-dates approval-gated movements (e.g. GRN returns created one
+                    // day, approved another) and produces a spurious COGS variance. See issue #21266.
+                    .append("AND FUNCTION('GREATEST', bi.bill.createdAt, COALESCE(bi.bill.completedAt, bi.bill.createdAt), COALESCE(bi.bill.checkeAt, bi.bill.createdAt)) BETWEEN :fd AND :td ");
 
             baseQuery.append("AND (bi.bill.paymentMethod IN :pm ");
             baseQuery.append("OR (bi.bill.paymentMethod = :multiPm AND EXISTS ("
@@ -12145,7 +12180,11 @@ public class PharmacyReportController implements Serializable {
                     .append("FROM BillItem bi ")
                     .append("WHERE bi.retired = :ret ")
                     .append("AND bi.bill.billTypeAtomic IN :billTypes ")
-                    .append("AND bi.bill.createdAt BETWEEN :fd AND :td ");
+                    // Use stock-movement date (completedAt) when present, else createdAt.
+                    // Stock moves on approval (completedAt = StockHistory date); filtering by
+                    // createdAt mis-dates approval-gated movements (e.g. GRN returns created one
+                    // day, approved another) and produces a spurious COGS variance. See issue #21266.
+                    .append("AND FUNCTION('GREATEST', bi.bill.createdAt, COALESCE(bi.bill.completedAt, bi.bill.createdAt), COALESCE(bi.bill.checkeAt, bi.bill.createdAt)) BETWEEN :fd AND :td ");
 
             baseQuery.append("AND (bi.bill.paymentMethod IN :pm ");
             baseQuery.append("OR (bi.bill.paymentMethod = :multiPm AND EXISTS ("
@@ -12205,7 +12244,11 @@ public class PharmacyReportController implements Serializable {
                     .append("FROM BillItem bi ")
                     .append("WHERE bi.retired = :ret ")
                     .append("AND bi.bill.billTypeAtomic = :preAddToStockType ")
-                    .append("AND bi.bill.createdAt BETWEEN :fd AND :td ");
+                    // Use stock-movement date (completedAt) when present, else createdAt.
+                    // Stock moves on approval (completedAt = StockHistory date); filtering by
+                    // createdAt mis-dates approval-gated movements (e.g. GRN returns created one
+                    // day, approved another) and produces a spurious COGS variance. See issue #21266.
+                    .append("AND FUNCTION('GREATEST', bi.bill.createdAt, COALESCE(bi.bill.completedAt, bi.bill.createdAt), COALESCE(bi.bill.checkeAt, bi.bill.createdAt)) BETWEEN :fd AND :td ");
 
             preAddParams.put("ret", false);
             preAddParams.put("preAddToStockType", BillTypeAtomic.PHARMACY_RETAIL_SALE_PRE_ADD_TO_STOCK);
@@ -12266,7 +12309,11 @@ public class PharmacyReportController implements Serializable {
                     .append("WHERE bi.retired = :ret ")
                     .append("AND bi.bill.billTypeAtomic IN :billTypes ")
                     .append("AND (rb IS NULL OR rb.createdAt > :td) ")
-                    .append("AND bi.bill.createdAt BETWEEN :fd AND :td ");
+                    // Use stock-movement date (completedAt) when present, else createdAt.
+                    // Stock moves on approval (completedAt = StockHistory date); filtering by
+                    // createdAt mis-dates approval-gated movements (e.g. GRN returns created one
+                    // day, approved another) and produces a spurious COGS variance. See issue #21266.
+                    .append("AND FUNCTION('GREATEST', bi.bill.createdAt, COALESCE(bi.bill.completedAt, bi.bill.createdAt), COALESCE(bi.bill.checkeAt, bi.bill.createdAt)) BETWEEN :fd AND :td ");
 
             commonParams.put("ret", false);
             commonParams.put("billTypes", billTypeValue);
@@ -12389,7 +12436,11 @@ public class PharmacyReportController implements Serializable {
                     .append("FROM BillItem bi ")
                     .append("WHERE bi.retired = :ret ")
                     .append("AND bi.bill.billTypeAtomic IN :billTypes ")
-                    .append("AND bi.bill.createdAt BETWEEN :fd AND :td ");
+                    // Use stock-movement date (completedAt) when present, else createdAt.
+                    // Stock moves on approval (completedAt = StockHistory date); filtering by
+                    // createdAt mis-dates approval-gated movements (e.g. GRN returns created one
+                    // day, approved another) and produces a spurious COGS variance. See issue #21266.
+                    .append("AND FUNCTION('GREATEST', bi.bill.createdAt, COALESCE(bi.bill.completedAt, bi.bill.createdAt), COALESCE(bi.bill.checkeAt, bi.bill.createdAt)) BETWEEN :fd AND :td ");
 
             commonParams.put("ret", false);
             commonParams.put("billTypes", billTypeValue);
@@ -13376,7 +13427,11 @@ public class PharmacyReportController implements Serializable {
                     .append("FROM BillItem bi ")
                     .append("WHERE bi.retired = :ret ")
                     .append("AND " + billTypeField + " IN :billTypes ")
-                    .append("AND bi.bill.createdAt BETWEEN :fd AND :td ");
+                    // Use stock-movement date (completedAt) when present, else createdAt.
+                    // Stock moves on approval (completedAt = StockHistory date); filtering by
+                    // createdAt mis-dates approval-gated movements (e.g. GRN returns created one
+                    // day, approved another) and produces a spurious COGS variance. See issue #21266.
+                    .append("AND FUNCTION('GREATEST', bi.bill.createdAt, COALESCE(bi.bill.completedAt, bi.bill.createdAt), COALESCE(bi.bill.checkeAt, bi.bill.createdAt)) BETWEEN :fd AND :td ");
 
             commonParams.put("ret", false);
             commonParams.put("billTypes", billTypeValue);
@@ -13467,7 +13522,8 @@ public class PharmacyReportController implements Serializable {
                     .append("FROM BillItem bi ")
                     .append("WHERE bi.retired = :ret ")
                     .append("AND bi.bill.billType IN :btas ")
-                    .append("AND bi.bill.createdAt BETWEEN :fd AND :td ")
+                    // Stock-movement date — see issue #21266 and the GREATEST note above.
+                    .append("AND FUNCTION('GREATEST', bi.bill.createdAt, COALESCE(bi.bill.completedAt, bi.bill.createdAt), COALESCE(bi.bill.checkeAt, bi.bill.createdAt)) BETWEEN :fd AND :td ")
                     .append("AND bi.pharmaceuticalBillItem.qty < 0.0 ");
 
             paramsIssue.put("ret", false);
@@ -13493,7 +13549,8 @@ public class PharmacyReportController implements Serializable {
                     .append("FROM BillItem bi ")
                     .append("WHERE bi.retired = :ret ")
                     .append("AND bi.bill.billType IN :btas ")
-                    .append("AND bi.bill.createdAt BETWEEN :fd AND :td ")
+                    // Stock-movement date — see issue #21266 and the GREATEST note above.
+                    .append("AND FUNCTION('GREATEST', bi.bill.createdAt, COALESCE(bi.bill.completedAt, bi.bill.createdAt), COALESCE(bi.bill.checkeAt, bi.bill.createdAt)) BETWEEN :fd AND :td ")
                     .append("AND bi.pharmaceuticalBillItem.qty > 0.0 ");
 
             paramsReceive.put("ret", false);
@@ -13601,8 +13658,13 @@ public class PharmacyReportController implements Serializable {
 
     private void calculateSaleWithoutCreditPaymentMethod() {
         try {
+            // FIX (variance double-count): the "Sale Credit" row (calculateSaleCreditValue())
+            // owns BOTH Credit AND Staff payment methods. This "Sale" row must therefore
+            // exclude Staff as well as Credit, otherwise a Staff-paid retail sale is summed
+            // in both rows and double-counted on the calculated side. (Latent in Ruhunu today
+            // since there are no Staff/Credit retail sales, but a correctness bug regardless.)
             List<PaymentMethod> nonCreditPaymentMethods = Arrays.stream(PaymentMethod.values())
-                    .filter(pm -> pm != PaymentMethod.Credit)
+                    .filter(pm -> pm != PaymentMethod.Credit && pm != PaymentMethod.Staff)
                     .collect(Collectors.toList());
 
             List<BillTypeAtomic> billTypes = Arrays.asList(

--- a/src/main/java/com/divudi/bean/report/ReportController.java
+++ b/src/main/java/com/divudi/bean/report/ReportController.java
@@ -4518,8 +4518,13 @@ public class ReportController implements Serializable, ControllerWithReportFilte
         return "/reports/inpatientReports/room_change?faces-redirect=true";
     }
 
+    @Deprecated
     public String navigateToconsumption() {
         return "/reports/inventoryReports/consumption?faces-redirect=true";
+    }
+
+    public String navigateToConsumptionDto() {
+        return "/reports/inventoryReports/consumption_dto?faces-redirect=true";
     }
 
     public String navigateToCostOfGoodSoldReports() {

--- a/src/main/java/com/divudi/bean/report/ReportController.java
+++ b/src/main/java/com/divudi/bean/report/ReportController.java
@@ -4547,7 +4547,7 @@ public class ReportController implements Serializable, ControllerWithReportFilte
             case "Drug Return Op":
                 return "/reports/inventoryReports/op_drug_return?faces-redirect=true";
             case "Stock Consumption":
-                return "/reports/inventoryReports/stock_consumption?faces-redirect=true";
+                return "/reports/inventoryReports/stock_consumption_dto?faces-redirect=true";
             case "Purchase Return":
                 return "/reports/inventoryReports/purchase_return?faces-redirect=true";
             case "Stock Adjustment Receive":

--- a/src/main/java/com/divudi/bean/report/ReportController.java
+++ b/src/main/java/com/divudi/bean/report/ReportController.java
@@ -4530,6 +4530,10 @@ public class ReportController implements Serializable, ControllerWithReportFilte
     public String navigateToCostOfGoodSoldReports() {
         pharmacyReportController.setBillItems(new ArrayList<>());
         pharmacyReportController.setNetTotal(0.0);
+        pharmacyReportController.setStockConsumptionItemDtos(new ArrayList<>());
+        pharmacyReportController.setDtoStockConsumptionPurchaseTotal(0.0);
+        pharmacyReportController.setDtoStockConsumptionCostTotal(0.0);
+        pharmacyReportController.setDtoStockConsumptionRetailTotal(0.0);
 
         if (reportTemplateFileIndexName == null) {
             return "";

--- a/src/main/java/com/divudi/core/data/PaymentMethodValue.java
+++ b/src/main/java/com/divudi/core/data/PaymentMethodValue.java
@@ -19,7 +19,7 @@ public class PaymentMethodValue implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private PaymentMethod paymentMethod;

--- a/src/main/java/com/divudi/core/data/PharmacyRow.java
+++ b/src/main/java/com/divudi/core/data/PharmacyRow.java
@@ -194,6 +194,11 @@ public class PharmacyRow implements Serializable {
     private BigDecimal valueOfStocksAtPurchaseRate = BigDecimal.ZERO;
     private BigDecimal valueOfStocksAtRetailSaleRate = BigDecimal.ZERO;
 
+    private double consumptionQty;
+    private double consumptionPurchaseValue;
+    private double consumptionCostValue;
+    private double consumptionRetailValue;
+
     private BigDecimal grossSaleRate = BigDecimal.ZERO;
     private BigDecimal discountRate = BigDecimal.ZERO;
     private BigDecimal marginRate = BigDecimal.ZERO;
@@ -1753,5 +1758,37 @@ public class PharmacyRow implements Serializable {
 
     public void setValueOfStocksAtRetailSaleRate(BigDecimal valueOfStocksAtRetailSaleRate) {
         this.valueOfStocksAtRetailSaleRate = valueOfStocksAtRetailSaleRate;
+    }
+
+    public double getConsumptionQty() {
+        return consumptionQty;
+    }
+
+    public void setConsumptionQty(double consumptionQty) {
+        this.consumptionQty = consumptionQty;
+    }
+
+    public double getConsumptionPurchaseValue() {
+        return consumptionPurchaseValue;
+    }
+
+    public void setConsumptionPurchaseValue(double consumptionPurchaseValue) {
+        this.consumptionPurchaseValue = consumptionPurchaseValue;
+    }
+
+    public double getConsumptionCostValue() {
+        return consumptionCostValue;
+    }
+
+    public void setConsumptionCostValue(double consumptionCostValue) {
+        this.consumptionCostValue = consumptionCostValue;
+    }
+
+    public double getConsumptionRetailValue() {
+        return consumptionRetailValue;
+    }
+
+    public void setConsumptionRetailValue(double consumptionRetailValue) {
+        this.consumptionRetailValue = consumptionRetailValue;
     }
 }

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -707,7 +707,49 @@ public enum Privileges {
     DeleteData("Delete Data"),
     BillCancel("Bill Cancel"),
     BillRefund("Bill Refund"), //</editor-fold>
-    AiChat("AI Chat")
+    AiChat("AI Chat"),
+    // Inward
+    InwardFormTemplateAdmin("Inward Form Template Admin"),
+    InwardFormFill("Inward Form Fill"),
+    InwardDocumentUpload("Inward Document Upload"),
+    InpatientClinicalDischarge("Inpatient Clinical Discharge"),
+    // Pharmacy workflow
+    PharmacyDischargeMedicineIssue("Pharmacy Discharge Medicine Issue"),
+    PharmacyIssueForRequestSave("Pharmacy Issue For Request Save"),
+    PharmacyIssueForRequestFinalize("Pharmacy Issue For Request Finalize"),
+    PharmacyIssueForRequestApprove("Pharmacy Issue For Request Approve"),
+    PharmacyReceiveFinalize("Pharmacy Receive Finalize"),
+    PharmacyReceiveApprove("Pharmacy Receive Approve"),
+    PharmacyDisposalIssueFinalize("Pharmacy Disposal Issue Finalize"),
+    PharmacyDisposalIssueApprove("Pharmacy Disposal Issue Approve"),
+    PharmacyDirectPurchaseSave("Pharmacy Direct Purchase Save"),
+    PharmacyDirectPurchaseFinalize("Pharmacy Direct Purchase Finalize"),
+    PharmacyDirectPurchaseApprove("Pharmacy Direct Purchase Approve"),
+    ArchiveOldStockHistory("Archive Old StockHistory Records"),
+    ArchiveOldItemBatch("Archive Old ItemBatch Records"),
+    // Cashier / petty cash
+    PettyCashEditFinancialYear("Petty Cash Edit Financial Year"),
+    PettyCashCancellationApproval("Petty-Cash Cancellation Approval"),
+    CashierHandoverStatusReport("Cashier Handover Status Report"),
+    SettleHandoverProofMissing("Settle Handover Proof Missing"),
+    SettleNonCashPayments("Settle Non-Cash Payments"),
+    ViewAllShiftShortageBills("View All Shift Shortage Bills"),
+    // Clinical
+    ClinicalPatientBlacklist("Clinical Patient Blacklist"),
+    ClinicalPatientPseudonymise("Clinical Patient Pseudonymise"),
+    // Admin
+    AdminPatientRelationships("Manage Patient Relationships"),
+    AdminInactivePatients("Manage Inactive Patients"),
+    MergePatients("Merge Patients"),
+    // Fund transfer
+    RequestFundTransfer("Request Float Transfer"),
+    IssueFundTransfer("Issue Float Transfer"),
+    ReceiveFundTransfer("Receive Float Transfer"),
+    DeclineFundTransfer("Decline Float Transfer"),
+    ProcessFundTransferRequest("Process Float Transfer Request"),
+    CancelOwnFundTransfer("Cancel Own Float Transfer"),
+    CancelOthersFundTransfer("Cancel Others Float Transfer"),
+    ViewFundTransferReports("View Float Transfer Reports")
     ;
 
     private final String label;
@@ -1013,6 +1055,10 @@ public enum Privileges {
             case InwardAppointmentUpdate:
             case InwardAppointmentCancel:
             case InpatientClinicalAssessment:
+            case InpatientClinicalDischarge:
+            case InwardFormTemplateAdmin:
+            case InwardFormFill:
+            case InwardDocumentUpload:
                 return "Inward";
 
             default:

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -87,6 +87,11 @@ public enum Privileges {
     InwardServicesAndItemsAddOutSideCharges("Inward Add Outside Charges"),
     InwardServicesAndItemsAddProfessionalFee("Inward Add Professional Fee"),
     InwardServicesAndItemsAddTimedServices("Inward Add Timed Services"),
+    InwardServiceItemRequestApproval("Inward Service/Item Request Approval"),
+    InwardServiceItemRequestRejection("Inward Service/Item Request Rejection"),
+    InwardAddChargesAfterNursingDischarge("Inward Add Charges After Nursing Discharge"),
+    InwardHoldProfessionalPayments("Hold Professional Payments"),
+    InwardPayProfessionalFeesWhileOnHold("Pay Professional Fees While On Hold"),
     InwardBilling("Inward Billing"),
     InwardBillingInterimBill("Inward Interim Bill"),
     InwardBillingInterimBillSearch("Inward Interim Bill Search"),
@@ -95,10 +100,31 @@ public enum Privileges {
     InwardSearchServiceBillUnrestrictedAccess("Inward Search Service Bill Without Restricted"),
     InwardSearchProfessionalBill("Inward Search Professional Bill"),
     InwardSearchFinalBill("Inward Search Final Bill"),
+    // Admission search scope buttons (issue #22382)
+    InwardSearchAdmissionsByAdmittedDepartmentAnyInstitute("Inward Search Admissions By Admitted Department - Any Institute"),
+    InwardSearchAdmissionsByAdmittedDepartmentLoggedInstitute("Inward Search Admissions By Admitted Department - Logged Institute"),
+    InwardSearchAdmissionsByAdmittedDepartmentLoggedDepartment("Inward Search Admissions By Admitted Department - Logged Department"),
+    InwardSearchAdmissionsByCurrentDepartmentAnyInstitute("Inward Search Admissions By Current Department - Any Institute"),
+    InwardSearchAdmissionsByCurrentDepartmentLoggedInstitute("Inward Search Admissions By Current Department - Logged Institute"),
+    InwardSearchAdmissionsByCurrentDepartmentLoggedDepartment("Inward Search Admissions By Current Department - Logged Department"),
+    InwardSearchAdmissionsGeneralSearch("Inward Search Admissions - General Search (Date Range)"),
     InwardSettleFinalBillUnrestricted("Inward Settle Final Bill Without Restricted"),
+    InwardSettleFinalBill("Inward Settle Final Bill"),
+    InwardFinalBillCreateVersion("Inward Final Bill Create New Version"),
+    InwardFinalBillSetConfirmed("Inward Final Bill Set As Confirmed"),
+    InwardFinalBillRetire("Inward Final Bill Retire"),
+    InwardFinalBillEmail("Inward Final Bill Email"),
+    InwardSaveProvisionalFinalBill("Inward Save Provisional Final Bill"),
     InwardReport("Inward Report"),
+    InwardPostDischargeReports("Inward Post-Discharge Reports"),
+    InwardLaboratory("Inward Laboratory"),
+    InwardLaboratoryBarcodeGeneration("Inward Laboratory Barcode Generation"),
+    InwardLaboratorySampleManagement("Inward Laboratory Sample Management"),
+    InwardLaboratoryReportSearch("Inward Laboratory Report Search"),
     InwardFinalBillReportEdit("Inward Final Bill Report Edit"),
     InwardAdministration("Inward Administration"),
+    InwardFormTemplateAdmin("Inward Form Template Admin"),
+    InwardFormFill("Inward Form Fill"),
     InwardAdditionalPrivilages("Inward Additional Privileges"),
     InwardBillSearch("Inward Bill Search"),
     InwardBillItemSearch("Inward Bill Item Search"),
@@ -116,25 +142,83 @@ public enum Privileges {
     InwardPharmacyIssueRequest("Inward Pharmacy Issue Request"),
     InwardPharmacyIssueRequestCancel("Inward Pharmacy Issue Request Cancel"),
     InwardPharmacyIssueRequestSearch("Inward Pharmacy Issue Request Search"),
+    InwardPharmacyReturnCancel("Inward Pharmacy Return Cancel"),
+    InwardPharmacyReturnSubmit("Inward Pharmacy Return Submit"),
+    InwardPharmacyBhtReceive("Inward Pharmacy BHT Receive"),
     InwardBillSettleWithoutCheck("Inward Bill Settle Without Check"),
     TheaterIssueBHT("Theater Issue BHT"),
     InpatientClinicalAssessment("Inpatient Clinical Assessment"),
+    InpatientClinicalDischarge("Inpatient Clinical Discharge"),
+    InwardNursingDischarge("Inward Nursing Discharge"),
+    InwardPhysicalDischarge("Inward Physical Discharge"),
+    InwardDocumentUpload("Inward Document Upload"),
+    InpatientLetter("Inpatient Letter"),
+    InwardSendEmail("Inward Send Email"),
+    InwardPackageAdministration("Inward Package Administration"),
+    InwardPackageAdmission("Inward Package Admission"),
+    InwardEditPatientDetailsFromAdmission("Inward Edit Patient Details From Admission"),
+    InwardEditPaymentDetails("Inward Edit Payment Details"),
+    InwardManageAllergies("Inward Manage Allergies"),
+    InwardDoctorPaymentAccess("Inward Doctor Payment Access"),
+    InwardMakeDepositAccess("Inward Make Deposit Access"),
+    InwardPostFinalPaymentAccess("Inward Post Final Payment Access"),
+    InwardSurgeryAdd("Inward Surgery Add"),
+    InwardSurgeryManage("Inward Surgery Manage"),
+    InwardSurgeryValidate("Inward Surgery Validate"),
+    InwardSurgeryValidationRevert("Inward Surgery Validation Revert"),
+    InwardPatientHistoryView("Inward Patient History View"),
+    InwardClinicalNotesView("Inward Clinical Notes View"),
+    InwardWardMedicationsView("Inward Ward Medications View"),
+    InwardDischargeMedicationsView("Inward Discharge Medications View"),
+    InwardInvestigationsView("Inward Investigations View"),
+    InwardImagesView("Inward Images View"),
+    InwardDiagnosisCardView("Inward Diagnosis Card View"),
+    InwardEventHistoryView("Inward Event History View"),
     //</editor-fold>
-    
+
+    //<editor-fold defaultstate="collapsed" desc="Inpatient Dashboard Panels">
+    InpatientDashboardPanelAdmission("Inpatient Dashboard - Admission Panel"),
+    InpatientDashboardPanelBilling("Inpatient Dashboard - Billing Panel"),
+    InpatientDashboardPanelServices("Inpatient Dashboard - Services Panel"),
+    InpatientDashboardPanelRoomManagement("Inpatient Dashboard - Room Management Panel"),
+    InpatientDashboardPanelOperationTheatre("Inpatient Dashboard - Operation Theatre Panel"),
+    InpatientDashboardPanelClinicalData("Inpatient Dashboard - Clinical Data Panel"),
+    InpatientDashboardPanelPharmaceuticals("Inpatient Dashboard - Pharmaceuticals Panel"),
+    InpatientDashboardPanelDocuments("Inpatient Dashboard - Documents Panel"),
+    InpatientDashboardPanelReports("Inpatient Dashboard - Reports Panel"),
+    //</editor-fold>
+
     //<editor-fold defaultstate="collapsed" desc="Nurse">
     NursingWorkBench("Nursing Work Bench"),
     ShowDrugCharges("Show Drug Charges"),
+    ShowServiceCharges("Show Service Charges"),
+    ShowTimeServiceCharges("Show Time Service Charges"),
+    //</editor-fold>
+
+    //<editor-fold defaultstate="collapsed" desc="Nursing Workbench Panels">
+    NursingWorkBenchPanelEdit("Nursing Workbench - Edit Panel"),
+    NursingWorkBenchPanelClinicalData("Nursing Workbench - Clinical Data Panel"),
+    NursingWorkBenchPanelRoomManagement("Nursing Workbench - Room Management Panel"),
+    NursingWorkBenchPanelService("Nursing Workbench - Service Panel"),
+    NursingWorkBenchPanelOperationTheatre("Nursing Workbench - Operation Theatre Panel"),
+    NursingWorkBenchPanelPharmaceuticals("Nursing Workbench - Pharmaceuticals Panel"),
+    NursingWorkBenchPanelReports("Nursing Workbench - Reports Panel"),
+    NursingWorkBenchPanelPayments("Nursing Workbench - Payments Panel"),
     //</editor-fold>
 
     //<editor-fold defaultstate="collapsed" desc="Finance">
     PettyCashBillCancellationApprove("Petty Cash Bill Cancellation Approval"),
     PettyCashBillApprove("Petty Cash Bill Approval"),
+    PettyCashEditFinancialYear("Petty Cash Edit Financial Year"),
     AllCashierSummery("All Cashier Summary"),
     CashTransactionCashIn("Cash Transaction Cash In"),
     CashTransactionCashOut("Cash Transaction Cash Out"),
     CashTransactionListToCashRecieve("Cash Transaction List to Cash Receive"),
     ShiftHandoverAcceptAsCashier("Shift Handover Accept As Cashier"),
     ShiftHandoverAcceptAsMainCashier("Shift Handover Accept As Main Cashier"),
+    CashierHandoverStatusReport("Cashier Handover Status Report"),
+    SettleHandoverProofMissing("Settle Handover Proof Missing"),
+    SettleNonCashPayments("Settle Non-Cash Payments"),
     //</editor-fold>
 
     //<editor-fold defaultstate="collapsed" desc="Lab">
@@ -269,6 +353,10 @@ public enum Privileges {
     Theatre("Theater"),
     TheatreAddSurgery("Theater Add Surgery"),
     TheatreBilling("Theater Billing"),
+    TheatreSendPatient("Theatre Send Patient"),
+    TheatreAcceptPatient("Theatre Accept Patient"),
+    TheatreReturnPatient("Theatre Return Patient"),
+    WardAcceptTheatreReturn("Ward Accept Theatre Return"),
     TheaterTransfer("Theater Transfer"),
     TheaterTransferRequest("Theater Transfer Request"),
     TheaterTransferIssue("Theater Transfer Issue"),
@@ -323,6 +411,7 @@ public enum Privileges {
     StoreReports("Store Reports"),
     StoreSummery("Store Summary"),
     StoreAdministration("Store Administration"),
+    PharmacyItemNameEdit("Pharmacy Item Name Edit"),
     //</editor-fold>
 
     //<editor-fold defaultstate="collapsed" desc="Channel">
@@ -481,6 +570,8 @@ public enum Privileges {
     ClinicalMembershipAdd("Clinical Membership Add"),
     ClinicalMembershipEdit("Clinical Membership Edit"),
     ClinicalPatientPhoneNumberEdit("Clinical Patient Phone Number Edit"),
+    ClinicalPatientBlacklist("Clinical Patient Blacklist"),
+    ClinicalPatientPseudonymise("Clinical Patient Pseudonymise"),
     //</editor-fold>
 
     //<editor-fold defaultstate="collapsed" desc="Pharmacy">
@@ -493,11 +584,22 @@ public enum Privileges {
     PharmacyDisbursementRecieve("Pharmacy Disbursement Receive"),
     PharmacyDisbursementReports("Pharmacy Disbursement Reports"),
     PharmacyDisbursementRequestApproval("Pharmacy Disbursement Request Approval"),
+    PharmacyIssueForRequestSave("Pharmacy Issue For Request Save"),
+    PharmacyIssueForRequestFinalize("Pharmacy Issue For Request Finalize"),
+    PharmacyIssueForRequestApprove("Pharmacy Issue For Request Approve"),
+    PharmacyReceiveSave("Pharmacy Receive Save"),
+    PharmacyReceiveFinalize("Pharmacy Receive Finalize"),
+    PharmacyReceiveApprove("Pharmacy Receive Approve"),
+    PharmacyTransferIssueCancel("Pharmacy Transfer Issue Cancel"),
+    PharmacyTransferReceiveCancel("Pharmacy Transfer Receive Cancel"),
     // Pharmacy Inpatient medication management
     InpatientMedicationManagementMenue("Inpatient Medication Management Menu"),
     PharmacyDirectIssueToBht("Pharmacy Direct Issue to BHT"),
+    PharmacyDischargeMedicineIssue("Pharmacy Discharge Medicine Issue"),
     PharmacyDirectIssueToTheaterCases("Pharmacy Direct Issue to Theater Cases"),
     PharmacyBhtIssueRequest("Pharmacy BHT Issue Request"),
+    PharmacyBhtRequestForceComplete("Pharmacy BHT Request Force Complete"),
+    PharmacyReturnFromWardForceComplete("Pharmacy Return From Ward Force Complete"),
     PharmacySearchInpatientDirectIssuesbyBill("Pharmacy Search Inpatient Direct Issues by Bill"),
     PharmacySearchInpatientDirectIssuesbyItem("Pharmacy Search Inpatient Direct Issues by Item"),
     PharmacySearchInpatientDirectIssueReturnsbyBill("Pharmacy Search Inpatient Direct Issue Returns by Bill"),
@@ -532,6 +634,10 @@ public enum Privileges {
     // Pharmacy Disposal
     PharmacyDisposalMenue("Pharmacy Disposal Menu"),
     PharmacyDisposalIssue("Pharmacy Disposal Issue"),
+    PharmacyDisposalIssueFinalize("Pharmacy Disposal Issue Finalize"),
+    PharmacyDisposalIssueApprove("Pharmacy Disposal Issue Approve"),
+    PharmacyDisposalIssueCancel("Pharmacy Disposal Issue Cancel"),
+    PharmacyDiscardCategoryManage("Pharmacy Issue Category Manage"),
     PharmacyDisposalSearchIssueBill("Pharmacy Disposal Search Issue Bill"),
     PharmacyDisposalSearchIssueBillItems("Pharmacy Disposal Search Issue Bill Items"),
     PharmacyDisposalSearchIssueReturnBill("Pharmacy Disposal Search Issue Return Bill"),
@@ -551,6 +657,8 @@ public enum Privileges {
     PharmacyAdjustmentCreateBatch("Pharmacy Adjustment Create Batch"),
     PharmacyPhysicalCountApprove("Pharmacy Physical Count Approve"),
     PharmacyStockTakeApprove("Pharmacy Stock Take Approve"),
+    ArchiveOldStockHistory("Archive Old StockHistory Records"),
+    ArchiveOldItemBatch("Archive Old ItemBatch Records"),
     // Pharmacy Dealer Payments
     PharmacyDealerPaymentMenue("Pharmacy Dealer Payment Menu"),
     PharmacyDealerDueSearch("Pharmacy Dealer Due Search"),
@@ -590,7 +698,12 @@ public enum Privileges {
     AutoOrderPModel("Auto Order P Model"),
     AutoOrderQModal("Auto Order Q Model"),
     DirectPurchase("Direct Purchase"),
+    PharmacyDirectPurchaseSave("Pharmacy Direct Purchase Save"),
+    PharmacyDirectPurchaseFinalize("Pharmacy Direct Purchase Finalize"),
+    PharmacyDirectPurchaseApprove("Pharmacy Direct Purchase Approve"),
     PurchaseOrdersApprovel("Purchase Orders Approval"),
+    PurchaseOrderSave("Purchase Order Save"),
+    PurchaseOrderFinalize("Purchase Order Finalize"),
     TransferReciveApproval("Transfer Receive Approval"),
     GoodsRecipt("Goods Receipt"),
     ReturnReceviedGoods("Return Received Goods"),
@@ -609,6 +722,8 @@ public enum Privileges {
     PharmacyGrnSave("Pharmacy GRN Save"),
     PharmacyGrnFinalize("Pharmacy GRN Finalize"),
     PharmacyGrnApprove("Pharmacy GRN Approve"),
+    PharmacyGrnCancel("Pharmacy GRN Cancel"),
+    PharmacyGrnReturnCancel("Pharmacy GRN Return Cancel"),
     PharmacyItemSearch("Pharmacy Item Search"),
     PharmacyGenarateReports("Pharmacy Generate Reports"),
     PharmacySummaryViews("Pharmacy Summary Views"),
@@ -685,15 +800,33 @@ public enum Privileges {
     AdminStaff("Admin Staff"),
     AdminItems("Admin Items"),
     AdminPrices("Admin Prices"),
+    AdminPatientRelationships("Manage Patient Relationships"),
+    AdminInactivePatients("Manage Inactive Patients"),
+    MergePatients("Merge Patients"),
     ManageCreditCompany("Manage Credit Company"),
     AdminFilterWithoutDepartment("Admin Filter Without Department"),
     //</editor-fold>
     
     //<editor-fold defaultstate="collapsed" desc="Approval">
+    RequestManager("Request Manager"),
     BillCancelRequestApproval("Bill Cancel Request Approval"),
     ItemRefundRequestApproval("Item Refund Request Approval"),
     DrawerAdjustmentRequestApproval("Drawer Adjustment Request Approval"),
     DrawerAdjustmentDirect("Drawer Adjustment Direct (No Approval)"),
+    PettyCashCancellationApproval("Petty-Cash Cancellation Approval"),
+    PharmacyRetailSaleReturnApproval("Pharmacy Retail Sale Return Approval"),
+    //</editor-fold>
+
+    //<editor-fold defaultstate="collapsed" desc="Float Transfer">
+    IssueFundTransfer("Issue Float Transfer"),
+    ReceiveFundTransfer("Receive Float Transfer"),
+    DeclineFundTransfer("Decline Float Transfer"),
+    RequestFundTransfer("Request Float Transfer"),
+    ProcessFundTransferRequest("Process Float Transfer Request"),
+    CancelOwnFundTransfer("Cancel Own Float Transfer"),
+    CancelOthersFundTransfer("Cancel Others Float Transfer"),
+    ViewFundTransferReports("View Float Transfer Reports"),
+    ViewAllShiftShortageBills("View All Shift Shortage Bills"),
     //</editor-fold>
 
     //<editor-fold defaultstate="collapsed" desc="Developers">
@@ -708,48 +841,7 @@ public enum Privileges {
     BillCancel("Bill Cancel"),
     BillRefund("Bill Refund"), //</editor-fold>
     AiChat("AI Chat"),
-    // Inward
-    InwardFormTemplateAdmin("Inward Form Template Admin"),
-    InwardFormFill("Inward Form Fill"),
-    InwardDocumentUpload("Inward Document Upload"),
-    InpatientClinicalDischarge("Inpatient Clinical Discharge"),
-    // Pharmacy workflow
-    PharmacyDischargeMedicineIssue("Pharmacy Discharge Medicine Issue"),
-    PharmacyIssueForRequestSave("Pharmacy Issue For Request Save"),
-    PharmacyIssueForRequestFinalize("Pharmacy Issue For Request Finalize"),
-    PharmacyIssueForRequestApprove("Pharmacy Issue For Request Approve"),
-    PharmacyReceiveFinalize("Pharmacy Receive Finalize"),
-    PharmacyReceiveApprove("Pharmacy Receive Approve"),
-    PharmacyDisposalIssueFinalize("Pharmacy Disposal Issue Finalize"),
-    PharmacyDisposalIssueApprove("Pharmacy Disposal Issue Approve"),
-    PharmacyDirectPurchaseSave("Pharmacy Direct Purchase Save"),
-    PharmacyDirectPurchaseFinalize("Pharmacy Direct Purchase Finalize"),
-    PharmacyDirectPurchaseApprove("Pharmacy Direct Purchase Approve"),
-    ArchiveOldStockHistory("Archive Old StockHistory Records"),
-    ArchiveOldItemBatch("Archive Old ItemBatch Records"),
-    // Cashier / petty cash
-    PettyCashEditFinancialYear("Petty Cash Edit Financial Year"),
-    PettyCashCancellationApproval("Petty-Cash Cancellation Approval"),
-    CashierHandoverStatusReport("Cashier Handover Status Report"),
-    SettleHandoverProofMissing("Settle Handover Proof Missing"),
-    SettleNonCashPayments("Settle Non-Cash Payments"),
-    ViewAllShiftShortageBills("View All Shift Shortage Bills"),
-    // Clinical
-    ClinicalPatientBlacklist("Clinical Patient Blacklist"),
-    ClinicalPatientPseudonymise("Clinical Patient Pseudonymise"),
-    // Admin
-    AdminPatientRelationships("Manage Patient Relationships"),
-    AdminInactivePatients("Manage Inactive Patients"),
-    MergePatients("Merge Patients"),
-    // Fund transfer
-    RequestFundTransfer("Request Float Transfer"),
-    IssueFundTransfer("Issue Float Transfer"),
-    ReceiveFundTransfer("Receive Float Transfer"),
-    DeclineFundTransfer("Decline Float Transfer"),
-    ProcessFundTransferRequest("Process Float Transfer Request"),
-    CancelOwnFundTransfer("Cancel Own Float Transfer"),
-    CancelOthersFundTransfer("Cancel Others Float Transfer"),
-    ViewFundTransferReports("View Float Transfer Reports")
+    ClientPortalCreateAccount("Create Client Portal Account")
     ;
 
     private final String label;
@@ -909,8 +1001,14 @@ public enum Privileges {
             // Inpatient medication management
             case InpatientMedicationManagementMenue:
             case PharmacyDirectIssueToBht:
+            case PharmacyDischargeMedicineIssue:
             case PharmacyDirectIssueToTheaterCases:
             case PharmacyBhtIssueRequest:
+            case PharmacyBhtRequestForceComplete:
+            case PharmacyReturnFromWardForceComplete:
+            case InwardPharmacyReturnCancel:
+            case InwardPharmacyReturnSubmit:
+            case InwardPharmacyBhtReceive:
             case PharmacySearchInpatientDirectIssuesbyBill:
             case PharmacySearchInpatientDirectIssuesbyItem:
             case PharmacySearchInpatientDirectIssueReturnsbyBill:
@@ -921,7 +1019,12 @@ public enum Privileges {
             case AutoOrderPModel:
             case AutoOrderQModal:
             case DirectPurchase:
+            case PharmacyDirectPurchaseSave:
+            case PharmacyDirectPurchaseFinalize:
+            case PharmacyDirectPurchaseApprove:
             case PurchaseOrdersApprovel:
+            case PurchaseOrderSave:
+            case PurchaseOrderFinalize:
             case GoodsRecipt:
             case ReturnReceviedGoods:
             case CreateGrnReturn:
@@ -943,6 +1046,14 @@ public enum Privileges {
             case PharmacyDisbursementDirectIssue:
             case PharmacyDisbursementRecieve:
             case PharmacyDisbursementReports:
+            case PharmacyIssueForRequestSave:
+            case PharmacyIssueForRequestFinalize:
+            case PharmacyIssueForRequestApprove:
+            case PharmacyReceiveSave:
+            case PharmacyReceiveFinalize:
+            case PharmacyReceiveApprove:
+            case PharmacyTransferIssueCancel:
+            case PharmacyTransferReceiveCancel:
 
             // Retail Transactions
             case PharmacyRetailTransaction:
@@ -973,6 +1084,10 @@ public enum Privileges {
 
             // Disposal
             case PharmacyDisposalIssue:
+            case PharmacyDisposalIssueFinalize:
+            case PharmacyDisposalIssueApprove:
+            case PharmacyDisposalIssueCancel:
+            case PharmacyDiscardCategoryManage:
             case PharmacyDisposalSearchIssueBill:
             case PharmacyDisposalSearchIssueBillItems:
             case PharmacyDisposalSearchIssueReturnBill:
@@ -992,6 +1107,8 @@ public enum Privileges {
             case PharmacyAdjustmentCreateBatch:
             case PharmacyPhysicalCountApprove:
             case PharmacyStockTakeApprove:
+            case ArchiveOldStockHistory:
+            case ArchiveOldItemBatch:
 
             // Pharmacy Dealer Payments
             case PharmacyDealerDueSearch:
@@ -1007,10 +1124,48 @@ public enum Privileges {
             case PharmacyGrnSave:
             case PharmacyGrnFinalize:
             case PharmacyGrnApprove:
+            case PharmacyGrnCancel:
+            case PharmacyGrnReturnCancel:
             case PrintOriginalPoBillFromReprint:
-            case PrintOriginalGrnBillFromReprint:    
+            case PrintOriginalGrnBillFromReprint:
+            case PharmacyItemNameEdit:
 
                 return "Pharmacy";
+
+            case Store:
+            case StoreIssue:
+            case StoreIssueInwardBilling:
+            case StoreIssueSearchBill:
+            case StoreIssueBillItems:
+            case StorePurchase:
+            case StorePurchaseOrder:
+            case StorePurchaseOrderApprove:
+            case StorePurchaseOrderApproveSearch:
+            case StorePurchaseGRNRecive:
+            case StorePurchaseGRNReturn:
+            case StorePurchasePurchase:
+            case StoreTransfer:
+            case StoreTransferRequest:
+            case StoreTransferIssue:
+            case StoreTransferRecive:
+            case StoreTransferReport:
+            case StoreAdjustment:
+            case StoreAdjustmentDepartmentStock:
+            case StoreAdjustmentStaffStock:
+            case StoreAdjustmentPurchaseRate:
+            case StoreAdjustmentSaleRate:
+            case StoreDealorPayment:
+            case StoreDealorPaymentDueSearch:
+            case StoreDealorPaymentDueByAge:
+            case StoreDealorPaymentPayment:
+            case StoreDealorPaymentPaymentGRN:
+            case StoreDealorPaymentPaymentGRNSelect:
+            case StoreDealorPaymentGRNDoneSearch:
+            case StoreSearch:
+            case StoreReports:
+            case StoreSummery:
+            case StoreAdministration:
+                return "Store";
 
             case Clinic:
             case ClinicCalendar:
@@ -1038,16 +1193,45 @@ public enum Privileges {
                 return "Collecting Centre";
             
             // Approval Privileges
+            case RequestManager:
             case BillCancelRequestApproval:
             case ItemRefundRequestApproval:
             case DrawerAdjustmentRequestApproval:
             case DrawerAdjustmentDirect:
+            case PettyCashCancellationApproval:
+            case PharmacyRetailSaleReturnApproval:
                 return "Approval";
-            
+
+            case CashierHandoverStatusReport:
+            case SettleHandoverProofMissing:
+            case SettleNonCashPayments:
+                return "Finance";
+
+            case IssueFundTransfer:
+            case ReceiveFundTransfer:
+            case DeclineFundTransfer:
+            case RequestFundTransfer:
+            case ProcessFundTransferRequest:
+            case CancelOwnFundTransfer:
+            case CancelOthersFundTransfer:
+            case ViewFundTransferReports:
+            case ViewAllShiftShortageBills:
+                return "Float Transfer";
+
             case NursingWorkBench:
             case ShowDrugCharges:
+            case ShowServiceCharges:
+            case ShowTimeServiceCharges:
+            case NursingWorkBenchPanelEdit:
+            case NursingWorkBenchPanelClinicalData:
+            case NursingWorkBenchPanelRoomManagement:
+            case NursingWorkBenchPanelService:
+            case NursingWorkBenchPanelOperationTheatre:
+            case NursingWorkBenchPanelPharmaceuticals:
+            case NursingWorkBenchPanelReports:
+            case NursingWorkBenchPanelPayments:
                 return "Nursing Work Bench";
-                
+
             case WatingRoomAdmitPatient:
             case InwardAppointmentMenu:
             case AddInwardAppointment:
@@ -1056,10 +1240,67 @@ public enum Privileges {
             case InwardAppointmentCancel:
             case InpatientClinicalAssessment:
             case InpatientClinicalDischarge:
+            case InwardNursingDischarge:
+            case InwardPhysicalDischarge:
+            case InwardAddChargesAfterNursingDischarge:
+            case InwardHoldProfessionalPayments:
+            case InwardPayProfessionalFeesWhileOnHold:
+            case InwardDocumentUpload:
+            case InpatientLetter:
+            case InwardSendEmail:
+            case InwardPackageAdministration:
+            case InwardPackageAdmission:
             case InwardFormTemplateAdmin:
             case InwardFormFill:
-            case InwardDocumentUpload:
+            case InwardSettleFinalBill:
+            case InwardFinalBillCreateVersion:
+            case InwardFinalBillSetConfirmed:
+            case InwardFinalBillRetire:
+            case InwardFinalBillEmail:
+            case InwardSaveProvisionalFinalBill:
+            case InwardLaboratory:
+            case InwardLaboratoryBarcodeGeneration:
+            case InwardLaboratorySampleManagement:
+            case InwardLaboratoryReportSearch:
+            case TheatreSendPatient:
+            case TheatreAcceptPatient:
+            case TheatreReturnPatient:
+            case WardAcceptTheatreReturn:
+            case InwardServiceItemRequestApproval:
+            case InwardServiceItemRequestRejection:
+            case InpatientDashboardPanelAdmission:
+            case InpatientDashboardPanelBilling:
+            case InpatientDashboardPanelServices:
+            case InpatientDashboardPanelRoomManagement:
+            case InpatientDashboardPanelOperationTheatre:
+            case InpatientDashboardPanelClinicalData:
+            case InpatientDashboardPanelPharmaceuticals:
+            case InpatientDashboardPanelDocuments:
+            case InpatientDashboardPanelReports:
+            case InwardEditPatientDetailsFromAdmission:
+            case InwardEditPaymentDetails:
+            case InwardManageAllergies:
+            case InwardDoctorPaymentAccess:
+            case InwardMakeDepositAccess:
+            case InwardPostFinalPaymentAccess:
+            case InwardSurgeryAdd:
+            case InwardSurgeryManage:
+            case InwardSurgeryValidate:
+            case InwardSurgeryValidationRevert:
+            case InwardPatientHistoryView:
+            case InwardClinicalNotesView:
+            case InwardWardMedicationsView:
+            case InwardDischargeMedicationsView:
+            case InwardInvestigationsView:
+            case InwardImagesView:
+            case InwardDiagnosisCardView:
+            case InwardEventHistoryView:
+            case InwardPostDischargeReports:
                 return "Inward";
+
+            case AdminInactivePatients:
+            case MergePatients:
+                return "Admin";
 
             default:
                 return this.toString();

--- a/src/main/java/com/divudi/core/data/clinical/PersonRelationship.java
+++ b/src/main/java/com/divudi/core/data/clinical/PersonRelationship.java
@@ -28,7 +28,7 @@ public class PersonRelationship implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/data/dto/CollectingCentrePaymentBillDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/CollectingCentrePaymentBillDTO.java
@@ -1,0 +1,145 @@
+package com.divudi.core.data.dto;
+
+import java.io.Serializable;
+import java.util.Date;
+
+/**
+ * DTO for the Collecting Centre Payment Bill search table
+ * (collecting_centre_repayment_bill_search.xhtml). Carries only the fields
+ * needed for that table, avoiding full Bill entity/relationship loading.
+ *
+ * @author H.K. Damith Deshan | hkddrajapaksha@gmail.com
+ */
+public class CollectingCentrePaymentBillDTO implements Serializable {
+
+    private Long id;
+    private String deptId;
+    private Date fromDate;
+    private Date toDate;
+    private Date createdAt;
+    private Boolean cancelled;
+    private Date cancelledAt;
+    private String createdByName;
+    private String cancelledByName;
+    private String toInstitutionCode;
+    private String toInstitutionName;
+    private Double netTotal;
+
+    public CollectingCentrePaymentBillDTO() {
+    }
+
+    public CollectingCentrePaymentBillDTO(Long id, String deptId, Date fromDate, Date toDate,
+            Date createdAt, Boolean cancelled, Date cancelledAt,
+            String createdByName, String cancelledByName,
+            String toInstitutionCode, String toInstitutionName, Double netTotal) {
+        this.id = id;
+        this.deptId = deptId;
+        this.fromDate = fromDate;
+        this.toDate = toDate;
+        this.createdAt = createdAt;
+        this.cancelled = cancelled;
+        this.cancelledAt = cancelledAt;
+        this.createdByName = createdByName;
+        this.cancelledByName = cancelledByName;
+        this.toInstitutionCode = toInstitutionCode;
+        this.toInstitutionName = toInstitutionName;
+        this.netTotal = netTotal;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getDeptId() {
+        return deptId;
+    }
+
+    public void setDeptId(String deptId) {
+        this.deptId = deptId;
+    }
+
+    public Date getFromDate() {
+        return fromDate;
+    }
+
+    public void setFromDate(Date fromDate) {
+        this.fromDate = fromDate;
+    }
+
+    public Date getToDate() {
+        return toDate;
+    }
+
+    public void setToDate(Date toDate) {
+        this.toDate = toDate;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Boolean getCancelled() {
+        return cancelled;
+    }
+
+    public void setCancelled(Boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+
+    public Date getCancelledAt() {
+        return cancelledAt;
+    }
+
+    public void setCancelledAt(Date cancelledAt) {
+        this.cancelledAt = cancelledAt;
+    }
+
+    public String getCreatedByName() {
+        return createdByName;
+    }
+
+    public void setCreatedByName(String createdByName) {
+        this.createdByName = createdByName;
+    }
+
+    public String getCancelledByName() {
+        return cancelledByName;
+    }
+
+    public void setCancelledByName(String cancelledByName) {
+        this.cancelledByName = cancelledByName;
+    }
+
+    public String getToInstitutionCode() {
+        return toInstitutionCode;
+    }
+
+    public void setToInstitutionCode(String toInstitutionCode) {
+        this.toInstitutionCode = toInstitutionCode;
+    }
+
+    public String getToInstitutionName() {
+        return toInstitutionName;
+    }
+
+    public void setToInstitutionName(String toInstitutionName) {
+        this.toInstitutionName = toInstitutionName;
+    }
+
+    public Double getNetTotal() {
+        return netTotal;
+    }
+
+    public void setNetTotal(Double netTotal) {
+        this.netTotal = netTotal;
+    }
+
+}

--- a/src/main/java/com/divudi/core/data/dto/ConsumptionBillDto.java
+++ b/src/main/java/com/divudi/core/data/dto/ConsumptionBillDto.java
@@ -1,0 +1,99 @@
+package com.divudi.core.data.dto;
+
+import java.io.Serializable;
+import java.util.Date;
+
+public class ConsumptionBillDto implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private Long billId;
+    private String deptId;
+    private String invoiceNumber;
+    private String toDepartmentName;
+    private boolean cancelled;
+    private boolean fullReturned;
+
+    private Long cancelledBillId;
+    private String cancelledBillDeptId;
+    private Long refundedBillId;
+    private String refundedBillDeptId;
+    private Long billedBillId;
+    private String billedBillDeptId;
+
+    private double consumptionPurchaseValue;
+    private double consumptionCostValue;
+    private double consumptionRetailValue;
+
+    private Date createdAt;
+    private String creatorName;
+    private String comments;
+
+    public ConsumptionBillDto() {}
+
+    // Full constructor for building from Object[] row
+    public ConsumptionBillDto(
+            Long billId, String deptId, String invoiceNumber,
+            String toDepartmentName, boolean cancelled, boolean fullReturned,
+            Long cancelledBillId, String cancelledBillDeptId,
+            Long refundedBillId, String refundedBillDeptId,
+            Long billedBillId, String billedBillDeptId,
+            double consumptionPurchaseValue, double consumptionCostValue, double consumptionRetailValue,
+            Date createdAt, String creatorName, String comments) {
+        this.billId = billId;
+        this.deptId = deptId;
+        this.invoiceNumber = invoiceNumber;
+        this.toDepartmentName = toDepartmentName;
+        this.cancelled = cancelled;
+        this.fullReturned = fullReturned;
+        this.cancelledBillId = cancelledBillId;
+        this.cancelledBillDeptId = cancelledBillDeptId;
+        this.refundedBillId = refundedBillId;
+        this.refundedBillDeptId = refundedBillDeptId;
+        this.billedBillId = billedBillId;
+        this.billedBillDeptId = billedBillDeptId;
+        this.consumptionPurchaseValue = consumptionPurchaseValue;
+        this.consumptionCostValue = consumptionCostValue;
+        this.consumptionRetailValue = consumptionRetailValue;
+        this.createdAt = createdAt;
+        this.creatorName = creatorName;
+        this.comments = comments;
+    }
+
+    // Standard getters and setters for all fields
+    public Long getBillId() { return billId; }
+    public void setBillId(Long billId) { this.billId = billId; }
+    public String getDeptId() { return deptId; }
+    public void setDeptId(String deptId) { this.deptId = deptId; }
+    public String getInvoiceNumber() { return invoiceNumber; }
+    public void setInvoiceNumber(String invoiceNumber) { this.invoiceNumber = invoiceNumber; }
+    public String getToDepartmentName() { return toDepartmentName; }
+    public void setToDepartmentName(String toDepartmentName) { this.toDepartmentName = toDepartmentName; }
+    public boolean isCancelled() { return cancelled; }
+    public void setCancelled(boolean cancelled) { this.cancelled = cancelled; }
+    public boolean isFullReturned() { return fullReturned; }
+    public void setFullReturned(boolean fullReturned) { this.fullReturned = fullReturned; }
+    public Long getCancelledBillId() { return cancelledBillId; }
+    public void setCancelledBillId(Long cancelledBillId) { this.cancelledBillId = cancelledBillId; }
+    public String getCancelledBillDeptId() { return cancelledBillDeptId; }
+    public void setCancelledBillDeptId(String cancelledBillDeptId) { this.cancelledBillDeptId = cancelledBillDeptId; }
+    public Long getRefundedBillId() { return refundedBillId; }
+    public void setRefundedBillId(Long refundedBillId) { this.refundedBillId = refundedBillId; }
+    public String getRefundedBillDeptId() { return refundedBillDeptId; }
+    public void setRefundedBillDeptId(String refundedBillDeptId) { this.refundedBillDeptId = refundedBillDeptId; }
+    public Long getBilledBillId() { return billedBillId; }
+    public void setBilledBillId(Long billedBillId) { this.billedBillId = billedBillId; }
+    public String getBilledBillDeptId() { return billedBillDeptId; }
+    public void setBilledBillDeptId(String billedBillDeptId) { this.billedBillDeptId = billedBillDeptId; }
+    public double getConsumptionPurchaseValue() { return consumptionPurchaseValue; }
+    public void setConsumptionPurchaseValue(double consumptionPurchaseValue) { this.consumptionPurchaseValue = consumptionPurchaseValue; }
+    public double getConsumptionCostValue() { return consumptionCostValue; }
+    public void setConsumptionCostValue(double consumptionCostValue) { this.consumptionCostValue = consumptionCostValue; }
+    public double getConsumptionRetailValue() { return consumptionRetailValue; }
+    public void setConsumptionRetailValue(double consumptionRetailValue) { this.consumptionRetailValue = consumptionRetailValue; }
+    public Date getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Date createdAt) { this.createdAt = createdAt; }
+    public String getCreatorName() { return creatorName; }
+    public void setCreatorName(String creatorName) { this.creatorName = creatorName; }
+    public String getComments() { return comments; }
+    public void setComments(String comments) { this.comments = comments; }
+}

--- a/src/main/java/com/divudi/core/data/dto/ConsumptionBillItemDto.java
+++ b/src/main/java/com/divudi/core/data/dto/ConsumptionBillItemDto.java
@@ -1,0 +1,133 @@
+package com.divudi.core.data.dto;
+
+import java.io.Serializable;
+import java.util.Date;
+
+public class ConsumptionBillItemDto implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private Long billItemId;
+    private Long billId;
+    private String billDeptId;
+    private String invoiceNumber;
+    private String toDepartmentName;
+    private String itemName;
+    private String categoryName;
+    private String dosageFormName;
+    private double consumptionQty;
+    private boolean billCancelled;
+    private boolean billFullReturned;
+
+    private Long cancelledBillId;
+    private String cancelledBillDeptId;
+    private Long refundedBillId;
+    private String refundedBillDeptId;
+    private Long billedBillId;
+    private String billedBillDeptId;
+
+    private double purchaseRate;
+    private double consumptionPurchaseValue;
+    private double retailRate;
+    private double consumptionRetailValue;
+    private double costRate;
+    private double consumptionCostValue;
+
+    private Date createdAt;
+    private String creatorName;
+    private String comments;
+
+    public ConsumptionBillItemDto() {}
+
+    public ConsumptionBillItemDto(
+            Long billItemId, Long billId, String billDeptId, String invoiceNumber,
+            String toDepartmentName, String itemName, String categoryName, String dosageFormName,
+            double consumptionQty, boolean billCancelled, boolean billFullReturned,
+            Long cancelledBillId, String cancelledBillDeptId,
+            Long refundedBillId, String refundedBillDeptId,
+            Long billedBillId, String billedBillDeptId,
+            double purchaseRate, double consumptionPurchaseValue,
+            double retailRate, double consumptionRetailValue,
+            double costRate, double consumptionCostValue,
+            Date createdAt, String creatorName, String comments) {
+        this.billItemId = billItemId;
+        this.billId = billId;
+        this.billDeptId = billDeptId;
+        this.invoiceNumber = invoiceNumber;
+        this.toDepartmentName = toDepartmentName;
+        this.itemName = itemName;
+        this.categoryName = categoryName;
+        this.dosageFormName = dosageFormName;
+        this.consumptionQty = consumptionQty;
+        this.billCancelled = billCancelled;
+        this.billFullReturned = billFullReturned;
+        this.cancelledBillId = cancelledBillId;
+        this.cancelledBillDeptId = cancelledBillDeptId;
+        this.refundedBillId = refundedBillId;
+        this.refundedBillDeptId = refundedBillDeptId;
+        this.billedBillId = billedBillId;
+        this.billedBillDeptId = billedBillDeptId;
+        this.purchaseRate = purchaseRate;
+        this.consumptionPurchaseValue = consumptionPurchaseValue;
+        this.retailRate = retailRate;
+        this.consumptionRetailValue = consumptionRetailValue;
+        this.costRate = costRate;
+        this.consumptionCostValue = consumptionCostValue;
+        this.createdAt = createdAt;
+        this.creatorName = creatorName;
+        this.comments = comments;
+    }
+
+    // All getters and setters
+    public Long getBillItemId() { return billItemId; }
+    public void setBillItemId(Long billItemId) { this.billItemId = billItemId; }
+    public Long getBillId() { return billId; }
+    public void setBillId(Long billId) { this.billId = billId; }
+    public String getBillDeptId() { return billDeptId; }
+    public void setBillDeptId(String billDeptId) { this.billDeptId = billDeptId; }
+    public String getInvoiceNumber() { return invoiceNumber; }
+    public void setInvoiceNumber(String invoiceNumber) { this.invoiceNumber = invoiceNumber; }
+    public String getToDepartmentName() { return toDepartmentName; }
+    public void setToDepartmentName(String toDepartmentName) { this.toDepartmentName = toDepartmentName; }
+    public String getItemName() { return itemName; }
+    public void setItemName(String itemName) { this.itemName = itemName; }
+    public String getCategoryName() { return categoryName; }
+    public void setCategoryName(String categoryName) { this.categoryName = categoryName; }
+    public String getDosageFormName() { return dosageFormName; }
+    public void setDosageFormName(String dosageFormName) { this.dosageFormName = dosageFormName; }
+    public double getConsumptionQty() { return consumptionQty; }
+    public void setConsumptionQty(double consumptionQty) { this.consumptionQty = consumptionQty; }
+    public boolean isBillCancelled() { return billCancelled; }
+    public void setBillCancelled(boolean billCancelled) { this.billCancelled = billCancelled; }
+    public boolean isBillFullReturned() { return billFullReturned; }
+    public void setBillFullReturned(boolean billFullReturned) { this.billFullReturned = billFullReturned; }
+    public Long getCancelledBillId() { return cancelledBillId; }
+    public void setCancelledBillId(Long cancelledBillId) { this.cancelledBillId = cancelledBillId; }
+    public String getCancelledBillDeptId() { return cancelledBillDeptId; }
+    public void setCancelledBillDeptId(String cancelledBillDeptId) { this.cancelledBillDeptId = cancelledBillDeptId; }
+    public Long getRefundedBillId() { return refundedBillId; }
+    public void setRefundedBillId(Long refundedBillId) { this.refundedBillId = refundedBillId; }
+    public String getRefundedBillDeptId() { return refundedBillDeptId; }
+    public void setRefundedBillDeptId(String refundedBillDeptId) { this.refundedBillDeptId = refundedBillDeptId; }
+    public Long getBilledBillId() { return billedBillId; }
+    public void setBilledBillId(Long billedBillId) { this.billedBillId = billedBillId; }
+    public String getBilledBillDeptId() { return billedBillDeptId; }
+    public void setBilledBillDeptId(String billedBillDeptId) { this.billedBillDeptId = billedBillDeptId; }
+    public double getPurchaseRate() { return purchaseRate; }
+    public void setPurchaseRate(double purchaseRate) { this.purchaseRate = purchaseRate; }
+    public double getConsumptionPurchaseValue() { return consumptionPurchaseValue; }
+    public void setConsumptionPurchaseValue(double consumptionPurchaseValue) { this.consumptionPurchaseValue = consumptionPurchaseValue; }
+    public double getRetailRate() { return retailRate; }
+    public void setRetailRate(double retailRate) { this.retailRate = retailRate; }
+    public double getConsumptionRetailValue() { return consumptionRetailValue; }
+    public void setConsumptionRetailValue(double consumptionRetailValue) { this.consumptionRetailValue = consumptionRetailValue; }
+    public double getCostRate() { return costRate; }
+    public void setCostRate(double costRate) { this.costRate = costRate; }
+    public double getConsumptionCostValue() { return consumptionCostValue; }
+    public void setConsumptionCostValue(double consumptionCostValue) { this.consumptionCostValue = consumptionCostValue; }
+    public Date getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Date createdAt) { this.createdAt = createdAt; }
+    public String getCreatorName() { return creatorName; }
+    public void setCreatorName(String creatorName) { this.creatorName = creatorName; }
+    public String getComments() { return comments; }
+    public void setComments(String comments) { this.comments = comments; }
+}

--- a/src/main/java/com/divudi/core/data/dto/ConsumptionCategoryItemDto.java
+++ b/src/main/java/com/divudi/core/data/dto/ConsumptionCategoryItemDto.java
@@ -5,6 +5,7 @@ import java.io.Serializable;
 public class ConsumptionCategoryItemDto implements Serializable {
     private static final long serialVersionUID = 1L;
 
+    private String sourceDepartmentName;
     private String departmentName;
     private String categoryName;
     private String itemName;
@@ -30,6 +31,16 @@ public class ConsumptionCategoryItemDto implements Serializable {
         this.netTotal = netTotal != null ? netTotal : 0.0;
     }
 
+    public ConsumptionCategoryItemDto(
+            String sourceDepartmentName, String departmentName, String categoryName, String itemName,
+            double qty, Double totalPurchaseValue, Double totalCostValue,
+            Double totalRetailValue, Double netTotal) {
+        this(departmentName, categoryName, itemName, qty, totalPurchaseValue, totalCostValue, totalRetailValue, netTotal);
+        this.sourceDepartmentName = sourceDepartmentName;
+    }
+
+    public String getSourceDepartmentName() { return sourceDepartmentName; }
+    public void setSourceDepartmentName(String sourceDepartmentName) { this.sourceDepartmentName = sourceDepartmentName; }
     public String getDepartmentName() { return departmentName; }
     public void setDepartmentName(String departmentName) { this.departmentName = departmentName; }
     public String getCategoryName() { return categoryName; }

--- a/src/main/java/com/divudi/core/data/dto/ConsumptionCategoryItemDto.java
+++ b/src/main/java/com/divudi/core/data/dto/ConsumptionCategoryItemDto.java
@@ -1,0 +1,49 @@
+package com.divudi.core.data.dto;
+
+import java.io.Serializable;
+
+public class ConsumptionCategoryItemDto implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private String departmentName;
+    private String categoryName;
+    private String itemName;
+    private double qty;
+    private Double totalPurchaseValue;
+    private Double totalCostValue;
+    private Double totalRetailValue;
+    private Double netTotal;
+
+    public ConsumptionCategoryItemDto() {}
+
+    public ConsumptionCategoryItemDto(
+            String departmentName, String categoryName, String itemName,
+            double qty, Double totalPurchaseValue, Double totalCostValue,
+            Double totalRetailValue, Double netTotal) {
+        this.departmentName = departmentName;
+        this.categoryName = categoryName;
+        this.itemName = itemName;
+        this.qty = qty;
+        this.totalPurchaseValue = totalPurchaseValue != null ? totalPurchaseValue : 0.0;
+        this.totalCostValue = totalCostValue != null ? totalCostValue : 0.0;
+        this.totalRetailValue = totalRetailValue != null ? totalRetailValue : 0.0;
+        this.netTotal = netTotal != null ? netTotal : 0.0;
+    }
+
+    public String getDepartmentName() { return departmentName; }
+    public void setDepartmentName(String departmentName) { this.departmentName = departmentName; }
+    public String getCategoryName() { return categoryName; }
+    public void setCategoryName(String categoryName) { this.categoryName = categoryName; }
+    public String getItemName() { return itemName; }
+    public void setItemName(String itemName) { this.itemName = itemName; }
+    public double getQty() { return qty; }
+    public void setQty(double qty) { this.qty = qty; }
+    public Double getTotalPurchaseValue() { return totalPurchaseValue; }
+    public void setTotalPurchaseValue(Double totalPurchaseValue) { this.totalPurchaseValue = totalPurchaseValue; }
+    public Double getTotalCostValue() { return totalCostValue; }
+    public void setTotalCostValue(Double totalCostValue) { this.totalCostValue = totalCostValue; }
+    public Double getTotalRetailValue() { return totalRetailValue; }
+    public void setTotalRetailValue(Double totalRetailValue) { this.totalRetailValue = totalRetailValue; }
+    public Double getNetTotal() { return netTotal; }
+    public void setNetTotal(Double netTotal) { this.netTotal = netTotal; }
+}

--- a/src/main/java/com/divudi/core/data/dto/StockConsumptionItemDto.java
+++ b/src/main/java/com/divudi/core/data/dto/StockConsumptionItemDto.java
@@ -1,0 +1,103 @@
+package com.divudi.core.data.dto;
+
+import java.io.Serializable;
+import java.util.Date;
+
+public class StockConsumptionItemDto implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private Long billItemId;
+    private Long billId;
+    private String deptId;
+    private Long referenceBillId;
+    private String referenceBillDeptId;
+    private Date createdAt;
+    private String itemName;
+    private String itemCode;
+    private String batchNo;
+    private double qty;
+    private double purchaseRate;
+    private double purchaseValue;
+    private double costRate;
+    private double costValue;
+    private double retailRate;
+    private double retailValue;
+    private String toDepartmentName;
+    private String comments;
+    private String measurementUnitName;
+
+    public StockConsumptionItemDto() {}
+
+    public StockConsumptionItemDto(
+            Long billItemId, Long billId, String deptId,
+            Long referenceBillId, String referenceBillDeptId,
+            Date createdAt, String itemName, String itemCode, String batchNo,
+            double qty,
+            double purchaseRate, double purchaseValue,
+            double costRate, double costValue,
+            double retailRate, double retailValue,
+            String toDepartmentName, String comments, String measurementUnitName) {
+        this.billItemId = billItemId;
+        this.billId = billId;
+        this.deptId = deptId;
+        this.referenceBillId = referenceBillId;
+        this.referenceBillDeptId = referenceBillDeptId;
+        this.createdAt = createdAt;
+        this.itemName = itemName;
+        this.itemCode = itemCode;
+        this.batchNo = batchNo;
+        this.qty = qty;
+        this.purchaseRate = purchaseRate;
+        this.purchaseValue = purchaseValue;
+        this.costRate = costRate;
+        this.costValue = costValue;
+        this.retailRate = retailRate;
+        this.retailValue = retailValue;
+        this.toDepartmentName = toDepartmentName;
+        this.comments = comments;
+        this.measurementUnitName = measurementUnitName;
+    }
+
+    public double getNetTotal() {
+        return purchaseValue;
+    }
+
+    public Long getBillItemId() { return billItemId; }
+    public void setBillItemId(Long billItemId) { this.billItemId = billItemId; }
+    public Long getBillId() { return billId; }
+    public void setBillId(Long billId) { this.billId = billId; }
+    public String getDeptId() { return deptId; }
+    public void setDeptId(String deptId) { this.deptId = deptId; }
+    public Long getReferenceBillId() { return referenceBillId; }
+    public void setReferenceBillId(Long referenceBillId) { this.referenceBillId = referenceBillId; }
+    public String getReferenceBillDeptId() { return referenceBillDeptId; }
+    public void setReferenceBillDeptId(String referenceBillDeptId) { this.referenceBillDeptId = referenceBillDeptId; }
+    public Date getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Date createdAt) { this.createdAt = createdAt; }
+    public String getItemName() { return itemName; }
+    public void setItemName(String itemName) { this.itemName = itemName; }
+    public String getItemCode() { return itemCode; }
+    public void setItemCode(String itemCode) { this.itemCode = itemCode; }
+    public String getBatchNo() { return batchNo; }
+    public void setBatchNo(String batchNo) { this.batchNo = batchNo; }
+    public double getQty() { return qty; }
+    public void setQty(double qty) { this.qty = qty; }
+    public double getPurchaseRate() { return purchaseRate; }
+    public void setPurchaseRate(double purchaseRate) { this.purchaseRate = purchaseRate; }
+    public double getPurchaseValue() { return purchaseValue; }
+    public void setPurchaseValue(double purchaseValue) { this.purchaseValue = purchaseValue; }
+    public double getCostRate() { return costRate; }
+    public void setCostRate(double costRate) { this.costRate = costRate; }
+    public double getCostValue() { return costValue; }
+    public void setCostValue(double costValue) { this.costValue = costValue; }
+    public double getRetailRate() { return retailRate; }
+    public void setRetailRate(double retailRate) { this.retailRate = retailRate; }
+    public double getRetailValue() { return retailValue; }
+    public void setRetailValue(double retailValue) { this.retailValue = retailValue; }
+    public String getToDepartmentName() { return toDepartmentName; }
+    public void setToDepartmentName(String toDepartmentName) { this.toDepartmentName = toDepartmentName; }
+    public String getComments() { return comments; }
+    public void setComments(String comments) { this.comments = comments; }
+    public String getMeasurementUnitName() { return measurementUnitName; }
+    public void setMeasurementUnitName(String measurementUnitName) { this.measurementUnitName = measurementUnitName; }
+}

--- a/src/main/java/com/divudi/core/entity/AgentHistory.java
+++ b/src/main/java/com/divudi/core/entity/AgentHistory.java
@@ -31,7 +31,7 @@ public class AgentHistory implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     BillItem billItem;

--- a/src/main/java/com/divudi/core/entity/AiConversation.java
+++ b/src/main/java/com/divudi/core/entity/AiConversation.java
@@ -18,7 +18,7 @@ public class AiConversation implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String title;

--- a/src/main/java/com/divudi/core/entity/AiMessage.java
+++ b/src/main/java/com/divudi/core/entity/AiMessage.java
@@ -19,7 +19,7 @@ public class AiMessage implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/ApiKey.java
+++ b/src/main/java/com/divudi/core/entity/ApiKey.java
@@ -19,7 +19,7 @@ public class ApiKey implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private ApiKeyType keyType;

--- a/src/main/java/com/divudi/core/entity/AppEmail.java
+++ b/src/main/java/com/divudi/core/entity/AppEmail.java
@@ -29,7 +29,7 @@ public class AppEmail implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/Appointment.java
+++ b/src/main/java/com/divudi/core/entity/Appointment.java
@@ -32,7 +32,7 @@ public class Appointment extends PatientEncounter implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     //Created Properties

--- a/src/main/java/com/divudi/core/entity/AppointmentScheduleDateOverride.java
+++ b/src/main/java/com/divudi/core/entity/AppointmentScheduleDateOverride.java
@@ -17,7 +17,7 @@ public class AppointmentScheduleDateOverride implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/AppointmentScheduleInstance.java
+++ b/src/main/java/com/divudi/core/entity/AppointmentScheduleInstance.java
@@ -14,7 +14,7 @@ public class AppointmentScheduleInstance implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/AppointmentScheduleTemplate.java
+++ b/src/main/java/com/divudi/core/entity/AppointmentScheduleTemplate.java
@@ -18,7 +18,7 @@ public class AppointmentScheduleTemplate implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;

--- a/src/main/java/com/divudi/core/entity/Area.java
+++ b/src/main/java/com/divudi/core/entity/Area.java
@@ -29,7 +29,7 @@ public class Area implements Serializable {
 
      static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
      Long id;
      String name;
      String description;

--- a/src/main/java/com/divudi/core/entity/AuditEvent.java
+++ b/src/main/java/com/divudi/core/entity/AuditEvent.java
@@ -28,7 +28,7 @@ public class AuditEvent implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @Temporal(javax.persistence.TemporalType.TIMESTAMP)
     private Date eventDataTime;

--- a/src/main/java/com/divudi/core/entity/Bill.java
+++ b/src/main/java/com/divudi/core/entity/Bill.java
@@ -53,7 +53,7 @@ import javax.persistence.JoinColumn;
 public class Bill implements Serializable, RetirableEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
 
     static final long serialVersionUID = 1L;

--- a/src/main/java/com/divudi/core/entity/BillComponent.java
+++ b/src/main/java/com/divudi/core/entity/BillComponent.java
@@ -22,7 +22,7 @@ public class BillComponent implements Serializable, RetirableEntity  {
 
     static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     //Main Properties
     Long id;
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/BillEntry.java
+++ b/src/main/java/com/divudi/core/entity/BillEntry.java
@@ -24,7 +24,7 @@ public class BillEntry implements Serializable, RetirableEntity  {
 
     static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
     @Transient
     BillItem billItem;

--- a/src/main/java/com/divudi/core/entity/BillFee.java
+++ b/src/main/java/com/divudi/core/entity/BillFee.java
@@ -28,7 +28,7 @@ public class BillFee implements Serializable, RetirableEntity {
 
     static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
     //Created Properties
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/BillFeePayment.java
+++ b/src/main/java/com/divudi/core/entity/BillFeePayment.java
@@ -24,7 +24,7 @@ import javax.persistence.Temporal;
 public class BillFeePayment implements Serializable {
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     //Created Properties

--- a/src/main/java/com/divudi/core/entity/BillFinanceDetails.java
+++ b/src/main/java/com/divudi/core/entity/BillFinanceDetails.java
@@ -24,7 +24,7 @@ public class BillFinanceDetails implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     // Inverse side of the relationship - Bill entity owns the FK BILLFINANCEDETAILS_ID

--- a/src/main/java/com/divudi/core/entity/BillItem.java
+++ b/src/main/java/com/divudi/core/entity/BillItem.java
@@ -41,7 +41,7 @@ import javax.persistence.Transient;
 public class BillItem implements Serializable, RetirableEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
 
     static final long serialVersionUID = 1L;

--- a/src/main/java/com/divudi/core/entity/BillItemFinanceDetails.java
+++ b/src/main/java/com/divudi/core/entity/BillItemFinanceDetails.java
@@ -24,7 +24,7 @@ public class BillItemFinanceDetails implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @OneToOne(mappedBy = "billItemFinanceDetails")

--- a/src/main/java/com/divudi/core/entity/BillNumber.java
+++ b/src/main/java/com/divudi/core/entity/BillNumber.java
@@ -31,7 +31,7 @@ public class BillNumber implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private Long lastBillNumber;
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/BillSession.java
+++ b/src/main/java/com/divudi/core/entity/BillSession.java
@@ -27,7 +27,7 @@ public class BillSession implements Serializable, RetirableEntity  {
 
     static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
     @ManyToOne
     Packege packege;

--- a/src/main/java/com/divudi/core/entity/CategoryItem.java
+++ b/src/main/java/com/divudi/core/entity/CategoryItem.java
@@ -18,7 +18,7 @@ public class CategoryItem implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/ConfigOption.java
+++ b/src/main/java/com/divudi/core/entity/ConfigOption.java
@@ -23,7 +23,7 @@ public class ConfigOption implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     public Long getId() {

--- a/src/main/java/com/divudi/core/entity/DatabaseMigration.java
+++ b/src/main/java/com/divudi/core/entity/DatabaseMigration.java
@@ -30,7 +30,7 @@ public class DatabaseMigration implements Serializable, Comparable<DatabaseMigra
     private static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(nullable = false, unique = true, length = 50)

--- a/src/main/java/com/divudi/core/entity/DefaultServiceDepartment.java
+++ b/src/main/java/com/divudi/core/entity/DefaultServiceDepartment.java
@@ -20,7 +20,7 @@ public class DefaultServiceDepartment implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/Department.java
+++ b/src/main/java/com/divudi/core/entity/Department.java
@@ -29,7 +29,7 @@ public class Department implements Serializable {
 
     static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     //Main Properties
     Long id;
     String departmentCode;

--- a/src/main/java/com/divudi/core/entity/EncounterCreditCompany.java
+++ b/src/main/java/com/divudi/core/entity/EncounterCreditCompany.java
@@ -22,7 +22,7 @@ public class EncounterCreditCompany implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/Family.java
+++ b/src/main/java/com/divudi/core/entity/Family.java
@@ -30,7 +30,7 @@ public class Family implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @OneToMany(mappedBy = "family", cascade = CascadeType.ALL, fetch = FetchType.EAGER)

--- a/src/main/java/com/divudi/core/entity/FamilyMember.java
+++ b/src/main/java/com/divudi/core/entity/FamilyMember.java
@@ -23,7 +23,7 @@ public class FamilyMember implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
 

--- a/src/main/java/com/divudi/core/entity/Fee.java
+++ b/src/main/java/com/divudi/core/entity/Fee.java
@@ -29,7 +29,7 @@ public class Fee implements Serializable {
 
     static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     //Main Properties
     Long id;
     String name;

--- a/src/main/java/com/divudi/core/entity/FeeChange.java
+++ b/src/main/java/com/divudi/core/entity/FeeChange.java
@@ -25,7 +25,7 @@ import javax.persistence.Temporal;
 public class FeeChange implements Serializable {
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @Temporal(javax.persistence.TemporalType.DATE)
     Date validFrom;

--- a/src/main/java/com/divudi/core/entity/FeeValue.java
+++ b/src/main/java/com/divudi/core/entity/FeeValue.java
@@ -19,7 +19,7 @@ public class FeeValue implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.EAGER)

--- a/src/main/java/com/divudi/core/entity/Form.java
+++ b/src/main/java/com/divudi/core/entity/Form.java
@@ -26,7 +26,7 @@ public class Form implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     //Created Properties

--- a/src/main/java/com/divudi/core/entity/FormItemValue.java
+++ b/src/main/java/com/divudi/core/entity/FormItemValue.java
@@ -30,7 +30,7 @@ public class FormItemValue implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     Patient patient;

--- a/src/main/java/com/divudi/core/entity/HistoricalRecord.java
+++ b/src/main/java/com/divudi/core/entity/HistoricalRecord.java
@@ -24,7 +24,7 @@ public class HistoricalRecord implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
 

--- a/src/main/java/com/divudi/core/entity/Institution.java
+++ b/src/main/java/com/divudi/core/entity/Institution.java
@@ -37,7 +37,7 @@ public class Institution implements Serializable, IdentifiableWithNameOrCode {
 
     static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
     // NOTE: No UNIQUE constraint on institutionCode - different institution types
     // (suppliers, labs, hospitals) can legitimately have the same codes (e.g., RH2003)

--- a/src/main/java/com/divudi/core/entity/IssueRateMargins.java
+++ b/src/main/java/com/divudi/core/entity/IssueRateMargins.java
@@ -23,7 +23,7 @@ import javax.persistence.Temporal;
 public class IssueRateMargins implements Serializable {
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     String name;
     @Temporal(javax.persistence.TemporalType.TIMESTAMP)

--- a/src/main/java/com/divudi/core/entity/Item.java
+++ b/src/main/java/com/divudi/core/entity/Item.java
@@ -72,7 +72,7 @@ public class Item implements Serializable, Comparable<Item>, RetirableEntity {
     static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
     int orderNo;
 

--- a/src/main/java/com/divudi/core/entity/ItemMapping.java
+++ b/src/main/java/com/divudi/core/entity/ItemMapping.java
@@ -19,7 +19,7 @@ public class ItemMapping implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/ItemPackage.java
+++ b/src/main/java/com/divudi/core/entity/ItemPackage.java
@@ -18,7 +18,7 @@ import javax.persistence.Id;
 public class ItemPackage implements Serializable {
      static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
      Long id;
 
     public Long getId() {

--- a/src/main/java/com/divudi/core/entity/ItemsCategories.java
+++ b/src/main/java/com/divudi/core/entity/ItemsCategories.java
@@ -22,7 +22,7 @@ public class ItemsCategories implements Serializable {
 
     static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
     //Created Properties
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/Logins.java
+++ b/src/main/java/com/divudi/core/entity/Logins.java
@@ -22,7 +22,7 @@ public class Logins implements Serializable {
 
      static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
      Long id;
     @ManyToOne
     WebUser webUser;

--- a/src/main/java/com/divudi/core/entity/Mapping.java
+++ b/src/main/java/com/divudi/core/entity/Mapping.java
@@ -20,7 +20,7 @@ import javax.persistence.ManyToOne;
 public class Mapping implements Serializable {
      static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
      Long id;
 
 

--- a/src/main/java/com/divudi/core/entity/MedicalPackageItem.java
+++ b/src/main/java/com/divudi/core/entity/MedicalPackageItem.java
@@ -22,7 +22,7 @@ public class MedicalPackageItem implements Serializable {
 
      static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
      Long id;
     @ManyToOne
      Item packege;

--- a/src/main/java/com/divudi/core/entity/Notification.java
+++ b/src/main/java/com/divudi/core/entity/Notification.java
@@ -26,7 +26,7 @@ public class Notification implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/OnlineBooking.java
+++ b/src/main/java/com/divudi/core/entity/OnlineBooking.java
@@ -24,7 +24,7 @@ import javax.persistence.TemporalType;
 public class OnlineBooking implements Serializable, RetirableEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
 //    class level variables

--- a/src/main/java/com/divudi/core/entity/PackageItem.java
+++ b/src/main/java/com/divudi/core/entity/PackageItem.java
@@ -22,7 +22,7 @@ public class PackageItem implements Serializable {
 
     static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
     @ManyToOne
     Packege packege;

--- a/src/main/java/com/divudi/core/entity/Patient.java
+++ b/src/main/java/com/divudi/core/entity/Patient.java
@@ -40,7 +40,7 @@ public class Patient implements Serializable, RetirableEntity {
 
     static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
 
     private Long patientPhoneNumber;

--- a/src/main/java/com/divudi/core/entity/PatientDeposit.java
+++ b/src/main/java/com/divudi/core/entity/PatientDeposit.java
@@ -22,7 +22,7 @@ public class PatientDeposit implements Serializable, RetirableEntity {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     private Patient patient;

--- a/src/main/java/com/divudi/core/entity/PatientDepositHistory.java
+++ b/src/main/java/com/divudi/core/entity/PatientDepositHistory.java
@@ -25,7 +25,7 @@ public class PatientDepositHistory implements Serializable, RetirableEntity {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/PatientEncounter.java
+++ b/src/main/java/com/divudi/core/entity/PatientEncounter.java
@@ -49,7 +49,7 @@ public class PatientEncounter implements Serializable, RetirableEntity {
 
     static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     //Main Properties
     Long id;
     String bhtNo;

--- a/src/main/java/com/divudi/core/entity/PatientFlag.java
+++ b/src/main/java/com/divudi/core/entity/PatientFlag.java
@@ -23,7 +23,7 @@ public class PatientFlag implements Serializable, RetirableEntity {
 
      static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     //Main Properties
      Long id;
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/PatientItem.java
+++ b/src/main/java/com/divudi/core/entity/PatientItem.java
@@ -23,7 +23,7 @@ public class PatientItem implements Serializable, RetirableEntity {
 
     static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     //Main Properties
     Long id;
     String name;

--- a/src/main/java/com/divudi/core/entity/Payment.java
+++ b/src/main/java/com/divudi/core/entity/Payment.java
@@ -34,7 +34,7 @@ public class Payment implements Serializable, RetirableEntity {
     static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/PaymentGatewayTransaction.java
+++ b/src/main/java/com/divudi/core/entity/PaymentGatewayTransaction.java
@@ -20,7 +20,7 @@ public class PaymentGatewayTransaction implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/PaymentHandoverItem.java
+++ b/src/main/java/com/divudi/core/entity/PaymentHandoverItem.java
@@ -19,7 +19,7 @@ public class PaymentHandoverItem implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/PaymentScheme.java
+++ b/src/main/java/com/divudi/core/entity/PaymentScheme.java
@@ -29,7 +29,7 @@ public class PaymentScheme implements Serializable {
 
     static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     //Main Properties
     Long id;
     String name;

--- a/src/main/java/com/divudi/core/entity/PersonInstitution.java
+++ b/src/main/java/com/divudi/core/entity/PersonInstitution.java
@@ -26,7 +26,7 @@ public class PersonInstitution implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/PharmacyBill.java
+++ b/src/main/java/com/divudi/core/entity/PharmacyBill.java
@@ -18,7 +18,7 @@ public class PharmacyBill implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     // Bidirectional One-to-One relationship with Bill
     @OneToOne(mappedBy = "pharmacyBill", cascade = CascadeType.ALL)

--- a/src/main/java/com/divudi/core/entity/PriceMatrix.java
+++ b/src/main/java/com/divudi/core/entity/PriceMatrix.java
@@ -30,7 +30,7 @@ public class PriceMatrix implements Serializable {
 
     static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
     BillType billType;
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/ReportTemplate.java
+++ b/src/main/java/com/divudi/core/entity/ReportTemplate.java
@@ -30,7 +30,7 @@ public class ReportTemplate implements Serializable {
     private static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Enumerated

--- a/src/main/java/com/divudi/core/entity/Request.java
+++ b/src/main/java/com/divudi/core/entity/Request.java
@@ -24,7 +24,7 @@ public class Request implements Serializable {
     private static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     
     private String requestNo;

--- a/src/main/java/com/divudi/core/entity/ScheduledProcessConfiguration.java
+++ b/src/main/java/com/divudi/core/entity/ScheduledProcessConfiguration.java
@@ -25,7 +25,7 @@ public class ScheduledProcessConfiguration implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/divudi/core/entity/ServiceSessionInstance.java
+++ b/src/main/java/com/divudi/core/entity/ServiceSessionInstance.java
@@ -29,7 +29,7 @@ public class ServiceSessionInstance implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private Double total = 0.0;

--- a/src/main/java/com/divudi/core/entity/Sex.java
+++ b/src/main/java/com/divudi/core/entity/Sex.java
@@ -26,7 +26,7 @@ public class Sex implements Serializable {
 
      static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
      Long id;
      String name;
      String sname;

--- a/src/main/java/com/divudi/core/entity/Sms.java
+++ b/src/main/java/com/divudi/core/entity/Sms.java
@@ -29,7 +29,7 @@ public class Sms implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/Staff.java
+++ b/src/main/java/com/divudi/core/entity/Staff.java
@@ -46,7 +46,7 @@ import javax.persistence.Transient;
 public class Staff implements Serializable, IdentifiableWithNameOrCode {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
 
     static final long serialVersionUID = 1L;

--- a/src/main/java/com/divudi/core/entity/StockBill.java
+++ b/src/main/java/com/divudi/core/entity/StockBill.java
@@ -19,7 +19,7 @@ public class StockBill implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private double stockValueAtPurchaseRates;

--- a/src/main/java/com/divudi/core/entity/Token.java
+++ b/src/main/java/com/divudi/core/entity/Token.java
@@ -22,7 +22,7 @@ public class Token implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     // <editor-fold defaultstate="collapsed" desc="Class variables">

--- a/src/main/java/com/divudi/core/entity/TriggerSubscription.java
+++ b/src/main/java/com/divudi/core/entity/TriggerSubscription.java
@@ -21,7 +21,7 @@ public class TriggerSubscription implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Enumerated(EnumType.ORDINAL)

--- a/src/main/java/com/divudi/core/entity/Upload.java
+++ b/src/main/java/com/divudi/core/entity/Upload.java
@@ -54,7 +54,7 @@ public class Upload implements Serializable {
 
     static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
 
     @Lob

--- a/src/main/java/com/divudi/core/entity/UserIcon.java
+++ b/src/main/java/com/divudi/core/entity/UserIcon.java
@@ -19,7 +19,7 @@ public class UserIcon implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/UserNotification.java
+++ b/src/main/java/com/divudi/core/entity/UserNotification.java
@@ -22,7 +22,7 @@ public class UserNotification implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/UserPreference.java
+++ b/src/main/java/com/divudi/core/entity/UserPreference.java
@@ -35,7 +35,7 @@ public class UserPreference implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     /*

--- a/src/main/java/com/divudi/core/entity/WebContent.java
+++ b/src/main/java/com/divudi/core/entity/WebContent.java
@@ -22,7 +22,7 @@ public class WebContent implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String name;
     private boolean retired;

--- a/src/main/java/com/divudi/core/entity/WebLanguage.java
+++ b/src/main/java/com/divudi/core/entity/WebLanguage.java
@@ -15,7 +15,7 @@ public class WebLanguage  implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String name;
     private String code;

--- a/src/main/java/com/divudi/core/entity/WebTheme.java
+++ b/src/main/java/com/divudi/core/entity/WebTheme.java
@@ -25,7 +25,7 @@ import javax.persistence.Temporal;
 public class WebTheme implements Serializable {
      static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
      Long id;
 
     //Main Properties

--- a/src/main/java/com/divudi/core/entity/WebUser.java
+++ b/src/main/java/com/divudi/core/entity/WebUser.java
@@ -34,7 +34,7 @@ public class WebUser implements Serializable {
 
     static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
 //    @ManyToOne(fetch = FetchType.LAZY)
 //    Drawer drawer;

--- a/src/main/java/com/divudi/core/entity/WebUserDashboard.java
+++ b/src/main/java/com/divudi/core/entity/WebUserDashboard.java
@@ -25,7 +25,7 @@ public class WebUserDashboard implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/WebUserDepartment.java
+++ b/src/main/java/com/divudi/core/entity/WebUserDepartment.java
@@ -21,7 +21,7 @@ import javax.persistence.Temporal;
 public class WebUserDepartment implements Serializable {
      static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
      Long id;
 
     //Created Properties

--- a/src/main/java/com/divudi/core/entity/WebUserPasswordHistory.java
+++ b/src/main/java/com/divudi/core/entity/WebUserPasswordHistory.java
@@ -18,7 +18,7 @@ public class WebUserPasswordHistory implements Serializable, RetirableEntity {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/WebUserPaymentScheme.java
+++ b/src/main/java/com/divudi/core/entity/WebUserPaymentScheme.java
@@ -21,7 +21,7 @@ import javax.persistence.Temporal;
 public class WebUserPaymentScheme implements Serializable {
      static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
      Long id;
 
     //Created Properties

--- a/src/main/java/com/divudi/core/entity/WebUserPrivilege.java
+++ b/src/main/java/com/divudi/core/entity/WebUserPrivilege.java
@@ -24,7 +24,7 @@ import javax.persistence.Temporal;
 public class WebUserPrivilege implements Serializable {
     static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
     String name;
     String description;

--- a/src/main/java/com/divudi/core/entity/WebUserRole.java
+++ b/src/main/java/com/divudi/core/entity/WebUserRole.java
@@ -27,7 +27,7 @@ public class WebUserRole implements Serializable {
 
     static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
 
     //Main Properties

--- a/src/main/java/com/divudi/core/entity/WebUserRolePrivilege.java
+++ b/src/main/java/com/divudi/core/entity/WebUserRolePrivilege.java
@@ -24,7 +24,7 @@ import javax.persistence.Temporal;
 public class WebUserRolePrivilege implements Serializable {
     static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
     String name;
     String description;

--- a/src/main/java/com/divudi/core/entity/WebUserRoleUser.java
+++ b/src/main/java/com/divudi/core/entity/WebUserRoleUser.java
@@ -22,7 +22,7 @@ public class WebUserRoleUser implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/WebUserRoute.java
+++ b/src/main/java/com/divudi/core/entity/WebUserRoute.java
@@ -22,7 +22,7 @@ public class WebUserRoute implements Serializable {
 
     static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
 
     //Created Properties

--- a/src/main/java/com/divudi/core/entity/analytics/AggregatedRecord.java
+++ b/src/main/java/com/divudi/core/entity/analytics/AggregatedRecord.java
@@ -25,7 +25,7 @@ public class AggregatedRecord implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     public Long getId() {

--- a/src/main/java/com/divudi/core/entity/cashTransaction/CashBook.java
+++ b/src/main/java/com/divudi/core/entity/cashTransaction/CashBook.java
@@ -22,7 +22,7 @@ public class CashBook implements Serializable, RetirableEntity  {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String Name;
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/cashTransaction/CashBookEntry.java
+++ b/src/main/java/com/divudi/core/entity/cashTransaction/CashBookEntry.java
@@ -26,7 +26,7 @@ public class CashBookEntry implements Serializable, RetirableEntity  {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;

--- a/src/main/java/com/divudi/core/entity/cashTransaction/CashTransaction.java
+++ b/src/main/java/com/divudi/core/entity/cashTransaction/CashTransaction.java
@@ -30,7 +30,7 @@ public class CashTransaction implements Serializable, RetirableEntity  {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @Enumerated(EnumType.STRING)
     private InOutType inOutType;

--- a/src/main/java/com/divudi/core/entity/cashTransaction/CashTransactionHistory.java
+++ b/src/main/java/com/divudi/core/entity/cashTransaction/CashTransactionHistory.java
@@ -29,7 +29,7 @@ public class CashTransactionHistory implements Serializable, RetirableEntity  {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Temporal(javax.persistence.TemporalType.DATE)

--- a/src/main/java/com/divudi/core/entity/cashTransaction/Denomination.java
+++ b/src/main/java/com/divudi/core/entity/cashTransaction/Denomination.java
@@ -19,7 +19,7 @@ public class Denomination implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;

--- a/src/main/java/com/divudi/core/entity/cashTransaction/DenominationTransaction.java
+++ b/src/main/java/com/divudi/core/entity/cashTransaction/DenominationTransaction.java
@@ -25,7 +25,7 @@ public class DenominationTransaction implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     private Denomination denomination;

--- a/src/main/java/com/divudi/core/entity/cashTransaction/DetailedFinancialBill.java
+++ b/src/main/java/com/divudi/core/entity/cashTransaction/DetailedFinancialBill.java
@@ -23,7 +23,7 @@ public class DetailedFinancialBill implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @OneToOne
     private Bill bill;

--- a/src/main/java/com/divudi/core/entity/cashTransaction/Drawer.java
+++ b/src/main/java/com/divudi/core/entity/cashTransaction/Drawer.java
@@ -17,7 +17,7 @@ public class Drawer implements Serializable, RetirableEntity  {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
     private String name;
     private WebUser drawerUser;

--- a/src/main/java/com/divudi/core/entity/cashTransaction/DrawerEntry.java
+++ b/src/main/java/com/divudi/core/entity/cashTransaction/DrawerEntry.java
@@ -26,7 +26,7 @@ public class DrawerEntry implements Serializable, RetirableEntity {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/channel/AgentReferenceBook.java
+++ b/src/main/java/com/divudi/core/entity/channel/AgentReferenceBook.java
@@ -31,7 +31,7 @@ public class AgentReferenceBook implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private double startingReferenceNumber = 0.0;
     private double endingReferenceNumber = 0.0;

--- a/src/main/java/com/divudi/core/entity/channel/AgentsFees.java
+++ b/src/main/java/com/divudi/core/entity/channel/AgentsFees.java
@@ -23,7 +23,7 @@ public class AgentsFees implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     private Institution agent;

--- a/src/main/java/com/divudi/core/entity/channel/AppointmentActivity.java
+++ b/src/main/java/com/divudi/core/entity/channel/AppointmentActivity.java
@@ -24,7 +24,7 @@ public class AppointmentActivity implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String name;
     private String code;

--- a/src/main/java/com/divudi/core/entity/channel/DoctorInstitution.java
+++ b/src/main/java/com/divudi/core/entity/channel/DoctorInstitution.java
@@ -25,7 +25,7 @@ import javax.persistence.Temporal;
 public class DoctorInstitution implements Serializable {
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
       private boolean booleanValue;

--- a/src/main/java/com/divudi/core/entity/channel/PatientSessionInstanceActivity.java
+++ b/src/main/java/com/divudi/core/entity/channel/PatientSessionInstanceActivity.java
@@ -21,7 +21,7 @@ public class PatientSessionInstanceActivity implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
 

--- a/src/main/java/com/divudi/core/entity/channel/SessionInstance.java
+++ b/src/main/java/com/divudi/core/entity/channel/SessionInstance.java
@@ -48,7 +48,7 @@ public class SessionInstance implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private Double total = 0.0;

--- a/src/main/java/com/divudi/core/entity/channel/SessionInstanceActivity.java
+++ b/src/main/java/com/divudi/core/entity/channel/SessionInstanceActivity.java
@@ -24,7 +24,7 @@ public class SessionInstanceActivity implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     private SessionInstance sessionInstance;

--- a/src/main/java/com/divudi/core/entity/clinical/ClinicalFindingValue.java
+++ b/src/main/java/com/divudi/core/entity/clinical/ClinicalFindingValue.java
@@ -32,7 +32,7 @@ public class ClinicalFindingValue implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/clinical/DocumentTemplate.java
+++ b/src/main/java/com/divudi/core/entity/clinical/DocumentTemplate.java
@@ -24,7 +24,7 @@ public class DocumentTemplate implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/clinical/ItemUsage.java
+++ b/src/main/java/com/divudi/core/entity/clinical/ItemUsage.java
@@ -41,7 +41,7 @@ public class ItemUsage implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/clinical/Prescription.java
+++ b/src/main/java/com/divudi/core/entity/clinical/Prescription.java
@@ -37,7 +37,7 @@ public class Prescription implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/clinical/PrescriptionTemplate.java
+++ b/src/main/java/com/divudi/core/entity/clinical/PrescriptionTemplate.java
@@ -41,7 +41,7 @@ public class PrescriptionTemplate implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/forms/ComponentAsignment.java
+++ b/src/main/java/com/divudi/core/entity/forms/ComponentAsignment.java
@@ -20,7 +20,7 @@ public class ComponentAsignment implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String Name;
     private String description;

--- a/src/main/java/com/divudi/core/entity/hr/BankAccount.java
+++ b/src/main/java/com/divudi/core/entity/hr/BankAccount.java
@@ -31,7 +31,7 @@ public class BankAccount implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/hr/FingerPrintRecord.java
+++ b/src/main/java/com/divudi/core/entity/hr/FingerPrintRecord.java
@@ -40,7 +40,7 @@ public class FingerPrintRecord implements Serializable {
     private FingerPrintRecord verifiedRecord;
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @Enumerated(EnumType.STRING)
     FingerPrintRecordType fingerPrintRecordType;

--- a/src/main/java/com/divudi/core/entity/hr/FingerPrintRecordHistory.java
+++ b/src/main/java/com/divudi/core/entity/hr/FingerPrintRecordHistory.java
@@ -26,7 +26,7 @@ public class FingerPrintRecordHistory implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     private FingerPrintRecord fingerPrintRecord;

--- a/src/main/java/com/divudi/core/entity/hr/HrmVariables.java
+++ b/src/main/java/com/divudi/core/entity/hr/HrmVariables.java
@@ -31,7 +31,7 @@ public class HrmVariables implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     /////////
     //Created Properties

--- a/src/main/java/com/divudi/core/entity/hr/Loan.java
+++ b/src/main/java/com/divudi/core/entity/hr/Loan.java
@@ -27,7 +27,7 @@ public class Loan implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String name;
     private double loanValue;

--- a/src/main/java/com/divudi/core/entity/hr/PayeeTaxRange.java
+++ b/src/main/java/com/divudi/core/entity/hr/PayeeTaxRange.java
@@ -23,7 +23,7 @@ public class PayeeTaxRange implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private double fromSalary;
     private double toSalary;

--- a/src/main/java/com/divudi/core/entity/hr/PaysheetComponent.java
+++ b/src/main/java/com/divudi/core/entity/hr/PaysheetComponent.java
@@ -33,7 +33,7 @@ public class PaysheetComponent implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String name;
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/divudi/core/entity/hr/PhDate.java
+++ b/src/main/java/com/divudi/core/entity/hr/PhDate.java
@@ -28,7 +28,7 @@ public class PhDate implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String name;
     @Temporal(javax.persistence.TemporalType.DATE)

--- a/src/main/java/com/divudi/core/entity/hr/Roster.java
+++ b/src/main/java/com/divudi/core/entity/hr/Roster.java
@@ -34,7 +34,7 @@ public class Roster implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String name;
     @OneToOne

--- a/src/main/java/com/divudi/core/entity/hr/SalaryCycle.java
+++ b/src/main/java/com/divudi/core/entity/hr/SalaryCycle.java
@@ -27,7 +27,7 @@ public class SalaryCycle implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Temporal(javax.persistence.TemporalType.TIMESTAMP)

--- a/src/main/java/com/divudi/core/entity/hr/SalaryHold.java
+++ b/src/main/java/com/divudi/core/entity/hr/SalaryHold.java
@@ -26,7 +26,7 @@ public class SalaryHold implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     //Created Properties
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/hr/Shift.java
+++ b/src/main/java/com/divudi/core/entity/hr/Shift.java
@@ -37,7 +37,7 @@ public class Shift implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String name;
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/hr/ShiftAmendment.java
+++ b/src/main/java/com/divudi/core/entity/hr/ShiftAmendment.java
@@ -26,7 +26,7 @@ public class ShiftAmendment implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     private Staff staff;

--- a/src/main/java/com/divudi/core/entity/hr/ShiftPreference.java
+++ b/src/main/java/com/divudi/core/entity/hr/ShiftPreference.java
@@ -29,7 +29,7 @@ public class ShiftPreference implements Serializable {
     private Shift shift;
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @OneToOne
     private Staff staff;

--- a/src/main/java/com/divudi/core/entity/hr/StaffBasics.java
+++ b/src/main/java/com/divudi/core/entity/hr/StaffBasics.java
@@ -27,7 +27,7 @@ public class StaffBasics implements Serializable {
     private StaffEmployment staffEmployment;
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @OneToOne

--- a/src/main/java/com/divudi/core/entity/hr/StaffDesignation.java
+++ b/src/main/java/com/divudi/core/entity/hr/StaffDesignation.java
@@ -27,7 +27,7 @@ public class StaffDesignation implements Serializable {
     private StaffEmployment staffEmployment;
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @OneToOne
     private Designation designation;

--- a/src/main/java/com/divudi/core/entity/hr/StaffEmployeeStatus.java
+++ b/src/main/java/com/divudi/core/entity/hr/StaffEmployeeStatus.java
@@ -29,7 +29,7 @@ public class StaffEmployeeStatus implements Serializable {
     private StaffEmployment staffEmployment;
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @Enumerated(EnumType.STRING)
     private EmployeeStatus employeeStatus;

--- a/src/main/java/com/divudi/core/entity/hr/StaffEmployment.java
+++ b/src/main/java/com/divudi/core/entity/hr/StaffEmployment.java
@@ -51,7 +51,7 @@ public class StaffEmployment implements Serializable {
     private Staff staff;
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     /////////////////////
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/divudi/core/entity/hr/StaffGrade.java
+++ b/src/main/java/com/divudi/core/entity/hr/StaffGrade.java
@@ -26,7 +26,7 @@ public class StaffGrade implements Serializable {
     private StaffEmployment staffEmployment;
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @OneToOne
     private Grade grade;

--- a/src/main/java/com/divudi/core/entity/hr/StaffLeave.java
+++ b/src/main/java/com/divudi/core/entity/hr/StaffLeave.java
@@ -32,7 +32,7 @@ public class StaffLeave implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     //Created Properties
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/hr/StaffLeaveEntitle.java
+++ b/src/main/java/com/divudi/core/entity/hr/StaffLeaveEntitle.java
@@ -30,7 +30,7 @@ public class StaffLeaveEntitle implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     Staff staff;

--- a/src/main/java/com/divudi/core/entity/hr/StaffPaysheetComponent.java
+++ b/src/main/java/com/divudi/core/entity/hr/StaffPaysheetComponent.java
@@ -28,7 +28,7 @@ public class StaffPaysheetComponent implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     private PaysheetComponent paysheetComponent;

--- a/src/main/java/com/divudi/core/entity/hr/StaffSalary.java
+++ b/src/main/java/com/divudi/core/entity/hr/StaffSalary.java
@@ -40,7 +40,7 @@ public class StaffSalary implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private double payeeValue;
 //    private double otValue;

--- a/src/main/java/com/divudi/core/entity/hr/StaffSalaryComponant.java
+++ b/src/main/java/com/divudi/core/entity/hr/StaffSalaryComponant.java
@@ -29,7 +29,7 @@ public class StaffSalaryComponant implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private double componantValue;
     private double epfValue;

--- a/src/main/java/com/divudi/core/entity/hr/StaffShift.java
+++ b/src/main/java/com/divudi/core/entity/hr/StaffShift.java
@@ -45,7 +45,7 @@ public class StaffShift implements Serializable {
     Shift shift;
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @OneToOne
     private Staff staff;

--- a/src/main/java/com/divudi/core/entity/hr/StaffShiftHistory.java
+++ b/src/main/java/com/divudi/core/entity/hr/StaffShiftHistory.java
@@ -26,7 +26,7 @@ public class StaffShiftHistory implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     StaffShift staffShift;

--- a/src/main/java/com/divudi/core/entity/hr/StaffStaffCategory.java
+++ b/src/main/java/com/divudi/core/entity/hr/StaffStaffCategory.java
@@ -27,7 +27,7 @@ public class StaffStaffCategory implements Serializable {
     private StaffEmployment staffEmployment;
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @OneToOne

--- a/src/main/java/com/divudi/core/entity/hr/StaffWorkDay.java
+++ b/src/main/java/com/divudi/core/entity/hr/StaffWorkDay.java
@@ -25,7 +25,7 @@ import javax.persistence.Temporal;
 public class StaffWorkDay implements Serializable {
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     private Staff staff;

--- a/src/main/java/com/divudi/core/entity/hr/StaffWorkingDepartment.java
+++ b/src/main/java/com/divudi/core/entity/hr/StaffWorkingDepartment.java
@@ -28,7 +28,7 @@ public class StaffWorkingDepartment implements Serializable {
     private StaffEmployment staffEmployment;
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @OneToOne

--- a/src/main/java/com/divudi/core/entity/hr/WorkingTime.java
+++ b/src/main/java/com/divudi/core/entity/hr/WorkingTime.java
@@ -35,7 +35,7 @@ public class WorkingTime implements Serializable {
     private WorkingTime continuedFrom;
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     StaffShift staffShift;

--- a/src/main/java/com/divudi/core/entity/inward/AdmissionNumber.java
+++ b/src/main/java/com/divudi/core/entity/inward/AdmissionNumber.java
@@ -31,7 +31,7 @@ public class AdmissionNumber implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private Long lastAdmissionNumber;
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/inward/EncounterComponent.java
+++ b/src/main/java/com/divudi/core/entity/inward/EncounterComponent.java
@@ -34,7 +34,7 @@ public class EncounterComponent implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
 

--- a/src/main/java/com/divudi/core/entity/inward/PatientRoom.java
+++ b/src/main/java/com/divudi/core/entity/inward/PatientRoom.java
@@ -35,7 +35,7 @@ public class PatientRoom implements Serializable, RetirableEntity {
     
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 //Main Properties
     private String name;

--- a/src/main/java/com/divudi/core/entity/inward/PatientTransferRequest.java
+++ b/src/main/java/com/divudi/core/entity/inward/PatientTransferRequest.java
@@ -24,7 +24,7 @@ public class PatientTransferRequest implements Serializable {
     private static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/inward/Reservation.java
+++ b/src/main/java/com/divudi/core/entity/inward/Reservation.java
@@ -24,7 +24,7 @@ import javax.persistence.Temporal;
 public class Reservation implements Serializable {
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     private Appointment appointment;

--- a/src/main/java/com/divudi/core/entity/inward/RoomFacilityCharge.java
+++ b/src/main/java/com/divudi/core/entity/inward/RoomFacilityCharge.java
@@ -31,7 +31,7 @@ public class RoomFacilityCharge implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private Double maintananceCharge = 0.0;
     private Double roomCharge = 0.0;

--- a/src/main/java/com/divudi/core/entity/lab/AnalyzerMessage.java
+++ b/src/main/java/com/divudi/core/entity/lab/AnalyzerMessage.java
@@ -19,7 +19,7 @@ public class AnalyzerMessage implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String messageType;

--- a/src/main/java/com/divudi/core/entity/lab/DepartmentMachine.java
+++ b/src/main/java/com/divudi/core/entity/lab/DepartmentMachine.java
@@ -23,7 +23,7 @@ public class DepartmentMachine implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private Department department;
     private Machine machine;

--- a/src/main/java/com/divudi/core/entity/lab/InvestigationComponent.java
+++ b/src/main/java/com/divudi/core/entity/lab/InvestigationComponent.java
@@ -21,7 +21,7 @@ public class InvestigationComponent implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     private Investigation investigation;

--- a/src/main/java/com/divudi/core/entity/lab/InvestigationItemValue.java
+++ b/src/main/java/com/divudi/core/entity/lab/InvestigationItemValue.java
@@ -28,7 +28,7 @@ public class InvestigationItemValue implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @JsonIgnore
     //Main Properties
     Long id;

--- a/src/main/java/com/divudi/core/entity/lab/InvestigationReportItemValue.java
+++ b/src/main/java/com/divudi/core/entity/lab/InvestigationReportItemValue.java
@@ -23,7 +23,7 @@ public class InvestigationReportItemValue implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     //Main Properties
     private Long id;
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/lab/InvestigationValidaterComponent.java
+++ b/src/main/java/com/divudi/core/entity/lab/InvestigationValidaterComponent.java
@@ -30,7 +30,7 @@ public class InvestigationValidaterComponent implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     //Created Properties
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/lab/InvestigationValidator.java
+++ b/src/main/java/com/divudi/core/entity/lab/InvestigationValidator.java
@@ -31,7 +31,7 @@ public class InvestigationValidator implements Serializable {
     private List<InvestigationValidaterComponent> investigationValidateComponents;
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     //Created Properties
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/lab/ItemForItem.java
+++ b/src/main/java/com/divudi/core/entity/lab/ItemForItem.java
@@ -23,7 +23,7 @@ import javax.persistence.Temporal;
 public class ItemForItem implements Serializable {
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
 

--- a/src/main/java/com/divudi/core/entity/lab/IxCal.java
+++ b/src/main/java/com/divudi/core/entity/lab/IxCal.java
@@ -23,7 +23,7 @@ public class IxCal implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
     @ManyToOne
     private InvestigationItem calIxItem;

--- a/src/main/java/com/divudi/core/entity/lab/LabTestHistory.java
+++ b/src/main/java/com/divudi/core/entity/lab/LabTestHistory.java
@@ -31,7 +31,7 @@ public class LabTestHistory implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/lab/PatientInvestigation.java
+++ b/src/main/java/com/divudi/core/entity/lab/PatientInvestigation.java
@@ -40,7 +40,7 @@ public class PatientInvestigation implements Serializable, RetirableEntity {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     //Created Properties
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/lab/PatientReport.java
+++ b/src/main/java/com/divudi/core/entity/lab/PatientReport.java
@@ -50,7 +50,7 @@ public class PatientReport implements Serializable, RetirableEntity {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     private Item item;

--- a/src/main/java/com/divudi/core/entity/lab/PatientReportGroup.java
+++ b/src/main/java/com/divudi/core/entity/lab/PatientReportGroup.java
@@ -20,7 +20,7 @@ public class PatientReportGroup implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     private PatientReport patientReport;

--- a/src/main/java/com/divudi/core/entity/lab/PatientReportItemValue.java
+++ b/src/main/java/com/divudi/core/entity/lab/PatientReportItemValue.java
@@ -29,7 +29,7 @@ public class PatientReportItemValue implements Serializable, RetirableEntity {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     private Patient patient;

--- a/src/main/java/com/divudi/core/entity/lab/PatientSample.java
+++ b/src/main/java/com/divudi/core/entity/lab/PatientSample.java
@@ -38,7 +38,7 @@ public class PatientSample implements Serializable, RetirableEntity {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private Long sampleId;
 

--- a/src/main/java/com/divudi/core/entity/lab/PatientSampleComponant.java
+++ b/src/main/java/com/divudi/core/entity/lab/PatientSampleComponant.java
@@ -31,7 +31,7 @@ public class PatientSampleComponant implements Serializable, RetirableEntity {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     private Patient patient;

--- a/src/main/java/com/divudi/core/entity/lab/ReportItem.java
+++ b/src/main/java/com/divudi/core/entity/lab/ReportItem.java
@@ -46,7 +46,7 @@ public class ReportItem implements Serializable {
 
     static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @JsonIgnore
     Long id;
     //Main Properties

--- a/src/main/java/com/divudi/core/entity/membership/AllowedPaymentMethod.java
+++ b/src/main/java/com/divudi/core/entity/membership/AllowedPaymentMethod.java
@@ -26,7 +26,7 @@ import javax.persistence.Temporal;
 public class AllowedPaymentMethod implements Serializable {
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     PaymentMethod paymentMethod;
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/pharmacy/AdjustmentBillItem.java
+++ b/src/main/java/com/divudi/core/entity/pharmacy/AdjustmentBillItem.java
@@ -26,7 +26,7 @@ public class AdjustmentBillItem implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private double qty;

--- a/src/main/java/com/divudi/core/entity/pharmacy/ItemBatch.java
+++ b/src/main/java/com/divudi/core/entity/pharmacy/ItemBatch.java
@@ -30,7 +30,7 @@ public class ItemBatch implements Serializable, RetirableEntity {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @Temporal(TemporalType.TIMESTAMP)
     private Date dateOfManufacture;

--- a/src/main/java/com/divudi/core/entity/pharmacy/ItemsDistributors.java
+++ b/src/main/java/com/divudi/core/entity/pharmacy/ItemsDistributors.java
@@ -25,7 +25,7 @@ public class ItemsDistributors implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     //Created Properties
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/pharmacy/PharmaceuticalBillItem.java
+++ b/src/main/java/com/divudi/core/entity/pharmacy/PharmaceuticalBillItem.java
@@ -32,7 +32,7 @@ public class PharmaceuticalBillItem implements Serializable {
     private StockHistory stockHistory;
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @OneToOne(fetch = FetchType.EAGER)

--- a/src/main/java/com/divudi/core/entity/pharmacy/Price.java
+++ b/src/main/java/com/divudi/core/entity/pharmacy/Price.java
@@ -24,7 +24,7 @@ public class Price implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     ItemBatch itemBatch;

--- a/src/main/java/com/divudi/core/entity/pharmacy/Reorder.java
+++ b/src/main/java/com/divudi/core/entity/pharmacy/Reorder.java
@@ -26,7 +26,7 @@ public class Reorder implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     Item item;

--- a/src/main/java/com/divudi/core/entity/pharmacy/Stock.java
+++ b/src/main/java/com/divudi/core/entity/pharmacy/Stock.java
@@ -28,7 +28,7 @@ public class Stock implements Serializable, RetirableEntity {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @Deprecated // Use Item Batch > Item > barcode
     @Column

--- a/src/main/java/com/divudi/core/entity/pharmacy/StockHistory.java
+++ b/src/main/java/com/divudi/core/entity/pharmacy/StockHistory.java
@@ -56,7 +56,7 @@ public class StockHistory implements Serializable, RetirableEntity {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Temporal(javax.persistence.TemporalType.DATE)

--- a/src/main/java/com/divudi/core/entity/pharmacy/StockVarientBillItem.java
+++ b/src/main/java/com/divudi/core/entity/pharmacy/StockVarientBillItem.java
@@ -26,7 +26,7 @@ import javax.persistence.Temporal;
 public class StockVarientBillItem implements Serializable, RetirableEntity  {
 
      @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/com/divudi/core/entity/pharmacy/UserStock.java
+++ b/src/main/java/com/divudi/core/entity/pharmacy/UserStock.java
@@ -28,7 +28,7 @@ public class UserStock implements Serializable, RetirableEntity  {
     private UserStockContainer userStockContainer;
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     //Created Properties
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/pharmacy/UserStockContainer.java
+++ b/src/main/java/com/divudi/core/entity/pharmacy/UserStockContainer.java
@@ -29,7 +29,7 @@ public class UserStockContainer implements Serializable, RetirableEntity  {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     //Created Properties
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/pharmacy/VirtualProductIngredient.java
+++ b/src/main/java/com/divudi/core/entity/pharmacy/VirtualProductIngredient.java
@@ -30,7 +30,7 @@ public class VirtualProductIngredient implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     Vtm vtm;

--- a/src/main/java/com/divudi/core/entity/process/ProcessInstance.java
+++ b/src/main/java/com/divudi/core/entity/process/ProcessInstance.java
@@ -25,7 +25,7 @@ public class ProcessInstance implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String status;

--- a/src/main/java/com/divudi/core/entity/process/ProcessStepActionDefinition.java
+++ b/src/main/java/com/divudi/core/entity/process/ProcessStepActionDefinition.java
@@ -26,7 +26,7 @@ public class ProcessStepActionDefinition implements Serializable {
     private static final long serialVersionUID = 1L;
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @JoinColumn(nullable = false)

--- a/src/main/java/com/divudi/core/entity/process/ProcessStepDefinition.java
+++ b/src/main/java/com/divudi/core/entity/process/ProcessStepDefinition.java
@@ -25,7 +25,7 @@ public class ProcessStepDefinition implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @JoinColumn(nullable = false)

--- a/src/main/java/com/divudi/core/entity/process/ProcessStepInstance.java
+++ b/src/main/java/com/divudi/core/entity/process/ProcessStepInstance.java
@@ -23,7 +23,7 @@ public class ProcessStepInstance implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne

--- a/src/main/java/com/divudi/core/entity/report/ReportLog.java
+++ b/src/main/java/com/divudi/core/entity/report/ReportLog.java
@@ -10,7 +10,7 @@ import java.util.Date;
 @Entity
 public class ReportLog implements Serializable {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     static final long serialVersionUID = 1L;

--- a/src/main/java/com/divudi/core/entity/web/CaptureComponent.java
+++ b/src/main/java/com/divudi/core/entity/web/CaptureComponent.java
@@ -29,7 +29,7 @@ public class CaptureComponent implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;

--- a/src/main/java/com/divudi/core/entity/web/DesignComponent.java
+++ b/src/main/java/com/divudi/core/entity/web/DesignComponent.java
@@ -23,7 +23,7 @@ public class DesignComponent implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;

--- a/src/main/java/com/divudi/core/entity/web/DesignComponentAssignment.java
+++ b/src/main/java/com/divudi/core/entity/web/DesignComponentAssignment.java
@@ -19,7 +19,7 @@ public class DesignComponentAssignment implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
     private DesignComponent designComponent;

--- a/src/main/java/com/divudi/core/entity/web/TemplateComponent.java
+++ b/src/main/java/com/divudi/core/entity/web/TemplateComponent.java
@@ -20,7 +20,7 @@ public class TemplateComponent implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String name;

--- a/src/main/java/com/divudi/core/entity/web/WebTemplate.java
+++ b/src/main/java/com/divudi/core/entity/web/WebTemplate.java
@@ -16,7 +16,7 @@ public class WebTemplate implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String name;
     @Lob

--- a/src/main/java/com/divudi/core/facade/AuditDatabaseFacade.java
+++ b/src/main/java/com/divudi/core/facade/AuditDatabaseFacade.java
@@ -5,9 +5,17 @@
 package com.divudi.core.facade;
 
 import com.divudi.core.entity.Item;
+import java.sql.Connection;
+import java.util.List;
 import javax.ejb.Stateless;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import javax.sql.DataSource;
+import org.eclipse.persistence.internal.jpa.EntityManagerImpl;
+import org.eclipse.persistence.sessions.JNDIConnector;
+import org.eclipse.persistence.sessions.server.ServerSession;
 
 /**
  * Facade for audit database operations including schema management.
@@ -29,5 +37,41 @@ public class AuditDatabaseFacade extends AbstractFacade<Item> {
 
     public AuditDatabaseFacade() {
         super(Item.class);
+    }
+
+    /**
+     * Temporary measure while this GenerationType.AUTO build (sequence-table
+     * IDs) and the newer GenerationType.IDENTITY build (AUTO_INCREMENT IDs)
+     * share the audit database (REPORTLOG, AUDITEVENT, ...). Separates the two
+     * allocators into disjoint ID ranges so they stop colliding on the same
+     * primary keys. THIS application server must be restarted after running —
+     * it holds a preallocated sequence block in memory. See {@link IdAllocatorSeparation}.
+     *
+     * @return human-readable report of what was changed
+     */
+    @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
+    public List<String> separateIdAllocatorsForDualVersionOperation() throws Exception {
+        Connection conn = getRawJdbcConnection();
+        try {
+            conn.setAutoCommit(true);
+            return IdAllocatorSeparation.separate(conn);
+        } finally {
+            // Restore autoCommit=false before returning connection to Payara's JTA pool.
+            try { conn.setAutoCommit(false); } catch (Exception ignored) { }
+            conn.close();
+        }
+    }
+
+    /**
+     * Obtain a raw JDBC connection from EclipseLink's JNDI datasource,
+     * completely outside JTA. ALTER TABLE causes MySQL implicit commits that
+     * desync the JTA transaction manager, so DDL must bypass it. Caller is
+     * responsible for closing the connection.
+     */
+    private Connection getRawJdbcConnection() throws Exception {
+        EntityManagerImpl emImpl = em.unwrap(EntityManagerImpl.class);
+        ServerSession serverSession = emImpl.getServerSession();
+        DataSource ds = ((JNDIConnector) serverSession.getLogin().getConnector()).getDataSource();
+        return ds.getConnection();
     }
 }

--- a/src/main/java/com/divudi/core/facade/DatabaseMigrationFacade.java
+++ b/src/main/java/com/divudi/core/facade/DatabaseMigrationFacade.java
@@ -6,12 +6,19 @@ package com.divudi.core.facade;
 
 import com.divudi.core.entity.DatabaseMigration;
 import com.divudi.core.data.MigrationStatus;
+import java.sql.Connection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.ejb.Stateless;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
+import javax.sql.DataSource;
+import org.eclipse.persistence.internal.jpa.EntityManagerImpl;
+import org.eclipse.persistence.sessions.JNDIConnector;
+import org.eclipse.persistence.sessions.server.ServerSession;
 
 /**
  * Facade for DatabaseMigration entity operations
@@ -31,6 +38,42 @@ public class DatabaseMigrationFacade extends AbstractFacade<DatabaseMigration> {
 
     public DatabaseMigrationFacade() {
         super(DatabaseMigration.class);
+    }
+
+    /**
+     * Temporary measure while this GenerationType.AUTO build (sequence-table
+     * IDs) and the newer GenerationType.IDENTITY build (AUTO_INCREMENT IDs)
+     * share the main database. Separates the two allocators into disjoint ID
+     * ranges so they stop colliding on the same primary keys. THIS application
+     * server must be restarted after running — it holds a preallocated
+     * sequence block in memory. See {@link IdAllocatorSeparation}.
+     *
+     * @return human-readable report of what was changed
+     */
+    @TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
+    public List<String> separateIdAllocatorsForDualVersionOperation() throws Exception {
+        Connection conn = getRawJdbcConnection();
+        try {
+            conn.setAutoCommit(true);
+            return IdAllocatorSeparation.separate(conn);
+        } finally {
+            // Restore autoCommit=false before returning connection to Payara's JTA pool.
+            try { conn.setAutoCommit(false); } catch (Exception ignored) { }
+            conn.close();
+        }
+    }
+
+    /**
+     * Obtain a raw JDBC connection from EclipseLink's JNDI datasource,
+     * completely outside JTA. ALTER TABLE causes MySQL implicit commits that
+     * desync the JTA transaction manager, so DDL must bypass it. Caller is
+     * responsible for closing the connection.
+     */
+    private Connection getRawJdbcConnection() throws Exception {
+        EntityManagerImpl emImpl = em.unwrap(EntityManagerImpl.class);
+        ServerSession serverSession = emImpl.getServerSession();
+        DataSource ds = ((JNDIConnector) serverSession.getLogin().getConnector()).getDataSource();
+        return ds.getConnection();
     }
 
     /**

--- a/src/main/java/com/divudi/core/facade/IdAllocatorSeparation.java
+++ b/src/main/java/com/divudi/core/facade/IdAllocatorSeparation.java
@@ -1,0 +1,175 @@
+/*
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.core.facade;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Temporary remedy for running two application builds against the same
+ * database when they use different ID generation strategies:
+ *
+ * <ul>
+ * <li>an old production build with {@code GenerationType.AUTO} — EclipseLink
+ * table sequencing, which allocates IDs from the {@code SEQUENCE} table and
+ * sends them explicitly on INSERT, and</li>
+ * <li>a new build with {@code GenerationType.IDENTITY} — MySQL
+ * {@code AUTO_INCREMENT}.</li>
+ * </ul>
+ *
+ * The two allocators are independent, and MySQL's auto_increment counter
+ * always chases the highest inserted ID, so the IDENTITY build's next insert
+ * lands exactly on the AUTO build's next preallocated sequence value —
+ * a guaranteed duplicate-primary-key collision (e.g. REPORTLOG at Ruhunu).
+ * Simply bumping the sequence cannot fix this; the two allocators must be
+ * separated into disjoint ranges:
+ *
+ * <ol>
+ * <li>every {@code SEQUENCE} row is raised just above the highest existing ID,
+ * so the AUTO build stops re-issuing IDs the IDENTITY build already used;</li>
+ * <li>every table's {@code AUTO_INCREMENT} counter is pushed
+ * {@link #AUTO_INCREMENT_OFFSET} above the highest existing ID, so the
+ * IDENTITY build allocates in a high band the sequence will not reach.
+ * Explicit inserts below an auto_increment counter never move it, so the
+ * bands stay disjoint.</li>
+ * </ol>
+ *
+ * The AUTO build's servers must be restarted after this runs — they hold a
+ * preallocated sequence block in memory and keep using it until restarted.
+ *
+ * Full background, runbook and removal plan:
+ * developer_docs/database/dual-version-id-allocator-separation.md
+ */
+final class IdAllocatorSeparation {
+
+    /**
+     * SEQUENCE rows are raised to global max ID + this margin. The margin
+     * absorbs IDENTITY-build inserts that happen between scanning the max and
+     * applying the AUTO_INCREMENT offsets below.
+     */
+    static final long SEQUENCE_SAFETY_MARGIN = 10_000L;
+
+    /**
+     * AUTO_INCREMENT counters jump to global max ID + this offset. The AUTO
+     * build's sequence would need to allocate this many IDs to catch up —
+     * far beyond the temporary dual-version window.
+     */
+    static final long AUTO_INCREMENT_OFFSET = 1_000_000_000L;
+
+    private IdAllocatorSeparation() {
+    }
+
+    /**
+     * Runs the separation on the schema of the given connection. The caller
+     * must supply a raw, autoCommit=true connection outside JTA (ALTER TABLE
+     * causes implicit commits) and is responsible for closing it.
+     *
+     * @return human-readable report of what was scanned and changed
+     */
+    static List<String> separate(Connection conn) throws SQLException {
+        List<String> report = new ArrayList<>();
+
+        // Step 1: inventory entity tables — BIGINT primary key named ID.
+        // The stored case of both table and column names varies between
+        // deployments (lower_case_table_names), so take them verbatim from
+        // INFORMATION_SCHEMA instead of hardcoding either case.
+        Map<String, String> idColumnByTable = new LinkedHashMap<>();
+        String tableQuery = "SELECT TABLE_NAME, COLUMN_NAME FROM information_schema.COLUMNS "
+                + "WHERE TABLE_SCHEMA = DATABASE() "
+                + "AND UPPER(COLUMN_NAME) = 'ID' "
+                + "AND COLUMN_KEY = 'PRI' "
+                + "AND DATA_TYPE = 'bigint' "
+                + "ORDER BY TABLE_NAME";
+        try (PreparedStatement ps = conn.prepareStatement(tableQuery);
+             ResultSet rs = ps.executeQuery()) {
+            while (rs.next()) {
+                idColumnByTable.put(rs.getString(1), rs.getString(2));
+            }
+        }
+        if (idColumnByTable.isEmpty()) {
+            report.add("No tables with a BIGINT ID primary key found — nothing to do.");
+            return report;
+        }
+
+        // Step 2: global max ID across every table. Both targets below are
+        // derived from one shared maximum so the sequence band and the
+        // auto_increment band are disjoint across ALL tables, not per table.
+        // MAX(primary key) is an index-end lookup — cheap even on BILL/BILLITEM.
+        long globalMaxId = 0;
+        for (Map.Entry<String, String> e : idColumnByTable.entrySet()) {
+            try (Statement stmt = conn.createStatement();
+                 ResultSet rs = stmt.executeQuery(
+                         "SELECT MAX(`" + e.getValue() + "`) FROM `" + e.getKey() + "`")) {
+                if (rs.next()) {
+                    globalMaxId = Math.max(globalMaxId, rs.getLong(1));
+                }
+            }
+        }
+        report.add("Scanned " + idColumnByTable.size() + " tables; highest existing ID = " + globalMaxId + ".");
+
+        // Step 3: raise every SEQUENCE row (not just SEQ_GEN — custom
+        // generators would collide the same way) above every existing ID.
+        // Rows already at or beyond the target are left alone, so re-running
+        // never rewinds a sequence.
+        String sequenceTable = findSequenceTableName(conn);
+        if (sequenceTable == null) {
+            report.add("No SEQUENCE table in this schema — sequence bump skipped.");
+        } else {
+            long sequenceTarget = globalMaxId + SEQUENCE_SAFETY_MARGIN;
+            try (Statement stmt = conn.createStatement();
+                 ResultSet rs = stmt.executeQuery("SELECT SEQ_NAME, SEQ_COUNT FROM `" + sequenceTable + "`")) {
+                while (rs.next()) {
+                    report.add("Sequence " + rs.getString(1) + " was at " + rs.getLong(2) + ".");
+                }
+            }
+            try (PreparedStatement ps = conn.prepareStatement(
+                    "UPDATE `" + sequenceTable + "` SET SEQ_COUNT = ? WHERE SEQ_COUNT < ?")) {
+                ps.setLong(1, sequenceTarget);
+                ps.setLong(2, sequenceTarget);
+                int updated = ps.executeUpdate();
+                report.add("Raised " + updated + " sequence row(s) to " + sequenceTarget + ".");
+            }
+        }
+
+        // Step 4: move every table's AUTO_INCREMENT counter into the high
+        // band — including empty tables, because the IDENTITY build must
+        // allocate high everywhere, even in tables it has not written yet.
+        // ALTER ... AUTO_INCREMENT is a metadata-only change (no row rewrite),
+        // and InnoDB ignores a target below the current counter, so re-running
+        // is harmless. Failures are collected per table rather than aborting:
+        // a partial separation still protects every table that was altered.
+        long autoIncrementTarget = globalMaxId + AUTO_INCREMENT_OFFSET;
+        int altered = 0;
+        List<String> failures = new ArrayList<>();
+        for (String tableName : idColumnByTable.keySet()) {
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute("ALTER TABLE `" + tableName + "` AUTO_INCREMENT = " + autoIncrementTarget);
+                altered++;
+            } catch (SQLException e) {
+                failures.add("Could not set AUTO_INCREMENT on `" + tableName + "`: " + e.getMessage());
+            }
+        }
+        report.add("Set AUTO_INCREMENT to " + autoIncrementTarget + " on " + altered + " of "
+                + idColumnByTable.size() + " table(s).");
+        report.addAll(failures);
+        return report;
+    }
+
+    private static String findSequenceTableName(Connection conn) throws SQLException {
+        String query = "SELECT TABLE_NAME FROM information_schema.TABLES "
+                + "WHERE TABLE_SCHEMA = DATABASE() AND UPPER(TABLE_NAME) = 'SEQUENCE'";
+        try (PreparedStatement ps = conn.prepareStatement(query);
+             ResultSet rs = ps.executeQuery()) {
+            return rs.next() ? rs.getString(1) : null;
+        }
+    }
+}

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>jdbc/ruhunu</jta-data-source>
+        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -17,7 +17,7 @@
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
+        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -2,7 +2,7 @@
 <persistence version="2.2" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_2.xsd">
     <persistence-unit name="hmisPU" transaction-type="JTA">
         <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
-        <jta-data-source>${JDBC_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/ruhunu</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>
@@ -17,7 +17,7 @@
         </properties>
     </persistence-unit>
     <persistence-unit name="hmisAuditPU" transaction-type="JTA">
-        <jta-data-source>${JDBC_AUDIT_DATASOURCE}</jta-data-source>
+        <jta-data-source>jdbc/ruhunuAudit</jta-data-source>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
             <property name="eclipselink.logging.level.sql" value="SEVERE"/>

--- a/src/main/webapp/admin/users/user_privileges.xhtml
+++ b/src/main/webapp/admin/users/user_privileges.xhtml
@@ -108,7 +108,7 @@
                                 autocomplete="off">
                                 <p:ajax
                                     event="keyup"
-                                    process="@this"
+                                    process="@this tree"
                                     listener="#{userPrivilageController.filterPrivileges}"
                                     update="tree"
                                     oncomplete="PF('privTree').filter()" />

--- a/src/main/webapp/collecting_centre/collecting_centre_repayment_bill_search.xhtml
+++ b/src/main/webapp/collecting_centre/collecting_centre_repayment_bill_search.xhtml
@@ -55,7 +55,18 @@
                                             value="Search" 
                                             icon="fa fa-search"
                                             class="ui-button-success mt-2"
-                                            action="#{collectingCentrePaymentController.findCollectingCentrePaymentBills()}" />
+                                            action="#{collectingCentrePaymentController.findCollectingCentrePaymentBills()}" >
+                                        </p:commandButton>
+                                        
+                                        <p:commandButton
+                                            id="btnExcel"
+                                            icon="fa-solid fa-file-excel"
+                                            ajax="false"
+                                            value="Download"
+                                            class="w-100 mt-1"
+                                            action="#{collectingCentrePaymentController.exportPaymentBillsToExcel()}">
+                                        </p:commandButton>
+                                        
                                         <hr/>
 
                                         <p:inputText 

--- a/src/main/webapp/collecting_centre/collecting_centre_repayment_bill_search.xhtml
+++ b/src/main/webapp/collecting_centre/collecting_centre_repayment_bill_search.xhtml
@@ -107,55 +107,67 @@
                                         paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
                                         rowsPerPageTemplate="20,50,100">
 
-                                        <p:column headerText="No" width="3em">
+                                        <p:column headerText="No" width="3em" style="padding: 6px;">
                                             <h:outputLabel  value="#{i+1}"></h:outputLabel>
                                         </p:column>
 
-                                        <p:column headerText="Bill No" width="12em">
-                                            <h:commandLink 
-                                                action="#{collectingCentrePaymentController.navigateToViewCCPaymentBill(bill)}" 
+                                        <p:column headerText="Bill No" width="12em" style="padding: 6px;">
+                                            <h:commandLink
+                                                action="#{collectingCentrePaymentController.navigateToViewCCPaymentBill(bill.id)}"
                                                 value="#{bill.deptId}">
                                             </h:commandLink>
                                         </p:column>
 
-                                        <p:column headerText="Billed at" width="12em" >
+                                        <p:column headerText="From" width="8em" style="padding: 6px;">
+                                            <h:outputLabel value="#{bill.fromDate}" >
+                                                <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                                            </h:outputLabel>
+                                        </p:column>
+
+                                        <p:column headerText="Tp" width="8em" style="padding: 6px;">
+                                            <h:outputLabel value="#{bill.toDate}" >
+                                                <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                                            </h:outputLabel>
+                                        </p:column>
+
+                                        <p:column headerText="Billed at" width="12em" style="padding: 6px;">
                                             <h:outputLabel value="#{bill.createdAt}" >
                                                 <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
                                             </h:outputLabel>
                                             <br/>
                                             <h:panelGroup rendered="#{bill.cancelled}" >
-                                                <h:outputLabel style="color: red;" rendered="#{bill.cancelled}" value="#{bill.cancelledBill.createdAt}" >
+                                                <h:outputLabel style="color: red;" rendered="#{bill.cancelled}" value="#{bill.cancelledAt}" >
                                                     <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
                                                 </h:outputLabel>
                                             </h:panelGroup>
-                                        </p:column>  
+                                        </p:column>
 
-                                        <p:column headerText="Billed by" width="10em">
-                                            <h:outputLabel value="#{bill.creater.webUserPerson.name}" ></h:outputLabel>
+                                        <p:column headerText="Billed by" width="13em" style="padding: 6px;">
+                                            <h:outputLabel value="#{bill.createdByName}" ></h:outputLabel>
                                             <br/>
                                             <h:panelGroup rendered="#{bill.cancelled}" >
-                                                <h:outputLabel style="color: red;" rendered="#{bill.cancelled}" value="#{bill.cancelledBill.creater.webUserPerson.name}" >                                       
+                                                <h:outputLabel style="color: red;" rendered="#{bill.cancelled}" value="#{bill.cancelledByName}" >
                                                 </h:outputLabel>
-                                            </h:panelGroup>                               
-                                        </p:column>    
+                                            </h:panelGroup>
+                                        </p:column>
 
-                                        <p:column headerText="CC Code" width="6em">
-                                            <h:outputLabel value="#{bill.toInstitution.institutionCode}" ></h:outputLabel>
-                                        </p:column>  
+                                        <p:column headerText="CC Code" width="6em" style="padding: 6px;">
+                                            <h:outputLabel value="#{bill.toInstitutionCode}" ></h:outputLabel>
+                                        </p:column>
 
-                                        <p:column headerText="CC Name">
-                                            <h:outputLabel value="#{bill.toInstitution.name}" ></h:outputLabel>
-                                        </p:column>  
-                                        
-                                        <p:column headerText="Status" width="10em">
+                                        <p:column headerText="CC Name" style="width: 450px; padding: 6px;">
+                                            <h:outputLabel value="#{bill.toInstitutionName}" ></h:outputLabel>
+                                        </p:column>
+
+                                        <p:column headerText="Status" width="10em" style="padding: 6px;">
                                             <p:badge value="Cancelled" styleClass="ui-badge-danger" rendered="#{bill.cancelled}" />
                                         </p:column>
 
-                                        <p:column headerText="Net Value" width="8em" style="text-align: end;">
+                                        <p:column headerText="Net Value" width="8em" style="padding: 6px; text-align: end;">
                                             <h:outputLabel value="#{bill.netTotal}" >
                                                 <f:convertNumber pattern="#,##0.00"/>
                                             </h:outputLabel>
-                                        </p:column>  
+                                        </p:column>
 
                                     </p:dataTable>
                                 </div>

--- a/src/main/webapp/dataAdmin/admin_functions.xhtml
+++ b/src/main/webapp/dataAdmin/admin_functions.xhtml
@@ -981,6 +981,48 @@
                             </div>
                         </p:tab>
 
+                        <p:tab id="tabIdGeneration" title="ID Generation — Dual Version Operation">
+                            <table class="table table-sm table-bordered w-100">
+                                <thead class="table-light">
+                                    <tr>
+                                        <th style="width: 15%;">Name</th>
+                                        <th style="width: 30%;">Description</th>
+                                        <th style="width: 10%;">Action</th>
+                                        <th style="width: 45%;">Output</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <td><strong>Separate ID Allocators</strong></td>
+                                        <td>
+                                            Temporary fix for running this production build (sequence-table ID
+                                            generation, GenerationType.AUTO) and the newer development build
+                                            (AUTO_INCREMENT, GenerationType.IDENTITY) against the same database — the
+                                            two independent allocators collide, e.g. Duplicate entry for key
+                                            REPORTLOG.PRIMARY. Raises every SEQUENCE row just above the highest
+                                            existing ID and pushes all table AUTO_INCREMENT counters one billion above
+                                            it, so the two builds allocate from non-overlapping ranges. Applies to both
+                                            the main and audit databases. Restart THIS application server immediately
+                                            after running — it keeps a preallocated ID block in memory until restarted.
+                                        </td>
+                                        <td>
+                                            <p:commandButton
+                                                id="btnSeparateIdAllocators"
+                                                action="#{dataAdministrationController.separateIdAllocatorsForDualVersionOperation()}"
+                                                ajax="false"
+                                                value="Separate ID Allocators"
+                                                styleClass="ui-button-danger m-1"
+                                                icon="pi pi-sort-numeric-up"
+                                                rendered="#{webUserController.hasPrivilege('Admin')}"
+                                                onclick="return confirm('This will raise the SEQUENCE table and move the AUTO_INCREMENT counters of ALL tables in the main and audit databases. Restart this application server afterwards. Proceed?');" />
+                                        </td>
+                                        <td>
+                                            <h:outputText value="#{dataAdministrationController.executionFeedback}" escape="false" />
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </p:tab>
 
                     </p:accordionPanel>
                 </h:form>

--- a/src/main/webapp/pharmacy/adjustments/pharmacy_adjustment_cost_rate.xhtml
+++ b/src/main/webapp/pharmacy/adjustments/pharmacy_adjustment_cost_rate.xhtml
@@ -79,7 +79,7 @@
                                             <i class="fas fa-pills me-2"></i>Select Item
                                         </label>
                                         <p:autoComplete id="acAmp" class="w-100" inputStyleClass="w-100"
-                                                       completeMethod="#{ampController.completeAmp}" var="amp"
+                                                       completeMethod="#{ampController.completeAmpAny}" var="amp"
                                                        itemLabel="#{amp.name}" itemValue="#{amp}"
                                                        value="#{pharmacyAdjustmentController.amp}"
                                                        maxResults="10" minQueryLength="3">

--- a/src/main/webapp/pharmacy/adjustments/pharmacy_adjustment_department.xhtml
+++ b/src/main/webapp/pharmacy/adjustments/pharmacy_adjustment_department.xhtml
@@ -92,7 +92,7 @@
                                             id="acAmp"
                                             class="w-100"
                                             inputStyleClass="w-100"
-                                            completeMethod="#{ampController.completeAmp}"
+                                            completeMethod="#{ampController.completeAmpAny}"
                                             var="amp"
                                             itemLabel="#{amp.name}"
                                             itemValue="#{amp}"

--- a/src/main/webapp/pharmacy/adjustments/pharmacy_adjustment_expiry_date.xhtml
+++ b/src/main/webapp/pharmacy/adjustments/pharmacy_adjustment_expiry_date.xhtml
@@ -93,7 +93,7 @@
                                             id="acAmp"
                                             class="w-100"
                                             inputStyleClass="w-100"
-                                            completeMethod="#{ampController.completeAmp}"
+                                            completeMethod="#{ampController.completeAmpAny}"
                                             var="amp"
                                             itemLabel="#{amp.name}"
                                             itemValue="#{amp}"

--- a/src/main/webapp/pharmacy/adjustments/pharmacy_adjustment_purchase_rate.xhtml
+++ b/src/main/webapp/pharmacy/adjustments/pharmacy_adjustment_purchase_rate.xhtml
@@ -83,7 +83,7 @@
                                         id="acAmp"
                                         class="w-100"
                                         inputStyleClass="w-100"
-                                        completeMethod="#{ampController.completeAmp}"
+                                        completeMethod="#{ampController.completeAmpAny}"
                                         var="amp"
                                         itemLabel="#{amp.name}"
                                         itemValue="#{amp}"

--- a/src/main/webapp/pharmacy/adjustments/pharmacy_adjustment_retail_sale_rate.xhtml
+++ b/src/main/webapp/pharmacy/adjustments/pharmacy_adjustment_retail_sale_rate.xhtml
@@ -83,7 +83,7 @@
                                         id="acAmp"
                                         class="w-100"
                                         inputStyleClass="w-100"
-                                        completeMethod="#{ampController.completeAmp}"
+                                        completeMethod="#{ampController.completeAmpAny}"
                                         var="amp"
                                         itemLabel="#{amp.name}"
                                         itemValue="#{amp}"

--- a/src/main/webapp/pharmacy/adjustments/pharmacy_adjustment_whole_sale_rate.xhtml
+++ b/src/main/webapp/pharmacy/adjustments/pharmacy_adjustment_whole_sale_rate.xhtml
@@ -27,7 +27,7 @@
                                             id="acAmp"
                                             class="w-100"
                                             inputStyleClass="w-100"
-                                            completeMethod="#{ampController.completeAmp}"
+                                            completeMethod="#{ampController.completeAmpAny}"
                                             var="amp"
                                             itemLabel="#{amp.name}"
                                             itemValue="#{amp}"

--- a/src/main/webapp/pharmacy/direct_purchase_return.xhtml
+++ b/src/main/webapp/pharmacy/direct_purchase_return.xhtml
@@ -115,15 +115,14 @@
                                         value="#{ph.billItemFinanceDetails.quantity}">
                                         <f:convertNumber pattern="#,##0.00##" integerOnly="#{!ph.item.allowFractions}" ></f:convertNumber>
                                         <f:validator validatorId="positiveNumberValidator" />
-                                    </p:inputText>
-                                    <p:keyFilter for="txtReturningTotalQty" mask="#{ph.item.allowFractions ? 'num' : 'int'}" />
-                                        <p:ajax 
-                                            event="keyup" 
+                                        <p:keyFilter for="txtReturningTotalQty" mask="#{ph.item.allowFractions ? 'num' : 'int'}" />
+                                        <p:ajax
+                                            event="keyup"
                                             process="@this"
-                                            update="txtLineReturnValue :#{p:resolveFirstComponentWithId('panelReturnBillDetails',view).clientId}" 
+                                            update="txtLineReturnValue :#{p:resolveFirstComponentWithId('panelReturnBillDetails',view).clientId}"
                                             listener="#{directPurchaseReturnController.onReturningTotalQtyChange(ph)}" />
-                                        <p:ajax 
-                                            event="blur" 
+                                        <p:ajax
+                                            event="blur"
                                             process="@this"
                                             update="@this" />
                                     </p:inputText>

--- a/src/main/webapp/pharmacy/pharmacy_bill_return_issue.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_return_issue.xhtml
@@ -198,10 +198,8 @@
                                                     action="#{issueReturnController.deleteSelectedItems()}"
                                                     disabled="#{issueReturnController.originalBill.fullReturned}"
                                                     update="itemList :#{p:resolveFirstComponentWithId('total',view).clientId} :#{p:resolveFirstComponentWithId('messages',view).clientId}"
-                                                    process="itemList @this">
-                                                    <p:confirm header="Confirmation"
-                                                               message="Are you sure you want to delete the selected items?"
-                                                               icon="pi pi-exclamation-triangle"/>
+                                                    process="itemList @this"
+                                                    onclick="return confirm('Are you sure you want to delete the selected items?')">
                                                 </p:commandButton>
                                             </div>
                                         </div>

--- a/src/main/webapp/pharmacy/pharmacy_bill_return_issue.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_return_issue.xhtml
@@ -89,7 +89,7 @@
                                             value="Save"
                                             title="Save return bill as draft"
                                             action="#{issueReturnController.saveDisposalIssueReturnBill()}"
-                                            rendered="#{issueReturnController.returnBill.checkedBy eq null and not issueReturnController.originalBill.fullReturned}"
+                                            rendered="#{issueReturnController.returnBill.checkedBy eq null and not issueReturnController.returnBill.billClosed and not issueReturnController.originalBill.fullReturned}"
                                             ajax="false">
                                         </p:commandButton>
                                         <p:commandButton
@@ -99,7 +99,7 @@
                                             onclick="return confirm('Are you sure you want to finalize this disposal issue? This action cannot be undone.');"
                                             title="Finalize return bill"
                                             action="#{issueReturnController.finalizeDisposalIssueReturnBill()}"
-                                            rendered="#{issueReturnController.returnBill.checkedBy eq null and not issueReturnController.originalBill.fullReturned}"
+                                            rendered="#{issueReturnController.returnBill.checkedBy eq null and not issueReturnController.returnBill.billClosed and not issueReturnController.originalBill.fullReturned}"
                                             ajax="false">
                                         </p:commandButton>
                                         <p:commandButton
@@ -109,7 +109,7 @@
                                             onclick="return confirm('Are you sure you want to approve this disposal issue? This action cannot be undone.');"
                                             title="Approve and process the return"
                                             action="#{issueReturnController.settleDisposalIssueReturnBill}"
-                                            rendered="#{issueReturnController.returnBill.checkedBy ne null and (issueReturnController.returnBill.completed eq false or issueReturnController.returnBill.completed eq null) and webUserController.hasPrivilege('ApproveDisposalReturn') and not issueReturnController.originalBill.fullReturned}"
+                                            rendered="#{issueReturnController.returnBill.checkedBy ne null and (issueReturnController.returnBill.completed eq false or issueReturnController.returnBill.completed eq null) and not issueReturnController.returnBill.billClosed and webUserController.hasPrivilege('ApproveDisposalReturn') and not issueReturnController.originalBill.fullReturned}"
                                             ajax="false">
                                         </p:commandButton>
                                     </div>
@@ -130,6 +130,50 @@
                                         <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateTimeFormat}"/>
                                     </h:outputText>
                                     <h:outputText value=" by #{issueReturnController.originalBill.fullReturnedBy.webUserPerson.nameWithTitle}. No further returns are allowed." styleClass="fw-bold"/>
+                                </div>
+                            </div>
+                        </p:panel>
+
+                        <!-- Status: return already approved (settled) - explains why no action buttons are shown -->
+                        <p:panel rendered="#{issueReturnController.returnBill.id ne null and issueReturnController.returnBill.completed and not issueReturnController.originalBill.fullReturned}" styleClass="mb-3">
+                            <div class="alert alert-success d-flex align-items-center">
+                                <i class="fas fa-check-circle me-2"></i>
+                                <div>
+                                    <h:outputText value="This disposal return #{issueReturnController.returnBill.deptId} has already been approved" styleClass="fw-bold"/>
+                                    <h:outputText value=" on " rendered="#{issueReturnController.returnBill.completedAt ne null}"/>
+                                    <h:outputText value="#{issueReturnController.returnBill.completedAt}" rendered="#{issueReturnController.returnBill.completedAt ne null}">
+                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateTimeFormat}"/>
+                                    </h:outputText>
+                                    <h:outputText value=" by #{issueReturnController.returnBill.completedBy.webUserPerson.nameWithTitle}" rendered="#{issueReturnController.returnBill.completedBy ne null}"/>
+                                    <h:outputText value=". No further changes are possible." styleClass="fw-bold"/>
+                                </div>
+                            </div>
+                        </p:panel>
+
+                        <!-- Status: return closed - explains why no action buttons are shown -->
+                        <p:panel rendered="#{issueReturnController.returnBill.id ne null and issueReturnController.returnBill.billClosed and not issueReturnController.returnBill.completed and not issueReturnController.originalBill.fullReturned}" styleClass="mb-3">
+                            <div class="alert alert-warning d-flex align-items-center">
+                                <i class="fas fa-ban me-2"></i>
+                                <div>
+                                    <h:outputText value="This disposal return has been closed. It can no longer be saved, finalized or approved - create a new return for this disposal issue if needed." styleClass="fw-bold"/>
+                                </div>
+                            </div>
+                        </p:panel>
+
+                        <!-- Status: finalized, awaiting approval - explains why Save/Finalize are hidden, and why Approve is hidden when the privilege is missing -->
+                        <p:panel rendered="#{issueReturnController.returnBill.checkedBy ne null and not issueReturnController.returnBill.completed and not issueReturnController.returnBill.billClosed and not issueReturnController.originalBill.fullReturned}" styleClass="mb-3">
+                            <div class="alert alert-info d-flex align-items-center">
+                                <i class="fas fa-info-circle me-2"></i>
+                                <div>
+                                    <h:outputText value="This return was finalized by #{issueReturnController.returnBill.checkedBy.webUserPerson.nameWithTitle}" styleClass="fw-bold"/>
+                                    <h:outputText value=" on " rendered="#{issueReturnController.returnBill.checkeAt ne null}"/>
+                                    <h:outputText value="#{issueReturnController.returnBill.checkeAt}" rendered="#{issueReturnController.returnBill.checkeAt ne null}">
+                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateTimeFormat}"/>
+                                    </h:outputText>
+                                    <h:outputText value=" and is awaiting approval. Items can no longer be edited." styleClass="fw-bold"/>
+                                    <h:outputText value=" You do not have the Approve Disposal Return privilege - please ask an authorized user to approve it."
+                                                  rendered="#{!webUserController.hasPrivilege('ApproveDisposalReturn')}"
+                                                  styleClass="fw-bold text-danger ms-1"/>
                                 </div>
                             </div>
                         </p:panel>

--- a/src/main/webapp/pharmacy/pharmacy_bill_return_issue.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_return_issue.xhtml
@@ -197,7 +197,8 @@
                                                     title="Delete selected items from return"
                                                     action="#{issueReturnController.deleteSelectedItems()}"
                                                     disabled="#{issueReturnController.originalBill.fullReturned}"
-                                                    ajax="false">
+                                                    update="itemList :#{p:resolveFirstComponentWithId('total',view).clientId} :#{p:resolveFirstComponentWithId('messages',view).clientId}"
+                                                    process="itemList @this">
                                                     <p:confirm header="Confirmation"
                                                                message="Are you sure you want to delete the selected items?"
                                                                icon="pi pi-exclamation-triangle"/>

--- a/src/main/webapp/pharmacy/pharmacy_direct_purchase_return_form.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_direct_purchase_return_form.xhtml
@@ -194,12 +194,12 @@
                                         autocomplete="off"
                                         class="w-100 text-end"
                                         onfocus="this.select()"
-                                        value="#{ph.billItemFinanceDetails.quantity}">
+                                        value="#{ph.qty}">
                                         <f:convertNumber pattern="#,##0.00##" integerOnly="#{!ph.item.allowFractions}" ></f:convertNumber>
-                                        <p:ajax 
-                                            event="keyup" 
+                                        <p:ajax
+                                            event="blur"
                                             process="@this"
-                                            update="txtLineReturnValue messages :#{p:resolveFirstComponentWithId('panelReturnBillDetails',view).clientId}" 
+                                            update="txtLineReturnValue messages :#{p:resolveFirstComponentWithId('panelReturnBillDetails',view).clientId}"
                                             listener="#{directPurchaseReturnWorkflowController.onReturningTotalQtyChange(ph)}" />
                                     </p:inputText>
                                     <p:keyFilter for="txtReturningTotalQty" mask="#{ph.item.allowFractions ? 'num' : 'int'}" />
@@ -215,7 +215,7 @@
                                         autocomplete="off"
                                         onfocus="this.select()"
                                         class="w-100 text-end"
-                                        value="#{ph.billItemFinanceDetails.quantity}">
+                                        value="#{ph.qty}">
                                         <f:convertNumber integerOnly="#{!ph.item.allowFractions}" />
                                         <p:ajax 
                                             process="@this"

--- a/src/main/webapp/pharmacy/pharmacy_direct_purchase_return_list_to_approve.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_direct_purchase_return_list_to_approve.xhtml
@@ -26,29 +26,27 @@
                                 <label class="form-label fw-bold text-secondary">
                                     <i class="fas fa-calendar-alt me-1"></i>From Date
                                 </label>
-                                <p:calendar 
-                                    class="w-100" 
-                                    inputStyleClass="form-control" 
-                                    id="fromDate" 
-                                    value="#{searchController.fromDate}" 
-                                    navigator="false" 
+                                <p:datePicker
+                                    class="w-100"
+                                    id="fromDate"
+                                    value="#{searchController.fromDate}"
                                     pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
-                                    placeholder="Select start date">      
-                                </p:calendar>
+                                    placeholder="Select start date"
+                                    showTime="true"
+                                    showSeconds="false" />
                             </div>
                             <div class="mb-3">
                                 <label class="form-label fw-bold text-secondary">
                                     <i class="fas fa-calendar-alt me-1"></i>To Date
                                 </label>
-                                <p:calendar 
-                                    class="w-100" 
-                                    inputStyleClass="form-control" 
-                                    id="toDate" 
-                                    value="#{searchController.toDate}" 
-                                    navigator="false" 
+                                <p:datePicker
+                                    class="w-100"
+                                    id="toDate"
+                                    value="#{searchController.toDate}"
                                     pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
-                                    placeholder="Select end date">                                                                              
-                                </p:calendar>
+                                    placeholder="Select end date"
+                                    showTime="true"
+                                    showSeconds="false" />
                             </div>
                             <div class="mb-3">
                                 <label class="form-label fw-bold text-secondary">

--- a/src/main/webapp/pharmacy/pharmacy_direct_purchase_return_list_to_finalize.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_direct_purchase_return_list_to_finalize.xhtml
@@ -26,29 +26,27 @@
                                 <label class="form-label fw-bold text-secondary">
                                     <i class="fas fa-calendar-alt me-1"></i>From Date
                                 </label>
-                                <p:calendar 
-                                    class="w-100" 
-                                    inputStyleClass="form-control" 
-                                    id="fromDate" 
-                                    value="#{searchController.fromDate}" 
-                                    navigator="false" 
+                                <p:datePicker
+                                    class="w-100"
+                                    id="fromDate"
+                                    value="#{searchController.fromDate}"
                                     pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
-                                    placeholder="Select start date">      
-                                </p:calendar>
+                                    placeholder="Select start date"
+                                    showTime="true"
+                                    showSeconds="false" />
                             </div>
                             <div class="mb-3">
                                 <label class="form-label fw-bold text-secondary">
                                     <i class="fas fa-calendar-alt me-1"></i>To Date
                                 </label>
-                                <p:calendar 
-                                    class="w-100" 
-                                    inputStyleClass="form-control" 
-                                    id="toDate" 
-                                    value="#{searchController.toDate}" 
-                                    navigator="false" 
+                                <p:datePicker
+                                    class="w-100"
+                                    id="toDate"
+                                    value="#{searchController.toDate}"
                                     pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
-                                    placeholder="Select end date">                                                                              
-                                </p:calendar>
+                                    placeholder="Select end date"
+                                    showTime="true"
+                                    showSeconds="false" />
                             </div>
                             <div class="mb-3">
                                 <label class="form-label fw-bold text-secondary">

--- a/src/main/webapp/pharmacy/pharmacy_grn_return_form.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_grn_return_form.xhtml
@@ -68,11 +68,12 @@
 
                     <div class="row" >
                         <div class="col-9" >
-                            <p:dataTable 
-                                var="ph" 
+                            <p:dataTable
+                                var="ph"
                                 value="#{grnReturnWorkflowController.billItems}"
-                                id="itemList" 
-                                rowKey="#{ph.id != null ? ph.id : ph.hashCode()}" >
+                                id="itemList"
+                                rowKey="#{ph.id != null ? ph.id : ph.hashCode()}"
+                                rowStyleClass="#{ph.retired ? 'd-none' : ''}">
 
                                 <f:facet name="header">
                                     <h:outputText value="Returning Items" ></h:outputText>
@@ -195,8 +196,8 @@
                                     </h:panelGroup>
                                 </p:column>
 
-                                <p:column 
-                                    width="5em" 
+                                <p:column
+                                    width="5em"
                                     headerText="Returning Total Qty"
                                     rendered="#{configOptionApplicationController.getBooleanValueByKey('Purchase Return by Total Quantity')}">
                                     <p:inputText
@@ -204,19 +205,19 @@
                                         autocomplete="off"
                                         class="w-100 text-end"
                                         onfocus="this.select()"
-                                        value="#{ph.billItemFinanceDetails.quantity}">
+                                        value="#{ph.qty}">
                                         <f:convertNumber pattern="#,##0.00##" integerOnly="#{!ph.item.allowFractions}" ></f:convertNumber>
-                                        <p:ajax 
-                                            event="blur" 
+                                        <p:ajax
+                                            event="blur"
                                             process="@this"
-                                            update="txtLineReturnValue returnTotal messages :#{p:resolveFirstComponentWithId('panelReturnBillDetails',view).clientId}" 
+                                            update="txtLineReturnValue returnTotal messages :#{p:resolveFirstComponentWithId('panelReturnBillDetails',view).clientId}"
                                             listener="#{grnReturnWorkflowController.onReturningTotalQtyChange(ph)}" />
                                     </p:inputText>
                                     <h:outputText value="&nbsp;Packs" rendered="#{ph.item.class eq 'class com.divudi.core.entity.pharmacy.Ampp'}" />
                                 </p:column>
 
                                 <p:column
-                                    width="5em" 
+                                    width="5em"
                                     headerText="Returning Qty"
                                     rendered="#{configOptionApplicationController.getBooleanValueByKey('Purchase Return by Quantity and Free Quantity')}">
                                     <p:inputText
@@ -224,13 +225,13 @@
                                         autocomplete="off"
                                         onfocus="this.select()"
                                         class="w-100 text-end"
-                                        value="#{ph.billItemFinanceDetails.quantity}">
+                                        value="#{ph.qty}">
                                         <f:convertNumber integerOnly="#{!ph.item.allowFractions}" />
-                                        <p:ajax 
+                                        <p:ajax
                                             process="@this"
-                                            event="blur" 
-                                            update="txtLineReturnValue returnTotal messages :#{p:resolveFirstComponentWithId('panelReturnBillDetails',view).clientId}" 
-                                            listener="#{grnReturnWorkflowController.onReturningQtyChange(ph)}" 
+                                            event="blur"
+                                            update="txtLineReturnValue returnTotal messages :#{p:resolveFirstComponentWithId('panelReturnBillDetails',view).clientId}"
+                                            listener="#{grnReturnWorkflowController.onReturningQtyChange(ph)}"
                                             />
                                     </p:inputText>
                                     <p:keyFilter for="txtReturningQty" mask="#{ph.item.allowFractions ? 'num' : 'int'}" />

--- a/src/main/webapp/pharmacy/pharmacy_grn_return_list_to_approve.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_grn_return_list_to_approve.xhtml
@@ -26,29 +26,27 @@
                                 <label class="form-label fw-bold text-secondary">
                                     <i class="fas fa-calendar-alt me-1"></i>From Date
                                 </label>
-                                <p:calendar 
-                                    class="w-100" 
-                                    inputStyleClass="form-control" 
-                                    id="fromDate" 
-                                    value="#{searchController.fromDate}" 
-                                    navigator="false" 
+                                <p:datePicker
+                                    class="w-100"
+                                    id="fromDate"
+                                    value="#{searchController.fromDate}"
                                     pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
-                                    placeholder="Select start date">      
-                                </p:calendar>
+                                    placeholder="Select start date"
+                                    showTime="true"
+                                    showSeconds="false" />
                             </div>
                             <div class="mb-3">
                                 <label class="form-label fw-bold text-secondary">
                                     <i class="fas fa-calendar-alt me-1"></i>To Date
                                 </label>
-                                <p:calendar 
-                                    class="w-100" 
-                                    inputStyleClass="form-control" 
-                                    id="toDate" 
-                                    value="#{searchController.toDate}" 
-                                    navigator="false" 
+                                <p:datePicker
+                                    class="w-100"
+                                    id="toDate"
+                                    value="#{searchController.toDate}"
                                     pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
-                                    placeholder="Select end date">                                                                              
-                                </p:calendar>
+                                    placeholder="Select end date"
+                                    showTime="true"
+                                    showSeconds="false" />
                             </div>
                             <div class="mb-3">
                                 <label class="form-label fw-bold text-secondary">

--- a/src/main/webapp/pharmacy/pharmacy_grn_return_list_to_finalize.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_grn_return_list_to_finalize.xhtml
@@ -26,29 +26,27 @@
                                 <label class="form-label fw-bold text-secondary">
                                     <i class="fas fa-calendar-alt me-1"></i>From Date
                                 </label>
-                                <p:calendar 
-                                    class="w-100" 
-                                    inputStyleClass="form-control" 
-                                    id="fromDate" 
-                                    value="#{searchController.fromDate}" 
-                                    navigator="false" 
+                                <p:datePicker
+                                    class="w-100"
+                                    id="fromDate"
+                                    value="#{searchController.fromDate}"
                                     pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
-                                    placeholder="Select start date">      
-                                </p:calendar>
+                                    placeholder="Select start date"
+                                    showTime="true"
+                                    showSeconds="false" />
                             </div>
                             <div class="mb-3">
                                 <label class="form-label fw-bold text-secondary">
                                     <i class="fas fa-calendar-alt me-1"></i>To Date
                                 </label>
-                                <p:calendar 
-                                    class="w-100" 
-                                    inputStyleClass="form-control" 
-                                    id="toDate" 
-                                    value="#{searchController.toDate}" 
-                                    navigator="false" 
+                                <p:datePicker
+                                    class="w-100"
+                                    id="toDate"
+                                    value="#{searchController.toDate}"
                                     pattern="#{sessionController.applicationPreference.longDateTimeFormat}"
-                                    placeholder="Select end date">                                                                              
-                                </p:calendar>
+                                    placeholder="Select end date"
+                                    showTime="true"
+                                    showSeconds="false" />
                             </div>
                             <div class="mb-3">
                                 <label class="form-label fw-bold text-secondary">

--- a/src/main/webapp/pharmacy/pharmacy_purchase_order_list_for_recieve.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purchase_order_list_for_recieve.xhtml
@@ -265,6 +265,7 @@
                                                 title="Create a GRN for Selected Approved PO with costing"
                                                 rendered="#{configOptionApplicationController.getBooleanValueByKey('Manage Costing', true)}"
                                                 action="#{grnCostingController.navigateToResiveCostingWithSaveApprove()}"
+                                                onclick="return confirm('Are you sure you want to create a GRN for this Purchase Order?');"
                                                 disabled="#{p.cancelled or p.billClosed or p.fullyIssued}">
                                                 <f:setPropertyActionListener target="#{grnCostingController.approveBill}" value="#{p}"/>
                                             </p:commandButton>

--- a/src/main/webapp/pharmacy/pharmacy_purhcase_order_approving.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purhcase_order_approving.xhtml
@@ -21,7 +21,7 @@
                                              class="ui-button-success m-1" 
                                              icon="fas fa-check" 
                                              disabled="#{!webUserController.hasPrivilege('PurchaseOrdersApprovel')}"
-                                             onclick="if(this.alreadyClicked) return false; if(!confirm('Are you sure you want to approve this purchase order? This action cannot be undone.')) return false; this.alreadyClicked=true; var btn=this; setTimeout(function(){ btn.alreadyClicked=false; }, 5000);"
+                                             onclick="return confirm('Are you sure you want to approve this purchase order? This action cannot be undone.');"
                                              action="#{purchaseOrderController.approve}">
                             </p:commandButton>
                             <p:commandButton ajax="false"  

--- a/src/main/webapp/pharmacy/pharmacy_purhcase_order_approving.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purhcase_order_approving.xhtml
@@ -21,7 +21,7 @@
                                              class="ui-button-success m-1" 
                                              icon="fas fa-check" 
                                              disabled="#{!webUserController.hasPrivilege('PurchaseOrdersApprovel')}"
-                                             onclick="return confirm('Are you sure you want to approve this purchase order? This action cannot be undone.');"
+                                             onclick="if(this.alreadyClicked) return false; if(!confirm('Are you sure you want to approve this purchase order? This action cannot be undone.')) return false; this.alreadyClicked=true; var btn=this; setTimeout(function(){ btn.alreadyClicked=false; }, 5000);"
                                              action="#{purchaseOrderController.approve}">
                             </p:commandButton>
                             <p:commandButton ajax="false"  

--- a/src/main/webapp/pharmacy/pharmacy_purhcase_order_request.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purhcase_order_request.xhtml
@@ -326,7 +326,7 @@
                                         action="#{purchaseOrderRequestController.finalizeRequest()}"
                                         icon="pi pi-check" 
                                         class="ui-button-warning m-1"
-                                        onclick="if(this.alreadyClicked) return false; if(!confirm('Are you sure you want to finalize this purchase order? This action cannot be undone.')) return false; this.alreadyClicked=true; var btn=this; setTimeout(function(){ btn.alreadyClicked=false; }, 5000);"
+                                        onclick="return confirm('Are you sure you want to finalize this purchase order? This action cannot be undone.');"
                                         disabled="#{purchaseOrderRequestController.currentBill.checked}"/>
                                     <p:commandButton 
                                         ajax="false"  

--- a/src/main/webapp/pharmacy/pharmacy_purhcase_order_request.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purhcase_order_request.xhtml
@@ -326,7 +326,7 @@
                                         action="#{purchaseOrderRequestController.finalizeRequest()}"
                                         icon="pi pi-check" 
                                         class="ui-button-warning m-1"
-                                        onclick="return confirm('Are you sure you want to finalize this purchase order? This action cannot be undone.');"
+                                        onclick="if(this.alreadyClicked) return false; if(!confirm('Are you sure you want to finalize this purchase order? This action cannot be undone.')) return false; this.alreadyClicked=true; var btn=this; setTimeout(function(){ btn.alreadyClicked=false; }, 5000);"
                                         disabled="#{purchaseOrderRequestController.currentBill.checked}"/>
                                     <p:commandButton 
                                         ajax="false"  

--- a/src/main/webapp/pharmacy/pharmacy_purhcase_order_request.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_purhcase_order_request.xhtml
@@ -86,14 +86,16 @@
                                         width="6em"
                                         class="text-end px-1"
                                         style="padding: 0px;"> 
-                                        <p:inputText 
-                                            autocomplete="off"  
-                                            id="qty" 
-                                            value="#{bi.billItemFinanceDetails.quantity}" 
-                                            style="padding: 0;" 
+                                        <p:inputText
+                                            autocomplete="off"
+                                            id="qty"
+                                            value="#{bi.billItemFinanceDetails.quantity}"
+                                            style="padding: 0;"
                                             label="Qty"
                                             class="text-end w-100"
-                                            onfocus="this.select()">  
+                                            onkeydown="if (event.keyCode === 13) { event.preventDefault(); }"
+                                            onkeyup="if (event.keyCode === 13) { event.preventDefault(); this.blur(); }"
+                                            onfocus="this.select()">
                                             <f:convertNumber pattern="0.#" ></f:convertNumber>
                                             <p:ajax 
                                                 event="blur" 
@@ -108,14 +110,16 @@
                                         headerText="Free Qty"
                                         class="text-end px-1"
                                         style="padding: 0px;"> 
-                                        <p:inputText 
-                                            autocomplete="off" 
-                                            id="freeQty" 
+                                        <p:inputText
+                                            autocomplete="off"
+                                            id="freeQty"
                                             onfocus="this.select()"
                                             class="text-end w-100"
-                                            value="#{bi.billItemFinanceDetails.freeQuantity}" 
-                                            style="padding: 0;" 
-                                            label="Qty">  
+                                            onkeydown="if (event.keyCode === 13) { event.preventDefault(); }"
+                                            onkeyup="if (event.keyCode === 13) { event.preventDefault(); this.blur(); }"
+                                            value="#{bi.billItemFinanceDetails.freeQuantity}"
+                                            style="padding: 0;"
+                                            label="Qty">
                                             <f:convertNumber pattern="0.#" ></f:convertNumber>
                                             <f:ajax 
                                                 event="blur" 
@@ -135,9 +139,11 @@
                                             <p:inputText
                                                 id="txtRetailRate"
                                                 onfocus="this.select()"
-                                                autocomplete="off" 
-                                                style="padding: 0;" 
-                                                value="#{bi.billItemFinanceDetails.lineGrossRate}" 
+                                                autocomplete="off"
+                                                style="padding: 0;"
+                                                onkeydown="if (event.keyCode === 13) { event.preventDefault(); }"
+                                                onkeyup="if (event.keyCode === 13) { event.preventDefault(); this.blur(); }"
+                                                value="#{bi.billItemFinanceDetails.lineGrossRate}"
                                                 class="w-100 text-end">
                                                 <f:convertNumber pattern="#,##0.00"/>
                                                 <f:ajax event="blur" render="total :#{p:resolveFirstComponentWithId('tot',view).clientId}"  execute="@this qty" listener="#{purchaseOrderRequestController.onEdit(bi)}" ></f:ajax>
@@ -220,11 +226,12 @@
                                     <p:outputLabel value="Supplier"
                                                    class="form-label"
                                                    for="acSupplier"></p:outputLabel>
-                                    <p:autoComplete 
+                                    <p:autoComplete
                                         id="acSupplier"
-                                        converter="deal" 
-                                        value="#{purchaseOrderRequestController.currentBill.toInstitution}"  
+                                        converter="deal"
+                                        value="#{purchaseOrderRequestController.currentBill.toInstitution}"
                                         forceSelection="true"
+                                        onkeydown="if (event.keyCode === 13) { var pnl = document.getElementById(this.id.replace(/_input$/, '_panel')); var panelOpen = pnl &amp;&amp; pnl.style.display !== 'none'; event.preventDefault(); if (!panelOpen) { return false; } }"
                                         class="w-100"
                                         inputStyleClass="w-100"
                                         completeMethod="#{dealerController.completeActiveDealor}"
@@ -388,6 +395,7 @@
                                         id="exItem"
                                         value="#{purchaseOrderRequestController.currentBillItem.item}"
                                         forceSelection="true"
+                                        onkeydown="if (event.keyCode === 13) { var pnl = document.getElementById(this.id.replace(/_input$/, '_panel')); var panelOpen = pnl &amp;&amp; pnl.style.display !== 'none'; event.preventDefault(); if (!panelOpen) { return false; } }"
                                         class="w-75"
                                         maxResults="50"
                                         scrollHeight="600"

--- a/src/main/webapp/pharmacy/pharmacy_reprint_bill_sale_cashier.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_reprint_bill_sale_cashier.xhtml
@@ -101,17 +101,22 @@
                                         rendered="#{webUserController.hasPrivilege('PharmacySaleCancel')}">                           
                                     </p:commandButton>
 
+                                    <!-- Cashier sale bill cancellation temporarily disabled (#21419 COGS remediation).
+                                         Cancelling this bill causes the COGS report to show incorrect figures.
+                                         Re-enable once the COGS variance is fixed. -->
+                                    <!--
                                     <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Accept Sale for Cashier Bill can be Cancelled', true)}">
-                                        <p:commandButton 
-                                            ajax="false" 
+                                        <p:commandButton
+                                            ajax="false"
                                             value="To Cancel"
                                             icon="fa fa-cancel"
                                             class="ui-button-danger m-1"
-                                            action="pharmacy_cancel_bill_retail?faces-redirect=true" 
+                                            action="pharmacy_cancel_bill_retail?faces-redirect=true"
                                             disabled="#{pharmacyBillSearch.bill.cancelled or pharmacyBillSearch.bill.refunded}"
-                                            rendered="#{webUserController.hasPrivilege('PharmacySaleCancel')}">                           
+                                            rendered="#{webUserController.hasPrivilege('PharmacySaleCancel')}">
                                         </p:commandButton>
                                     </h:panelGroup>
+                                    -->
                                 </div>
                             </div>
                         </f:facet>

--- a/src/main/webapp/pharmacy/pharmacy_reprint_bill_unit_issue.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_reprint_bill_unit_issue.xhtml
@@ -35,17 +35,7 @@
                                             <f:setPropertyActionListener value="false" target="#{pharmacyBillSearch.printPreview}"/>
                                         </p:commandButton>
                                     </h:panelGroup>
-                                    <h:panelGroup 
-                                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Disposal Returns are allowed', true)}" >
-                                        <p:commandButton 
-                                            ajax="false" 
-                                            value="To Return" 
-                                            class="mx-2 ui-button-danger"
-                                            icon="fa fa-money-bill-wave"
-                                            action="#{issueReturnController.navigateToReturnDisposalIssueBill(pharmacyBillSearch.bill)}"   
-                                            disabled="#{pharmacyBillSearch.bill.cancelled eq true}"  >                                
-                                        </p:commandButton>
-                                    </h:panelGroup>
+
                                     <p:commandButton
                                         accesskey="n"
                                         value="New Disposal Issue Bill"
@@ -89,10 +79,7 @@
                                     rendered="#{not configOptionApplicationController.getBooleanValueByKey('Pharmacy Disposal Cancellation is allowed', false)}" >
                                     <p:outputLabel value="Disposal Cancellation is Disabled by Configuration - Pharmacy Disposal Cancellation is allowed" ></p:outputLabel>
                                 </h:panelGroup>
-                                <h:panelGroup 
-                                    rendered="#{not configOptionApplicationController.getBooleanValueByKey('Pharmacy Disposal Returns are allowed', true)}" >
-                                    <p:outputLabel value="Disposal Returns are Disabled by Configuration - Pharmacy Disposal Returns are allowed" ></p:outputLabel>
-                                </h:panelGroup>
+
                             </div>
                         </div>
                     </p:panel>

--- a/src/main/webapp/pharmacy/pharmacy_reprint_purchase_return.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_reprint_purchase_return.xhtml
@@ -22,9 +22,14 @@
                                 <p:printer target="gpBillPreview" ></p:printer>
 
                             </p:commandButton>
+                            <!-- GRN Return cancellation temporarily disabled (#21266 stock remediation).
+                                 Cancelling a GRN Return has caused stock data errors in production.
+                                 Re-enable only after all stock discrepancy issues are settled. -->
+                            <!--
                             <p:commandButton value="Cancel" ajax="false"
-                                             action="pharmacy_cancel_grn_return" 
+                                             action="pharmacy_cancel_grn_return"
                                              disabled="#{pharmacyBillSearch.bill.cancelled}"/>
+                            -->
 
 
                         </f:facet>

--- a/src/main/webapp/pharmacy/pharmacy_reprint_transfer_receive.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_reprint_transfer_receive.xhtml
@@ -32,6 +32,10 @@
                                     ajax="false" >
                                     <p:printer target="gpBillPreview" ></p:printer>
                                 </p:commandButton>
+                                <!-- Transfer Receive cancellation temporarily disabled (#21419 COGS remediation).
+                                     Cancelling a Transfer Receive bill causes the COGS report to show
+                                     incorrect figures. Re-enable once the COGS variance is fixed. -->
+                                <!--
                                 <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Transfer Receives can be Cancelled', true)}" >
                                     <p:commandButton
                                         id="btnToCancel"
@@ -45,6 +49,7 @@
                                         <f:setPropertyActionListener target="#{transferReceiveCancellationController.originalReceiveBillId}" value="#{pharmacyBillSearch.bill.id}" />
                                     </p:commandButton>
                                 </h:panelGroup>
+                                -->
                                 <p:commandButton
                                     value="Back"
                                     icon="fas fa-arrow-left"

--- a/src/main/webapp/pharmacy/pharmacy_transfer_receive.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_receive.xhtml
@@ -85,7 +85,7 @@
                                     </p:column>  
 
                                     <p:column headerText="Expiration Date"  style="width:25px!important; margin: 0px; padding: 1px 2px; line-height: 1.1;">
-                                        <h:outputText id="doe" value="#{ph.pharmaceuticalBillItem.stock.itemBatch.dateOfExpire}" >  
+                                        <h:outputText id="doe" value="#{ph.pharmaceuticalBillItem.itemBatch.dateOfExpire}" >  
                                             <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"/>
                                         </h:outputText>
                                     </p:column>  

--- a/src/main/webapp/pharmacy/pharmacy_transfer_receive.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_receive.xhtml
@@ -28,14 +28,15 @@
                 <p:panel>
                     <f:facet name="header" >                                  
 
-                        <p:commandButton  
+                        <p:commandButton
                             id="btnSettleReceive"
-                            value="Receive" 
+                            value="Receive"
                             icon="fas fa-check"
                             style="float: right;"
                             class="ui-button-success mx-2"
-                            action="#{transferReceiveController.settle}" 
-                            ajax="false" >
+                            action="#{transferReceiveController.settle}"
+                            ajax="false"
+                            onclick="return confirm('Are you sure you want to receive this transfer?');" >
                         </p:commandButton>
                         <h:panelGroup rendered="#{transferReceiveController.issuedBill.comments ne null and not empty transferReceiveController.issuedBill.comments}">
                             <p:outputLabel class="mx-4 text-break" value="Note :  #{transferReceiveController.issuedBill.comments}" />
@@ -61,6 +62,7 @@
                                             icon="pi pi-search"
                                             id="btnViewSelectedItemDetails"
                                             title="View Item Details"
+                                            ariaLabel="View Item Details"
                                             action="#{transferReceiveController.displayItemDetails(ph)}"
                                             update=":#{p:resolveFirstComponentWithId('tab',view).clientId}"
                                             process="@this"
@@ -69,6 +71,7 @@
                                             icon="pi pi-info-circle"
                                             id="btnViewBatchDetails"
                                             title="View Batch Details"
+                                            ariaLabel="View Batch Details"
                                             actionListener="#{transferReceiveController.prepareBatchDetails(ph)}"
                                             update=":#{p:resolveFirstComponentWithId('batchDetailsForm',view).clientId}"
                                             oncomplete="PF('batchDetailsDialog').show();"
@@ -308,7 +311,7 @@
                                 </div>
                                 <div class="card-body">
                                     <div class="mb-3">
-                                        <p:selectBooleanCheckbox
+                                        <h:selectBooleanCheckbox
                                             id="transferReceiveA4"
                                             value="#{pharmacyConfigController.transferReceiveA4}" />
                                         <p:outputLabel for="transferReceiveA4" value="A4 Receipt Format" class="ms-2" />
@@ -316,15 +319,15 @@
                                     </div>
 
                                     <div class="mb-3">
-                                        <p:selectBooleanCheckbox
+                                        <h:selectBooleanCheckbox
                                             id="transferReceiveTemplate"
                                             value="#{pharmacyConfigController.transferReceiveTemplate}" />
                                         <p:outputLabel for="transferReceiveTemplate" value="Template Bill Format" class="ms-2" />
                                         <small class="form-text text-muted d-block">Template-based receipt format for transfer receive bills</small>
                                     </div>
-                                    
+
                                     <div class="mb-3">
-                                        <p:selectBooleanCheckbox
+                                        <h:selectBooleanCheckbox
                                             id="transferReceiveCustom1"
                                             value="#{pharmacyConfigController.transferReceiveCustom1}" />
                                         <p:outputLabel for="transferReceiveCustom1" value="Letter Paper Format Custom 1" class="ms-2" />
@@ -332,7 +335,7 @@
                                     </div>
 
                                     <div class="mb-3">
-                                        <p:selectBooleanCheckbox
+                                        <h:selectBooleanCheckbox
                                             id="transferReceiveA4Detailed"
                                             value="#{pharmacyConfigController.transferReceiveA4Detailed}" />
                                         <p:outputLabel for="transferReceiveA4Detailed" value="A4 Detailed Receipt" class="ms-2" />
@@ -340,7 +343,7 @@
                                     </div>
 
                                     <div class="mb-3">
-                                        <p:selectBooleanCheckbox
+                                        <h:selectBooleanCheckbox
                                             id="transferReceiveA4Custom1"
                                             value="#{pharmacyConfigController.transferReceiveA4Custom1}" />
                                         <p:outputLabel for="transferReceiveA4Custom1" value="A4 Custom Format 1" class="ms-2" />
@@ -348,7 +351,7 @@
                                     </div>
 
                                     <div class="mb-3">
-                                        <p:selectBooleanCheckbox
+                                        <h:selectBooleanCheckbox
                                             id="transferReceiveA4Custom2"
                                             value="#{pharmacyConfigController.transferReceiveA4Custom2}" />
                                         <p:outputLabel for="transferReceiveA4Custom2" value="A4 Custom Format 2" class="ms-2" />

--- a/src/main/webapp/pharmacy/pharmacy_transfer_receive_approval.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_receive_approval.xhtml
@@ -76,7 +76,7 @@
                             </p:column>
 
                             <p:column headerText="Expiry Date"  style="width:25px!important;">
-                                <h:outputText id="doe" value="#{ph.pharmaceuticalBillItem.stock.itemBatch.dateOfExpire}" >
+                                <h:outputText id="doe" value="#{ph.pharmaceuticalBillItem.itemBatch.dateOfExpire}" >
                                     <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"/>
                                 </h:outputText>
                             </p:column>

--- a/src/main/webapp/pharmacy/pharmacy_transfer_receive_with_approval.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_receive_with_approval.xhtml
@@ -84,7 +84,7 @@
                             </p:column> 
 
                             <p:column headerText="Expiry Date"  style="width:25px!important;">  
-                                <h:outputText id="doe" value="#{ph.pharmaceuticalBillItem.stock.itemBatch.dateOfExpire}" >  
+                                <h:outputText id="doe" value="#{ph.pharmaceuticalBillItem.itemBatch.dateOfExpire}" >  
                                     <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"/>
                                 </h:outputText>
                             </p:column>  

--- a/src/main/webapp/pharmacy/pharmacy_transfer_request_list_search_for_approval.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_request_list_search_for_approval.xhtml
@@ -113,8 +113,9 @@
                                     icon="fas fa-check-circle"
                                     class="ui-button-success m-1"
                                     disabled="#{p.checkedBy eq null or p.approveUser ne null or p.cancelled eq true and not webUserController.hasPrivilege('PharmacyDisbursementRequestApproval')}"
-                                    action="#{transferRequestController.navigateToApproveRequest()}">
-                                    <f:setPropertyActionListener 
+                                    action="#{transferRequestController.navigateToApproveRequest()}"
+                                    onclick="return confirm('Proceed to review and approve this transfer request?');">
+                                    <f:setPropertyActionListener
                                         target="#{transferRequestController.transferRequestBillPre}"
                                         value="#{p}"/>
                                 </p:commandButton>

--- a/src/main/webapp/pharmacy/pharmacy_transfer_request_list_to_approve.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_request_list_to_approve.xhtml
@@ -76,6 +76,7 @@
                                     title="Approve Request"
                                     icon="fas fa-check-double" class="ui-button-success mx-2"
                                     action="#{transferRequestController.navigateToApproveRequest}"
+                                    onclick="return confirm('Proceed to review and approve this transfer request?');"
                                     disabled="#{b.cancelled eq true}">
                                     <f:setPropertyActionListener target="#{transferRequestController.transferRequestBillPre}" value="#{b}"/>
                                 </p:commandButton>

--- a/src/main/webapp/reports/index.xhtml
+++ b/src/main/webapp/reports/index.xhtml
@@ -435,7 +435,8 @@
                                         ajax="false" 
                                         value="1. Closing Stock" 
                                         action="#{reportController.navigateToClosingStockReport()}"/>
-                                    <p:commandButton   class="w-100"  ajax="false" value="2. Consumption" action="#{reportController.navigateToconsumption()}"  />
+                                    <p:commandButton class="w-100 ui-button-secondary" ajax="false" value="2. Consumption (Legacy)" action="#{reportController.navigateToconsumption()}" title="Legacy entity-based report (deprecated)"/>
+                                    <p:commandButton class="w-100 ui-button-success" ajax="false" value="2. Consumption" action="#{reportController.navigateToConsumptionDto()}" icon="fa fa-rocket" title="High-performance DTO-based Consumption report"/>
                                     <p:commandButton   class="w-100"  ajax="false" value="3. Stock Transfers"  action="#{reportController.navigateToStockTransferReport()}" />
                                     <p:commandButton   class="w-100"  ajax="false" value="4. Cost Of Good Sold" action="#{reportController.navigateToCostOfGoodsSold()}" />
                                     <p:commandButton   class="w-100"  ajax="false" value="5. Good in Transit" action="#{reportController.navigateToGoodInTransit()}" />

--- a/src/main/webapp/reports/inventoryReports/consumption.xhtml
+++ b/src/main/webapp/reports/inventoryReports/consumption.xhtml
@@ -208,8 +208,8 @@
                         <div class="d-flex align-items-center mt-3">
                             <p:commandButton class="ui-button-warning mx-1"
                                              icon="fas fa-cogs"
-                                             ajax="false"
                                              value="Process"
+                                             update="@form"
                                              action="#{pharmacyController.createConsumptionReportTable()}">
                             </p:commandButton>
                             <p:commandButton class="ui-button- mx-1" icon="fas fa-print" ajax="false" value="Print All"

--- a/src/main/webapp/reports/inventoryReports/consumption.xhtml
+++ b/src/main/webapp/reports/inventoryReports/consumption.xhtml
@@ -518,8 +518,8 @@
                                     width="4em"
                                     style="text-align: right;"
                                     filterMatchMode="contains"
-                                    sortBy="#{b.bill.billFinanceDetails.totalPurchaseValue}">
-                                    <h:outputText value="#{b.bill.billFinanceDetails.totalPurchaseValue}">
+                                    sortBy="#{b.consumptionPurchaseValue}">
+                                    <h:outputText value="#{b.consumptionPurchaseValue}">
                                         <f:convertNumber pattern="#,##0.00"/>
                                     </h:outputText>
                                     <f:facet name="footer">
@@ -533,8 +533,8 @@
                                     width="4em"
                                     style="text-align: right;"
                                     filterMatchMode="contains"
-                                    sortBy="#{b.bill.billFinanceDetails.totalCostValue}">
-                                    <h:outputText value="#{b.bill.billFinanceDetails.totalCostValue}">
+                                    sortBy="#{b.consumptionCostValue}">
+                                    <h:outputText value="#{b.consumptionCostValue}">
                                         <f:convertNumber pattern="#,##0.00"/>
                                     </h:outputText>
                                     <f:facet name="footer">
@@ -548,8 +548,8 @@
                                     width="4em"
                                     style="text-align: right;"
                                     filterMatchMode="contains"
-                                    sortBy="#{b.bill.billFinanceDetails.totalRetailSaleValue}">
-                                    <h:outputText value="#{b.bill.billFinanceDetails.totalRetailSaleValue}">
+                                    sortBy="#{b.consumptionRetailValue}">
+                                    <h:outputText value="#{b.consumptionRetailValue}">
                                         <f:convertNumber pattern="#,##0.00"/>
                                     </h:outputText>
                                     <f:facet name="footer">
@@ -658,9 +658,9 @@
                                     width="4em"
                                     style="text-align: right; padding-right: 20px;"
                                     filterMatchMode="contains"
-                                    sortBy="#{i.billItem.qty}"
-                                    filterBy="#{i.billItem.qty}">
-                                    <p:outputLabel value="#{i.billItem.qty}"/>
+                                    sortBy="#{i.consumptionQty}"
+                                    filterBy="#{i.consumptionQty}">
+                                    <p:outputLabel value="#{i.consumptionQty}"/>
                                 </p:column>
 
                                 <p:column headerText="Status/Links" width="10em" exportable="false">
@@ -732,9 +732,8 @@
                                     width="6em"
                                     style="text-align: right;"
                                     filterMatchMode="contains"
-                                    sortBy="#{i.billItem.billItemFinanceDetails.valueAtPurchaseRate}">
-                                    <p:outputLabel
-                                        value="#{i.billItem.billItemFinanceDetails.valueAtPurchaseRate}">
+                                    sortBy="#{i.consumptionPurchaseValue}">
+                                    <p:outputLabel value="#{i.consumptionPurchaseValue}">
                                         <f:convertNumber pattern="#,##0.00"/>
                                     </p:outputLabel>
                                     <f:facet name="footer">
@@ -759,8 +758,8 @@
                                     width="6em"
                                     style="text-align: right;"
                                     filterMatchMode="contains"
-                                    sortBy="#{i.billItem.billItemFinanceDetails.valueAtRetailRate}">
-                                    <p:outputLabel value="#{i.billItem.billItemFinanceDetails.valueAtRetailRate}">
+                                    sortBy="#{i.consumptionRetailValue}">
+                                    <p:outputLabel value="#{i.consumptionRetailValue}">
                                         <f:convertNumber pattern="#,##0.00"/>
                                     </p:outputLabel>
                                     <f:facet name="footer">
@@ -785,8 +784,8 @@
                                     width="6em"
                                     style="text-align: right;"
                                     filterMatchMode="contains"
-                                    sortBy="#{i.billItem.billItemFinanceDetails.valueAtCostRate}">
-                                    <p:outputLabel value="#{i.billItem.billItemFinanceDetails.valueAtCostRate}">
+                                    sortBy="#{i.consumptionCostValue}">
+                                    <p:outputLabel value="#{i.consumptionCostValue}">
                                         <f:convertNumber pattern="#,##0.00"/>
                                     </p:outputLabel>
                                     <f:facet name="footer">

--- a/src/main/webapp/reports/inventoryReports/consumption_dto.xhtml
+++ b/src/main/webapp/reports/inventoryReports/consumption_dto.xhtml
@@ -1,0 +1,967 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+    <h:body>
+        <ui:composition template="/reports/index.xhtml">
+            <ui:define name="subcontent">
+                <h:form>
+                    <p:panel header="Consumption">
+                        <h:panelGrid columns="8" class="w-100">
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf073;" styleClass="fa ml-5"/>
+                                <p:outputLabel value="From Date" for="fromDate" class="mx-3">
+                                </p:outputLabel>
+                            </h:panelGroup>
+                            <p:calendar
+                                class="w-100"
+                                inputStyleClass="w-100"
+                                id="fromDate"
+                                value="#{pharmacyController.fromDate}"
+                                pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+
+                            <p:spacer width="20"/>
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf073;" styleClass="fa ml-5"/>
+                                <p:outputLabel value="To Date" for="toDate" class="mx-3">
+                                </p:outputLabel>
+                            </h:panelGroup>
+                            <p:calendar
+                                class="w-100"
+                                inputStyleClass="w-100"
+                                id="toDate"
+                                value="#{pharmacyController.toDate}"
+                                pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+
+                            <p:spacer width="20"/>
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText styleClass="fa fa-building ml-5"/>
+                                <p:outputLabel value="Item Department Type" for="departmentTypeFilter" class="mx-3"/>
+                            </h:panelGroup>
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <p:selectCheckboxMenu
+                                    id="departmentTypeFilter"
+                                    value="#{pharmacyController.selectedDepartmentTypes}"
+                                    label="Select Department Types"
+                                    class="w-100"
+                                    filter="true"
+                                    filterMatchMode="contains"
+                                    showHeader="true"
+                                    scrollHeight="200"
+                                    title="Select one or more department types to filter results. Leave empty to include all.">
+                                    <f:selectItems
+                                        value="#{pharmacyController.availableDepartmentTypes}"
+                                        var="depType"
+                                        itemLabel="#{depType.label}"
+                                        itemValue="#{depType}"/>
+                                </p:selectCheckboxMenu>
+                                <p:tooltip for="departmentTypeFilter" value="Select one or more department types to filter results. Leave empty to include all." position="top"/>
+                            </h:panelGroup>
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText styleClass="fa fa-university ml-5"/>
+                                <p:outputLabel value="Institution" for="phmIns" class="mx-3">
+                                </p:outputLabel>
+                            </h:panelGroup>
+                            <p:selectOneMenu
+                                id="phmIns"
+                                class="w-100"
+                                value="#{pharmacyController.institution}"
+                                filter="true">
+                                <f:selectItem itemLabel="All Institutions"/>
+                                <f:selectItems value="#{institutionController.companies}" var="ins" itemLabel="#{ins.name}"
+                                               itemValue="#{ins}"/>
+                                <p:ajax process="phmIns" update="phmDept"/>
+                            </p:selectOneMenu>
+
+                            <p:spacer width="20"/>
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText styleClass="fa fa-map-marker-alt ml-5"/>
+                                <p:outputLabel value="Site" for="phmSite" class="mx-3"/>
+                            </h:panelGroup>
+                            <p:selectOneMenu
+                                id="phmSite"
+                                class="w-100"
+                                value="#{pharmacyController.site}"
+                                filter="true">
+                                <f:selectItem itemLabel="All Sites"/>
+                                <f:selectItems value="#{institutionController.sites}" var="site" itemLabel="#{site.name}"
+                                               itemValue="#{site}"/>
+                                <p:ajax process="phmSite" update="phmDept"/>
+                            </p:selectOneMenu>
+
+                            <p:spacer width="20"/>
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText styleClass="fa fa-building ml-5"/>
+                                <p:outputLabel value="Department" for="phmDept" class="mx-3">
+                                </p:outputLabel>
+                            </h:panelGroup>
+                            <p:selectOneMenu
+                                id="phmDept"
+                                class="w-100"
+                                value="#{pharmacyController.dept}"
+                                filter="true">
+                                <f:selectItem itemLabel="All Departments"/>
+                                <f:selectItems
+                                    value="#{departmentController.getDepartmentsOfInstitutionAndSite(pharmacyController.institution, pharmacyController.site)}"
+                                    var="dept"
+                                    itemLabel="#{dept.name}"
+                                    itemValue="#{dept}"/>
+                            </p:selectOneMenu>
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText styleClass="fa fa-tags ml-5"/>
+                                <p:outputLabel value="Category" for="phmCategory" class="mx-3">
+                                </p:outputLabel>
+                            </h:panelGroup>
+                            <p:selectOneMenu
+                                id="phmCategory"
+                                value="#{pharmacyController.category}"
+                                filter="true"
+                                class="w-100 ">
+                                <f:selectItem itemLabel="All Categories"/>
+                                <f:selectItems value="#{pharmaceuticalItemCategoryController.items}"
+                                               var="category"
+                                               itemLabel="#{category.name}"
+                                               itemValue="#{category}"/>
+                            </p:selectOneMenu>
+
+                            <p:spacer width="20"/>
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText styleClass="fa fa-capsules ml-5"/>
+                                <p:outputLabel value="Dosage Form" for="phmDf" class="mx-3">
+                                </p:outputLabel>
+                            </h:panelGroup>
+                            <p:selectOneMenu
+                                id="phmDf"
+                                value="#{pharmacyController.dosageForm}"
+                                class="w-100"
+                                filter="true"
+                                filterMatchMode="contains">
+                                <f:selectItem itemLabel="All Dosage Forms"/>
+                                <f:selectItems value="#{dosageFormController.items}" var="df" itemLabel="#{df.name}" itemValue="#{df}"/>
+                            </p:selectOneMenu>
+
+                            <p:spacer width="20"/>
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText styleClass="fa fa-box ml-5"/>
+                                <p:outputLabel value="Item" class="mx-3">
+                                </p:outputLabel>
+                            </h:panelGroup>
+                            <p:autoComplete value="#{pharmacyController.item}"
+                                            inputStyleClass="w-100"
+                                            class="w-100"
+                                            minQueryLength="3" queryDelay="300" completeMethod="#{itemController.completeAmpItemAll}"
+                                            var="item" itemValue="#{item}" itemLabel="#{item.name}"
+                                            forceSelection="true">
+                                <p:column headerText="Item">
+                                    <h:outputLabel value="#{item.name}"/>
+                                </p:column>
+                                <p:column headerText="Code">
+                                    <h:outputLabel value="#{item.code}"/>
+                                </p:column>
+                            </p:autoComplete>
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText styleClass="fa fa-list-alt ml-5"/>
+                                <p:outputLabel value="Report Type" class="mx-3" for="grnReportType">
+                                </p:outputLabel>
+                            </h:panelGroup>
+                            <p:selectOneMenu class="w-100" id="grnReportType" value="#{pharmacyController.reportType}">
+                                <f:selectItem itemLabel="Summary" itemValue="summeryReport"/>
+                                <f:selectItem itemLabel="By Bill" itemValue="byBill"/>
+                                <f:selectItem itemLabel="By Bill Item" itemValue="byBillItem"/>
+                                <f:selectItem itemLabel="By Category"
+                                              itemValue="categoryWise"/>
+                            </p:selectOneMenu>
+
+                            <p:spacer width="20"/>
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText styleClass="fa fa-barcode ml-5"/>
+                                <p:outputLabel value="Consumption Department" for="phmCde" class="mx-3">
+                                </p:outputLabel>
+                            </h:panelGroup>
+                            <p:autoComplete value="#{pharmacyController.toDepartment}"
+                                            inputStyleClass="w-100"
+                                            id="phmCde"
+                                            class="w-100"
+                                            completeMethod="#{departmentController.completeDept}"
+                                            var="i" itemValue="#{i}" itemLabel="#{i.name}"
+                                            forceSelection="true">
+                                <p:column headerText="Department">
+                                    <h:outputLabel value="#{i.name}"/>
+                                </p:column>
+                            </p:autoComplete>
+
+                        </h:panelGrid>
+
+                        <div class="d-flex align-items-center mt-3">
+                            <p:commandButton class="ui-button-warning mx-1"
+                                             icon="fas fa-cogs"
+                                             value="Process"
+                                             widgetVar="wBtnProcess"
+                                             update="@form :growl"
+                                             onstart="PF('wBtnProcess').disable()"
+                                             oncomplete="PF('wBtnProcess').enable()"
+                                             action="#{pharmacyController.createConsumptionReportTableDto()}">
+                            </p:commandButton>
+                            <p:commandButton class="ui-button- mx-1" icon="fas fa-print" ajax="false" value="Print All"
+                                             rendered="#{pharmacyController.reportType eq 'summeryReport' or pharmacyController.reportType eq null or empty pharmacyController.reportType}"
+                                             onclick="hidePaginatorBeforePrint()">
+                                <p:printer target="tbl1" oncomplete="restorePaginatorAfterPrint()"/>
+                            </p:commandButton>
+                            <p:commandButton class="ui-button- mx-1" icon="fas fa-print" ajax="false" value="Print All"
+                                             rendered="#{pharmacyController.reportType eq 'byBill'}"
+                                             onclick="hidePaginatorBeforePrint()">
+                                <p:printer target="tblListBillsDto" oncomplete="restorePaginatorAfterPrint()"/>
+                            </p:commandButton>
+                            <p:commandButton class="ui-button- mx-1" icon="fas fa-print" ajax="false" value="Print All"
+                                             rendered="#{pharmacyController.reportType eq 'byBillItem'}"
+                                             onclick="hidePaginatorBeforePrint()">
+                                <p:printer target="tblListBillItemsDto" oncomplete="restorePaginatorAfterPrint()"/>
+                            </p:commandButton>
+                            <p:commandButton class="ui-button- mx-1" icon="fas fa-print" ajax="false" value="Print All"
+                                             rendered="#{pharmacyController.reportType eq 'categoryWise'}"
+                                             onclick="hidePaginatorBeforePrint()">
+                                <p:printer target="tblCategoryDto" oncomplete="restorePaginatorAfterPrint()"/>
+                            </p:commandButton>
+                            <h:outputScript>
+                                function hidePaginatorBeforePrint() {
+                                let paginators = document.querySelectorAll('.ui-paginator');
+                                paginators.forEach(el => el.style.display = 'none');
+                                }
+
+                                function restorePaginatorAfterPrint() {
+                                let paginators = document.querySelectorAll('.ui-paginator');
+                                paginators.forEach(el => el.style.display = '');
+                                }
+
+                                window.onafterprint = function () {
+                                restorePaginatorAfterPrint();
+                                };
+                            </h:outputScript>
+
+                            <p:commandButton class="ui-button-success mx-1" icon="fas fa-file-excel" ajax="false"
+                                             value="Download"
+                                             rendered="#{pharmacyController.reportType eq 'summeryReport' or pharmacyController.reportType eq null or empty pharmacyController.reportType}"
+                                             action="#{pharmacyController.exportConsumptionReportSummaryToExcel()}">
+                            </p:commandButton>
+                            <p:commandButton class="ui-button-success mx-1" icon="fas fa-file-excel" ajax="false"
+                                             value="Download" rendered="#{pharmacyController.reportType eq 'byBill'}">
+                                <p:dataExporter type="xlsx" target="tblListBillsDto"
+                                                fileName="#{pharmacyController.generateFileNameForReport('Consumption')}"/>
+                            </p:commandButton>
+                            <p:commandButton class="ui-button-success mx-1" icon="fas fa-file-excel" ajax="false"
+                                             value="Download" rendered="#{pharmacyController.reportType eq 'byBillItem'}">
+                                <p:dataExporter type="xlsx" target="tblListBillItemsDto"
+                                                fileName="#{pharmacyController.generateFileNameForReport('Consumption')}"/>
+                            </p:commandButton>
+                            <p:commandButton class="ui-button-success mx-1" icon="fas fa-file-excel" ajax="false"
+                                             value="Download" rendered="#{pharmacyController.reportType eq 'categoryWise'}"
+                                             action="#{pharmacyController.exportConsumptionReportCategoryWiseToExcel()}"/>
+
+                            <p:commandButton class="ui-button-danger mx-1" icon="fas fa-file-pdf" ajax="false" value="PDF"
+                                             rendered="#{pharmacyController.reportType eq 'summeryReport' or pharmacyController.reportType eq null or empty pharmacyController.reportType}"
+                                             action="#{pharmacyController.exportConsumptionReportSummaryToPdf()}">
+                            </p:commandButton>
+                            <p:commandButton class="ui-button-danger mx-1" icon="fas fa-file-pdf" ajax="false" value="PDF"
+                                             rendered="#{pharmacyController.reportType eq 'byBill'}"
+                                             action="#{pharmacyController.exportConsumptionReportByBillToPdf()}">
+                            </p:commandButton>
+                            <p:commandButton class="ui-button-danger mx-1" icon="fas fa-file-pdf" ajax="false" value="PDF"
+                                             rendered="#{pharmacyController.reportType eq 'byBillItem'}">
+                                <p:dataExporter type="pdf" target="tblListBillItemsDto"
+                                                fileName="#{pharmacyController.generateFileNameForReport('Consumption')}"/>
+                            </p:commandButton>
+                            <p:commandButton class="ui-button-danger mx-1" icon="fas fa-file-pdf" ajax="false" value="PDF"
+                                             rendered="#{pharmacyController.reportType eq 'categoryWise'}"
+                                             action="#{pharmacyController.exportConsumptionReportCategoryWiseToPdf()}">
+                            </p:commandButton>
+                        </div>
+
+                        <h:panelGroup rendered="#{pharmacyController.reportType eq 'summeryReport' and (pharmacyController.totalPurchase != 0 or pharmacyController.totalCostValue != 0 or pharmacyController.totalRetailValue != 0 or pharmacyController.totalSaleValue != 0)}" id="tbl1">
+                            <h5 class="mt-3">Department Summary</h5>
+                            <h:panelGroup layout="block" styleClass="mb-3 p-2" style="background: #f8f9fa; border: 1px solid #dee2e6; border-radius: 4px; font-size: 0.9em;">
+                                <h:panelGroup layout="block">
+                                    <strong>From: </strong>
+                                    <h:outputText value="#{pharmacyController.fromDate}">
+                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                    </h:outputText>
+                                    <strong class="ml-3">To: </strong>
+                                    <h:outputText value="#{pharmacyController.toDate}">
+                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                    </h:outputText>
+                                </h:panelGroup>
+                                <h:panelGroup layout="block" rendered="#{pharmacyController.institution ne null}">
+                                    <strong>Institution: </strong>
+                                    <h:outputText value="#{pharmacyController.institution.name}"/>
+                                </h:panelGroup>
+                                <h:panelGroup layout="block" rendered="#{pharmacyController.site ne null}">
+                                    <strong>Site: </strong>
+                                    <h:outputText value="#{pharmacyController.site.name}"/>
+                                </h:panelGroup>
+                                <h:panelGroup layout="block" rendered="#{pharmacyController.dept ne null}">
+                                    <strong>Department: </strong>
+                                    <h:outputText value="#{pharmacyController.dept.name}"/>
+                                </h:panelGroup>
+                                <h:panelGroup layout="block" rendered="#{pharmacyController.category ne null}">
+                                    <strong>Category: </strong>
+                                    <h:outputText value="#{pharmacyController.category.name}"/>
+                                </h:panelGroup>
+                                <h:panelGroup layout="block" rendered="#{pharmacyController.dosageForm ne null}">
+                                    <strong>Dosage Form: </strong>
+                                    <h:outputText value="#{pharmacyController.dosageForm.name}"/>
+                                </h:panelGroup>
+                                <h:panelGroup layout="block" rendered="#{pharmacyController.item ne null}">
+                                    <strong>Item: </strong>
+                                    <h:outputText value="#{pharmacyController.item.name}"/>
+                                </h:panelGroup>
+                                <h:panelGroup layout="block" rendered="#{pharmacyController.toDepartment ne null}">
+                                    <strong>Consumption Department: </strong>
+                                    <h:outputText value="#{pharmacyController.toDepartment.name}"/>
+                                </h:panelGroup>
+                            </h:panelGroup>
+
+                            <ui:repeat value="#{pharmacyController.departmentTotals.entrySet()}" var="map"
+                                       varStatus="status">
+                                <p:dataTable id="tblSummary" value="#{map.value.entrySet()}" var="entry"
+                                             rowIndexVar="n" rowKey="#{entry.key}"
+                                             paginator="true"
+                                             paginatorPosition="bottom"
+                                             rows="10"
+                                             paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                             currentPageReportTemplate="Showing {startRecord} to {endRecord} of {totalRecords}"
+                                             rowsPerPageTemplate="5,10,15,25,50,100,500,1000">
+
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Department" rendered="#{status.first}"/>
+                                    </f:facet>
+
+                                    <p:column headerText="#{map.key}"
+                                              filterBy="#{entry.key}"
+                                              filterMatchMode="contains">
+                                        <h:outputLabel value="#{entry.key}"/>
+                                    </p:column>
+
+                                    <p:column headerText="Purchase Value" style="text-align: right">
+                                        <h:outputLabel value="#{entry.value[0]}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </h:outputLabel>
+                                    </p:column>
+
+                                    <p:column headerText="Cost Value" style="text-align: right">
+                                        <h:outputLabel value="#{entry.value[1]}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </h:outputLabel>
+                                    </p:column>
+
+                                    <p:column headerText="Retail Value" style="text-align: right">
+                                        <h:outputLabel value="#{entry.value[2]}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </h:outputLabel>
+                                    </p:column>
+
+                                    <p:column headerText="Net Total" style="text-align: right">
+                                        <h:outputLabel value="#{entry.value[3]}">
+                                            <f:convertNumber pattern="#,##0.00"/>
+                                        </h:outputLabel>
+                                    </p:column>
+                                    <p:columnGroup type="footer">
+                                        <p:row rendered="#{status.last}">
+                                            <p:column colspan="1">
+                                                <f:facet name="footer">
+                                                    <h:outputLabel value="Total" style="font-weight: bold;"/>
+                                                </f:facet>
+                                            </p:column>
+                                            <p:column style="text-align: right; font-weight: bold;">
+                                                <f:facet name="footer">
+                                                    <h:outputLabel value="#{pharmacyController.totalPurchase}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputLabel>
+                                                </f:facet>
+                                            </p:column>
+                                            <p:column style="text-align: right; font-weight: bold;">
+                                                <f:facet name="footer">
+                                                    <h:outputLabel value="#{pharmacyController.totalCostValue}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputLabel>
+                                                </f:facet>
+                                            </p:column>
+                                            <p:column style="text-align: right; font-weight: bold;">
+                                                <f:facet name="footer">
+                                                    <h:outputLabel value="#{pharmacyController.totalRetailValue}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputLabel>
+                                                </f:facet>
+                                            </p:column>
+                                            <p:column style="text-align: right; font-weight: bold;">
+                                                <f:facet name="footer">
+                                                    <h:outputLabel value="#{pharmacyController.totalSaleValue}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputLabel>
+                                                </f:facet>
+                                            </p:column>
+                                        </p:row>
+                                    </p:columnGroup>
+                                </p:dataTable>
+                            </ui:repeat>
+                        </h:panelGroup>
+
+                        <!-- No data message for Summary report -->
+                        <h:panelGroup rendered="#{pharmacyController.reportType eq 'summeryReport' and pharmacyController.totalPurchase == 0 and pharmacyController.totalCostValue == 0 and pharmacyController.totalRetailValue == 0 and pharmacyController.totalSaleValue == 0}">
+                            <div class="ui-messages ui-widget ui-corner-all ui-messages-info ui-messages-noicon" style="margin-top: 20px;">
+                                <div class="ui-messages-info-summary">No data found for the selected criteria.</div>
+                            </div>
+                        </h:panelGroup>
+
+                        <h:panelGroup rendered="#{pharmacyController.reportType eq 'byBill'}">
+                            <h5 class="mt-3">Department unit issue by Bill No</h5>
+                            <p:dataTable
+                                id="tblListBillsDto"
+                                value="#{pharmacyController.consumptionBillDtos}"
+                                var="b"
+                                rowIndexVar="n"
+                                rowKey="#{b.billId}"
+                                paginator="true"
+                                rows="10"
+                                paginatorPosition="bottom"
+                                paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                currentPageReportTemplate="Showing {startRecord} to {endRecord} of {totalRecords}"
+                                rowsPerPageTemplate="5,10,15,25,50,100,500,1000">
+                                <p:column
+                                    headerText="Bill No"
+                                    width="10em"
+                                    filterMatchMode="contains"
+                                    sortBy="#{b.deptId}"
+                                    filterBy="#{b.deptId}">
+                                    <h:outputText value="#{b.deptId}"/>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Consumption Department"
+                                    width="10em"
+                                    filterMatchMode="contains"
+                                    sortBy="#{b.toDepartmentName}"
+                                    filterBy="#{b.toDepartmentName}">
+                                    <h:outputText value="#{b.toDepartmentName}"/>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Request No"
+                                    width="6em"
+                                    filterMatchMode="contains"
+                                    sortBy="#{b.invoiceNumber}"
+                                    filterBy="#{b.invoiceNumber}">
+                                    <h:outputText value="#{b.invoiceNumber}"/>
+                                </p:column>
+
+                                <p:column headerText="Status/Links" width="10em">
+                                    <!-- Show status if this bill is cancelled or returned -->
+                                    <h:panelGroup rendered="#{b.cancelled}">
+                                        <h:outputText value="CANCELLED" style="color: red; font-weight: bold; display: block;" />
+                                    </h:panelGroup>
+                                    <h:panelGroup rendered="#{b.fullReturned}">
+                                        <h:outputText value="RETURNED" style="color: orange; font-weight: bold; display: block;" />
+                                    </h:panelGroup>
+
+                                    <!-- If this bill has been cancelled, show link to cancellation bill -->
+                                    <h:panelGroup rendered="#{b.cancelledBillId != null}" styleClass="d-block mt-1">
+                                        <h:outputText value="Cancel: #{b.cancelledBillDeptId}" style="color: red;"/>
+                                        <p:commandButton
+                                            title="View Cancellation Bill"
+                                            ajax="false"
+                                            styleClass="mx-1 ui-button-sm"
+                                            icon="pi pi-eye"
+                                            action="#{billSearch.navigateToViewBillByAtomicBillTypeByBillId(b.cancelledBillId)}" />
+                                    </h:panelGroup>
+
+                                    <!-- If this bill has been returned, show link to return bill -->
+                                    <h:panelGroup rendered="#{b.refundedBillId != null}" styleClass="d-block mt-1">
+                                        <h:outputText value="Return: #{b.refundedBillDeptId}" style="color: orange;"/>
+                                        <p:commandButton
+                                            title="View Return Bill"
+                                            ajax="false"
+                                            styleClass="mx-1 ui-button-sm"
+                                            icon="pi pi-eye"
+                                            action="#{billSearch.navigateToViewBillByAtomicBillTypeByBillId(b.refundedBillId)}" />
+                                    </h:panelGroup>
+
+                                    <!-- If this is a cancellation/return bill, show link to original bill -->
+                                    <h:panelGroup rendered="#{b.billedBillId != null}" styleClass="d-block mt-1">
+                                        <h:outputText value="Original: #{b.billedBillDeptId}" style="color: blue;"/>
+                                        <p:commandButton
+                                            title="View Original Bill"
+                                            ajax="false"
+                                            styleClass="mx-1 ui-button-sm ui-button-info"
+                                            icon="pi pi-eye"
+                                            action="#{billSearch.navigateToViewBillByAtomicBillTypeByBillId(b.billedBillId)}" />
+                                    </h:panelGroup>
+                                </p:column>
+
+                                <p:column
+                                    exportable="false"
+                                    headerText="Action" width="5em">
+                                    <p:commandButton
+                                        id="btnViewBill"
+                                        title="View Bill"
+                                        ajax="false"
+                                        styleClass="mx-1 ui-button-sm"
+                                        icon="pi pi-eye"
+                                        action="#{billSearch.navigateToViewBillByAtomicBillTypeByBillId(b.billId)}" />
+                                </p:column>
+
+                                <p:column
+                                    headerText="Purchase Value"
+                                    width="4em"
+                                    style="text-align: right;"
+                                    filterMatchMode="contains"
+                                    sortBy="#{b.consumptionPurchaseValue}">
+                                    <h:outputText value="#{b.consumptionPurchaseValue}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </h:outputText>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{pharmacyController.totalPurchase}">
+                                            <f:convertNumber pattern="#,##0.00"/></h:outputLabel>
+                                    </f:facet>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Cost Value"
+                                    width="4em"
+                                    style="text-align: right;"
+                                    filterMatchMode="contains"
+                                    sortBy="#{b.consumptionCostValue}">
+                                    <h:outputText value="#{b.consumptionCostValue}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </h:outputText>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{pharmacyController.totalCostValue}">
+                                            <f:convertNumber pattern="#,##0.00"/></h:outputLabel>
+                                    </f:facet>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Retail Value"
+                                    width="4em"
+                                    style="text-align: right;"
+                                    filterMatchMode="contains"
+                                    sortBy="#{b.consumptionRetailValue}">
+                                    <h:outputText value="#{b.consumptionRetailValue}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </h:outputText>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{pharmacyController.totalRetailValue}">
+                                            <f:convertNumber pattern="#,##0.00"/></h:outputLabel>
+                                    </f:facet>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Created Date and Time"
+                                    width="6em"
+                                    filterMatchMode="contains"
+                                    sortBy="#{b.createdAt}"
+                                    filterBy="#{pharmacyController.formatDate(b.createdAt)}">
+                                    <h:outputText value="#{b.createdAt}">
+                                        <f:convertDateTime
+                                            pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                    </h:outputText>
+                                </p:column>
+
+                                <p:column headerText="Document Created By" width="10em">
+                                    <h:outputText value="#{b.creatorName}"/>
+                                </p:column>
+
+                                <p:column headerText="Remarks" width="10em">
+                                    <h:outputText value="#{b.comments}"/>
+                                </p:column>
+                            </p:dataTable>
+                        </h:panelGroup>
+
+                        <h:panelGroup rendered="#{pharmacyController.reportType eq 'byBillItem'}">
+                            <h5 class="mt-3"> Department unit issue by Bill Item</h5>
+                            <p:dataTable
+                                id="tblListBillItemsDto"
+                                value="#{pharmacyController.consumptionBillItemDtos}"
+                                var="i"
+                                rowIndexVar="n"
+                                rowKey="#{i.billItemId}"
+                                paginator="true"
+                                rows="10"
+                                paginatorPosition="bottom"
+                                paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                currentPageReportTemplate="Showing {startRecord} to {endRecord} of {totalRecords}"
+                                rowsPerPageTemplate="5,10,15,25,50,100,500,1000">
+                                <p:column headerText="No" width="2em">
+                                    <p:outputLabel value="#{n+1}"/>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Bill No"
+                                    width="6em"
+                                    filterMatchMode="contains"
+                                    sortBy="#{i.billDeptId}"
+                                    filterBy="#{i.billDeptId}">
+                                    <p:outputLabel value="#{i.billDeptId}"/>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Request No"
+                                    width="6em"
+                                    filterMatchMode="contains"
+                                    sortBy="#{i.invoiceNumber}"
+                                    filterBy="#{i.invoiceNumber}">
+                                    <p:outputLabel value="#{i.invoiceNumber}"/>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Consumption Department"
+                                    width="10em"
+                                    filterMatchMode="contains"
+                                    sortBy="#{i.toDepartmentName}"
+                                    filterBy="#{i.toDepartmentName}">
+                                    <p:outputLabel value="#{i.toDepartmentName}"/>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Item"
+                                    width="6em"
+                                    filterMatchMode="contains"
+                                    sortBy="#{i.itemName}"
+                                    filterBy="#{i.itemName}">
+                                    <p:outputLabel value="#{i.itemName}"/>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Item Category"
+                                    width="6em"
+                                    filterMatchMode="contains"
+                                    sortBy="#{i.categoryName}"
+                                    filterBy="#{i.categoryName}">
+                                    <p:outputLabel value="#{i.categoryName}"/>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Dosage Form"
+                                    width="6em"
+                                    filterMatchMode="contains"
+                                    sortBy="#{i.dosageFormName}"
+                                    filterBy="#{i.dosageFormName}">
+                                    <p:outputLabel value="#{i.dosageFormName}"/>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Quantity"
+                                    width="4em"
+                                    style="text-align: right; padding-right: 20px;"
+                                    filterMatchMode="contains"
+                                    sortBy="#{i.consumptionQty}"
+                                    filterBy="#{i.consumptionQty}">
+                                    <p:outputLabel value="#{i.consumptionQty}"/>
+                                </p:column>
+
+                                <p:column headerText="Status/Links" width="10em" exportable="false">
+                                    <!-- Show status if this bill is cancelled or returned -->
+                                    <h:panelGroup rendered="#{i.billCancelled}">
+                                        <h:outputText value="CANCELLED" style="color: red; font-weight: bold; display: block;" />
+                                    </h:panelGroup>
+                                    <h:panelGroup rendered="#{i.billFullReturned}">
+                                        <h:outputText value="RETURNED" style="color: orange; font-weight: bold; display: block;" />
+                                    </h:panelGroup>
+
+                                    <!-- If this bill has been cancelled, show link to cancellation bill -->
+                                    <h:panelGroup rendered="#{i.cancelledBillId != null}" styleClass="d-block mt-1">
+                                        <h:outputText value="Cancel: #{i.cancelledBillDeptId}" style="color: red;"/>
+                                        <p:commandButton
+                                            title="View Cancellation Bill"
+                                            ajax="false"
+                                            styleClass="mx-1 ui-button-sm"
+                                            icon="pi pi-eye"
+                                            action="#{billSearch.navigateToViewBillByAtomicBillTypeByBillId(i.cancelledBillId)}" />
+                                    </h:panelGroup>
+
+                                    <!-- If this bill has been returned, show link to return bill -->
+                                    <h:panelGroup rendered="#{i.refundedBillId != null}" styleClass="d-block mt-1">
+                                        <h:outputText value="Return: #{i.refundedBillDeptId}" style="color: orange;"/>
+                                        <p:commandButton
+                                            title="View Return Bill"
+                                            ajax="false"
+                                            styleClass="mx-1 ui-button-sm"
+                                            icon="pi pi-eye"
+                                            action="#{billSearch.navigateToViewBillByAtomicBillTypeByBillId(i.refundedBillId)}" />
+                                    </h:panelGroup>
+
+                                    <!-- If this is a cancellation/return bill, show link to original bill -->
+                                    <h:panelGroup rendered="#{i.billedBillId != null}" styleClass="d-block mt-1">
+                                        <h:outputText value="Original: #{i.billedBillDeptId}" style="color: blue;"/>
+                                        <p:commandButton
+                                            title="View Original Bill"
+                                            ajax="false"
+                                            styleClass="mx-1 ui-button-sm ui-button-info"
+                                            icon="pi pi-eye"
+                                            action="#{billSearch.navigateToViewBillByAtomicBillTypeByBillId(i.billedBillId)}" />
+                                    </h:panelGroup>
+                                </p:column>
+
+                                <p:column headerText="Action" width="5em" exportable="false">
+                                    <p:commandButton
+                                        id="btnViewBillItem"
+                                        title="View Bill"
+                                        ajax="false"
+                                        styleClass="mx-1 ui-button-sm"
+                                        icon="pi pi-eye"
+                                        action="#{billSearch.navigateToViewBillByAtomicBillTypeByBillItemId(i.billItemId)}" />
+                                </p:column>
+
+                                <p:column
+                                    headerText="Purchase Rate"
+                                    width="6em"
+                                    style="text-align: right;"
+                                    filterMatchMode="contains"
+                                    sortBy="#{i.purchaseRate}">
+                                    <p:outputLabel value="#{i.purchaseRate}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </p:outputLabel>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Purchase Value"
+                                    width="6em"
+                                    style="text-align: right;"
+                                    filterMatchMode="contains"
+                                    sortBy="#{i.consumptionPurchaseValue}">
+                                    <p:outputLabel value="#{i.consumptionPurchaseValue}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </p:outputLabel>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{pharmacyController.totalPurchase}">
+                                            <f:convertNumber pattern="#,##0.00"/></h:outputLabel>
+                                    </f:facet>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Retail Rate"
+                                    width="6em"
+                                    style="text-align: right;"
+                                    filterMatchMode="contains"
+                                    sortBy="#{i.retailRate}">
+                                    <p:outputLabel value="#{i.retailRate}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </p:outputLabel>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Retail Value"
+                                    width="6em"
+                                    style="text-align: right;"
+                                    filterMatchMode="contains"
+                                    sortBy="#{i.consumptionRetailValue}">
+                                    <p:outputLabel value="#{i.consumptionRetailValue}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </p:outputLabel>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{pharmacyController.totalRetailValue}">
+                                            <f:convertNumber pattern="#,##0.00"/></h:outputLabel>
+                                    </f:facet>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Cost Rate"
+                                    width="6em"
+                                    style="text-align: right;"
+                                    filterMatchMode="contains"
+                                    sortBy="#{i.costRate}">
+                                    <p:outputLabel value="#{i.costRate}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </p:outputLabel>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Cost Value"
+                                    width="6em"
+                                    style="text-align: right;"
+                                    filterMatchMode="contains"
+                                    sortBy="#{i.consumptionCostValue}">
+                                    <p:outputLabel value="#{i.consumptionCostValue}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </p:outputLabel>
+                                    <f:facet name="footer">
+                                        <h:outputLabel value="#{pharmacyController.totalCostValue}">
+                                            <f:convertNumber pattern="#,##0.00"/></h:outputLabel>
+                                    </f:facet>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Created At"
+                                    width="8em"
+                                    filterMatchMode="contains"
+                                    sortBy="#{i.createdAt}"
+                                    filterBy="#{pharmacyController.formatDate(i.createdAt)}">
+                                    <p:outputLabel value="#{i.createdAt}">
+                                        <f:convertDateTime
+                                            pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                    </p:outputLabel>
+                                </p:column>
+
+                                <p:column headerText="User" width="8em">
+                                    <p:outputLabel value="#{i.creatorName}"/>
+                                </p:column>
+
+                                <p:column headerText="Remarks" width="10em">
+                                    <p:outputLabel value="#{i.comments}"/>
+                                </p:column>
+                            </p:dataTable>
+                        </h:panelGroup>
+
+                        <h:panelGroup
+                            rendered="#{pharmacyController.reportType eq 'categoryWise'}"
+                            id="tblCategoryDto">
+                            <h5 class="mt-3">Category Wise Issue Details by Department</h5>
+                            <ui:repeat value="#{pharmacyController.consumptionCategoryDtoMap.entrySet()}" var="map"
+                                       varStatus="status">
+                                <p:dataTable id="itblCategoryDto"
+                                             value="#{map.value.entrySet()}"
+                                             var="entry"
+                                             rowIndexVar="n"
+                                             rowKey="#{entry.key}"
+                                             paginator="true"
+                                             paginatorPosition="bottom"
+                                             rows="10"
+                                             paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                             currentPageReportTemplate="Showing {startRecord} to {endRecord} of {totalRecords}"
+                                             rowsPerPageTemplate="5,10,15,25,50,100,500,1000">
+                                    <p:columnGroup type="header">
+                                        <p:row style="background: #e5e9ec" rendered="#{status.first}">
+                                            <p:column headerText="Department Unit"
+                                                      style="font-weight: bold; background: #e5e9ec" colspan="7"/>
+                                        </p:row>
+                                        <p:row style="background: #70a4ca">
+                                            <p:column headerText="#{map.key}" style="font-weight: bold; background: #70a4ca"
+                                                      colspan="3"/>
+                                            <p:column
+                                                headerText="#{pharmacyController.getDepartmentPurchaseTotalForConsumptionReport(map.key)}"
+                                                style="font-weight: bold; background: #70a4ca; text-align: right;"/>
+                                            <p:column
+                                                headerText="#{pharmacyController.getDepartmentCostTotalForConsumptionReport(map.key)}"
+                                                style="font-weight: bold; background: #70a4ca; text-align: right;"/>
+                                            <p:column
+                                                headerText="#{pharmacyController.getDepartmentRetailTotalForConsumptionReport(map.key)}"
+                                                style="font-weight: bold; background: #70a4ca; text-align: right;"/>
+                                            <p:column
+                                                headerText="#{pharmacyController.getDepartmentNetTotalForConsumptionReport(map.key)}"
+                                                style="font-weight: bold; background: #70a4ca; text-align: right;"/>
+                                        </p:row>
+                                        <p:row>
+                                            <p:column headerText="Category" style="font-weight: bold;"/>
+                                            <p:column headerText="Issues" style="font-weight: bold;"/>
+                                            <p:column headerText="" style="font-weight: bold;" colspan="4"/>
+                                        </p:row>
+                                        <p:row>
+                                            <p:column headerText="" style="font-weight: bold;"/>
+                                            <p:column headerText="Qty" style="font-weight: bold;"/>
+                                            <p:column headerText="Purchase Value" style="font-weight: bold;"/>
+                                            <p:column headerText="Cost Value" style="font-weight: bold;"/>
+                                            <p:column headerText="Retail Value" style="font-weight: bold;"/>
+                                            <p:column headerText="Net Total" style="font-weight: bold;"/>
+                                        </p:row>
+                                    </p:columnGroup>
+                                    <p:subTable value="#{entry.value}" var="item">
+                                        <p:columnGroup type="header">
+                                            <p:row>
+                                                <p:column headerText="#{entry.key}" style="font-weight: bold;" colspan="2"/>
+                                                <p:column
+                                                    headerText="#{pharmacyController.getCategoryPurchaseTotalForConsumptionReport(map.key, entry.key)}"
+                                                    style="font-weight: bold; text-align: right;"/>
+                                                <p:column
+                                                    headerText="#{pharmacyController.getCategoryCostTotalForConsumptionReport(map.key, entry.key)}"
+                                                    style="font-weight: bold; text-align: right;"/>
+                                                <p:column
+                                                    headerText="#{pharmacyController.getCategoryRetailTotalForConsumptionReport(map.key, entry.key)}"
+                                                    style="font-weight: bold; text-align: right;"/>
+                                                <p:column
+                                                    headerText="#{pharmacyController.getCategoryNetTotalForConsumptionReport(map.key, entry.key)}"
+                                                    style="font-weight: bold; text-align: right;"/>
+                                            </p:row>
+                                        </p:columnGroup>
+                                        <p:column headerText="Item Name">
+                                            <h:outputText value="#{item.itemName}"/>
+                                        </p:column>
+                                        <p:column headerText="Quantity">
+                                            <h:outputText value="#{item.qty}"/>
+                                        </p:column>
+                                        <p:column headerText="Purchase Value" style="text-align: right;">
+                                            <h:outputText value="#{item.totalPurchaseValue}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputText>
+                                        </p:column>
+                                        <p:column headerText="Cost Value" style="text-align: right;">
+                                            <h:outputText value="#{item.totalCostValue}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputText>
+                                        </p:column>
+                                        <p:column headerText="Retail Value" style="text-align: right;">
+                                            <h:outputText value="#{item.totalRetailValue}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputText>
+                                        </p:column>
+                                        <p:column headerText="Net Total" style="text-align: right;">
+                                            <h:outputText value="#{item.netTotal}">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputText>
+                                        </p:column>
+                                    </p:subTable>
+                                    <p:columnGroup type="footer" rendered="#{status.last}">
+                                        <p:row>
+                                            <p:column colspan="2">
+                                                <f:facet name="footer">
+                                                    <h:outputLabel value="Total" style="font-weight: bold;"/>
+                                                </f:facet>
+                                            </p:column>
+                                            <p:column style="font-weight: bold; text-align: right;">
+                                                <f:facet name="footer">
+                                                    <h:outputLabel value="#{pharmacyController.totalPurchase}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputLabel>
+                                                </f:facet>
+                                            </p:column>
+                                            <p:column style="font-weight: bold; text-align: right;">
+                                                <f:facet name="footer">
+                                                    <h:outputLabel value="#{pharmacyController.totalCostValue}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputLabel>
+                                                </f:facet>
+                                            </p:column>
+                                            <p:column style="font-weight: bold; text-align: right;">
+                                                <f:facet name="footer">
+                                                    <h:outputLabel value="#{pharmacyController.totalRetailValue}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputLabel>
+                                                </f:facet>
+                                            </p:column>
+                                            <p:column style="font-weight: bold; text-align: right;">
+                                                <f:facet name="footer">
+                                                    <h:outputLabel value="#{pharmacyController.totalSaleValue}">
+                                                        <f:convertNumber pattern="#,##0.00"/>
+                                                    </h:outputLabel>
+                                                </f:facet>
+                                            </p:column>
+                                        </p:row>
+                                    </p:columnGroup>
+                                </p:dataTable>
+                            </ui:repeat>
+                        </h:panelGroup>
+                    </p:panel>
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/reports/inventoryReports/consumption_dto.xhtml
+++ b/src/main/webapp/reports/inventoryReports/consumption_dto.xhtml
@@ -274,9 +274,11 @@
                                              rendered="#{pharmacyController.reportType eq 'summeryReport' or pharmacyController.reportType eq null or empty pharmacyController.reportType}"
                                              action="#{pharmacyController.exportConsumptionReportSummaryToPdf()}">
                             </p:commandButton>
+                            <!-- By Bill PDF export uses pharmacyRows (legacy); use dataExporter from DTO table instead -->
                             <p:commandButton class="ui-button-danger mx-1" icon="fas fa-file-pdf" ajax="false" value="PDF"
-                                             rendered="#{pharmacyController.reportType eq 'byBill'}"
-                                             action="#{pharmacyController.exportConsumptionReportByBillToPdf()}">
+                                             rendered="#{pharmacyController.reportType eq 'byBill'}">
+                                <p:dataExporter type="pdf" target="tblListBillsDto"
+                                                fileName="#{pharmacyController.generateFileNameForReport('Consumption')}"/>
                             </p:commandButton>
                             <p:commandButton class="ui-button-danger mx-1" icon="fas fa-file-pdf" ajax="false" value="PDF"
                                              rendered="#{pharmacyController.reportType eq 'byBillItem'}">
@@ -842,11 +844,11 @@
                                     <p:columnGroup type="header">
                                         <p:row style="background: #e5e9ec" rendered="#{status.first}">
                                             <p:column headerText="Department Unit"
-                                                      style="font-weight: bold; background: #e5e9ec" colspan="7"/>
+                                                      style="font-weight: bold; background: #e5e9ec" colspan="6"/>
                                         </p:row>
                                         <p:row style="background: #70a4ca">
                                             <p:column headerText="#{map.key}" style="font-weight: bold; background: #70a4ca"
-                                                      colspan="3"/>
+                                                      colspan="2"/>
                                             <p:column
                                                 headerText="#{pharmacyController.getDepartmentPurchaseTotalForConsumptionReport(map.key)}"
                                                 style="font-weight: bold; background: #70a4ca; text-align: right;"/>

--- a/src/main/webapp/reports/inventoryReports/consumption_dto.xhtml
+++ b/src/main/webapp/reports/inventoryReports/consumption_dto.xhtml
@@ -266,9 +266,7 @@
                                 <p:dataExporter type="xlsx" target="tblListBillItemsDto"
                                                 fileName="#{pharmacyController.generateFileNameForReport('Consumption')}"/>
                             </p:commandButton>
-                            <p:commandButton class="ui-button-success mx-1" icon="fas fa-file-excel" ajax="false"
-                                             value="Download" rendered="#{pharmacyController.reportType eq 'categoryWise'}"
-                                             action="#{pharmacyController.exportConsumptionReportCategoryWiseToExcel()}"/>
+                            <!-- Category-wise Excel export uses legacy departmentCategoryMap; new DTO export is future work -->
 
                             <p:commandButton class="ui-button-danger mx-1" icon="fas fa-file-pdf" ajax="false" value="PDF"
                                              rendered="#{pharmacyController.reportType eq 'summeryReport' or pharmacyController.reportType eq null or empty pharmacyController.reportType}"
@@ -285,10 +283,7 @@
                                 <p:dataExporter type="pdf" target="tblListBillItemsDto"
                                                 fileName="#{pharmacyController.generateFileNameForReport('Consumption')}"/>
                             </p:commandButton>
-                            <p:commandButton class="ui-button-danger mx-1" icon="fas fa-file-pdf" ajax="false" value="PDF"
-                                             rendered="#{pharmacyController.reportType eq 'categoryWise'}"
-                                             action="#{pharmacyController.exportConsumptionReportCategoryWiseToPdf()}">
-                            </p:commandButton>
+                            <!-- Category-wise PDF export uses legacy departmentCategoryMap; new DTO export is future work -->
                         </div>
 
                         <h:panelGroup rendered="#{pharmacyController.reportType eq 'summeryReport' and (pharmacyController.totalPurchase != 0 or pharmacyController.totalCostValue != 0 or pharmacyController.totalRetailValue != 0 or pharmacyController.totalSaleValue != 0)}" id="tbl1">
@@ -850,16 +845,16 @@
                                             <p:column headerText="#{map.key}" style="font-weight: bold; background: #70a4ca"
                                                       colspan="2"/>
                                             <p:column
-                                                headerText="#{pharmacyController.getDepartmentPurchaseTotalForConsumptionReport(map.key)}"
+                                                headerText="#{pharmacyController.getDtoDeptPurchaseTotalForConsumptionReport(map.key)}"
                                                 style="font-weight: bold; background: #70a4ca; text-align: right;"/>
                                             <p:column
-                                                headerText="#{pharmacyController.getDepartmentCostTotalForConsumptionReport(map.key)}"
+                                                headerText="#{pharmacyController.getDtoDeptCostTotalForConsumptionReport(map.key)}"
                                                 style="font-weight: bold; background: #70a4ca; text-align: right;"/>
                                             <p:column
-                                                headerText="#{pharmacyController.getDepartmentRetailTotalForConsumptionReport(map.key)}"
+                                                headerText="#{pharmacyController.getDtoDeptRetailTotalForConsumptionReport(map.key)}"
                                                 style="font-weight: bold; background: #70a4ca; text-align: right;"/>
                                             <p:column
-                                                headerText="#{pharmacyController.getDepartmentNetTotalForConsumptionReport(map.key)}"
+                                                headerText="#{pharmacyController.getDtoDeptNetTotalForConsumptionReport(map.key)}"
                                                 style="font-weight: bold; background: #70a4ca; text-align: right;"/>
                                         </p:row>
                                         <p:row>
@@ -881,16 +876,16 @@
                                             <p:row>
                                                 <p:column headerText="#{entry.key}" style="font-weight: bold;" colspan="2"/>
                                                 <p:column
-                                                    headerText="#{pharmacyController.getCategoryPurchaseTotalForConsumptionReport(map.key, entry.key)}"
+                                                    headerText="#{pharmacyController.getDtoCategoryPurchaseTotalForConsumptionReport(map.key, entry.key)}"
                                                     style="font-weight: bold; text-align: right;"/>
                                                 <p:column
-                                                    headerText="#{pharmacyController.getCategoryCostTotalForConsumptionReport(map.key, entry.key)}"
+                                                    headerText="#{pharmacyController.getDtoCategoryCostTotalForConsumptionReport(map.key, entry.key)}"
                                                     style="font-weight: bold; text-align: right;"/>
                                                 <p:column
-                                                    headerText="#{pharmacyController.getCategoryRetailTotalForConsumptionReport(map.key, entry.key)}"
+                                                    headerText="#{pharmacyController.getDtoCategoryRetailTotalForConsumptionReport(map.key, entry.key)}"
                                                     style="font-weight: bold; text-align: right;"/>
                                                 <p:column
-                                                    headerText="#{pharmacyController.getCategoryNetTotalForConsumptionReport(map.key, entry.key)}"
+                                                    headerText="#{pharmacyController.getDtoCategoryNetTotalForConsumptionReport(map.key, entry.key)}"
                                                     style="font-weight: bold; text-align: right;"/>
                                             </p:row>
                                         </p:columnGroup>

--- a/src/main/webapp/reports/inventoryReports/cost_of_goods_sold.xhtml
+++ b/src/main/webapp/reports/inventoryReports/cost_of_goods_sold.xhtml
@@ -115,7 +115,7 @@
 
                             <h:panelGroup layout="block" styleClass="form-group">
                                 <h:outputText styleClass="fa fa-building ml-3" />
-                                <p:outputLabel value="Department" class="mx-3"/>
+                                <p:outputLabel value="Department" class="mx-3" for="phmDept"/>
                             </h:panelGroup>
                             <h:panelGroup id="phmDept">
 

--- a/src/main/webapp/reports/inventoryReports/cost_of_goods_sold.xhtml
+++ b/src/main/webapp/reports/inventoryReports/cost_of_goods_sold.xhtml
@@ -29,13 +29,13 @@
 
                             <h:panelGroup layout="block" styleClass="form-group">
                                 <h:outputText value="&#xf073;" styleClass="fa ml-3" />
-                                <p:outputLabel value="From Date" class="mx-3" >
-                                </p:outputLabel>
+                                <p:outputLabel value="From Date" class="mx-3" for="fromDate"/>
                             </h:panelGroup>
                             <p:calendar
                                 class="w-100"
                                 inputStyleClass="w-100"
                                 id="fromDate"
+                                ariaLabel="From Date"
                                 value="#{pharmacyReportController.fromDate}"
                                 pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
 
@@ -43,13 +43,13 @@
 
                             <h:panelGroup layout="block" styleClass="form-group">
                                 <h:outputText value="&#xf073;" styleClass="fa ml-3" />
-                                <p:outputLabel value="To Date" class="mx-3" >
-                                </p:outputLabel>
+                                <p:outputLabel value="To Date" class="mx-3" for="toDate"/>
                             </h:panelGroup>
                             <p:calendar
                                 class="w-100"
                                 inputStyleClass="w-100"
                                 id="toDate"
+                                ariaLabel="To Date"
                                 value="#{pharmacyReportController.toDate}"
                                 pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
 
@@ -82,12 +82,12 @@
 
                             <h:panelGroup layout="block" styleClass="form-group">
                                 <h:outputText styleClass="fa fa-university ml-3" />
-                                <p:outputLabel value="Institution" class="mx-3" >
-                                </p:outputLabel>
+                                <p:outputLabel value="Institution" class="mx-3" for="phmIns"/>
                             </h:panelGroup>
                             <p:selectOneMenu
                                 id="phmIns"
                                 class="w-100"
+                                ariaLabel="Institution"
                                 value="#{pharmacyReportController.institution}"
                                 filter="true">
                                 <f:selectItem itemLabel="All Institutions"/>
@@ -98,12 +98,13 @@
 
                             <h:panelGroup layout="block" styleClass="form-group">
                                 <h:outputText styleClass="fa fa-map-marker-alt ml-3" />
-                                <p:outputLabel value="Site" class="mx-3"></p:outputLabel>
+                                <p:outputLabel value="Site" class="mx-3" for="phmSite"/>
                             </h:panelGroup>
                             <p:selectOneMenu
                                 id="phmSite"
                                 class="w-100"
                                 styleClass="w-100"
+                                ariaLabel="Site"
                                 value="#{pharmacyReportController.site}"
                                 filter="true">
                                 <f:selectItem itemLabel="All Sites"/>
@@ -114,8 +115,7 @@
 
                             <h:panelGroup layout="block" styleClass="form-group">
                                 <h:outputText styleClass="fa fa-building ml-3" />
-                                <p:outputLabel value="Department" class="mx-3">
-                                </p:outputLabel>
+                                <p:outputLabel value="Department" class="mx-3"/>
                             </h:panelGroup>
                             <h:panelGroup id="phmDept">
 
@@ -123,6 +123,7 @@
                                 <p:selectOneMenu
                                     rendered="#{pharmacyReportController.institution eq null and pharmacyReportController.site eq null}"
                                     value="#{pharmacyReportController.department}"
+                                    ariaLabel="Department"
                                     filterMatchMode="contains"
                                     filter="true">
                                     <f:selectItem itemLabel="All Departments"/>
@@ -137,6 +138,7 @@
                                 <p:selectOneMenu
                                     rendered="#{pharmacyReportController.institution eq null and pharmacyReportController.site ne null}"
                                     value="#{pharmacyReportController.department}"
+                                    ariaLabel="Department"
                                     filterMatchMode="contains"
                                     filter="true">
                                     <f:selectItem itemLabel="All Departments"/>
@@ -151,6 +153,7 @@
                                 <p:selectOneMenu
                                     rendered="#{pharmacyReportController.institution ne null and pharmacyReportController.site eq null}"
                                     value="#{pharmacyReportController.department}"
+                                    ariaLabel="Department"
                                     filterMatchMode="contains"
                                     filter="true">
                                     <f:selectItem itemLabel="All Departments"/>
@@ -165,6 +168,7 @@
                                 <p:selectOneMenu
                                     rendered="#{pharmacyReportController.institution ne null and pharmacyReportController.site ne null}"
                                     value="#{pharmacyReportController.department}"
+                                    ariaLabel="Department"
                                     filterMatchMode="contains"
                                     filter="true">
                                     <f:selectItem itemLabel="All Departments"/>
@@ -178,13 +182,13 @@
 
                             <h:panelGroup layout="block" styleClass="form-group">
                                 <h:outputText styleClass="fa fa-pills ml-3" />
-                                <p:outputLabel value="Item" class="mx-3">
-                                </p:outputLabel>
+                                <p:outputLabel value="Item" class="mx-3" for="phmItem"/>
                             </h:panelGroup>
                             <p:autoComplete
                                 id="phmItem"
                                 class="w-100"
                                 inputStyleClass="w-100"
+                                ariaLabel="Item"
                                 value="#{pharmacyReportController.item}"
                                 completeMethod="#{itemController.completeItem}"
                                 var="itm"

--- a/src/main/webapp/reports/inventoryReports/cost_of_goods_sold.xhtml
+++ b/src/main/webapp/reports/inventoryReports/cost_of_goods_sold.xhtml
@@ -199,10 +199,10 @@
                         </p:panelGrid>
 
                         <div class="d-flex align-items-center">
-                            <p:commandButton class="ui-button-warning mx-1" 
-                                             icon="fas fa-cogs" 
-                                             ajax="false"  
-                                             value="Process" 
+                            <p:commandButton class="ui-button-warning mx-1"
+                                             icon="fas fa-cogs"
+                                             value="Process"
+                                             update="@form"
                                              action="#{pharmacyReportController.processCostOfGoodSoldReport()}">
                             </p:commandButton>
                            

--- a/src/main/webapp/reports/inventoryReports/stock_consumption_dto.xhtml
+++ b/src/main/webapp/reports/inventoryReports/stock_consumption_dto.xhtml
@@ -1,0 +1,378 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
+    <h:body>
+        <ui:composition template="/reports/index.xhtml">
+            <ui:define name="subcontent">
+                <h:form>
+                    <p:panel header="Stock Consumption (DTO)">
+
+                        <h:panelGrid columns="8" class="w-100">
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf073;" styleClass="fa mr-2"/>
+                                <p:outputLabel value="From Date" for="fromDate" class="m-3"/>
+                            </h:panelGroup>
+                            <p:calendar
+                                styleClass="w-100"
+                                inputStyleClass="w-100 form-control"
+                                id="fromDate"
+                                value="#{pharmacyReportController.fromDate}"
+                                navigator="false"
+                                pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+
+                            <p:spacer width="20"/>
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText value="&#xf073;" styleClass="fa mr-2"/>
+                                <p:outputLabel value="To Date" for="toDate" class="m-3"/>
+                            </h:panelGroup>
+                            <p:calendar
+                                styleClass="w-100"
+                                inputStyleClass="w-100 form-control"
+                                id="toDate"
+                                value="#{pharmacyReportController.toDate}"
+                                navigator="false"
+                                pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+
+                            <p:spacer width="20"/>
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText styleClass="fa fa-building mr-2"/>
+                                <p:outputLabel value="Department Type" for="departmentTypeFilter" class="m-3"/>
+                            </h:panelGroup>
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <p:selectCheckboxMenu
+                                    id="departmentTypeFilter"
+                                    value="#{pharmacyReportController.selectedDepartmentTypes}"
+                                    label="Select Department Types"
+                                    class="w-100"
+                                    filter="true"
+                                    filterMatchMode="contains"
+                                    showHeader="true"
+                                    scrollHeight="200"
+                                    title="Select one or more department types to filter results. Leave empty to include all departments.">
+                                    <f:selectItems
+                                        value="#{pharmacyReportController.availableDepartmentTypes}"
+                                        var="depType"
+                                        itemLabel="#{depType.label}"
+                                        itemValue="#{depType}"/>
+                                </p:selectCheckboxMenu>
+                                <p:tooltip for="departmentTypeFilter" value="Select one or more department types to filter results. Leave empty to include all departments." position="top"/>
+                            </h:panelGroup>
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText styleClass="fa fa-university mr-2"/>
+                                <p:outputLabel value="Institution" for="phmIns" class="m-3"/>
+                            </h:panelGroup>
+                            <p:selectOneMenu
+                                id="phmIns"
+                                class="w-100"
+                                value="#{pharmacyReportController.institution}"
+                                filter="true">
+                                <f:selectItem itemLabel="All Institutions"/>
+                                <f:selectItems value="#{institutionController.companies}" var="ins" itemLabel="#{ins.name}" itemValue="#{ins}"/>
+                                <p:ajax process="phmIns" update="phmDept"/>
+                            </p:selectOneMenu>
+
+                            <p:spacer width="20"/>
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText styleClass="fa fa-map-marker-alt mr-2"/>
+                                <p:outputLabel value="Site" for="phmSite" class="m-3"/>
+                            </h:panelGroup>
+                            <p:selectOneMenu
+                                id="phmSite"
+                                class="w-100"
+                                value="#{pharmacyReportController.site}"
+                                filter="true">
+                                <f:selectItem itemLabel="All Sites"/>
+                                <f:selectItems value="#{institutionController.sites}" var="site" itemLabel="#{site.name}" itemValue="#{site}"/>
+                                <p:ajax process="phmSite" update="phmDept"/>
+                            </p:selectOneMenu>
+
+                            <p:spacer width="20"/>
+
+                            <h:panelGroup layout="block" styleClass="form-group">
+                                <h:outputText styleClass="fa fa-building mr-2"/>
+                                <p:outputLabel value="Department" for="phmDept" class="m-3"/>
+                            </h:panelGroup>
+                            <h:panelGroup id="phmDept">
+                                <p:selectOneMenu
+                                    rendered="#{pharmacyReportController.institution eq null and pharmacyReportController.site eq null}"
+                                    styleClass="w-100 form-control"
+                                    value="#{pharmacyReportController.department}"
+                                    filterMatchMode="contains"
+                                    filter="true">
+                                    <f:selectItem itemLabel="All Departments"/>
+                                    <f:selectItems
+                                        value="#{departmentController.getDepartmentsOfInstitutionAndSite()}"
+                                        var="dept"
+                                        itemLabel="#{dept.name}"
+                                        itemValue="#{dept}"/>
+                                </p:selectOneMenu>
+                                <p:selectOneMenu
+                                    rendered="#{pharmacyReportController.institution eq null and pharmacyReportController.site ne null}"
+                                    styleClass="w-100 form-control"
+                                    value="#{pharmacyReportController.department}"
+                                    filterMatchMode="contains"
+                                    filter="true">
+                                    <f:selectItem itemLabel="All Departments"/>
+                                    <f:selectItems
+                                        value="#{departmentController.getDepartmentsOfInstitutionAndSite(pharmacyReportController.site)}"
+                                        var="dept"
+                                        itemLabel="#{dept.name}"
+                                        itemValue="#{dept}"/>
+                                </p:selectOneMenu>
+                                <p:selectOneMenu
+                                    rendered="#{pharmacyReportController.institution ne null and pharmacyReportController.site eq null}"
+                                    styleClass="w-100 form-control"
+                                    value="#{pharmacyReportController.department}"
+                                    filterMatchMode="contains"
+                                    filter="true">
+                                    <f:selectItem itemLabel="All Departments"/>
+                                    <f:selectItems
+                                        value="#{departmentController.getDepartmentsOfInstitutionAndSite(pharmacyReportController.institution)}"
+                                        var="dept"
+                                        itemLabel="#{dept.name}"
+                                        itemValue="#{dept}"/>
+                                </p:selectOneMenu>
+                                <p:selectOneMenu
+                                    rendered="#{pharmacyReportController.institution ne null and pharmacyReportController.site ne null}"
+                                    styleClass="w-100 form-control"
+                                    value="#{pharmacyReportController.department}"
+                                    filterMatchMode="contains"
+                                    filter="true">
+                                    <f:selectItem itemLabel="All Departments"/>
+                                    <f:selectItems
+                                        value="#{departmentController.getDepartmentsOfInstitutionAndSite(pharmacyReportController.institution, pharmacyReportController.site)}"
+                                        var="dept"
+                                        itemLabel="#{dept.name}"
+                                        itemValue="#{dept}"/>
+                                </p:selectOneMenu>
+                            </h:panelGroup>
+
+                        </h:panelGrid>
+
+                        <div class="d-flex align-items-center mt-5">
+                            <p:commandButton
+                                class="ui-button-secondary mx-1"
+                                icon="fas fa-arrow-left"
+                                ajax="false"
+                                value="Back"
+                                action="#{reportController.navigateToCostOfGoodsSold()}"/>
+
+                            <p:commandButton
+                                class="ui-button-warning mx-1"
+                                icon="fas fa-cogs"
+                                ajax="false"
+                                value="Process"
+                                action="#{pharmacyReportController.processStockConsumptionDto()}"/>
+
+                            <p:commandButton
+                                class="ui-button- mx-1"
+                                icon="fas fa-print"
+                                ajax="false"
+                                value="Print"
+                                onclick="hidePaginatorBeforePrint()">
+                                <p:printer target="tblDto" oncomplete="restorePaginatorAfterPrint()"/>
+                            </p:commandButton>
+
+                            <p:commandButton
+                                class="ui-button-success mx-1"
+                                icon="fas fa-file-excel"
+                                ajax="false"
+                                value="Download">
+                                <p:dataExporter type="xlsx" target="tblDto"
+                                                fileName="Stock_Consumption_Report"/>
+                            </p:commandButton>
+
+                            <p:commandButton
+                                class="ui-button-danger mx-1"
+                                icon="fas fa-file-pdf"
+                                ajax="false"
+                                value="PDF">
+                                <p:dataExporter type="pdf" target="tblDto"
+                                                fileName="Stock_Consumption_Report"/>
+                            </p:commandButton>
+
+                            <p:commandButton
+                                class="ui-button-secondary mx-1"
+                                icon="fas fa-exchange-alt"
+                                ajax="false"
+                                value="View Legacy Report"
+                                title="Switch to the entity-based report for cross-checking"
+                                action="stock_consumption?faces-redirect=true"/>
+                        </div>
+
+                        <h:outputScript>
+                            function hidePaginatorBeforePrint() {
+                                let paginators = document.querySelectorAll('.ui-paginator');
+                                paginators.forEach(el => el.style.display = 'none');
+                            }
+                            function restorePaginatorAfterPrint() {
+                                let paginators = document.querySelectorAll('.ui-paginator');
+                                paginators.forEach(el => el.style.display = '');
+                            }
+                            window.onafterprint = function () { restorePaginatorAfterPrint(); };
+                        </h:outputScript>
+
+                        <p:dataTable id="tblDto"
+                                     value="#{pharmacyReportController.stockConsumptionItemDtos}"
+                                     var="f"
+                                     rowIndexVar="n"
+                                     rowKey="#{f.billItemId}"
+                                     paginator="true"
+                                     paginatorPosition="bottom"
+                                     rows="10"
+                                     paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                     currentPageReportTemplate="Showing {startRecord} to {endRecord} of {totalRecords}"
+                                     rowsPerPageTemplate="5,10,15,25,50,100,500,1000">
+
+                            <p:column headerText="Date" width="5em">
+                                <h:outputText value="#{f.createdAt}">
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                </h:outputText>
+                                <f:facet name="footer">
+                                    <h:outputText value="Total"/>
+                                </f:facet>
+                            </p:column>
+
+                            <p:column headerText="Item Name" width="5em"
+                                      filterMatchMode="contains" filterBy="#{f.itemName}">
+                                <h:outputText value="#{f.itemName}"/>
+                            </p:column>
+
+                            <p:column headerText="Batch Code" width="5em"
+                                      filterMatchMode="contains" filterBy="#{f.batchNo}">
+                                <h:outputText value="#{f.batchNo}"/>
+                            </p:column>
+
+                            <p:column headerText="Doc No" width="5em"
+                                      filterMatchMode="contains" filterBy="#{f.deptId}">
+                                <h:outputText value="#{f.deptId}" class="m-1 w-100"/>
+                            </p:column>
+
+                            <p:column headerText="Ref. Doc No" width="5em"
+                                      filterMatchMode="contains" filterBy="#{f.referenceBillDeptId}">
+                                <h:outputText value="#{f.referenceBillDeptId}" class="m-1 w-100"/>
+                            </p:column>
+
+                            <p:column headerText="QTY" width="5em" style="text-align: right;">
+                                <h:outputText value="#{f.qty}">
+                                    <f:convertNumber pattern="#,##0"/>
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Code" width="5em"
+                                      filterMatchMode="contains" filterBy="#{f.itemCode}">
+                                <h:outputText value="#{f.itemCode}"/>
+                            </p:column>
+
+                            <p:column headerText="Purchase Rate" width="5em" style="text-align: right;">
+                                <h:outputText value="#{f.purchaseRate}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Purchase Value" width="5em" style="text-align: right;">
+                                <h:outputText value="#{f.purchaseValue}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputText>
+                                <f:facet name="footer">
+                                    <h:outputText value="#{pharmacyReportController.dtoStockConsumptionPurchaseTotal}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </h:outputText>
+                                </f:facet>
+                            </p:column>
+
+                            <p:column headerText="Cost Rate" width="5em" style="text-align: right;">
+                                <h:outputText value="#{f.costRate}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Cost Value" width="5em" style="text-align: right;">
+                                <h:outputText value="#{f.costValue}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputText>
+                                <f:facet name="footer">
+                                    <h:outputText value="#{pharmacyReportController.dtoStockConsumptionCostTotal}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </h:outputText>
+                                </f:facet>
+                            </p:column>
+
+                            <p:column headerText="Retail Rate" width="5em" style="text-align: right;">
+                                <h:outputText value="#{f.retailRate}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputText>
+                            </p:column>
+
+                            <p:column headerText="Retail Value" width="5em" style="text-align: right;">
+                                <h:outputText value="#{f.retailValue}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputText>
+                                <f:facet name="footer">
+                                    <h:outputText value="#{pharmacyReportController.dtoStockConsumptionRetailTotal}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </h:outputText>
+                                </f:facet>
+                            </p:column>
+
+                            <p:column headerText="Net Total" width="5em" style="text-align: right;">
+                                <h:outputText value="#{f.netTotal}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputText>
+                                <f:facet name="footer">
+                                    <h:outputText value="#{pharmacyReportController.dtoStockConsumptionPurchaseTotal}">
+                                        <f:convertNumber pattern="#,##0.00"/>
+                                    </h:outputText>
+                                </f:facet>
+                            </p:column>
+
+                            <p:column headerText="Consumption Department" width="5em"
+                                      filterMatchMode="contains" filterBy="#{f.toDepartmentName}">
+                                <h:outputText value="#{f.toDepartmentName}"/>
+                            </p:column>
+
+                            <p:column headerText="Remarks" width="5em">
+                                <h:outputText value="#{f.comments}"/>
+                            </p:column>
+
+                            <p:column headerText="UOM" width="5em">
+                                <h:outputText value="#{f.measurementUnitName}"/>
+                            </p:column>
+
+                            <p:column
+                                exportable="false"
+                                headerText="Actions"
+                                width="5em">
+                                <p:commandButton
+                                    value="View Bill"
+                                    class="m-1 ui-button-info"
+                                    style="width: 100px;"
+                                    action="#{billSearch.navigateToViewBillByAtomicBillTypeByBillId(f.billId)}"
+                                    ajax="false"/>
+
+                                <p:commandButton
+                                    value="View Ref Bill"
+                                    rendered="#{f.referenceBillId != null}"
+                                    class="m-1 ui-button-info"
+                                    style="width: 100px;"
+                                    action="#{billSearch.navigateToViewBillByAtomicBillTypeByBillId(f.referenceBillId)}"
+                                    ajax="false"/>
+                            </p:column>
+
+                        </p:dataTable>
+
+                    </p:panel>
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/resources/css/opd_five_five.css
+++ b/src/main/webapp/resources/css/opd_five_five.css
@@ -22,7 +22,6 @@
         font-size: 9px!important;
         font-size: 80%;
         text-transform: capitalize!important;
-        page-break-before: always!important;
     }
 
     .channelRecipt_24_2x9_3{

--- a/src/main/webapp/resources/css/opd_five_five.css
+++ b/src/main/webapp/resources/css/opd_five_five.css
@@ -22,6 +22,7 @@
         font-size: 9px!important;
         font-size: 80%;
         text-transform: capitalize!important;
+        page-break-before: always!important;
     }
 
     .channelRecipt_24_2x9_3{

--- a/src/main/webapp/resources/css/opd_pos_bill.css
+++ b/src/main/webapp/resources/css/opd_pos_bill.css
@@ -64,7 +64,7 @@
         /*        font:*/
         font-size: 11px!important; 
         /*        text-transform: uppercase!important;*/
-        page-break-after:always!important;
+        page-break-before:always!important;
 
     }
 

--- a/src/main/webapp/resources/css/pharmacypos.css
+++ b/src/main/webapp/resources/css/pharmacypos.css
@@ -26,6 +26,7 @@
         background-size: 100% auto !important;
         font-size: 130%;
         text-transform: capitalize !important;
+        page-break-before: always!important;
     }
 
     /* Add this new rule to hide the header specifically for inward service bills */
@@ -68,8 +69,8 @@
         /*        font:*/
         font-size: 11px!important;
         /*        text-transform: uppercase!important;*/
-        page-break-after:always!important;
-
+        page-break-before: always!important;
+        page-break-after:avoid!important;
     }
 
     /*    .billDetails{
@@ -79,7 +80,8 @@
         }*/
 
     .a4bill{
-        page-break-after:always!important;
+        page-break-after:avoid!important;
+        page-break-before: always!important;
         font-family: sans-serif!important;
         font-size: 11px!important;
         position: relative!important;

--- a/src/main/webapp/resources/ezcomp/menu.xhtml
+++ b/src/main/webapp/resources/ezcomp/menu.xhtml
@@ -1413,8 +1413,11 @@
                 </p:submenu>
 
                 <!--            Store Section-->
-                <p:submenu   
-                    id="smStore"  icon="fa fa-fw fa-store"  rendered="#{webUserController.hasPrivilege('Store')}">                                                           
+                <!-- Stores menu temporarily hidden for production hotfix (#21423).
+                     Forced to not render regardless of privilege; remove this override
+                     once a configuration toggle for hiding the Stores menu is in place. -->
+                <p:submenu
+                    id="smStore"  icon="fa fa-fw fa-store"  rendered="false">
                     <p:submenu label="BHT Issue" icon="fas fa-procedures" rendered="#{webUserController.hasPrivilege('StoreIssueInwardBilling')}">
                         <p:menuitem ajax="false" action="/store/store_retail_sale_bht?faces-redirect=true"  value="Inward Billing"
                                     rendered="#{webUserController.hasPrivilege('StoreIssueInwardBilling')}"

--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_coustom_1.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_coustom_1.xhtml
@@ -32,7 +32,7 @@
             }
         </style>
 
-        <div class="fiveinchbill" style="page-break-after: always" >
+        <div class="fiveinchbill" style="page-break-before: always" >
 
             <div class="institutionName">
                 <h:outputLabel style="font-size: 14pt" value="#{cc.attrs.bill.department.printingName}" />

--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_coustom_1_OPD_Batch_Bill.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_coustom_1_OPD_Batch_Bill.xhtml
@@ -20,7 +20,7 @@
     <cc:implementation>
 
         <h:outputStylesheet library="css" name="opd_five_five.css" ></h:outputStylesheet>
-        <div class="fiveinchbill" style="page-break-after: always" >
+        <div class="fiveinchbill" style="page-break-before: always" >
 
             <div class="institutionName">
                 <h:outputLabel style="font-size: 14pt" value="#{cc.attrs.bill.department.printingName}" />

--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings.xhtml
@@ -22,7 +22,7 @@
 
 
         <h:outputStylesheet library="css" name="opd_five_five.css" ></h:outputStylesheet>
-        <div class="fiveinchbill">
+        <div class="fiveinchbill" style="page-break-before: always!important;">
 
             <div class="institutionName">
                 <h:outputLabel value="#{cc.attrs.bill.department.printingName}" />

--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings.xhtml
@@ -22,7 +22,7 @@
 
 
         <h:outputStylesheet library="css" name="opd_five_five.css" ></h:outputStylesheet>
-        <div class="fiveinchbill" style="page-break-after: always" >
+        <div class="fiveinchbill">
 
             <div class="institutionName">
                 <h:outputLabel value="#{cc.attrs.bill.department.printingName}" />

--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings_badge_bill.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings_badge_bill.xhtml
@@ -17,7 +17,7 @@
     <!-- IMPLEMENTATION -->
     <cc:implementation>
         <h:outputStylesheet library="css" name="pharmacypos.css" ></h:outputStylesheet>
-        <div class="fiveinchbill" style="page-break-after: always">
+        <div class="fiveinchbill" style="page-break-before: always">
             <div class="institutionName">
                 <h:outputLabel value="#{cc.attrs.billController.batchBill.department.printingName}" />
             </div>

--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_without_headings.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_without_headings.xhtml
@@ -20,7 +20,7 @@
     <cc:implementation>
 
         <h:outputStylesheet library="css" name="opd_five_five.css" ></h:outputStylesheet>
-        <div class="fiveinchbill " style="page-break-after: always" >
+        <div class="fiveinchbill " >
 
             <div style="font-weight: bold;text-align: left;font-size: 10pt" class="row mt-2 d-flex align-items-center">
                 <div class="col-5">

--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_without_headings.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_without_headings.xhtml
@@ -20,7 +20,7 @@
     <cc:implementation>
 
         <h:outputStylesheet library="css" name="opd_five_five.css" ></h:outputStylesheet>
-        <div class="fiveinchbill " >
+        <div class="fiveinchbill "  style="page-break-before: always!important;">
 
             <div style="font-weight: bold;text-align: left;font-size: 10pt" class="row mt-2 d-flex align-items-center">
                 <div class="col-5">

--- a/src/main/webapp/resources/ezcomp/prints/posOpdBill.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/posOpdBill.xhtml
@@ -17,7 +17,7 @@
     <cc:implementation>
 
         <h:outputStylesheet library="css" name="pharmacypos.css" ></h:outputStylesheet>
-        <div class="posbillBreak" style="page-break-after: always">
+        <div class="posbillBreak" style="page-break-after: avoid!important;">
 
 
             <div class="institutionName" style="text-align: center!important;

--- a/src/main/webapp/resources/ezcomp/prints/posOpdBillWithoutLogo.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/posOpdBillWithoutLogo.xhtml
@@ -17,7 +17,7 @@
     <cc:implementation>
 
         <h:outputStylesheet library="css" name="opd_pos_bill.css" ></h:outputStylesheet>
-        <div class="posbillBreak">            
+        <div class="posbillBreak" style="page-break-after: avoid!important;">            
 
 
             <!--            <div class="institutionName" style="text-align: center!important;

--- a/src/main/webapp/resources/ezcomp/prints/pos_opd_bill_batch.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/pos_opd_bill_batch.xhtml
@@ -19,7 +19,7 @@
         <h:outputStylesheet library="css" name="pharmacypos.css" ></h:outputStylesheet>
         
         <ui:repeat value="#{cc.attrs.billController.bills}" var="ffb">
-            <div class="posbillBreak" style="page-break-after: always">
+            <div class="posbillBreak">
 
 
                 <div class="institutionName" style="text-align: center!important;

--- a/src/main/webapp/resources/ezcomp/prints/pos_opd_bill_without_logo_batch.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/pos_opd_bill_without_logo_batch.xhtml
@@ -18,7 +18,7 @@
 
         <h:outputStylesheet library="css" name="pharmacypos.css" ></h:outputStylesheet>
         <ui:repeat value="#{cc.attrs.billController.bills}" var="ffb">
-            <div class="posbillBreak" style="page-break-after: always">
+            <div class="posbillBreak" >
 
                 <div class="headingBill">
                     <h:outputLabel value="INVOICE"   />    

--- a/src/main/webapp/resources/pharmacy/direct_purchase_return_receipt_with_costing.xhtml
+++ b/src/main/webapp/resources/pharmacy/direct_purchase_return_receipt_with_costing.xhtml
@@ -12,6 +12,7 @@
     </cc:interface>
     <!-- IMPLEMENTATION -->
     <cc:implementation>
+        <style>.hidden { display: none !important; } @media print { .hidden { display: none !important; } }</style>
         <div class="purhcaseBill"
              style="font-family: sans-serif!important;
              border: none!important;
@@ -88,7 +89,9 @@
                         rowIndexVar="rowIndex"
                         value="#{cc.attrs.bill.billItems}"
                         var="bip"
-                        style="font-size: 16px; margin-left: 3%; margin-right: 3%;">
+                        rowStyleClass="#{bip.retired ? 'hidden' : ''}"
+                        style="font-size: 16px; margin-left: 3%; margin-right: 3%;"
+                        rendered="#{not empty cc.attrs.bill.billItems}">
 
                     <p:column style="padding: 4px; width: 2em;">
                         <f:facet name="header">No</f:facet>
@@ -116,21 +119,21 @@
                             style="padding: 4px; width: 7em;" class="text-end"
                             rendered="#{configOptionApplicationController.getBooleanValueByKey('Purchase Return by Total Quantity', false)}">
                         <f:facet name="header">Return Total QTY</f:facet>
-                        <h:outputLabel value="#{bip.billItemFinanceDetails.quantity + bip.billItemFinanceDetails.freeQuantity}"/>
+                        <h:outputLabel value="#{bip.qty + (bip.billItemFinanceDetails.freeQuantity != null ? 0 - bip.billItemFinanceDetails.freeQuantity : 0)}"/>
                     </p:column>
 
                     <p:column
                             style="padding: 4px; width: 7em;" class="text-end"
                             rendered="#{!configOptionApplicationController.getBooleanValueByKey('Purchase Return by Total Quantity', false)}">
                         <f:facet name="header">Return QTY</f:facet>
-                        <h:outputLabel value="#{bip.billItemFinanceDetails.quantity}"/>
+                        <h:outputLabel value="#{bip.qty}"/>
                     </p:column>
 
                     <p:column
                             style="padding: 4px; width: 7em;" class="text-end"
                             rendered="#{!configOptionApplicationController.getBooleanValueByKey('Purchase Return by Total Quantity', false)}">
                         <f:facet name="header">Free QTY</f:facet>
-                        <h:outputLabel value="#{bip.billItemFinanceDetails.freeQuantity}"/>
+                        <h:outputLabel value="#{bip.billItemFinanceDetails.freeQuantity != null ? 0 - bip.billItemFinanceDetails.freeQuantity : 0}"/>
                     </p:column>
 
                     <p:column style="padding: 4px; width: 7em;" class="text-end">
@@ -142,7 +145,7 @@
 
                     <p:column style="padding: 4px; width: 7em;" class="text-end">
                         <f:facet name="header">Amount</f:facet>
-                        <h:outputLabel value="#{bip.billItemFinanceDetails.lineGrossRate*(bip.billItemFinanceDetails.quantity + bip.billItemFinanceDetails.freeQuantity)}" >
+                        <h:outputLabel value="#{bip.netValue}" >
                             <f:convertNumber pattern="#,##0.00" />
                         </h:outputLabel>
                     </p:column>
@@ -150,9 +153,9 @@
                     <p:columnGroup type="footer">
                         <p:row>
                             <p:column style="padding: 4px;" colspan="#{configOptionApplicationController.getBooleanValueByKey('Purchase Return by Total Quantity', false) ? 7 : 7}" footerText="Total"/>
-                            <p:column style="padding: 4px; width: 7em;" footerText="#{0-cc.attrs.bill.total}" class="text-end">
+                            <p:column style="padding: 4px; width: 7em;" class="text-end">
                                 <f:facet name="footer" >
-                                    <h:outputLabel value="#{0-cc.attrs.bill.total}" >
+                                    <h:outputLabel value="#{cc.attrs.bill.total}" >
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
                                 </f:facet>

--- a/src/main/webapp/resources/pharmacy/direct_purchase_return_receipt_with_costing_custom_1.xhtml
+++ b/src/main/webapp/resources/pharmacy/direct_purchase_return_receipt_with_costing_custom_1.xhtml
@@ -16,6 +16,7 @@
     <!-- IMPLEMENTATION -->
     <cc:implementation>
         <h:outputStylesheet library="css" name="pharmacyLetter.css"/>
+        <style>.hidden { display: none !important; } @media print { .hidden { display: none !important; } }</style>
         <div style="width: 212mm; padding-left: 0px">
 
             <div class="institutionName">
@@ -126,7 +127,7 @@
 
                         <tbody style="font-size: 14px;">
                             <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip" varStatus="st">
-                                <tr>
+                                <tr style="#{bip.retired ? 'display:none;' : ''}">
                                     <td style="text-align: center; border: 1px solid black;">#{st.index + 1}</td>
                                     <td style="text-align: left; border: 1px solid black; padding-left: 4px">#{bip.item.name}</td>
                                     <td style="text-align: right; border: 1px solid black; padding-right: 4px">
@@ -138,20 +139,20 @@
 
                                     <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Purchase Return by Total Quantity', false)}">
                                         <td style="text-align: right; border: 1px solid black; padding-right: 4px">
-                                            <h:outputText value="#{bip.billItemFinanceDetails.quantity + bip.billItemFinanceDetails.freeQuantity}">
+                                            <h:outputText value="#{bip.qty + (bip.billItemFinanceDetails.freeQuantity != null ? 0 - bip.billItemFinanceDetails.freeQuantity : 0)}">
                                                 <f:convertNumber />
-                                            </h:outputText>                
+                                            </h:outputText>
                                         </td>
                                     </h:panelGroup>
 
                                     <h:panelGroup rendered="#{!configOptionApplicationController.getBooleanValueByKey('Purchase Return by Total Quantity', false)}">
                                         <td style="text-align: right; border: 1px solid black; padding-right: 4px">
-                                            <h:outputText value="#{bip.billItemFinanceDetails.quantity}">
+                                            <h:outputText value="#{bip.qty}">
                                                 <f:convertNumber />
-                                            </h:outputText>         
+                                            </h:outputText>
                                         </td>
                                         <td style="text-align: right; border: 1px solid black; padding-right: 4px">
-                                            <h:outputText value="#{bip.billItemFinanceDetails.freeQuantity}">
+                                            <h:outputText value="#{bip.billItemFinanceDetails.freeQuantity != null ? 0 - bip.billItemFinanceDetails.freeQuantity : 0}">
                                                 <f:convertNumber />
                                             </h:outputText>
                                         </td>
@@ -163,7 +164,7 @@
                                         </h:outputText>
                                     </td>
                                     <td style="text-align: right; border: 1px solid black;">
-                                        <h:outputText value="#{bip.billItemFinanceDetails.lineGrossRate * (bip.billItemFinanceDetails.quantity + bip.billItemFinanceDetails.freeQuantity)}">
+                                        <h:outputText value="#{bip.netValue}">
                                             <f:convertNumber pattern="#,##0.00" />
                                         </h:outputText>
                                     </td>
@@ -177,7 +178,7 @@
                                     <h:outputText value="Total"/>
                                 </td> 
                                 <td style="text-align: right; border: 1px solid black;">
-                                    <h:outputText value="#{0-cc.attrs.bill.total}">
+                                    <h:outputText value="#{cc.attrs.bill.total}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputText>
                                 </td>

--- a/src/main/webapp/resources/pharmacy/grn_return_receipt_with_costing.xhtml
+++ b/src/main/webapp/resources/pharmacy/grn_return_receipt_with_costing.xhtml
@@ -12,7 +12,7 @@
     </cc:interface>
     <!-- IMPLEMENTATION -->
     <cc:implementation>
-        <style>.hidden { display: none !important; }</style>
+        <style>.hidden { display: none !important; } @media print { .hidden { display: none !important; } }</style>
         <div class="purhcaseBill"
              style="font-family: sans-serif!important;
              border: none!important;
@@ -119,21 +119,21 @@
                             style="padding: 4px; width: 7em;" class="text-end"
                             rendered="#{configOptionApplicationController.getBooleanValueByKey('Purchase Return by Total Quantity', false)}">
                         <f:facet name="header">Return Total QTY</f:facet>
-                        <h:outputLabel value="#{0 - (bip.billItemFinanceDetails.quantity + bip.billItemFinanceDetails.freeQuantity)}"/>
+                        <h:outputLabel value="#{bip.qty + (bip.billItemFinanceDetails.freeQuantity != null ? 0 - bip.billItemFinanceDetails.freeQuantity : 0)}"/>
                     </p:column>
 
                     <p:column
                             style="padding: 4px; width: 7em;" class="text-end"
                             rendered="#{!configOptionApplicationController.getBooleanValueByKey('Purchase Return by Total Quantity', false)}">
                         <f:facet name="header">Return QTY</f:facet>
-                        <h:outputLabel value="#{0 - bip.billItemFinanceDetails.quantity}"/>
+                        <h:outputLabel value="#{bip.qty}"/>
                     </p:column>
 
                     <p:column
                             style="padding: 4px; width: 7em;" class="text-end"
                             rendered="#{!configOptionApplicationController.getBooleanValueByKey('Purchase Return by Total Quantity', false)}">
                         <f:facet name="header">Free QTY</f:facet>
-                        <h:outputLabel value="#{0 - bip.billItemFinanceDetails.freeQuantity}"/>
+                        <h:outputLabel value="#{bip.billItemFinanceDetails.freeQuantity != null ? 0 - bip.billItemFinanceDetails.freeQuantity : 0}"/>
                     </p:column>
 
                     <p:column style="padding: 4px; width: 7em;" class="text-end">
@@ -145,7 +145,7 @@
 
                     <p:column style="padding: 4px; width: 7em;" class="text-end">
                         <f:facet name="header">Amount</f:facet>
-                        <h:outputLabel value="#{bip.billItemFinanceDetails.lineGrossRate * (0 - (bip.billItemFinanceDetails.quantity + bip.billItemFinanceDetails.freeQuantity))}" >
+                        <h:outputLabel value="#{bip.netValue}" >
                             <f:convertNumber pattern="#,##0.00" />
                         </h:outputLabel>
                     </p:column>

--- a/src/main/webapp/resources/pharmacy/grn_return_receipt_with_costing.xhtml
+++ b/src/main/webapp/resources/pharmacy/grn_return_receipt_with_costing.xhtml
@@ -12,6 +12,7 @@
     </cc:interface>
     <!-- IMPLEMENTATION -->
     <cc:implementation>
+        <style>.hidden { display: none !important; }</style>
         <div class="purhcaseBill"
              style="font-family: sans-serif!important;
              border: none!important;
@@ -88,6 +89,7 @@
                         rowIndexVar="rowIndex"
                         value="#{cc.attrs.bill.billItems}"
                         var="bip"
+                        rowStyleClass="#{bip.retired ? 'hidden' : ''}"
                         style="font-size: 16px; margin-left: 3%; margin-right: 3%;"
                         rendered="#{not empty cc.attrs.bill.billItems}">
 
@@ -117,21 +119,21 @@
                             style="padding: 4px; width: 7em;" class="text-end"
                             rendered="#{configOptionApplicationController.getBooleanValueByKey('Purchase Return by Total Quantity', false)}">
                         <f:facet name="header">Return Total QTY</f:facet>
-                        <h:outputLabel value="#{bip.billItemFinanceDetails.quantity + bip.billItemFinanceDetails.freeQuantity}"/>
+                        <h:outputLabel value="#{0 - (bip.billItemFinanceDetails.quantity + bip.billItemFinanceDetails.freeQuantity)}"/>
                     </p:column>
 
                     <p:column
                             style="padding: 4px; width: 7em;" class="text-end"
                             rendered="#{!configOptionApplicationController.getBooleanValueByKey('Purchase Return by Total Quantity', false)}">
                         <f:facet name="header">Return QTY</f:facet>
-                        <h:outputLabel value="#{bip.billItemFinanceDetails.quantity}"/>
+                        <h:outputLabel value="#{0 - bip.billItemFinanceDetails.quantity}"/>
                     </p:column>
 
                     <p:column
                             style="padding: 4px; width: 7em;" class="text-end"
                             rendered="#{!configOptionApplicationController.getBooleanValueByKey('Purchase Return by Total Quantity', false)}">
                         <f:facet name="header">Free QTY</f:facet>
-                        <h:outputLabel value="#{bip.billItemFinanceDetails.freeQuantity}"/>
+                        <h:outputLabel value="#{0 - bip.billItemFinanceDetails.freeQuantity}"/>
                     </p:column>
 
                     <p:column style="padding: 4px; width: 7em;" class="text-end">
@@ -143,7 +145,7 @@
 
                     <p:column style="padding: 4px; width: 7em;" class="text-end">
                         <f:facet name="header">Amount</f:facet>
-                        <h:outputLabel value="#{bip.billItemFinanceDetails.lineGrossRate*(bip.billItemFinanceDetails.quantity + bip.billItemFinanceDetails.freeQuantity)}" >
+                        <h:outputLabel value="#{bip.billItemFinanceDetails.lineGrossRate * (0 - (bip.billItemFinanceDetails.quantity + bip.billItemFinanceDetails.freeQuantity))}" >
                             <f:convertNumber pattern="#,##0.00" />
                         </h:outputLabel>
                     </p:column>
@@ -151,9 +153,9 @@
                     <p:columnGroup type="footer">
                         <p:row>
                             <p:column style="padding: 4px;" colspan="#{configOptionApplicationController.getBooleanValueByKey('Purchase Return by Total Quantity', false) ? 6 : 7}" footerText="Total"/>
-                            <p:column style="padding: 4px; width: 7em;" footerText="#{0-cc.attrs.bill.total}" class="text-end">
+                            <p:column style="padding: 4px; width: 7em;" class="text-end">
                                 <f:facet name="footer" >
-                                    <h:outputLabel value="#{0-cc.attrs.bill.total}" >
+                                    <h:outputLabel value="#{cc.attrs.bill.total}" >
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
                                 </f:facet>

--- a/src/main/webapp/resources/pharmacy/grn_return_receipt_with_costing_custom_1.xhtml
+++ b/src/main/webapp/resources/pharmacy/grn_return_receipt_with_costing_custom_1.xhtml
@@ -126,7 +126,7 @@
 
                         <tbody style="font-size: 14px;">
                             <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip" varStatus="st">
-                                <tr>
+                                <tr style="#{bip.retired ? 'display:none;' : ''}">
                                     <td style="text-align: center; border: 1px solid black;">#{st.index + 1}</td>
                                     <td style="text-align: left; border: 1px solid black; padding-left: 4px">#{bip.item.name}</td>
                                     <td style="text-align: right; border: 1px solid black; padding-right: 4px">
@@ -138,20 +138,20 @@
 
                                     <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Purchase Return by Total Quantity', false)}">
                                         <td style="text-align: right; border: 1px solid black; padding-right: 4px">
-                                            <h:outputText value="#{bip.billItemFinanceDetails.quantity + bip.billItemFinanceDetails.freeQuantity}">
+                                            <h:outputText value="#{bip.qty + (bip.billItemFinanceDetails.freeQuantity != null ? 0 - bip.billItemFinanceDetails.freeQuantity : 0)}">
                                                 <f:convertNumber />
-                                            </h:outputText>                
+                                            </h:outputText>
                                         </td>
                                     </h:panelGroup>
 
                                     <h:panelGroup rendered="#{!configOptionApplicationController.getBooleanValueByKey('Purchase Return by Total Quantity', false)}">
                                         <td style="text-align: right; border: 1px solid black; padding-right: 4px">
-                                            <h:outputText value="#{bip.billItemFinanceDetails.quantity}">
+                                            <h:outputText value="#{bip.qty}">
                                                 <f:convertNumber />
-                                            </h:outputText>         
+                                            </h:outputText>
                                         </td>
                                         <td style="text-align: right; border: 1px solid black; padding-right: 4px">
-                                            <h:outputText value="#{bip.billItemFinanceDetails.freeQuantity}">
+                                            <h:outputText value="#{bip.billItemFinanceDetails.freeQuantity != null ? 0 - bip.billItemFinanceDetails.freeQuantity : 0}">
                                                 <f:convertNumber />
                                             </h:outputText>
                                         </td>
@@ -163,7 +163,7 @@
                                         </h:outputText>
                                     </td>
                                     <td style="text-align: right; border: 1px solid black;">
-                                        <h:outputText value="#{bip.billItemFinanceDetails.lineGrossRate * (bip.billItemFinanceDetails.quantity + bip.billItemFinanceDetails.freeQuantity)}">
+                                        <h:outputText value="#{bip.netValue}">
                                             <f:convertNumber pattern="#,##0.00" />
                                         </h:outputText>
                                     </td>
@@ -177,7 +177,7 @@
                                     <h:outputText value="Total"/>
                                 </td> 
                                 <td style="text-align: right; border: 1px solid black;">
-                                    <h:outputText value="#{0-cc.attrs.bill.total}">
+                                    <h:outputText value="#{cc.attrs.bill.total}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputText>
                                 </td>

--- a/src/test/java/com/divudi/bean/opd/OpdBillControllerTest.java
+++ b/src/test/java/com/divudi/bean/opd/OpdBillControllerTest.java
@@ -1,0 +1,27 @@
+package com.divudi.bean.opd;
+
+import com.divudi.core.entity.BillItem;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OpdBillControllerTest {
+
+    @Test
+    void isPersistedBillItem_returnsFalse_whenNull() {
+        assertFalse(OpdBillController.isPersistedBillItem(null));
+    }
+
+    @Test
+    void isPersistedBillItem_returnsFalse_whenIdIsNull() {
+        assertFalse(OpdBillController.isPersistedBillItem(new BillItem()));
+    }
+
+    @Test
+    void isPersistedBillItem_returnsTrue_whenIdIsSet() {
+        BillItem bi = new BillItem();
+        bi.setId(1L);
+        assertTrue(OpdBillController.isPersistedBillItem(bi));
+    }
+}


### PR DESCRIPTION
## Summary
- `processCollectingCentrePayment()` now charges the Collecting Centre settlement amount as the sum of the itemized bills being settled (`totalCCAmount`) instead of the ledger's overall balance delta across the date range, and guards against settling a range that leaves older unpaid bills behind it.
- `getAllHistoryFromPaymentBill()` falls back to the min/max `createdAt` of the bills referenced by the payment bill's BillItems when `fromDate`/`toDate` are null, so cancelling legacy (pre-date-field) payment bills correctly clears `paymentDone` instead of no-op'ing.
- CC Payment Bill search/export switched to a lightweight `CollectingCentrePaymentBillDTO` instead of loading full Bill entities/relationships, with From/To date columns added to the search table.

## Why
The ledger-delta calculation produced a ~9-10x cash/bill-value mismatch on two collecting centres in Ruhunu Prod and led to a wrongful "duplicate payment" cancellation that reinstated hundreds of thousands of rupees of phantom debt. Hotfixed directly to Ruhunu Prod on 2026-08-17; this PR merges that fix into `development`.

Closes #23095

## Test plan
- [x] Verified in Ruhunu Prod: settlement amount now matches itemized bill totals for the affected collecting centres
- [x] Verified cancelling a legacy null-date payment bill clears `paymentDone` on its underlying AgentHistory rows
- [ ] Regression check of CC Payment Bill search/export table (DTO-backed) in development environment

🤖 Generated with [Claude Code](https://claude.ai/code)