### PR TITLE
feat(skills): dev-issue-unattended supports multiple issues and flags poor descriptions

### DIFF
--- a/.claude/skills/dev-issue-unattended/SKILL.md
+++ b/.claude/skills/dev-issue-unattended/SKILL.md
@@ -83,6 +83,45 @@ and end the run — do not guess.
   history, and related issues give no clear signal either way — by picking an
   option silently. That is exactly the "stop and flag" case in steps 3 and 14.
 
+### Insufficient issue description — hand back to the reporter, don't just stop
+
+One flavor of stop gets a different resolution than the rest of this
+section: when a stop at step 2, 2a, or 3 traces back to **the issue's own
+description being inadequate** — not a code-architecture question, not a
+schema/security limit — hand it back to whoever filed it instead of posting
+a bare blocker comment.
+
+This is a judgment call at runtime, same as any other step-3 decision:
+document the reasoning. When genuinely unclear whether a stop is a
+description problem or an architecture problem, default to the plain hard
+limit above (post blocker, stop) — don't reassign work to a reporter who
+can't actually resolve a code-level question.
+
+When it does fire:
+
+1. Post a comment on the issue asking **only** for what actually stalled
+   this run — drawn from, not a fixed template dumped every time:
+   - the exact page/screen: URL or menu breadcrumb (`Menu > Submenu >
+     Page`)
+   - a clear description of current vs. expected behavior
+   - for report/analytics requests: desired filters, columns, grouping
+   - repro steps including a concrete example record/BHT/bill number
+   - screenshot(s) of the current behavior or desired layout
+
+   Ground the ask in what was actually tried, e.g. "Searched for a page
+   matching this description under Inward and Reports; couldn't identify
+   which screen this refers to. Could you share the URL or navigation
+   path?" — not a bare template.
+2. `@mention` the issue's creator:
+   `gh issue view <n> --repo hmislk/hmis --json author --jq '.author.login'`
+3. `gh issue edit <n> --repo hmislk/hmis --add-assignee <creator-login>` —
+   **added alongside** `buddhika75`, never replacing them.
+4. Set the project-board (#11) Status field back to **Backlog** (same
+   GraphQL mutation pattern `start-issue` step 5 uses to set it forward to
+   "In Progress" — same field, different target option).
+5. Record this issue's outcome as "needs info" for the batch summary (step
+   15), then continue to the next issue in the batch (step 0).
+
 ## 1. Setup
 
 **If given an issue number:** run the `start-issue` skill for it, as

--- a/.claude/skills/dev-issue-unattended/SKILL.md
+++ b/.claude/skills/dev-issue-unattended/SKILL.md
@@ -318,6 +318,17 @@ run (same as `dev-issue`).
 
 ## 15. Notify
 
-Produce one skimmable summary the user can catch up on in a single read:
-what was found, every decision made and why (from step 3/13), what was
-verified and how, links to issue/PR/wiki. **Never merge.**
+Produce one skimmable summary covering **every issue in the batch** (a
+single issue is just a batch of one), one line each:
+
+- `#N — shipped as PR #M` (link to the PR)
+- `#N — needs info from reporter` (link to the comment posted in the
+  Insufficient issue description flow)
+- `#N — stopped: <short reason>` (link to the blocker comment)
+- `#N — could not resolve issue number/URL`
+
+For issues that shipped, include what was found, every decision made and
+why (from step 3/13), what was verified and how, and links to the
+issue/PR/wiki — same depth as a solo run. For issues that didn't ship, the
+link to the comment is enough; don't re-summarize what's already written
+there. **Never merge.**

--- a/.claude/skills/dev-issue-unattended/SKILL.md
+++ b/.claude/skills/dev-issue-unattended/SKILL.md
@@ -28,15 +28,18 @@ not re-ask before any of them.
 ## 0. Parse input
 
 Accept a comma/space/newline-separated list mixing bare issue numbers
-(`23100`) and full GitHub issue URLs
-(`https://github.com/hmislk/hmis/issues/23100` — extract the trailing
-number with a regex on `/issues/(\d+)`).
+(`23100`) and full GitHub issue URLs. Accept only bare numeric tokens or a
+URL matching exactly `^https://github.com/hmislk/hmis/issues/(\d+)/?$` —
+any other host or repo path (e.g. a URL pointing at a fork or a different
+project) is an invalid token, not a source of an issue number for this
+repo. Report invalid tokens rather than guessing at what they meant.
 
