### PR TITLE
fix(pharmacy): bind Enter key to Add button on direct department issue

### DIFF
--- a/src/main/webapp/pharmacy/pharmacy_transfer_issue_direct_department.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_issue_direct_department.xhtml
@@ -207,6 +207,7 @@
                                                 action="#{transferIssueDirectController.addNewBillItem}"
                                                 ajax="false"
                                                 update="focusItem"/>
+                                            <p:defaultCommand target="btnAdd" />
                                             <p:focus id="focusQty" for="txtQty"/>
                                             <p:focus id="focusItem" for="acStock"/>
                                         </h:panelGrid>


### PR DESCRIPTION
## Summary
- On the Pharmacy Direct Department Transfer Issue page, pressing Enter anywhere in the Add Items fields fell back to the browser's implicit-submission behavior, which activates the *first* submit button in the form's DOM order — "Change Department" — whose action (`changeDepartment()` → `makeNull()`) wipes the selected department and all added items.
- Adds `<p:defaultCommand target="btnAdd" />` next to the Add button so Enter explicitly adds the item instead, matching the existing pattern used on `pharmacy_issue.xhtml` and other item-entry pages.

## Test plan
- [ ] Open Pharmacy > Disbursement > Transfer Issue (Direct Department)
- [ ] Select a destination department
- [ ] Search an item, enter a quantity, press Enter → item should be added (not clear the screen)
- [ ] Confirm "Change Department" and "Settle Issue" buttons still work when clicked directly

Fixes #23103

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled the form’s default action to trigger the **Add Item** operation using the standard Enter-key behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->