### PR TITLE
fix(pharmacy): exclude staff-custody StockHistory rows from Stock Ledger DTO report

### DIFF
--- a/src/main/java/com/divudi/bean/report/PharmacyReportController.java
+++ b/src/main/java/com/divudi/bean/report/PharmacyReportController.java
@@ -11259,6 +11259,13 @@ public class PharmacyReportController implements Serializable {
             jpql.append(" LEFT JOIN b.toDepartment toDep");
             jpql.append(" LEFT JOIN b.department billDep");
             jpql.append(" WHERE s.createdAt BETWEEN :fd AND :td");
+            // Exclude staff-custody StockHistory rows. Transfer Issue/Receive (and
+            // similar ward-return flows) write two StockHistory rows per movement -
+            // one department-level (addToStockHistory(..., Department)) and one
+            // staff-level (addToStockHistory(..., Staff)) recording the same signed
+            // pbi.qty as the item passes through staff custody. Without this filter
+            // the Stock Ledger double-counts every such movement (issue #20330).
+            jpql.append(" AND s.department IS NOT NULL");
 
             if (institution != null) {
                 jpql.append(" AND s.institution = :ins");


### PR DESCRIPTION
## Summary

Fixes #20330 — the Stock Ledger (DTO) report double-counted every transfer
issue/receive (and similar ward-return-to-pharmacy) movement: a transfer of
2 units showed as 4 in the ledger.

## Decisions made without approval

- **Root cause confirmed in code**: `TransferIssueController` /
  `TransferIssueDirectController` (and the receive / ward-return-to-pharmacy
  counterparts) call `deductFromStock(..., Department)` +
  `addToStock(..., Staff)` (or the reverse) for a single stock movement.
  Both calls write a `StockHistory` row via `addToStockHistory(pbi, stock, ...)`
  for the **same** `PharmaceuticalBillItem`, so its signed `qty` is recorded
  twice — once department-level, once staff-custody. The report's JPQL
  (`processStockLedgerDtoReport()` in `PharmacyReportController`) summed
  `pbi.qty` across both without a department filter.
- **Fix chosen at the report-query level** (`AND s.department IS NOT NULL`)
  rather than suppressing the staff-level `StockHistory` write at record
  time. The issue's own root-cause comment (posted 2026-06-30) proposed both
  options. The staff-level write is read by roughly 10 other
  controllers/reports (`StockHistory.staff`), so changing the recording
  logic risked regressing functionality outside this issue's scope. The
  Stock Ledger is department-scoped by definition — every other document
  type it reports on (sale, GRN, purchase, adjustment) only ever writes a
  department-level row, so this filter drops nothing for them.

## Verification

Reproduced and confirmed against real local data (Pharmacy Direct Issue
transfer bills, 2026-07-14): `StockHistory` had 2 rows per line item
(one `department_id` set, one `staff_id` set), both carrying the same
signed qty. Rebuilt, redeployed locally, and confirmed via Playwright that
the Stock Ledger DTO report now shows exactly one row per movement at the
correct quantity (`-10.00` Stock Out, not `-20.00`).

![Stock Ledger fixed](https://github.com/hmislk/hmis.wiki/raw/master/images/issue-20330-stock-ledger-fixed.png)

## Scope

Report-query change only — no change to stock-recording logic, no schema
change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)