### PR TITLE
fix(inward): Remove/Settle no longer crash on Issuing Bill Item autocomplete

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/StockController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/StockController.java
@@ -1205,7 +1205,7 @@ public class StockController implements Serializable {
     /**
      *
      */
-    @FacesConverter(forClass = Stock.class)
+    @FacesConverter(value = "stockConverter", forClass = Stock.class)
     public static class StockConverter implements Converter {
 
         @Override

--- a/src/main/webapp/ward/ward_pharmacy_bht_issue.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_bht_issue.xhtml
@@ -407,7 +407,8 @@
                                     icon="fas fa-trash"
                                     action="#{pharmacySaleBhtController.removeBillItemFromBhtRequest(bItm)}"
                                     class="ui-button-danger"
-                                    ajax="false" >
+                                    process="@this"
+                                    update="itemList">
                                 </p:commandButton>
                             </div>
 

--- a/src/main/webapp/ward/ward_pharmacy_bht_issue.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_bht_issue.xhtml
@@ -365,6 +365,7 @@
                         <p:column headerText="Issuing Bill Item" style="padding: 6px;">
                             <p:autoComplete id="Isitem"
                                             value="#{pharmacySaleBhtController.issuingSelections[bItm]}"
+                                            converter="stockConverter"
                                             completeMethod="#{pharmacySaleBhtController.completeAllDepartmentStock}"
                                             var="stk"
                                             itemLabel="#{stk.itemBatch.item.name} (Batch: #{stk.itemBatch.batchNo}, Qty: #{stk.stock})"


### PR DESCRIPTION
## Summary
Fixes #23141 - on `ward/ward_pharmacy_bht_issue.xhtml`, clicking **Remove** on an "Issuing Items" row, or clicking **Issue to BHT** (Settle), threw:

```
javax.el.PropertyNotFoundException: ... itemLabel="#{stk.itemBatch.item.name} ...": The class 'java.lang.String' does not have the property 'itemBatch'.
```

### Root cause
The "Issuing Bill Item" `p:autoComplete` (`Isitem`) binds its value through map-bracket EL (`issuingSelections[bItm]`, a `Map<BillItem, Stock>`). JSF can't type-infer a value reached through `MapELResolver` (`getType()` always returns `Object.class`), so the existing `Stock` entity converter (`forClass = Stock.class`) never auto-attaches to this field. Without a converter, PrimeFaces round-trips the *displayed* value via raw `Stock#toString()` on a hidden input. That's fine during a live AJAX search/select, but breaks on any full-form submit that reprocesses the table - such as the non-AJAX **Issue to BHT** button, or the **Remove** button's old `ajax="false"` full postback. JSF decodes the stale `toString()` text and stores it straight into `issuingSelections` (generics are erased at runtime), corrupting the map entry from `Stock` into a `String`. The next render's `itemLabel` EL then blows up on that `String`.

### Fix (two commits)
1. **Remove button**: switched from `ajax="false"` (full page postback, reprocesses every row's autocomplete) to AJAX with `process="@this"` / `update="itemList"`, matching the pattern already used by the row-edit and item-select handlers on the same table.
2. **Settle / general full-form postback**: gave `StockController.StockConverter` an explicit converter id (`stockConverter`) alongside its existing `forClass = Stock.class`, and referenced it directly (`converter="stockConverter"`) on the `Isitem` autocomplete, so the round-tripped value is always a stable numeric `Stock` id (resolved via `stockController.getEjbFacade().find(id)`) instead of a fragile `toString()` that only worked inside a live AJAX search/select cycle.

## Test plan
- [x] Reviewed JSF/PrimeFaces decode path (`AutoCompleteRenderer`, `AutoComplete#queueEvent`) against the vendored PrimeFaces 14.0.6 source to confirm the map-bracket EL/`Object.class` type-inference gap and the `toString()` fallback behavior.
- [ ] Open a BHT issue request, select an "Issuing Bill Item" for a row via the autocomplete, click **Remove** on a row - confirm no exception and the row disappears.
- [ ] Repeat, then click **Issue to BHT** to settle - confirm no exception and the bill settles correctly with the selected stock.

Note: `src/main/resources/META-INF/persistence.xml` is intentionally excluded from this PR - it's local-only JNDI configuration per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stock selection handling in the ward pharmacy issue workflow.
  - Removing an item now updates the item list without submitting the entire form.
  - Standardized stock conversion for autocomplete selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->