-- Dedupe the resulting set.
+- Dedupe the resulting set of valid numbers.
 - Validate each with `gh issue view <n> --repo hmislk/hmis --json title`.
-  Any that don't resolve are **not** a whole-batch abort — drop them, note
-  "could not resolve issue #N" for the final summary (step 15), and
-  continue with the rest.
+  Any that don't resolve (invalid token or nonexistent issue) are **not** a
+  whole-batch abort — drop them, note "could not resolve issue #N" (or the
+  raw invalid token) for the final summary (step 15), and continue with the
+  rest.
 - Process the remaining issues **one at a time, lowest issue number
   first**. Steps 1–14 below are the per-issue body of this loop: each issue
   gets its own branch (via `start-issue`), its own commits, its own PR, and
@@ -56,7 +59,13 @@ number with a regex on `/issues/(\d+)`).
 
 These are not judgment calls. If one of these is required to proceed, STOP,
 post the blocker as a comment on the issue (creating one first if needed),
-and end the run — do not guess.
+and end the run — do not guess. **"End the run," here and everywhere else
+in this skill, is always scoped to the current issue**: in batch mode
+(step 0), it means stop work on this issue, record its outcome, and
+continue the batch with the next one — never abort the whole batch.
+Reserve a true whole-batch abort for a failure that isn't scoped to one
+issue at all (e.g. `gh` itself is unreachable) — that's outside anything
+documented here, and warrants stopping and asking rather than guessing.
 
 - Never merge a PR, and never push directly to `development`, `master`, or
   any production branch — everything goes through a PR.
@@ -94,32 +103,42 @@ a bare blocker comment.
 This is a judgment call at runtime, same as any other step-3 decision:
 document the reasoning. When genuinely unclear whether a stop is a
 description problem or an architecture problem, default to the plain hard
-limit above (post blocker, stop) — don't reassign work to a reporter who
-can't actually resolve a code-level question.
+limit above (post a blocker comment and stop) — don't reassign work to a
+reporter who can't actually resolve a code-level question.
 
 When it does fire:
 
-1. Post a comment on the issue asking **only** for what actually stalled
-   this run — drawn from, not a fixed template dumped every time:
+1. Look up the issue's creator first, before composing anything:
+   `gh issue view <n> --repo hmislk/hmis --json author --jq '.author.login'`
+2. Post a comment on the issue that opens with `@<creator-login>` and asks
+   **only** for what actually stalled this run — drawn from, not a fixed
+   template dumped every time:
    - the exact page/screen: URL or menu breadcrumb (`Menu > Submenu >
      Page`)
    - a clear description of current vs. expected behavior
    - for report/analytics requests: desired filters, columns, grouping
-   - repro steps including a concrete example record/BHT/bill number
+   - repro steps that pin down the scenario without a real record
+     identifier — ask for a redacted/synthetic example (e.g. "a BHT like
+     the one in this scenario, with any real patient/bill numbers replaced")
+     rather than a real BHT or bill number, same "no patient-linked
+     identifiers in a GitHub comment" rule as the hard limits above
    - screenshot(s) of the current behavior or desired layout
 
    Ground the ask in what was actually tried, e.g. "Searched for a page
    matching this description under Inward and Reports; couldn't identify
    which screen this refers to. Could you share the URL or navigation
    path?" — not a bare template.
-2. `@mention` the issue's creator:
-   `gh issue view <n> --repo hmislk/hmis --json author --jq '.author.login'`
 3. `gh issue edit <n> --repo hmislk/hmis --add-assignee <creator-login>` —
    **added alongside** `buddhika75`, never replacing them.
 4. Set the project-board (#11) Status field back to **Backlog** (same
    GraphQL mutation pattern `start-issue` step 5 uses to set it forward to
    "In Progress" — same field, different target option).
-5. Record this issue's outcome as "needs info" for the batch summary (step
+5. Check each of steps 2–4 actually succeeded (non-error `gh`/API output)
+   before calling this "needs info" — if one failed partway (e.g. the
+   comment posted but the assignee edit errored), don't silently record it
+   as fully done; note exactly which parts succeeded in the batch summary
+   (step 15) so it's clear what still needs finishing by hand.
+6. Record this issue's outcome as "needs info" for the batch summary (step
    15), then continue to the next issue in the batch (step 0).
 
 ## 1. Setup
