### PR TITLE
fix(pharmacy): fall back to legacy last retail rate when BillItemFinanceDetails missing

### DIFF
--- a/src/main/java/com/divudi/ejb/PharmacyBean.java
+++ b/src/main/java/com/divudi/ejb/PharmacyBean.java
@@ -2852,7 +2852,7 @@ public class PharmacyBean {
 
         BillItemFinanceDetails f = bi.getBillItemFinanceDetails();
         if (f == null || f.getRetailSaleRate() == null) {
-            return 0.0;
+            return getLastRetailRateByPharmaceuticalBillItem(item, dept);
         }
 
         return f.getRetailSaleRate().doubleValue();


### PR DESCRIPTION
## Summary
- `PharmacyPurchaseController.findLastRetailRate(Amp amp)` → `PharmacyBean.getLastRetailRate(item, dept)` → (Manage Costing = true) → `PharmacyBean.getLastRetailRateByBillItemFinanceDetails(Item, Department)`.
- That method located the latest GRN/purchase `BillItem` for the item but returned `0.0` whenever that `BillItem`'s `billItemFinanceDetails` (or its `retailSaleRate`) was `null`, instead of falling back to any other known rate.
- Now falls back to `getLastRetailRateByPharmaceuticalBillItem(item, dept)` (the `ItemBatch.retailsaleRate` lookup) in that case, matching the fallback pattern already used elsewhere in the codebase (e.g. `PharmacyDirectPurchaseController.onItemSelect`).

## Where
`src/main/java/com/divudi/ejb/PharmacyBean.java` — `getLastRetailRateByBillItemFinanceDetails(Item, Department)`

## Test plan
- [ ] JSF pages that call `findLastRetailRate`/`getLastRetailRate` (e.g. `pharmacy_bill_retail_sale*.xhtml`, `search_medicine_dialog.xhtml`) show a non-zero last retail rate for items whose latest GRN/purchase bill item has no `BillItemFinanceDetails`, using the legacy `ItemBatch.retailsaleRate` value instead.
- [ ] Items whose latest GRN/purchase bill item does have `BillItemFinanceDetails` with a `retailSaleRate` are unaffected.

Closes #23133

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pharmacy pricing by falling back to the latest available retail rate when finance details or a recorded retail rate are unavailable.
  * Prevented applicable items from incorrectly displaying a retail rate of zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->