### PR TITLE
fix(pharmacy): auto-calculate GRN Difference before Invoice Total is entered

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/GrnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnController.java
@@ -423,6 +423,7 @@ public class GrnController implements Serializable {
     public void removeItem(BillItem bi) {
         getBillItems().remove(bi.getSearialNo());
         calGrossTotal();
+        calDifference();
     }
 
     public List<BillItem> findAllBillItemsRefernceToOriginalItem(BillItem referenceBillItem) {
@@ -473,6 +474,7 @@ public class GrnController implements Serializable {
             getBillItems().add(newBillItemCreatedByDuplication);
         }
         calGrossTotal();
+        calDifference();
     }
 
     public void removeSelected() {
@@ -488,6 +490,7 @@ public class GrnController implements Serializable {
             getBillItems().remove(b.getSearialNo());
             calGrossTotal();
         }
+        calDifference();
 
         selectedBillItems = null;
     }
@@ -1413,6 +1416,10 @@ public class GrnController implements Serializable {
         setReferenceInstitution(getSessionController().getLoggedUser().getInstitution());
         generateBillComponent();
         calGrossTotal();
+        // Difference must reflect the GRN total as soon as the items are loaded, not
+        // only after the user types into Invoice Total (issue #23086) - insTotal is
+        // still 0 here, so this correctly shows the full GRN total as the difference.
+        calDifference();
     }
 
     public void createGrn(Bill importGrn) {
@@ -1420,6 +1427,7 @@ public class GrnController implements Serializable {
         setReferenceInstitution(importGrn.getDepartment().getInstitution());
         generateBillComponent(importGrn);
         calGrossTotal();
+        calDifference();
     }
 
     public void createGrnAll() {
@@ -1428,6 +1436,7 @@ public class GrnController implements Serializable {
         getGrnBill().setReferenceInstitution(getSessionController().getLoggedUser().getInstitution());
         generateBillComponentAll();
         calGrossTotal();
+        calDifference();
     }
 
     public void createGrnWholesale() {
@@ -1437,6 +1446,7 @@ public class GrnController implements Serializable {
         getGrnBill().setReferenceInstitution(getSessionController().getLoggedUser().getInstitution());
         generateBillComponent();
         calGrossTotal();
+        calDifference();
     }
 
     private double getRetailPrice(BillItem billItem) {

--- a/src/main/java/com/divudi/bean/pharmacy/GrnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnController.java
@@ -1412,6 +1412,12 @@ public class GrnController implements Serializable {
     }
 
     public void createGrn() {
+        // insTotal/difference are @SessionScoped fields that can carry over from a
+        // previous GRN the user worked on in this session; reset them here so this
+        // entry point is self-contained regardless of whether the caller already
+        // reset state (CodeRabbit review on #23086/PR #23122).
+        insTotal = 0;
+        difference = 0;
         setFromInstitution(getApproveBill().getToInstitution());
         setReferenceInstitution(getSessionController().getLoggedUser().getInstitution());
         generateBillComponent();
@@ -1423,6 +1429,8 @@ public class GrnController implements Serializable {
     }
 
     public void createGrn(Bill importGrn) {
+        insTotal = 0;
+        difference = 0;
         setFromInstitution(importGrn.getToInstitution());
         setReferenceInstitution(importGrn.getDepartment().getInstitution());
         generateBillComponent(importGrn);
@@ -1431,6 +1439,8 @@ public class GrnController implements Serializable {
     }
 
     public void createGrnAll() {
+        insTotal = 0;
+        difference = 0;
         getGrnBill().setPaymentMethod(getApproveBill().getPaymentMethod());
         getGrnBill().setFromInstitution(getApproveBill().getToInstitution());
         getGrnBill().setReferenceInstitution(getSessionController().getLoggedUser().getInstitution());
@@ -1440,6 +1450,8 @@ public class GrnController implements Serializable {
     }
 
     public void createGrnWholesale() {
+        insTotal = 0;
+        difference = 0;
         getGrnBill().setBillTypeAtomic(BillTypeAtomic.PHARMACY_GRN_WHOLESALE);
         getGrnBill().setPaymentMethod(getApproveBill().getPaymentMethod());
         getGrnBill().setFromInstitution(getApproveBill().getToInstitution());


### PR DESCRIPTION
## Summary

Fixes #23086 — the Difference field on the GRN receive page
(`pharmacy_grn.xhtml`) stayed at `0` until the user typed into Invoice
Total, even though items were already loaded with a known GRN total.

## Decisions made without approval

- **Root cause confirmed in code**: `calDifference()` is correctly wired
  to the Invoice Total field's `keyup` event and to per-row edit handlers
  (`onEdit()`), but `createGrn()`, `createGrn(Bill)`, `createGrnAll()`,
  and `createGrnWholesale()` — the entry points that first populate the
  GRN's item list and totals when a PO is received — only called
  `calGrossTotal()`, never the paired `calDifference()`. Same gap existed
  in `removeItem()`, `duplicateItem()`, and `removeSelected()`.
- **Fix chosen**: add `calDifference()` next to every `calGrossTotal()`
  call that was missing it, mirroring the pairing already used correctly
  in `onEdit()`. Considered converting `difference` into a derived getter
  instead, but that would be a larger behavioral change touching read
  semantics used elsewhere in this heavily-reused controller — the
  targeted fix stays scoped to the actual gap.

## Verification

Reached the legacy `pharmacy_grn.xhtml` page (the current default
"Create GRN" button routes through the newer
`GrnCostingNativeSqlController`/native-costing page instead — reaching
the page this issue names required temporarily toggling the "Manage
Costing" config option locally; reverted after verification). Received
a real Purchase Order and confirmed that **before** touching Invoice
Total, Gross Total showed `132.90` and Difference correctly showed
`-132.90` (`0 - 132.90`), matching the exact formula described in the
issue:

![GRN Difference auto-calculated](https://github.com/hmislk/hmis.wiki/raw/master/images/issue-23086-grn-difference-fixed.png)

## Scope

Single-controller fix (`GrnController`) — no schema change, no XHTML
change needed (existing `ajax="false"` full-page and `tot`-panelGrid
AJAX updates already refresh the field correctly once the server-side
value is right).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invoice differences are now recalculated immediately after removing, duplicating, or bulk-removing items.
  * Invoice differences are calculated correctly when creating imported, all-item, and wholesale goods receipts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->