@@ -185,8 +204,8 @@ Where `dev-issue` enters Plan Mode and waits for approval, instead:
    "genuinely ambiguous" — stop, but which stop depends on *why* it's
    ambiguous: if the codebase itself gives conflicting signals (two
    existing patterns both plausible), use the plain hard limit above (post
-   blocker, stop). If the ambiguity is instead about *what the reporter
-   wants* — e.g. a report request with no filters/columns/grouping
+   a blocker comment and stop). If the ambiguity is instead about *what
+   the reporter wants* — e.g. a report request with no filters/columns/grouping
    specified, a feature request with no acceptance criteria — that's the
    **Insufficient issue description** case; route there instead.
 3. Write the reasoning down **now**, in a form that survives to the PR

--- a/.claude/skills/dev-issue-unattended/SKILL.md
+++ b/.claude/skills/dev-issue-unattended/SKILL.md
@@ -36,10 +36,16 @@ repo. Report invalid tokens rather than guessing at what they meant.
 
 - Dedupe the resulting set of valid numbers.
 - Validate each with `gh issue view <n> --repo hmislk/hmis --json title`.
-  Any that don't resolve (invalid token or nonexistent issue) are **not** a
-  whole-batch abort — drop them, note "could not resolve issue #N" (or the
-  raw invalid token) for the final summary (step 15), and continue with the
-  rest.
+  Only drop-and-continue when GitHub itself confirms the issue doesn't
+  exist (a clean "not found" from `gh`) or the token was invalid per the
+  URL rule above — note "could not resolve issue #N" (or the raw invalid
+  token) for the final summary (step 15) and move on. Any other failure
+  from this command — auth, permission, rate-limit, network/transport
+  errors — is not evidence the issue doesn't exist; it's the "true
+  whole-batch abort" case from the Hard limits section below (`gh` itself
+  is unreachable/broken), since it will affect every remaining issue the
+  same way. Stop and report it rather than silently dropping issues one by
+  one.
 - Process the remaining issues **one at a time, lowest issue number
   first**. Steps 1–14 below are the per-issue body of this loop: each issue
   gets its own branch (via `start-issue`), its own commits, its own PR, and
@@ -94,11 +100,12 @@ documented here, and warrants stopping and asking rather than guessing.
 
 ### Insufficient issue description — hand back to the reporter, don't just stop
 
-One flavor of stop gets a different resolution than the rest of this
-section: when a stop at step 2, 2a, or 3 traces back to **the issue's own
-description being inadequate** — not a code-architecture question, not a
-schema/security limit — hand it back to whoever filed it instead of posting
-a bare blocker comment.
+Two flavors of stop below get a different resolution than the rest of this
+section — this one and "Cannot reproduce with adequate information" further
+down. This one: when a stop at step 2, 2a, or 3 traces back to **the
+issue's own description being inadequate** — not a code-architecture
+question, not a schema/security limit — hand it back to whoever filed it
+instead of posting a bare blocker comment.
 
 This is a judgment call at runtime, same as any other step-3 decision:
 document the reasoning. When genuinely unclear whether a stop is a
@@ -109,7 +116,12 @@ reporter who can't actually resolve a code-level question.
 When it does fire:
 
 1. Look up the issue's creator first, before composing anything:
-   `gh issue view <n> --repo hmislk/hmis --json author --jq '.author.login'`
+   `gh issue view <n> --repo hmislk/hmis --json author --jq '.author.login'`.
+   If this fails or returns an empty login, stop here — do not post the
+   comment, edit the assignee, or touch the project board with a broken or
+   missing `@mention`. Record this issue's outcome as "stopped — could not
+   resolve issue creator" for the batch summary (step 15) and continue to
+   the next issue.
 2. Post a comment on the issue that opens with `@<creator-login>` and asks
    **only** for what actually stalled this run — drawn from, not a fixed
    template dumped every time:
@@ -140,6 +152,35 @@ When it does fire:
    (step 15) so it's clear what still needs finishing by hand.
 6. Record this issue's outcome as "needs info" for the batch summary (step
    15), then continue to the next issue in the batch (step 0).
