### PR TITLE
fix(pharmacy): use backwardReferenceBill to find received transfer bills

### DIFF
--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -4389,12 +4389,18 @@ public class SearchController implements Serializable {
         Map<String, Object> params = new HashMap<>();
         params.put("btp", BillTypeAtomic.PHARMACY_RECEIVE);
         params.put("issuedBillIds", issuedBillIds);
+        // Receive bills link back to the issued bill via backwardReferenceBill -
+        // both the deprecated TransferReceiveController and the current
+        // TransferReceiveNativeSqlController set it on every receive. referenceBill
+        // is only set by one legacy code path, so filtering on it here silently
+        // dropped every native-path receive from the issued list's "Received"
+        // column (issue #20717).
         String jpql = "SELECT NEW com.divudi.core.data.dto.PharmacyTransferReceivedListDTO("
-                + "b.id, b.referenceBill.id, b.deptId, b.cancelled) "
+                + "b.id, b.backwardReferenceBill.id, b.deptId, b.cancelled) "
                 + "FROM Bill b "
                 + "WHERE b.retired = false "
                 + "AND b.billTypeAtomic = :btp "
-                + "AND b.referenceBill.id IN :issuedBillIds";
+                + "AND b.backwardReferenceBill.id IN :issuedBillIds";
         List<PharmacyTransferReceivedListDTO> result = (List<PharmacyTransferReceivedListDTO>)
                 getBillFacade().findDTOsByJpql(jpql, params);
         return result != null ? result : new ArrayList<>();


### PR DESCRIPTION
## Summary

Fixes #20717 — the issued-transfer list's "Received" column
(`pharmacy_transfer_issued_list.xhtml`) was empty for any receive bill
created via the current native-SQL receive path, even though the receive
had completed successfully.

## Decisions made without approval

- **Root cause confirmed in code**: `SearchController.fetchReceivedBillsForIssuedIds()`
  filtered on `Bill.referenceBill`, but only one legacy branch of the
  deprecated `TransferReceiveController` ever sets that field. Every other
  write path — `TransferReceiveNativeSqlController` (the current path) and
  most of the old controller's own branches — sets
  `Bill.backwardReferenceBill` instead, matching the pattern the
  neighboring `populatePendingReceivePre()` method (a few lines above in
  the same file) already uses correctly.
- **Fix chosen**: switch the query to `backwardReferenceBill` outright
  rather than querying both fields with `OR` (the issue's own root-cause
  comment proposed either option). Confirmed via the local database: of
  919 `PHARMACY_RECEIVE` bills, all 919 have `backwardReferenceBill` set
  and only 594 also have the legacy `referenceBill` set — zero bills have
  `referenceBill` without `backwardReferenceBill`. Switching exclusively
  is a strict superset with no regression risk, so the `OR` was
  unnecessary complexity.

## Verification

Found a real local example: issued bill `MPPHTI/469` (Main Pharmacy → OPD
Pharmacy) has a receive bill `OPPHTI/205` with `backwardReferenceBill` set
but `referenceBill` `NULL` — exactly the case the old query missed.
Rebuilt, redeployed locally, and confirmed via Playwright that the
"Received" column now shows the `OPPHTI/205` button for this issued bill:

![Received column fixed](https://github.com/hmislk/hmis.wiki/raw/master/images/issue-20717-received-fixed.png)

## Scope

Single-method JPQL fix — no schema change, no change to bill-creation
logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected pharmacy transfer receive-bill searches to consistently identify and display the linked issued bill.
  * Improved filtering so receive-bill results use the correct transfer relationship.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->