### PR TITLE
fix(collecting-centre): charge CC settlement amount from itemized bills, not ledger delta

### DIFF
--- a/src/main/java/com/divudi/bean/common/CollectingCentrePaymentController.java
+++ b/src/main/java/com/divudi/bean/common/CollectingCentrePaymentController.java
@@ -9,6 +9,7 @@ import com.divudi.core.entity.Bill;
 import com.divudi.core.entity.BillItem;
 import com.divudi.core.entity.Institution;
 import com.divudi.core.entity.Payment;
+import com.divudi.core.data.dto.CollectingCentrePaymentBillDTO;
 import com.divudi.core.facade.AgentHistoryFacade;
 import com.divudi.core.facade.BillFacade;
 import com.divudi.core.facade.BillItemFacade;
@@ -94,7 +95,7 @@ public class CollectingCentrePaymentController implements Serializable {
     private double payingBalanceAcodingToCCBalabce = 0.0;
     private Bill currentPaymentBill;
 
-    private List<Bill> paymentBills;
+    private List<CollectingCentrePaymentBillDTO> paymentBills;
 
     private String billNumber;
     private String comment;
@@ -108,8 +109,12 @@ public class CollectingCentrePaymentController implements Serializable {
         return "/collecting_centre/collecting_centre_repayment_bill_search?faces-redirect=true";
     }
 
-    public String navigateToViewCCPaymentBill(Bill bill) {
-        setCurrentPaymentBill(bill);
+    public String navigateToViewCCPaymentBill(Long billId) {
+        if (billId == null) {
+            JsfUtil.addErrorMessage("Payment Bill is Missing");
+            return "";
+        }
+        setCurrentPaymentBill(billFacade.find(billId));
         return "/collecting_centre/cc_repayment_bill_reprint?faces-redirect=true";
     }
 
@@ -712,7 +717,16 @@ public class CollectingCentrePaymentController implements Serializable {
         String jpql;
         Map temMap = new HashMap();
 
-        jpql = "select b from Bill b "
+        jpql = "select new com.divudi.core.data.dto.CollectingCentrePaymentBillDTO("
+                + " b.id, b.deptId, b.fromDate, b.toDate, b.createdAt, b.cancelled, cb.createdAt,"
+                + " cwup.name, ccrwup.name, ti.institutionCode, ti.name, b.netTotal) "
+                + " from Bill b "
+                + " left join b.cancelledBill cb "
+                + " left join b.creater c "
+                + " left join c.webUserPerson cwup "
+                + " left join cb.creater ccr "
+                + " left join ccr.webUserPerson ccrwup "
+                + " left join b.toInstitution ti "
                 + " where b.billTypeAtomic =:atomic "
                 + " and b.createdAt between :fromDate and :toDate "
                 + " and b.retired=false ";
@@ -733,7 +747,7 @@ public class CollectingCentrePaymentController implements Serializable {
         temMap.put("toDate", getToDate());
         temMap.put("fromDate", getFromDate());
 
-        paymentBills = billFacade.findByJpql(jpql, temMap, TemporalType.TIMESTAMP);
+        paymentBills = (List<CollectingCentrePaymentBillDTO>) billFacade.findLightsByJpqlWithoutCache(jpql, temMap, TemporalType.TIMESTAMP);
 
     }
 
@@ -871,8 +885,10 @@ public class CollectingCentrePaymentController implements Serializable {
 
             XSSFCellStyle amountStyle = workbook.createCellStyle();
 
+            SimpleDateFormat sdfDate = new SimpleDateFormat("dd-MM-yyyy");
+
             Row headerRow = sheet.createRow(rowIndex++);
-            String[] headers = {"No", "Bill No", "Bill At", "Billed By", "CC Code", "CC Name", "Status", "Cancelled At", "Cancelled By", "Net Total"};
+            String[] headers = {"No", "Bill No", "From", "To", "Bill At", "Billed By", "CC Code", "CC Name", "Status", "Cancelled At", "Cancelled By", "Net Total"};
 
             for (int i = 0; i < headers.length; i++) {
                 Cell cell = headerRow.createCell(i);
@@ -881,35 +897,46 @@ public class CollectingCentrePaymentController implements Serializable {
             }
 
             int no = 1;
-            for (Bill bill : paymentBills) {
+            for (CollectingCentrePaymentBillDTO bill : paymentBills) {
                 Row row = sheet.createRow(rowIndex++);
 
                 row.createCell(0).setCellValue(no++);
                 row.createCell(1).setCellValue(defaultIfNullOrEmpty(bill.getDeptId(), ""));
 
-                Cell billAtCell = row.createCell(2);
+                Cell fromDateCell = row.createCell(2);
+                if (bill.getFromDate() != null) {
+                    fromDateCell.setCellValue(sdfDate.format(bill.getFromDate()));
+                }
+
+                Cell toDateCell = row.createCell(3);
+                if (bill.getToDate() != null) {
+                    toDateCell.setCellValue(sdfDate.format(bill.getToDate()));
+                }
+
+                Cell billAtCell = row.createCell(4);
                 if (bill.getCreatedAt() != null) {
                     billAtCell.setCellValue(sdf.format(bill.getCreatedAt()));
                 }
 
-                row.createCell(3).setCellValue(defaultIfNullOrEmpty(getUserNameWithTitle(bill.getCreater()), ""));
+                row.createCell(5).setCellValue(defaultIfNullOrEmpty(bill.getCreatedByName(), ""));
 
-                row.createCell(4).setCellValue(bill.getToInstitution() != null ? defaultIfNullOrEmpty(bill.getToInstitution().getInstitutionCode(), "") : "");
-                row.createCell(5).setCellValue(bill.getToInstitution() != null ? defaultIfNullOrEmpty(bill.getToInstitution().getName(), "") : "");
+                row.createCell(6).setCellValue(defaultIfNullOrEmpty(bill.getToInstitutionCode(), ""));
+                row.createCell(7).setCellValue(defaultIfNullOrEmpty(bill.getToInstitutionName(), ""));
 
-                row.createCell(6).setCellValue(bill.isCancelled() ? "Cancelled" : "");
+                boolean cancelled = Boolean.TRUE.equals(bill.getCancelled());
+                row.createCell(8).setCellValue(cancelled ? "Cancelled" : "");
 
-                Cell cancelAtCell = row.createCell(7);
-                Cell cancelByCell = row.createCell(8);
-                if (bill.isCancelled() && bill.getCancelledBill() != null) {
-                    if (bill.getCancelledBill().getCreatedAt() != null) {
-                        cancelAtCell.setCellValue(sdf.format(bill.getCancelledBill().getCreatedAt()));
+                Cell cancelAtCell = row.createCell(9);
+                Cell cancelByCell = row.createCell(10);
+                if (cancelled) {
+                    if (bill.getCancelledAt() != null) {
+                        cancelAtCell.setCellValue(sdf.format(bill.getCancelledAt()));
                     }
-                    cancelByCell.setCellValue(defaultIfNullOrEmpty(getUserNameWithTitle(bill.getCancelledBill().getCreater()), ""));
+                    cancelByCell.setCellValue(defaultIfNullOrEmpty(bill.getCancelledByName(), ""));
                 }
 
-                Cell netTotalCell = row.createCell(9);
-                netTotalCell.setCellValue(bill.getNetTotal());
+                Cell netTotalCell = row.createCell(11);
+                netTotalCell.setCellValue(bill.getNetTotal() != null ? bill.getNetTotal() : 0.0);
                 netTotalCell.setCellStyle(amountStyle);
             }
 
@@ -924,13 +951,6 @@ public class CollectingCentrePaymentController implements Serializable {
 
         } catch (Exception e) {
         }
-    }
-
-    private String getUserNameWithTitle(com.divudi.core.entity.WebUser user) {
-        if (user == null || user.getWebUserPerson() == null) {
-            return "";
-        }
-        return user.getWebUserPerson().getNameWithTitle();
     }
 
     public void cancelPaymentBill() {
@@ -1179,11 +1199,11 @@ public class CollectingCentrePaymentController implements Serializable {
         this.currentPaymentBill = currentPaymentBill;
     }
 
-    public List<Bill> getPaymentBills() {
+    public List<CollectingCentrePaymentBillDTO> getPaymentBills() {
         return paymentBills;
     }
 
-    public void setPaymentBills(List<Bill> paymentBills) {
+    public void setPaymentBills(List<CollectingCentrePaymentBillDTO> paymentBills) {
         this.paymentBills = paymentBills;
     }
 

--- a/src/main/java/com/divudi/bean/common/CollectingCentrePaymentController.java
+++ b/src/main/java/com/divudi/bean/common/CollectingCentrePaymentController.java
@@ -161,15 +161,21 @@ public class CollectingCentrePaymentController implements Serializable {
             return;
         }
 
-        double paymentDone = getAllAgentHistory(currentCollectingCentre, true);
+        findPendingCCBills();
 
-        if (paymentDone > 0.0) {
-            JsfUtil.addErrorMessage("There is a bill that was taken within this range.");
+        if (selectedCCpaymentBills == null || selectedCCpaymentBills.isEmpty()) {
+            JsfUtil.addErrorMessage("There are no unpaid bills for this Collecting Centre within this range.");
             setCurrentCollectingCentre(null);
             return;
         }
 
-        findPendingCCBills();
+        long unpaidBillsBeforeRange = countUnpaidCCBillsBefore(currentCollectingCentre, fromDate);
+        if (unpaidBillsBeforeRange > 0) {
+            JsfUtil.addErrorMessage("There are " + unpaidBillsBeforeRange + " unpaid bill(s) for this Collecting Centre dated before the selected From Date. "
+                    + "Extend the range to include them before settling, otherwise they will be left unpaid.");
+            setCurrentCollectingCentre(null);
+            return;
+        }
 
         allHistorys = getAllAgentHistory(currentCollectingCentre);
 
@@ -182,12 +188,34 @@ public class CollectingCentrePaymentController implements Serializable {
         if (endingHistory != null) {
             finalEndingBalanseInCC = endingHistory.getBalanceAfterTransaction();
         }
-        
+
         periodPaidAmount = getPaidAgentPaymentsDuringThisPeriod(currentCollectingCentre);
 
-        calculaPayingBalanceAcodingToCCBalabce(startingHistory, endingHistory,periodPaidAmount);
+        // Ledger balance-delta is retained only for display/reconciliation (startingBalanseInCC /
+        // finalEndingBalanseInCC) - it must not drive the amount actually charged, since it can
+        // silently include activity that was already settled outside the selected date range.
+        calculaPayingBalanceAcodingToCCBalabce(startingHistory, endingHistory, periodPaidAmount);
+
+        // The amount charged is always the value of the itemized bills being marked paid.
+        payingBalanceAcodingToCCBalabce = totalCCAmount;
 
         calculateTotalOfPaymentReceive();
+    }
+
+    public long countUnpaidCCBillsBefore(Institution collectingCentre, Date beforeDate) {
+        String jpql = "select count(bill.id) "
+                + " from Bill bill "
+                + " where bill.collectingCentre=:cc "
+                + " and bill.createdAt < :beforeDate "
+                + " and bill.paid =:paid"
+                + " and bill.retired=false ";
+
+        Map<String, Object> m = new HashMap<>();
+        m.put("cc", collectingCentre);
+        m.put("beforeDate", beforeDate);
+        m.put("paid", false);
+
+        return billFacade.findLongByJpql(jpql, m, TemporalType.TIMESTAMP);
     }
     
     public List<AgentHistory> getAllHistoryFromPaymentBill(Bill ccPaymentBill) {

--- a/src/main/java/com/divudi/bean/common/CollectingCentrePaymentController.java
+++ b/src/main/java/com/divudi/bean/common/CollectingCentrePaymentController.java
@@ -244,12 +244,50 @@ public class CollectingCentrePaymentController implements Serializable {
         m.put("ret", false);
         m.put("cc", ccPaymentBill.getCollectingCentre());
         m.put("types", types);
-        m.put("fromDate", ccPaymentBill.getFromDate());
-        m.put("toDate", ccPaymentBill.getToDate());
+
+        Date rangeFromDate = ccPaymentBill.getFromDate();
+        Date rangeToDate = ccPaymentBill.getToDate();
+
+        if (rangeFromDate == null || rangeToDate == null) {
+            // Legacy payment bills created before fromDate/toDate were persisted on the Bill itself.
+            // Fall back to the date span of the bills it actually settled so a BETWEEN NULL AND NULL
+            // does not silently match zero rows and skip clearing paymentDone on cancellation.
+            Date[] derivedRange = deriveDateRangeFromBillItems(ccPaymentBill);
+            rangeFromDate = derivedRange[0];
+            rangeToDate = derivedRange[1];
+        }
+
+        m.put("fromDate", rangeFromDate);
+        m.put("toDate", rangeToDate);
+
+        if (rangeFromDate == null || rangeToDate == null) {
+            return new ArrayList<>();
+        }
 
         List<AgentHistory> listCount = agentHistoryFacade.findByJpql(jpql, m, TemporalType.TIMESTAMP);
 
         return listCount;
+    }
+
+    private Date[] deriveDateRangeFromBillItems(Bill ccPaymentBill) {
+        Date min = null;
+        Date max = null;
+        if (ccPaymentBill.getBillItems() != null) {
+            for (BillItem bi : ccPaymentBill.getBillItems()) {
+                Bill referenced = bi.getReferenceBill();
+                if (referenced == null || referenced.getCreatedAt() == null) {
+                    continue;
+                }
+                Date createdAt = referenced.getCreatedAt();
+                if (min == null || createdAt.before(min)) {
+                    min = createdAt;
+                }
+                if (max == null || createdAt.after(max)) {
+                    max = createdAt;
+                }
+            }
+        }
+        return new Date[]{min, max};
     }
 
     public double calculaPayingBalanceAcodingToCCBalabce(AgentHistory startingHistory, AgentHistory endingHistory, double paidCCAmount) {

--- a/src/main/java/com/divudi/bean/common/CollectingCentrePaymentController.java
+++ b/src/main/java/com/divudi/bean/common/CollectingCentrePaymentController.java
@@ -213,14 +213,26 @@ public class CollectingCentrePaymentController implements Serializable {
                 + " where bill.collectingCentre=:cc "
                 + " and bill.createdAt < :beforeDate "
                 + " and bill.paid =:paid"
-                + " and bill.retired=false ";
+                + " and bill.retired=false "
+                + " and bill.billTypeAtomic not in :excludedAtomics ";
 
         Map<String, Object> m = new HashMap<>();
         m.put("cc", collectingCentre);
         m.put("beforeDate", beforeDate);
         m.put("paid", false);
+        m.put("excludedAtomics", ccSettlementVoucherAtomicTypes());
 
         return billFacade.findLongByJpql(jpql, m, TemporalType.TIMESTAMP);
+    }
+
+    // CC_AGENT_PAYMENT/CC_AGENT_PAYMENT_CANCELLATION vouchers are created with the same
+    // collectingCentre and default to paid=false, so they must be excluded from the unpaid-bill
+    // queries below - otherwise a settlement voucher blocks or pollutes the next settlement.
+    private List<BillTypeAtomic> ccSettlementVoucherAtomicTypes() {
+        List<BillTypeAtomic> types = new ArrayList<>();
+        types.add(BillTypeAtomic.CC_AGENT_PAYMENT);
+        types.add(BillTypeAtomic.CC_AGENT_PAYMENT_CANCELLATION);
+        return types;
     }
     
     public List<AgentHistory> getAllHistoryFromPaymentBill(Bill ccPaymentBill) {
@@ -473,13 +485,15 @@ public class CollectingCentrePaymentController implements Serializable {
                 + " where bill.collectingCentre=:cc "
                 + " and bill.createdAt between :fromDate and :toDate "
                 + " and bill.paid =:paid"
-                + " and bill.retired=false ";
+                + " and bill.retired=false "
+                + " and bill.billTypeAtomic not in :excludedAtomics ";
 
         jpql += " order by bill.createdAt asc ";
         temMap.put("cc", currentCollectingCentre);
         temMap.put("fromDate", fromDate);
         temMap.put("paid", false);
         temMap.put("toDate", toDate);
+        temMap.put("excludedAtomics", ccSettlementVoucherAtomicTypes());
 
         selectedCCpaymentBills = billFacade.findLightsByJpql(jpql, temMap, TemporalType.TIMESTAMP);
 

--- a/src/main/java/com/divudi/core/data/dto/CollectingCentrePaymentBillDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/CollectingCentrePaymentBillDTO.java
@@ -1,0 +1,145 @@
+package com.divudi.core.data.dto;
+
+import java.io.Serializable;
+import java.util.Date;
+
+/**
+ * DTO for the Collecting Centre Payment Bill search table
+ * (collecting_centre_repayment_bill_search.xhtml). Carries only the fields
+ * needed for that table, avoiding full Bill entity/relationship loading.
+ *
+ * @author H.K. Damith Deshan | hkddrajapaksha@gmail.com
+ */
+public class CollectingCentrePaymentBillDTO implements Serializable {
+
+    private Long id;
+    private String deptId;
+    private Date fromDate;
+    private Date toDate;
+    private Date createdAt;
+    private Boolean cancelled;
+    private Date cancelledAt;
+    private String createdByName;
+    private String cancelledByName;
+    private String toInstitutionCode;
+    private String toInstitutionName;
+    private Double netTotal;
+
+    public CollectingCentrePaymentBillDTO() {
+    }
+
+    public CollectingCentrePaymentBillDTO(Long id, String deptId, Date fromDate, Date toDate,
+            Date createdAt, Boolean cancelled, Date cancelledAt,
+            String createdByName, String cancelledByName,
+            String toInstitutionCode, String toInstitutionName, Double netTotal) {
+        this.id = id;
+        this.deptId = deptId;
+        this.fromDate = fromDate;
+        this.toDate = toDate;
+        this.createdAt = createdAt;
+        this.cancelled = cancelled;
+        this.cancelledAt = cancelledAt;
+        this.createdByName = createdByName;
+        this.cancelledByName = cancelledByName;
+        this.toInstitutionCode = toInstitutionCode;
+        this.toInstitutionName = toInstitutionName;
+        this.netTotal = netTotal;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getDeptId() {
+        return deptId;
+    }
+
+    public void setDeptId(String deptId) {
+        this.deptId = deptId;
+    }
+
+    public Date getFromDate() {
+        return fromDate;
+    }
+
+    public void setFromDate(Date fromDate) {
+        this.fromDate = fromDate;
+    }
+
+    public Date getToDate() {
+        return toDate;
+    }
+
+    public void setToDate(Date toDate) {
+        this.toDate = toDate;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Boolean getCancelled() {
+        return cancelled;
+    }
+
+    public void setCancelled(Boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+
+    public Date getCancelledAt() {
+        return cancelledAt;
+    }
+
+    public void setCancelledAt(Date cancelledAt) {
+        this.cancelledAt = cancelledAt;
+    }
+
+    public String getCreatedByName() {
+        return createdByName;
+    }
+
+    public void setCreatedByName(String createdByName) {
+        this.createdByName = createdByName;
+    }
+
+    public String getCancelledByName() {
+        return cancelledByName;
+    }
+
+    public void setCancelledByName(String cancelledByName) {
+        this.cancelledByName = cancelledByName;
+    }
+
+    public String getToInstitutionCode() {
+        return toInstitutionCode;
+    }
+
+    public void setToInstitutionCode(String toInstitutionCode) {
+        this.toInstitutionCode = toInstitutionCode;
+    }
+
+    public String getToInstitutionName() {
+        return toInstitutionName;
+    }
+
+    public void setToInstitutionName(String toInstitutionName) {
+        this.toInstitutionName = toInstitutionName;
+    }
+
+    public Double getNetTotal() {
+        return netTotal;
+    }
+
+    public void setNetTotal(Double netTotal) {
+        this.netTotal = netTotal;
+    }
+
+}

--- a/src/main/webapp/collecting_centre/collecting_centre_repayment_bill_search.xhtml
+++ b/src/main/webapp/collecting_centre/collecting_centre_repayment_bill_search.xhtml
@@ -124,7 +124,7 @@
                                             </h:outputLabel>
                                         </p:column>
 
-                                        <p:column headerText="Tp" width="8em" style="padding: 6px;">
+                                        <p:column headerText="To" width="8em" style="padding: 6px;">
                                             <h:outputLabel value="#{bill.toDate}" >
                                                 <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateFormat}" />
                                             </h:outputLabel>

--- a/src/main/webapp/collecting_centre/collecting_centre_repayment_bill_search.xhtml
+++ b/src/main/webapp/collecting_centre/collecting_centre_repayment_bill_search.xhtml
@@ -107,55 +107,67 @@
                                         paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
                                         rowsPerPageTemplate="20,50,100">
 
-                                        <p:column headerText="No" width="3em">
+                                        <p:column headerText="No" width="3em" style="padding: 6px;">
                                             <h:outputLabel  value="#{i+1}"></h:outputLabel>
                                         </p:column>
 
-                                        <p:column headerText="Bill No" width="12em">
-                                            <h:commandLink 
-                                                action="#{collectingCentrePaymentController.navigateToViewCCPaymentBill(bill)}" 
+                                        <p:column headerText="Bill No" width="12em" style="padding: 6px;">
+                                            <h:commandLink
+                                                action="#{collectingCentrePaymentController.navigateToViewCCPaymentBill(bill.id)}"
                                                 value="#{bill.deptId}">
                                             </h:commandLink>
                                         </p:column>
 
-                                        <p:column headerText="Billed at" width="12em" >
+                                        <p:column headerText="From" width="8em" style="padding: 6px;">
+                                            <h:outputLabel value="#{bill.fromDate}" >
+                                                <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                                            </h:outputLabel>
+                                        </p:column>
+
+                                        <p:column headerText="Tp" width="8em" style="padding: 6px;">
+                                            <h:outputLabel value="#{bill.toDate}" >
+                                                <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                                            </h:outputLabel>
+                                        </p:column>
+
+                                        <p:column headerText="Billed at" width="12em" style="padding: 6px;">
                                             <h:outputLabel value="#{bill.createdAt}" >
                                                 <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
                                             </h:outputLabel>
                                             <br/>
                                             <h:panelGroup rendered="#{bill.cancelled}" >
-                                                <h:outputLabel style="color: red;" rendered="#{bill.cancelled}" value="#{bill.cancelledBill.createdAt}" >
+                                                <h:outputLabel style="color: red;" rendered="#{bill.cancelled}" value="#{bill.cancelledAt}" >
                                                     <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
                                                 </h:outputLabel>
                                             </h:panelGroup>
-                                        </p:column>  
+                                        </p:column>
 
-                                        <p:column headerText="Billed by" width="10em">
-                                            <h:outputLabel value="#{bill.creater.webUserPerson.name}" ></h:outputLabel>
+                                        <p:column headerText="Billed by" width="13em" style="padding: 6px;">
+                                            <h:outputLabel value="#{bill.createdByName}" ></h:outputLabel>
                                             <br/>
                                             <h:panelGroup rendered="#{bill.cancelled}" >
-                                                <h:outputLabel style="color: red;" rendered="#{bill.cancelled}" value="#{bill.cancelledBill.creater.webUserPerson.name}" >                                       
+                                                <h:outputLabel style="color: red;" rendered="#{bill.cancelled}" value="#{bill.cancelledByName}" >
                                                 </h:outputLabel>
-                                            </h:panelGroup>                               
-                                        </p:column>    
+                                            </h:panelGroup>
+                                        </p:column>
 
-                                        <p:column headerText="CC Code" width="6em">
-                                            <h:outputLabel value="#{bill.toInstitution.institutionCode}" ></h:outputLabel>
-                                        </p:column>  
+                                        <p:column headerText="CC Code" width="6em" style="padding: 6px;">
+                                            <h:outputLabel value="#{bill.toInstitutionCode}" ></h:outputLabel>
+                                        </p:column>
 
-                                        <p:column headerText="CC Name">
-                                            <h:outputLabel value="#{bill.toInstitution.name}" ></h:outputLabel>
-                                        </p:column>  
-                                        
-                                        <p:column headerText="Status" width="10em">
+                                        <p:column headerText="CC Name" style="width: 450px; padding: 6px;">
+                                            <h:outputLabel value="#{bill.toInstitutionName}" ></h:outputLabel>
+                                        </p:column>
+
+                                        <p:column headerText="Status" width="10em" style="padding: 6px;">
                                             <p:badge value="Cancelled" styleClass="ui-badge-danger" rendered="#{bill.cancelled}" />
                                         </p:column>
 
-                                        <p:column headerText="Net Value" width="8em" style="text-align: end;">
+                                        <p:column headerText="Net Value" width="8em" style="padding: 6px; text-align: end;">
                                             <h:outputLabel value="#{bill.netTotal}" >
                                                 <f:convertNumber pattern="#,##0.00"/>
                                             </h:outputLabel>
-                                        </p:column>  
+                                        </p:column>
 
                                     </p:dataTable>
                                 </div>


### PR DESCRIPTION
## Summary
- `processCollectingCentrePayment()` now charges the Collecting Centre settlement amount as the sum of the itemized bills being settled (`totalCCAmount`) instead of the ledger's overall balance delta across the date range, and guards against settling a range that leaves older unpaid bills behind it.
- `getAllHistoryFromPaymentBill()` falls back to the min/max `createdAt` of the bills referenced by the payment bill's BillItems when `fromDate`/`toDate` are null, so cancelling legacy (pre-date-field) payment bills correctly clears `paymentDone` instead of no-op'ing.
- CC Payment Bill search/export switched to a lightweight `CollectingCentrePaymentBillDTO` instead of loading full Bill entities/relationships, with From/To date columns added to the search table.

## Why
The ledger-delta calculation produced a ~9-10x cash/bill-value mismatch on two collecting centres in Ruhunu Prod and led to a wrongful "duplicate payment" cancellation that reinstated hundreds of thousands of rupees of phantom debt. Hotfixed directly to Ruhunu Prod on 2026-08-17; this PR merges that fix into `development`.

Closes #23095

Supersedes #23096, which was built on stale history (based on old master history rather than `origin/development`) and got auto-closed by GitHub after the branch was rebuilt/force-pushed onto `origin/development`.

## Test plan
- [x] Verified in Ruhunu Prod: settlement amount now matches itemized bill totals for the affected collecting centres
- [x] Verified cancelling a legacy null-date payment bill clears `paymentDone` on its underlying AgentHistory rows
- [ ] Regression check of CC Payment Bill search/export table (DTO-backed) in development environment

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Payment-bill search results now display bill dates, creator details, destination institution, cancellation information, and net totals.
  * Excel exports include expanded bill and payment details.
  * Users can open payment bills directly from search results.

* **Bug Fixes**
  * Settlement now prevents processing when earlier unpaid bills exist.
  * Settlement totals use itemized bill values for improved accuracy.
  * Payment history now handles legacy bills with missing date ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->