+
+### Cannot reproduce with adequate information — close and invite discussion
+
+The second special-cased flavor: step 2a's bug genuinely does not reproduce
+under a reasonable, documented attempt, **and** the issue already gave
+enough to work with — this is distinct from the missing-specifics case
+above, which stays on the "ask for more info, keep open" path. Here, more
+async back-and-forth isn't likely to help; close the issue instead of
+leaving it open indefinitely with just a blocker comment, and let the
+reporter bring it back with a live discussion if it's still happening.
+
+1. Look up the issue's creator first, same as the Insufficient issue
+   description flow above — including its failure guard: if the lookup
+   fails or returns an empty login, stop here without posting or closing.
+   Record "stopped — could not resolve issue creator" for the batch summary
+   (step 15) and continue to the next issue.
+2. Post a comment that opens with `@<creator-login>`: what was tried, what
+   didn't reproduce, and an explicit invite to discuss rather than reopen
+   async — e.g. "Attempted to reproduce via <what was tried>; did not
+   observe the described behavior. Closing for now — if this is still
+   occurring, let's discuss and file a fresh issue with updated repro
+   details."
+3. `gh issue close <n> --repo hmislk/hmis --reason "not planned"`.
+4. Check that both the comment and the close actually succeeded before
+   calling this outcome final — if the close command errors after the
+   comment posted, note that in the batch summary rather than assuming the
+   issue is closed.
+5. Record this issue's outcome as "closed — could not reproduce" for the
+   batch summary (step 15), then continue to the next issue.
 
 ## 1. Setup
 
@@ -186,10 +227,12 @@ confirmed root cause from code + history alone.
   it didn't reproduce is missing specifics from the issue itself (no concrete
   example record, no repro steps, an ambiguous "sometimes it fails" with no
   stated conditions), that's the **Insufficient issue description** case —
-  route there. If instead it's an environment mismatch unrelated to what the
-  issue said, use the plain hard limit: post the finding to the issue and end
-  the run. This is a hard limit either way, not a style preference — an
-  unverified fix for an unreproduced bug is worse than no fix.
+  route there. If instead the issue gave enough to try and it genuinely
+  doesn't reproduce, that's the **Cannot reproduce with adequate
+  information** case — close it and invite a discussion instead of leaving
+  a blocker comment open indefinitely. This is a hard limit either way, not
+  a style preference — an unverified fix for an unreproduced bug is worse
+  than no fix.
 
 ## 3. Decide the approach (no Plan Mode pause)
 
@@ -343,6 +386,7 @@ single issue is just a batch of one), one line each:
 - `#N — shipped as PR #M` (link to the PR)
 - `#N — needs info from reporter` (link to the comment posted in the
   Insufficient issue description flow)
+- `#N — closed, could not reproduce` (link to the closing comment)
 - `#N — stopped: <short reason>` (link to the blocker comment)
 - `#N — could not resolve issue number/URL`
 

--- a/.claude/skills/dev-issue-unattended/SKILL.md
+++ b/.claude/skills/dev-issue-unattended/SKILL.md
@@ -146,6 +146,11 @@ root cause by reading code — git archaeology (`git log -p -S<term>`,
 `git blame`, related closed issues/PRs) is often decisive here and costs
 nothing to try before falling back to live reproduction.
 
+If this investigation — including the git archaeology above — cannot
+identify which entities/services/pages are even involved, that's the
+**Insufficient issue description** case from the Hard limits section, not
+a reason to guess. Route there instead of continuing to step 2a/3.
+
 ## 2a. Reproduce the bug (bug issues only, root cause still unconfirmed)
 
 Skip for feature/enhancement issues and for bugs where step 2 already found a
@@ -157,11 +162,15 @@ confirmed root cause from code + history alone.
   not** ask which one to use — auto-discover the closest real match with a
   read-only query, and only fall back to generating one through the app (see
   step 4) if nothing suitable exists.
