### PR TITLE
fix(pharmacy): show Tendered/Balance only for cash payments on native sale bill header

### DIFF
--- a/src/main/webapp/resources/pharmacy/saleBill_Header_native.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBill_Header_native.xhtml
@@ -256,6 +256,7 @@
                     </tr>
 
                     <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Allow Tendered Amount for pharmacy sale for cashier')}">
+                        <h:panelGroup rendered="#{cc.attrs.bill.paymentMethodLabel eq 'Cash'}">
                         <tr>
                             <td class="totalsItemBlock1" style="text-align: left;">
                                 <h:outputLabel value="Tendered"/>
@@ -276,6 +277,7 @@
                                 </h:outputLabel>
                             </td>
                         </tr>
+                    </h:panelGroup>
                     </h:panelGroup>
 
                     <tr>


### PR DESCRIPTION
## Summary
- On the native pharmacy sale bill header, wrap the existing Tendered/Balance `h:panelGroup` in an additional `rendered` check for `cc.attrs.bill.paymentMethodLabel eq 'Cash'`, so these rows only appear for cash payments instead of for every payment method whenever the tendered-amount config option is enabled.

Fixes #23101

## Test plan
- [ ] Enable `Allow Tendered Amount for pharmacy sale for cashier`.
- [ ] Create a pharmacy retail sale paid by Cash — confirm Tendered/Balance still render.
- [ ] Create a pharmacy retail sale paid by Card/Credit — confirm Tendered/Balance no longer render.
- [ ] JSF-only change (no Java) — no compilation required per project conventions.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tendered and Balance details now appear only for cash payments when the pharmacy cashier configuration is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->