### PR TITLE
Widen retail sale medicine autocomplete list and make result limit configurable

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController.java
@@ -1244,9 +1244,15 @@ public class RetailSaleNativeSqlController implements Serializable, ControllerWi
             sql.append("OR i.itemBatch.item.vmp.vtm.name LIKE :query ");
         }
         sql.append(") ORDER BY i.itemBatch.item.name, i.itemBatch.dateOfExpire");
+        
+        Integer configuredMaxResult = configOptionApplicationController.getIntegerValueByKey(
+                "Pharmacy Retail Sale - Medicine Autocomplete Max Results", 20);
+        int maxResult = configuredMaxResult == null || configuredMaxResult < 1
+                ? 20
+                : configuredMaxResult;
 
         lastAutocompleteResults = (List<StockDTO>) stockFacade.findLightsByJpql(
-                sql.toString(), parameters, TemporalType.TIMESTAMP, 20);
+                sql.toString(), parameters, TemporalType.TIMESTAMP, maxResult);
         if (lastAutocompleteResults == null) {
             lastAutocompleteResults = new ArrayList<>();
         }

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController1.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController1.java
@@ -1236,8 +1236,14 @@ public class RetailSaleNativeSqlController1 implements Serializable, ControllerW
         }
         sql.append(") ORDER BY i.itemBatch.item.name, i.itemBatch.dateOfExpire");
 
+        Integer configuredMaxResult = configOptionApplicationController.getIntegerValueByKey(
+                "Pharmacy Retail Sale - Medicine Autocomplete Max Results", 20);
+        int maxResult = configuredMaxResult == null || configuredMaxResult < 1
+                ? 20
+                : configuredMaxResult;
+
         lastAutocompleteResults = (List<StockDTO>) stockFacade.findLightsByJpql(
-                sql.toString(), parameters, TemporalType.TIMESTAMP, 20);
+                sql.toString(), parameters, TemporalType.TIMESTAMP, maxResult);
         if (lastAutocompleteResults == null) {
             lastAutocompleteResults = new ArrayList<>();
         }

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController2.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController2.java
@@ -1236,8 +1236,14 @@ public class RetailSaleNativeSqlController2 implements Serializable, ControllerW
         }
         sql.append(") ORDER BY i.itemBatch.item.name, i.itemBatch.dateOfExpire");
 
+        Integer configuredMaxResult = configOptionApplicationController.getIntegerValueByKey(
+                "Pharmacy Retail Sale - Medicine Autocomplete Max Results", 20);
+        int maxResult = configuredMaxResult == null || configuredMaxResult < 1
+                ? 20
+                : configuredMaxResult;
+
         lastAutocompleteResults = (List<StockDTO>) stockFacade.findLightsByJpql(
-                sql.toString(), parameters, TemporalType.TIMESTAMP, 20);
+                sql.toString(), parameters, TemporalType.TIMESTAMP, maxResult);
         if (lastAutocompleteResults == null) {
             lastAutocompleteResults = new ArrayList<>();
         }

--- a/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController3.java
+++ b/src/main/java/com/divudi/bean/pharmacy/RetailSaleNativeSqlController3.java
@@ -1236,8 +1236,14 @@ public class RetailSaleNativeSqlController3 implements Serializable, ControllerW
         }
         sql.append(") ORDER BY i.itemBatch.item.name, i.itemBatch.dateOfExpire");
 
+        Integer configuredMaxResult = configOptionApplicationController.getIntegerValueByKey(
+                "Pharmacy Retail Sale - Medicine Autocomplete Max Results", 20);
+        int maxResult = configuredMaxResult == null || configuredMaxResult < 1
+                ? 20
+                : configuredMaxResult;
+
         lastAutocompleteResults = (List<StockDTO>) stockFacade.findLightsByJpql(
-                sql.toString(), parameters, TemporalType.TIMESTAMP, 20);
+                sql.toString(), parameters, TemporalType.TIMESTAMP, maxResult);
         if (lastAutocompleteResults == null) {
             lastAutocompleteResults = new ArrayList<>();
         }

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native.xhtml
@@ -177,18 +177,20 @@
                                                         accesskey="i"
                                                         inputStyleClass="w-100"
                                                         minQueryLength="3"
-                                                        maxResults="10"
+                                                        maxResults="30"
                                                         styleClass="w-100"
                                                         forceSelection="true"
                                                         value="#{retailSaleNativeSqlController.stockDto}"