-- If it still doesn't reproduce under a reasonable, documented attempt: stop,
-  post the finding to the issue (what was tried, what didn't reproduce), and
-  end the run rather than guessing at a fix for a bug you couldn't observe.
-  This is a hard limit, not a style preference — an unverified fix for an
-  unreproduced bug is worse than no fix.
+- If it still doesn't reproduce under a reasonable, documented attempt: stop
+  rather than guessing at a fix for a bug you couldn't observe. If the reason
+  it didn't reproduce is missing specifics from the issue itself (no concrete
+  example record, no repro steps, an ambiguous "sometimes it fails" with no
+  stated conditions), that's the **Insufficient issue description** case —
+  route there. If instead it's an environment mismatch unrelated to what the
+  issue said, use the plain hard limit: post the finding to the issue and end
+  the run. This is a hard limit either way, not a style preference — an
+  unverified fix for an unreproduced bug is worse than no fix.
 
 ## 3. Decide the approach (no Plan Mode pause)
 
@@ -173,8 +182,13 @@ Where `dev-issue` enters Plan Mode and waits for approval, instead:
    the original #19963 design instead of guessing at a new one).
 2. Pick the option best supported by that evidence. When two options are
    both plausible and the evidence doesn't clearly favor one, that is
-   "genuinely ambiguous" — stop per the hard limits above instead of
-   flipping a coin.
+   "genuinely ambiguous" — stop, but which stop depends on *why* it's
+   ambiguous: if the codebase itself gives conflicting signals (two
+   existing patterns both plausible), use the plain hard limit above (post
+   blocker, stop). If the ambiguity is instead about *what the reporter
+   wants* — e.g. a report request with no filters/columns/grouping
+   specified, a feature request with no acceptance criteria — that's the
+   **Insufficient issue description** case; route there instead.
 3. Write the reasoning down **now**, in a form that survives to the PR
    description (step 13) and, for any non-obvious interpretation, an issue
    comment — not just in conversation. The user is reviewing this after the

--- a/.claude/skills/dev-issue-unattended/SKILL.md
+++ b/.claude/skills/dev-issue-unattended/SKILL.md
@@ -1,16 +1,17 @@
 ---
 name: dev-issue-unattended
 description: >
-  Run a GitHub issue through its full lifecycle end-to-end with NO pauses for
-  user input — investigate, decide the approach, gather test context, and run
-  the CI/review loop entirely autonomously, documenting every judgment call
-  for after-the-fact review instead of asking. Use ONLY when the user has
-  explicitly said they will be unreachable (away from the computer, asleep,
-  offline) and wants an issue (or an unfiled bug/request they just described)
-  shipped as a mergeable PR without them. Do not use this for normal work —
-  use dev-issue instead, which asks for input at the same points this skill
-  auto-resolves.
-argument-hint: "[issue-number | problem description]"
+  Run one or more GitHub issues through their full lifecycle end-to-end with
+  NO pauses for user input — investigate, decide the approach, gather test
+  context, and run the CI/review loop entirely autonomously, documenting
+  every judgment call for after-the-fact review instead of asking. Accepts
+  a single issue, a batch of issue numbers/URLs, or an unfiled bug/request
+  described in plain text. Use ONLY when the user has explicitly said they
+  will be unreachable (away from the computer, asleep, offline) and wants
+  the issue(s) shipped as mergeable PR(s) without them. Do not use this for
+  normal work — use dev-issue instead, which asks for input at the same
+  points this skill auto-resolves.
+argument-hint: "[issue-number|issue-url][, issue-number|issue-url ...] | problem description"
 ---
 
 # Full Issue Lifecycle, Unattended (HMIS)
@@ -23,6 +24,33 @@ skill only when the user has told you up front they won't be reachable.
 Invoking this skill is explicit authorization for every commit/push/PR/issue
 step below, including filing the GitHub issue itself if none exists yet — do
 not re-ask before any of them.
+
+## 0. Parse input
+
+Accept a comma/space/newline-separated list mixing bare issue numbers
+(`23100`) and full GitHub issue URLs
+(`https://github.com/hmislk/hmis/issues/23100` — extract the trailing
+number with a regex on `/issues/(\d+)`).
+
+- Dedupe the resulting set.
+- Validate each with `gh issue view <n> --repo hmislk/hmis --json title`.
+  Any that don't resolve are **not** a whole-batch abort — drop them, note
+  "could not resolve issue #N" for the final summary (step 15), and
+  continue with the rest.
+- Process the remaining issues **one at a time, lowest issue number
+  first**. Steps 1–14 below are the per-issue body of this loop: each issue
+  gets its own branch (via `start-issue`), its own commits, its own PR, and
+  its own review loop, exactly as if `dev-issue-unattended` had been run
+  solo on just that issue.
+- If an issue hits any stop — an existing hard limit, the "insufficient
+  issue description" flag (see Hard limits below), or the "could not
+  resolve" case above — record the outcome for that issue and move on to
+  the next one. The batch is done once every issue in the list has been
+  attempted.
+- A single free-text problem description with no issue number (the
+  existing "if given only a problem description" mode in step 1) is
+  unchanged and is not part of batch mode — it still handles exactly one ad
+  hoc request per run.
 
 ## Hard limits — never bypassed, no matter how confident
 


