### PR TITLE
fix(inward): show Settle button before New Bill on BHT direct issue page

### DIFF
--- a/src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml
+++ b/src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml
@@ -191,14 +191,6 @@
                             <!-- RIGHT: actions, left=least important -> right=primary -->
                             <div class="d-flex gap-2 align-items-center">
                                 <p:commandButton
-                                    value="New Bill"
-                                    ajax="false"
-                                    styleClass="ui-button-warning"
-                                    icon="fa-solid fa-plus"
-                                    action="pharmacy_bill_issue_bht"
-                                    actionListener="#{inpatientDirectIssueNativeSqlController.resetAll}">
-                                </p:commandButton>
-                                <p:commandButton
                                     id="btnSettleNative"
                                     value="Settle"
                                     ajax="true"
@@ -211,6 +203,15 @@
                                     style="min-width:120px"
                                     icon="fa-solid fa-check-circle">
                                 </p:commandButton>
+                                <p:commandButton
+                                    value="New Bill"
+                                    ajax="false"
+                                    styleClass="ui-button-warning"
+                                    icon="fa-solid fa-plus"
+                                    action="pharmacy_bill_issue_bht"
+                                    actionListener="#{inpatientDirectIssueNativeSqlController.resetAll}">
+                                </p:commandButton>
+                                
                             </div>
                         </div>
                     </f:facet>


### PR DESCRIPTION
## Summary
- Reorders the action toolbar on the inpatient direct-issue (BHT) pharmacy bill page (`pharmacy_bill_issue_bht.xhtml`) so **Settle** appears before **New Bill**, matching the natural workflow of finishing the current bill before starting a new one.

## Test plan
- [x] JSF-only change (XHTML only, no Java) — no compilation/testing required per project convention.
- [ ] Manually verify button order on the "Direct Issue of Medicines to Inpatients (Native SQL)" page.

Closes #23131

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reordered the pharmacy billing page actions so that “Settle” appears before “New Bill.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->