-                                                        queryDelay="300" completeMethod="#{retailSaleNativeSqlController.completeAvailableStockOptimizedDto}"
+                                                        queryDelay="300" 
+                                                        scrollHeight="450"
+                                                        completeMethod="#{retailSaleNativeSqlController.completeAvailableStockOptimizedDto}"
                                                         converter="#{retailSaleNativeSqlController.stockDtoConverter}"
                                                         var="i"
                                                         itemLabel="#{i.itemName}"
                                                         itemValue="#{i}">
                                                         <p:column
                                                             headerText="Item"
-                                                            width="400"
+                                                            style="padding: 6px; width: 650px;"
                                                             styleClass="#{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
                                                             <h:outputText value="#{i.itemName}" />
                                                             &#160;<p:tag
@@ -197,14 +199,14 @@
                                                                 severity="#{commonFunctionsProxy.currentDateTime > i.dateOfExpire ? 'danger' : commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.dateOfExpire ? 'warning' : ''}" />
                                                         </p:column>
                                                         <p:column
-                                                            width="20em"
+                                                            style="padding: 6px; width: 100px;"
                                                             rendered="#{configOptionApplicationController.getBooleanValueByKey('Medicine Identification Codes Used', true)}"
                                                             headerText="Code"
                                                             styleClass="#{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
                                                             <h:outputText value="#{i.code}" />
                                                         </p:column>
                                                         <p:column
-                                                            width="20em"
+                                                            style="padding: 6px; width: 100px;"
                                                             headerText="Rate"
                                                             styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
                                                             <h:outputLabel value="#{i.retailRate}">
@@ -212,7 +214,7 @@
                                                             </h:outputLabel>
                                                         </p:column>
                                                         <p:column
-                                                            width="20em"
+                                                            style="padding: 6px; width: 100px;"
                                                             headerText="Stocks"
                                                             styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
                                                             <h:outputLabel value="#{i.stockQty}">
@@ -220,7 +222,7 @@
                                                             </h:outputLabel>
                                                         </p:column>
                                                         <p:column
-                                                            width="20em"
+                                                            style="padding: 6px; width: 100px;"
                                                             headerText="Total Stock"
                                                             rendered="#{configOptionApplicationController.getBooleanValueByKeyReadOnly('Pharmacy Retail Sale - Show Total AMP Stock in Autocomplete', false)}"
                                                             styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
@@ -229,7 +231,7 @@
                                                             </h:outputLabel>
                                                         </p:column>
                                                         <p:column
-                                                            width="20em"
+                                                            style="padding: 6px; width: 150px;"
                                                             headerText="Expiry"
                                                             styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
                                                             <h:outputLabel value="#{i.dateOfExpire}">

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native_1.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native_1.xhtml
@@ -177,18 +177,20 @@
                                                         accesskey="i"
                                                         inputStyleClass="w-100"
                                                         minQueryLength="3"
-                                                        maxResults="10"
+                                                        maxResults="30"
                                                         styleClass="w-100"
                                                         forceSelection="true"
                                                         value="#{retailSaleNativeSqlController1.stockDto}"
-                                                        queryDelay="300" completeMethod="#{retailSaleNativeSqlController1.completeAvailableStockOptimizedDto}"
+                                                        queryDelay="300"
+                                                        scrollHeight="450"
+                                                        completeMethod="#{retailSaleNativeSqlController1.completeAvailableStockOptimizedDto}"
                                                         converter="#{retailSaleNativeSqlController1.stockDtoConverter}"
                                                         var="i"
                                                         itemLabel="#{i.itemName}"
                                                         itemValue="#{i}">
                                                         <p:column
                                                             headerText="Item"
-                                                            width="400"
+                                                            style="padding: 6px; width: 650px;"
                                                             styleClass="#{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
                                                             <h:outputText value="#{i.itemName}" />
                                                             &#160;<p:tag
@@ -197,14 +199,14 @@
                                                                 severity="#{commonFunctionsProxy.currentDateTime > i.dateOfExpire ? 'danger' : commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.dateOfExpire ? 'warning' : ''}" />
                                                         </p:column>
                                                         <p:column
-                                                            width="20em"
+                                                            style="padding: 6px; width: 100px;"
                                                             rendered="#{configOptionApplicationController.getBooleanValueByKey('Medicine Identification Codes Used', true)}"
                                                             headerText="Code"
                                                             styleClass="#{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
                                                             <h:outputText value="#{i.code}" />
                                                         </p:column>
                                                         <p:column
-                                                            width="20em"
+                                                            style="padding: 6px; width: 100px;"
                                                             headerText="Rate"
                                                             styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
                                                             <h:outputLabel value="#{i.retailRate}">
@@ -212,7 +214,7 @@
                                                             </h:outputLabel>
                                                         </p:column>
                                                         <p:column