### PR DESCRIPTION
## What changed

`dev-issue-unattended` gains three capabilities:

1. **Multi-issue input** (new `## 0. Parse input`). Accepts a comma/space/
   newline-separated list of issue numbers and/or full GitHub issue URLs
   (validated against the exact `hmislk/hmis` issues path, not any host),
   not just a single number. Each issue still gets its own independent
   lifecycle — own branch, own commits, own PR, own review loop — and if
   one issue hits a stop, the run logs it and continues to the next rather
   than aborting the whole batch. A `gh` failure that isn't a confirmed
   "issue not found" (auth/permission/rate-limit/transport) is treated as
   a whole-batch infrastructure failure, not a reason to drop an issue.
2. **"Insufficient issue description" hard limit.** A new named flow
   alongside the existing hard limits: when a stop at step 2 (can't
   identify entities/pages), step 2a (bug won't reproduce because of
   missing specifics), or step 3 (approach is ambiguous about what the
   reporter actually wants) traces back to the issue's own description
   being inadequate — rather than a code-architecture or schema/security
   question — the skill looks up the issue's creator, posts a comment
   (opening with the `@mention`) asking only for what's actually missing
   (URL/nav path, expected-vs-actual, report filters/columns, redacted/
   synthetic repro steps — never a real BHT/bill number, screenshots),
   adds the creator as a co-assignee (alongside `buddhika75`, not
   replacing), and resets the project-board status back to Backlog, then
   moves to the next issue in the batch. Guards against a failed/empty
   creator lookup before any of those mutations run.
3. **"Cannot reproduce with adequate information" — close and invite
   discussion.** When step 2a's bug genuinely doesn't reproduce and the
   issue *did* give enough to work with (distinct from #2's missing-
   specifics case, which stays on the "ask for more info, keep open"
   path), the skill now posts a comment summarizing what was tried and
   inviting a live discussion + fresh issue if it's still occurring, then
   closes the issue (`--reason "not planned"`) instead of leaving it open
   indefinitely with just a blocker comment.

All other existing hard limits are unchanged. Step 15 (Notify) is rewritten
as a per-batch summary (one line per issue: shipped as PR / needs info /
closed-could-not-reproduce / stopped / could not resolve) instead of a
single-issue report.

Scope: `.claude/skills/dev-issue-unattended/SKILL.md` only. The interactive
`dev-issue` skill is untouched, by design (see design doc).

## Why

Requested directly — the skill was limited to one issue per unattended run,
had no way to hand a poorly-described issue back to its reporter instead of
silently guessing or leaving a generic unhelpful blocker comment, and had
no way to close out a bug that simply doesn't reproduce rather than leaving
it stuck open indefinitely.

## Testing

This is a skill-definition (prompt/Markdown) change, not application code —
no build, no deploy, no automated test suite applies. Verification was a
full re-read of the edited file end-to-end confirming: section numbering
still reads 0, Hard limits, 1–15 with no gaps; every cross-reference to
"Insufficient issue description" and "Cannot reproduce with adequate
information" resolves to the section that defines it; the frontmatter
`description`/`argument-hint` match what steps 0 and 15 actually describe.

Design doc (local-only, `docs/` is gitignored in this repo so it isn't part
of this diff): `docs/superpowers/specs/2026-08-18-dev-issue-unattended-multi-issue-design.md`

## Review

All 8 CodeRabbit findings across two review passes were addressed (URL
host validation, batch- vs issue-scoped stop wording, comment-ordering for
the `@mention`, no raw patient-linked identifiers in comments, partial-
mutation-failure handling, `gh` failure-mode distinction, creator-lookup
failure guard) — see the threaded replies on each comment for what changed
where.

Closes #23113
