### PR TITLE
fix(inward): include room-linked timed item charges in bill totals

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -2129,6 +2129,7 @@ public class BhtSummeryController implements Serializable {
         pr.setCurrentAdministrationCharge(rfc.getAdminstrationCharge());
         pr.setCurrentMedicalCareCharge(rfc.getMedicalCareCharge());
         getPatientRoomFacade().edit(pr);
+        getInwardBean().snapshotTimedItems(pr, rfc);
         patientRooms = null;
         createTables();
     }
@@ -5141,32 +5142,18 @@ public class BhtSummeryController implements Serializable {
         medicineCancellationBtas.add(BillTypeAtomic.DIRECT_ISSUE_THEATRE_MEDICINE_RETURN);
 
         for (ChargeItemTotal i : chargeItemTotals) {
+            Double roomSum = roomSums.get(i.getInwardChargeType());
+            if (roomSum != null) {
+                i.setTotal(roomSum);
+            }
+        }
+
+        for (ChargeItemTotal i : chargeItemTotals) {
             switch (i.getInwardChargeType()) {
                 case AdmissionFee:
                     if (getPatientEncounter().getAdmissionType() != null) {
                         i.setTotal(getInwardBean().getAdmissionCharge(getPatientEncounter(), childPatientEncouters));
                     }
-                    break;
-                case RoomCharges:
-                    i.setTotal(roomSums.getOrDefault(InwardChargeType.RoomCharges, 0.0));
-                    break;
-                case MOCharges:
-                    i.setTotal(roomSums.getOrDefault(InwardChargeType.MOCharges, 0.0));
-                    break;
-                case NursingCharges:
-                    i.setTotal(roomSums.getOrDefault(InwardChargeType.NursingCharges, 0.0));
-                    break;
-                case MaintainCharges:
-                    i.setTotal(roomSums.getOrDefault(InwardChargeType.MaintainCharges, 0.0));
-                    break;
-                case MedicalCareICU:
-                    i.setTotal(roomSums.getOrDefault(InwardChargeType.MedicalCareICU, 0.0));
-                    break;
-                case AdministrationCharge:
-                    i.setTotal(roomSums.getOrDefault(InwardChargeType.AdministrationCharge, 0.0));
-                    break;
-                case LinenCharges:
-                    i.setTotal(roomSums.getOrDefault(InwardChargeType.LinenCharges, 0.0));
                     break;
                 case Medicine:
                     if (!configOptionApplicationController.getBooleanValueByKey("Medicine, Sort by the type of department that issued it.", false)) {

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -2114,7 +2114,10 @@ public class BhtSummeryController implements Serializable {
             return;
         }
         if (pr.isFromPackage() && !isPackageRoomDurationExceeded(pr)) {
-            // Package-locked charge stays as set by InpatientPackageApplicationBean.
+            // Package-locked charge stays as set by InpatientPackageApplicationBean,
+            // but newly-linked timed items still need to be snapshotted so their
+            // charges aren't silently dropped from the bill.
+            getInwardBean().snapshotTimedItems(pr, pr.getRoomFacilityCharge());
             patientRooms = null;
             createTables();
             return;
@@ -5142,13 +5145,6 @@ public class BhtSummeryController implements Serializable {
         medicineCancellationBtas.add(BillTypeAtomic.DIRECT_ISSUE_THEATRE_MEDICINE_RETURN);
 
         for (ChargeItemTotal i : chargeItemTotals) {
-            Double roomSum = roomSums.get(i.getInwardChargeType());
-            if (roomSum != null) {
-                i.setTotal(roomSum);
-            }
-        }
-
-        for (ChargeItemTotal i : chargeItemTotals) {
             switch (i.getInwardChargeType()) {
                 case AdmissionFee:
                     if (getPatientEncounter().getAdmissionType() != null) {
@@ -5184,6 +5180,17 @@ public class BhtSummeryController implements Serializable {
                         i.setTotal(getInwardBean().calculateDoctorAndNurseCharges(getPatientEncounter(), childPatientEncouters));
                     }
                     break;
+            }
+        }
+
+        // Apply room-linked timed item sums after the category-specific switch above,
+        // additively, so a timed item configured with one of the switch's own charge
+        // categories (e.g. Medicine, ProfessionalCharge) is added on top of that
+        // category's own total instead of being overwritten by it.
+        for (ChargeItemTotal i : chargeItemTotals) {
+            Double roomSum = roomSums.get(i.getInwardChargeType());
+            if (roomSum != null) {
+                i.setTotal(i.getTotal() + roomSum);
             }
         }
 


### PR DESCRIPTION
## Decisions made without approval

This PR was developed unattended (`dev-issue-unattended`) while the requesting
developer was away. Every judgment call below was made autonomously and
should be double-checked first:

1. **Filed the issue myself** from a live demonstration/investigation session
   (browser repro + code reading), before handing off to the unattended
   pipeline — see issue #23118 for the full root-cause write-up and evidence.
2. **Fix shape for `setKnownChargeTot()`**: chose to generalize the existing
   `roomSums` merge into a single loop (matching the additive pattern already
   used by `setServiceTotCategoryWise()`/`setTimedServiceTotCategoryWise()`
   two methods later in the same file) rather than adding an 8th, 9th, ...
   explicit `case` per newly-discovered charge category. This was picked
   because it's the smallest change that fixes the bug for *every* charge
   category (not just the one reproduced), and it's consistent with a pattern
   the codebase already uses twice — not a new design.
3. **Fix shape for the missing backfill**: chose to call the existing,
   already-idempotent `snapshotTimedItems()` from `updateChargesForRoom()`
   (the "Update Charges from Room Rates" button) rather than, e.g., adding a
   scheduled job or a new button. This was picked because it's the one
   existing user-facing action that already refreshes a room's charges from
   its `RoomFacilityCharge`, so it's the natural place to also catch up newly
   linked timed items, and it required no new UI.
4. **Test data**: reused an existing local demo/test admission (`BHT/56755`,
   a synthetic "Demo Test Patient", not a real patient) already admitted to
   an existing test room ("Room 100 wm"), and reused the one pre-existing
   `TimedItem` in the local DB ("Nebulization Test 22316", category
   "Nebulisation") rather than creating new fixtures, per the "prefer an
   existing record" rule.

## Summary

Room-linked dynamic Timed Item charges (`RoomFacilityTimedItem` →
`PatientRoomTimedItemCharge`) were correctly calculated and shown on the
Patient Room Details page, but never reached the interim or final bill
totals — the patient was silently under-billed for that charge.

Fixes #23118.

## Root cause

Two compounding gaps in `BhtSummeryController.java` — see the issue body for
the full trace with line numbers. In short:

1. `setKnownChargeTot()` only copied the bulk `roomSums` map into
   `chargeItemTotals` via a `switch` hardcoded to 7 specific
   `InwardChargeType`s. Any `TimedItem` using one of the ~150 *other*
   selectable charge categories had its already-computed charge silently
   dropped.
2. `snapshotTimedItems()` — which creates the `PatientRoomTimedItemCharge`
   link row a `RoomFacilityTimedItem` needs — was only called from the two
   admission-time `savePatientRoom()` overloads, never from any
   recalculation path, so linking a timed item to a room *after* a patient
   was already admitted to that room type never created a charge row for
   that patient.

## Fix

- `setKnownChargeTot()`: replaced the 7-case switch handling of `roomSums`
  with one generic loop — `roomSums.get(i.getInwardChargeType())` applied to
  every `ChargeItemTotal` — matching the additive pattern already used by
  `setServiceTotCategoryWise()`/`setTimedServiceTotCategoryWise()`. No
  behavior change for the 7 original types; every other type now flows
  through too.
- `updateChargesForRoom()` (the "Update Charges from Room Rates" action) now
  also calls the existing, already-idempotent `snapshotTimedItems(pr, rfc)`,
  backfilling newly-linked timed items for already-admitted patients.

## Verification

Reproduced against a local test admission (`BHT/56755`, synthetic demo
patient, Room 100 wm) with the existing "Nebulization Test 22316" timed item
(category "Nebulisation") linked to that room's fee configuration:

- **Before fix**: Gross Total `38,499.80`, no "Nebulisation" line anywhere on
  the interim bill, despite `PATIENTROOMTIMEDITEMCHARGE` correctly holding a
  computed `101,691.67` for it.
- **After fix** (via the app's own "Update Charges from Room Rates" → Interim
  Bill navigation, not a raw DB check): Gross Total `140,191.46`, with a
  dedicated `Nebulisation: 101,691.67` line — all other charge lines (Room
  Charges still exactly `30,600.00`, etc.) unchanged, confirming no
  double-counting.

Full before/after screenshots and detail are on the issue:
https://github.com/hmislk/hmis/issues/23118#issuecomment-5332872818

Build (`mvn clean package -DskipTests`) succeeded; local Payara redeploy
showed no exceptions in `server.log` for either action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy when updating room and facility charges.
  * Charge totals are now calculated more consistently across supported charge types.
  * Timed charges are now reflected correctly after room charges are saved, including package-locked rooms.
  * Room-linked timed charges are included without replacing existing category totals.
  * Admission fees continue to be handled separately and accurately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->