-                                                            width="20em"
+                                                            style="padding: 6px; width: 100px;"
                                                             headerText="Stocks"
                                                             styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
                                                             <h:outputLabel value="#{i.stockQty}">
@@ -220,7 +222,7 @@
                                                             </h:outputLabel>
                                                         </p:column>
                                                         <p:column
-                                                            width="20em"
+                                                            style="padding: 6px; width: 100px;"
                                                             headerText="Total Stock"
                                                             rendered="#{configOptionApplicationController.getBooleanValueByKeyReadOnly('Pharmacy Retail Sale - Show Total AMP Stock in Autocomplete', false)}"
                                                             styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
@@ -229,7 +231,7 @@
                                                             </h:outputLabel>
                                                         </p:column>
                                                         <p:column
-                                                            width="20em"
+                                                            style="padding: 6px; width: 150px;"
                                                             headerText="Expiry"
                                                             styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
                                                             <h:outputLabel value="#{i.dateOfExpire}">

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native_2.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native_2.xhtml
@@ -177,18 +177,20 @@
                                                         accesskey="i"
                                                         inputStyleClass="w-100"
                                                         minQueryLength="3"
-                                                        maxResults="10"
+                                                        maxResults="30"
                                                         styleClass="w-100"
                                                         forceSelection="true"
                                                         value="#{retailSaleNativeSqlController2.stockDto}"
-                                                        queryDelay="300" completeMethod="#{retailSaleNativeSqlController2.completeAvailableStockOptimizedDto}"
+                                                        queryDelay="300"
+                                                        scrollHeight="450"
+                                                        completeMethod="#{retailSaleNativeSqlController2.completeAvailableStockOptimizedDto}"
                                                         converter="#{retailSaleNativeSqlController2.stockDtoConverter}"
                                                         var="i"
                                                         itemLabel="#{i.itemName}"
                                                         itemValue="#{i}">
                                                         <p:column
                                                             headerText="Item"
-                                                            width="400"
+                                                            style="padding: 6px; width: 650px;"
                                                             styleClass="#{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
                                                             <h:outputText value="#{i.itemName}" />
                                                             &#160;<p:tag
@@ -197,14 +199,14 @@
                                                                 severity="#{commonFunctionsProxy.currentDateTime > i.dateOfExpire ? 'danger' : commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.dateOfExpire ? 'warning' : ''}" />
                                                         </p:column>
                                                         <p:column
-                                                            width="20em"
+                                                            style="padding: 6px; width: 100px;"
                                                             rendered="#{configOptionApplicationController.getBooleanValueByKey('Medicine Identification Codes Used', true)}"
                                                             headerText="Code"
                                                             styleClass="#{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
                                                             <h:outputText value="#{i.code}" />
                                                         </p:column>
                                                         <p:column
-                                                            width="20em"
+                                                            style="padding: 6px; width: 100px;"
                                                             headerText="Rate"
                                                             styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
                                                             <h:outputLabel value="#{i.retailRate}">
@@ -212,7 +214,7 @@
                                                             </h:outputLabel>
                                                         </p:column>
                                                         <p:column
-                                                            width="20em"
+                                                            style="padding: 6px; width: 100px;"
                                                             headerText="Stocks"
                                                             styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
                                                             <h:outputLabel value="#{i.stockQty}">
@@ -220,7 +222,7 @@
                                                             </h:outputLabel>
                                                         </p:column>
                                                         <p:column
-                                                            width="20em"
+                                                            style="padding: 6px; width: 100px;"
                                                             headerText="Total Stock"
                                                             rendered="#{configOptionApplicationController.getBooleanValueByKeyReadOnly('Pharmacy Retail Sale - Show Total AMP Stock in Autocomplete', false)}"
                                                             styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
@@ -229,7 +231,7 @@
                                                             </h:outputLabel>
                                                         </p:column>
                                                         <p:column
-                                                            width="20em"
+                                                            style="padding: 6px; width: 150px;"
                                                             headerText="Expiry"
                                                             styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
                                                             <h:outputLabel value="#{i.dateOfExpire}">

--- a/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native_3.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_bill_retail_sale_native_3.xhtml
@@ -177,18 +177,20 @@
                                                         accesskey="i"
                                                         inputStyleClass="w-100"
                                                         minQueryLength="3"
-                                                        maxResults="10"
+                                                        maxResults="30"
                                                         styleClass="w-100"
                                                         forceSelection="true"
                                                         value="#{retailSaleNativeSqlController3.stockDto}"
