### PR TITLE
feat(pharmacy): improve direct-issue item/staff search UX and receipt item source

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/StockController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/StockController.java
@@ -406,7 +406,11 @@ public class StockController implements Serializable {
 
         sql.append(") ORDER BY i.itemBatch.item.name, i.itemBatch.dateOfExpire");
         
-        int maxResult = configOptionApplicationController.getIntegerValueByKey("Pharmacy Retail Sale - Medicine Autocomplete Max Results", 20);
+        Integer configuredMaxResult = configOptionApplicationController.getIntegerValueByKey(
+                "Pharmacy Retail Sale - Medicine Autocomplete Max Results", 20);
+        int maxResult = configuredMaxResult == null || configuredMaxResult < 1
+                ? 20
+                : configuredMaxResult;
 
         List<StockDTO> stockDtos = (List<StockDTO>) getStockFacade().findLightsByJpql(sql.toString(), parameters, TemporalType.TIMESTAMP, maxResult);
 
@@ -466,9 +470,6 @@ public class StockController implements Serializable {
 
     public void addItemStockToStockDtos(List<StockDTO> inputStockDtos) {
         if (inputStockDtos == null || inputStockDtos.isEmpty()) {
-            return;
-        }
-        if (inputStockDtos.size() > 20) {
             return;
         }
 

--- a/src/main/java/com/divudi/bean/pharmacy/StockController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/StockController.java
@@ -405,8 +405,10 @@ public class StockController implements Serializable {
         }
 
         sql.append(") ORDER BY i.itemBatch.item.name, i.itemBatch.dateOfExpire");
+        
+        int maxResult = configOptionApplicationController.getIntegerValueByKey("Pharmacy Retail Sale - Medicine Autocomplete Max Results", 20);
 
-        List<StockDTO> stockDtos = (List<StockDTO>) getStockFacade().findLightsByJpql(sql.toString(), parameters, TemporalType.TIMESTAMP, 20);
+        List<StockDTO> stockDtos = (List<StockDTO>) getStockFacade().findLightsByJpql(sql.toString(), parameters, TemporalType.TIMESTAMP, maxResult);
 
         // Calculate total stock quantities per item
         addItemStockToStockDtos(stockDtos);

--- a/src/main/webapp/pharmacy/pharmacy_transfer_issue_direct_department.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_issue_direct_department.xhtml
@@ -378,20 +378,22 @@
                                         completeMethod="#{staffController.completeStaffWithoutDoctors}"
                                         forceSelection="true"
                                         var="w"
-                                        itemLabel="#{w.person.name}"
+                                        itemLabel="#{w.person.nameWithTitle}"
                                         itemValue="#{w}"
+                                        minQueryLength="3"
+                                        maxResults="20"
                                         placeholder="Search staff by name..."
                                         value="#{transferIssueDirectController.issuedBill.toStaff}" >
-                                        <p:column headerText="Name">
+                                        <p:column headerText="Name" style="padding: 6px; width: 450px;">
                                             <h:outputText value="#{w.person.nameWithTitle}" ></h:outputText>
                                         </p:column>
-                                        <p:column headerText="Speciality">
+                                        <p:column headerText="Speciality" style="padding: 6px; width: 150px;">
                                             <h:outputText value="#{w.speciality.name}" ></h:outputText>
                                         </p:column>
-                                        <p:column headerText="Code">
+                                        <p:column headerText="Code" style="padding: 6px; width: 100px;">
                                             <h:outputText value="#{w.code}" ></h:outputText>
                                         </p:column>
-                                        <p:column headerText="Staff Code">
+                                        <p:column headerText="Staff Code" style="padding: 6px; width: 100px;">
                                             <h:outputText value="#{w.staffCode}" ></h:outputText>
                                         </p:column>
                                     </p:autoComplete>

--- a/src/main/webapp/pharmacy/pharmacy_transfer_issue_direct_department.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_issue_direct_department.xhtml
@@ -147,29 +147,32 @@
                                                 inputStyleClass="w-100"
                                                 id="acStock"
                                                 value="#{transferIssueDirectController.stockDto}"
-                                                minQueryLength="3" queryDelay="300" completeMethod="#{stockController.completeAvailableStocksWithItemStockDtoForAllowedDepartments}"
+                                                minQueryLength="3" 
+                                                queryDelay="300" 
+                                                completeMethod="#{stockController.completeAvailableStocksWithItemStockDtoForAllowedDepartments}"
                                                 converter="stockDtoConverter"
                                                 var="i"
+                                                scrollHeight="450"
                                                 itemLabel="#{i.itemName}"
                                                 itemValue="#{i}"
-                                                maxResults="5">
-                                                <p:column headerText="Item">
+                                                maxResults="30">
+                                                <p:column headerText="Item" style="padding: 6px; width: 450px;">
                                                     <h:outputText value="#{i.itemName}"/>
                                                 </p:column>
-                                                <p:column headerText="Code">
+                                                <p:column headerText="Code" style="padding: 6px; width: 80px;">
                                                     <h:outputLabel value="#{i.code}"/>
                                                 </p:column>
-                                                <p:column headerText="Expiry">
+                                                <p:column headerText="Expiry" style="padding: 6px; width: 150px;">
                                                     <h:outputLabel value="#{i.dateOfExpire}" style="width: 100px!important;">
                                                         <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"/>
                                                     </h:outputLabel>
                                                 </p:column>
-                                                <p:column headerText="Stocks" styleClass="text-end">
+                                                <p:column headerText="Stocks" styleClass="text-end" style="padding: 6px; width: 100px;">
                                                     <h:outputLabel value="#{i.stockQty}">
                                                         <f:convertNumber pattern="#,###"/>
                                                     </h:outputLabel>
                                                 </p:column>
-                                                <p:column headerText="Retail Rate" styleClass="text-end">
+                                                <p:column headerText="Retail Rate" styleClass="text-end" style="padding: 6px; width: 120px;">
                                                     <h:outputLabel value="#{i.retailRate}">
                                                         <f:convertNumber pattern="#,##0.00"/>
                                                     </h:outputLabel>

--- a/src/main/webapp/resources/pharmacy/saleBill_Header_Transfer.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBill_Header_Transfer.xhtml
@@ -159,7 +159,7 @@
                         </td>
 
                     </tr>
-                    <ui:repeat value="#{billBeanController.fetchBillItems(cc.attrs.bill)}" var="bip">
+                    <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
                         <tr>
                             <td colspan="4" style="overflow: visible;">
                                 <h:outputLabel value="#{bip.item.name}"  styleClass="itemsBlock1" style="text-transform: capitalize!important;"  >


### PR DESCRIPTION
## Summary
- Make the medicine autocomplete result limit on the Direct Department Transfer Issue page configurable (`Pharmacy Retail Sale - Medicine Autocomplete Max Results`, default 20), raise `maxResults` to 30, and widen the dropdown columns/scroll height.
- Improve the receiving-staff autocomplete: show name with title, add `minQueryLength="3"`/`maxResults="20"`, widen columns to match the item search box.
- `saleBill_Header_Transfer.xhtml` (POS-header print format) now binds directly to `cc.attrs.bill.billItems` instead of the deprecated `billBeanController.fetchBillItems(bill)`.

## Test plan
- [ ] Open Pharmacy > Disbursement > Transfer Issue (Direct Department)
- [ ] Search medicines — confirm more than 5 results can appear and columns are readable
- [ ] Search receiving staff — confirm title shows in the input and dropdown, and results are capped/filtered correctly
- [ ] Settle a direct issue with "POS Paper with Header" enabled and confirm the printed receipt still lists all items correctly

Fixes #23105

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Pharmacy stock autocomplete results now support configurable limits, expanded results, scrolling, and clearer item, code, expiry, stock, and rate details.
  - Staff search displays titled names and detailed results, with focused searches requiring at least three characters.

- **Bug Fixes**
  - Stock totals are now calculated correctly for larger result sets.
  - Transfer bills now display items consistently from the selected bill, improving item loading reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->