-                                                        queryDelay="300" completeMethod="#{retailSaleNativeSqlController3.completeAvailableStockOptimizedDto}"
+                                                        queryDelay="300"
+                                                        scrollHeight="450"
+                                                        completeMethod="#{retailSaleNativeSqlController3.completeAvailableStockOptimizedDto}"
                                                         converter="#{retailSaleNativeSqlController3.stockDtoConverter}"
                                                         var="i"
                                                         itemLabel="#{i.itemName}"
                                                         itemValue="#{i}">
                                                         <p:column
                                                             headerText="Item"
-                                                            width="400"
+                                                            style="padding: 6px; width: 650px;"
                                                             styleClass="#{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
                                                             <h:outputText value="#{i.itemName}" />
                                                             &#160;<p:tag
@@ -197,14 +199,14 @@
                                                                 severity="#{commonFunctionsProxy.currentDateTime > i.dateOfExpire ? 'danger' : commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.dateOfExpire ? 'warning' : ''}" />
                                                         </p:column>
                                                         <p:column
-                                                            width="20em"
+                                                            style="padding: 6px; width: 100px;"
                                                             rendered="#{configOptionApplicationController.getBooleanValueByKey('Medicine Identification Codes Used', true)}"
                                                             headerText="Code"
                                                             styleClass="#{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
                                                             <h:outputText value="#{i.code}" />
                                                         </p:column>
                                                         <p:column
-                                                            width="20em"
+                                                            style="padding: 6px; width: 100px;"
                                                             headerText="Rate"
                                                             styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
                                                             <h:outputLabel value="#{i.retailRate}">
@@ -212,7 +214,7 @@
                                                             </h:outputLabel>
                                                         </p:column>
                                                         <p:column
-                                                            width="20em"
+                                                            style="padding: 6px; width: 100px;"
                                                             headerText="Stocks"
                                                             styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
                                                             <h:outputLabel value="#{i.stockQty}">
@@ -220,7 +222,7 @@
                                                             </h:outputLabel>
                                                         </p:column>
                                                         <p:column
-                                                            width="20em"
+                                                            style="padding: 6px; width: 100px;"
                                                             headerText="Total Stock"
                                                             rendered="#{configOptionApplicationController.getBooleanValueByKeyReadOnly('Pharmacy Retail Sale - Show Total AMP Stock in Autocomplete', false)}"
                                                             styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
@@ -229,7 +231,7 @@
                                                             </h:outputLabel>
                                                         </p:column>
                                                         <p:column
-                                                            width="20em"
+                                                            style="padding: 6px; width: 150px;"
                                                             headerText="Expiry"
                                                             styleClass="text-end #{pharmacyController.getExpiryStyleClass(i.dateOfExpire)}">
                                                             <h:outputLabel value="#{i.dateOfExpire}">


### PR DESCRIPTION
## Summary
- Widened the medicine autocomplete item column (400px → 650px) and re-styled the Code/Rate/Stocks/Total Stock/Expiry columns for consistent padding, so long item names are readable.
- Raised `maxResults` on the autocomplete from 10 to 30 and added `scrollHeight="450"` so the dropdown scrolls instead of overflowing.
- Made the backend JPQL result cap in `completeAvailableStockOptimizedDto` configurable via a new config option key `Pharmacy Retail Sale - Medicine Autocomplete Max Results` (default 20), instead of a hardcoded `20`.
- Applied the same changes identically to the three "counter variant" pages/beans (`_1`, `_2`, `_3`) used for parallel retail sale billing counters, so all counters behave consistently.

## Files changed
- `pharmacy_bill_retail_sale_native.xhtml` + `RetailSaleNativeSqlController.java`
- `pharmacy_bill_retail_sale_native_1.xhtml` + `RetailSaleNativeSqlController1.java`
- `pharmacy_bill_retail_sale_native_2.xhtml` + `RetailSaleNativeSqlController2.java`
- `pharmacy_bill_retail_sale_native_3.xhtml` + `RetailSaleNativeSqlController3.java`

Closes #23108

## Test plan
- [ ] Rebuild and redeploy locally
- [ ] Open Pharmacy Retail Sale (native), search a medicine, confirm the item column is wider and dropdown shows up to 30 results with a scrollbar
- [ ] Repeat on counter variants 1, 2, and 3
- [ ] Set config option `Pharmacy Retail Sale - Medicine Autocomplete Max Results` to a custom value (e.g. 5) and confirm the autocomplete respects it on all four pages
- [ ] Confirm behavior with the option unset/invalid falls back to 20

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pharmacy medicine autocomplete result counts can now be configured, with a default of 20 results when unset or invalid.
  * Stock autocomplete displays up to 30 results with improved scrolling and clearer column spacing.

* **UI Improvements**
  * Adjusted autocomplete column widths and padding to improve readability of medicine details, pricing, stock, and expiry information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->