### PR TITLE
feat(inward): add REST API for room facility timed items

### DIFF
--- a/developer_docs/api/using-apis/API_INWARD_ROOM.md
+++ b/developer_docs/api/using-apis/API_INWARD_ROOM.md
@@ -262,6 +262,69 @@ DELETE /api/inward/room-facility-charges/{id}?retireComments=reason
 
 ---
 
+## 4. Room Facility Timed Items — `/api/inward/room-facility-charges/{id}/timed-items`
+
+Manages the list of individual `TimedItem` services attached to a room facility charge (issue
+#23147), so each is auto-billed based on duration of stay alongside the fixed room charges. This
+is distinct from the `timedItemFee` block-duration/overshoot config on the parent charge (§3
+above) — that config controls *how* time-based billing is calculated; this list controls *which*
+items get billed that way.
+
+### GET — List attached timed items
+
+```
+GET /api/inward/room-facility-charges/{id}/timed-items
+```
+
+`{id}` is the `RoomFacilityCharge` id. Returns 404 if not found / retired.
+
+**Response 200:**
+```json
+{
+  "status": "success",
+  "code": 200,
+  "data": [
+    {
+      "id": 7,
+      "timedItem": { "id": 42, "name": "ICU Bed Charge" },
+      "createdAt": "2026-08-20 10:15:00",
+      "retired": false
+    }
+  ]
+}
+```
+
+### POST — Attach a timed item
+
+```
+POST /api/inward/room-facility-charges/{id}/timed-items
+Content-Type: application/json
+```
+
+```json
+{ "timedItemId": 42 }
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| timedItemId | Yes | ID of the `TimedItem` to attach |
+
+**Response 201** — created attachment record (same shape as the GET list rows).
+**Response 409** — already attached (an active attachment for this `TimedItem` already exists on
+this room facility charge).
+**Response 400** — `timedItemId` missing, or the `TimedItem` doesn't exist / is retired.
+
+### DELETE — Soft-retire an attachment
+
+```
+DELETE /api/inward/room-facility-charges/{id}/timed-items/{linkId}?retireComments=reason
+```
+
+Retires the attachment (`{linkId}`), not the underlying `TimedItem`. Returns 404 if the
+attachment doesn't belong to `{id}` or doesn't exist; 400 if already retired.
+
+---
+
 ## Bed-board SVG (issue #21592)
 
 A room is a **leaf** in the bed-board hierarchy (Site → Building → Floor → Unit →
@@ -317,6 +380,11 @@ curl -s -H "Finance: $KEY" -H "Content-Type: application/json" \
   -X POST "$BASE/api/inward/room-facility-charges" \
   -d '{"name":"Room 101 - Cash","roomId":10,"roomCategoryId":1,"roomCharge":1500,"timedItemFeeDurationHours":24}' | python -m json.tool
 
-# 4. Verify capabilities
+# 4. Attach a Timed Item to that charge (use the charge id from step 3, TimedItem id from /api/timed-items)
+curl -s -H "Finance: $KEY" -H "Content-Type: application/json" \
+  -X POST "$BASE/api/inward/room-facility-charges/20/timed-items" \
+  -d '{"timedItemId":42}' | python -m json.tool
+
+# 5. Verify capabilities
 curl -s "$BASE/api/capabilities" | python -m json.tool
 ```

--- a/developer_docs/api/using-apis/API_INWARD_ROOM.md
+++ b/developer_docs/api/using-apis/API_INWARD_ROOM.md
@@ -264,15 +264,15 @@ DELETE /api/inward/room-facility-charges/{id}?retireComments=reason
 
 ## 4. Room Facility Timed Items — `/api/inward/room-facility-charges/{id}/timed-items`
 
-Manages the list of individual `TimedItem` services attached to a room facility charge (issue
-#23147), so each is auto-billed based on duration of stay alongside the fixed room charges. This
+Manages the list of individual `TimedItem` services attached to a room facility charge
+(issue `#23147`), so each is auto-billed based on duration of stay alongside the fixed room charges. This
 is distinct from the `timedItemFee` block-duration/overshoot config on the parent charge (§3
 above) — that config controls *how* time-based billing is calculated; this list controls *which*
 items get billed that way.
 
 ### GET — List attached timed items
 
-```
+```text
 GET /api/inward/room-facility-charges/{id}/timed-items
 ```
 
@@ -296,7 +296,7 @@ GET /api/inward/room-facility-charges/{id}/timed-items
 
 ### POST — Attach a timed item
 
-```
+```text
 POST /api/inward/room-facility-charges/{id}/timed-items
 Content-Type: application/json
 ```
@@ -310,18 +310,20 @@ Content-Type: application/json
 | timedItemId | Yes | ID of the `TimedItem` to attach |
 
 **Response 201** — created attachment record (same shape as the GET list rows).
+**Response 404** — room facility charge `{id}` not found or retired.
 **Response 409** — already attached (an active attachment for this `TimedItem` already exists on
 this room facility charge).
 **Response 400** — `timedItemId` missing, or the `TimedItem` doesn't exist / is retired.
 
 ### DELETE — Soft-retire an attachment
 
-```
+```text
 DELETE /api/inward/room-facility-charges/{id}/timed-items/{linkId}?retireComments=reason
 ```
 
 Retires the attachment (`{linkId}`), not the underlying `TimedItem`. Returns 404 if the
-attachment doesn't belong to `{id}` or doesn't exist; 400 if already retired.
+attachment doesn't belong to `{id}` or doesn't exist, or if the room facility charge `{id}` itself
+is not found or retired; 400 if already retired.
 
 ---
 

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -774,7 +774,11 @@ public class AnthropicApiService implements Serializable {
                         "Manage inward room master data: room categories, rooms, and room facility charges (room fee configs). "
                         + "Methods: LIST_CATEGORIES, POST_CATEGORY, PUT_CATEGORY, DELETE_CATEGORY, "
                         + "LIST_ROOMS, POST_ROOM, PUT_ROOM, DELETE_ROOM, "
-                        + "LIST_CHARGES, POST_CHARGE, PUT_CHARGE, DELETE_CHARGE. "
+                        + "LIST_CHARGES, POST_CHARGE, PUT_CHARGE, DELETE_CHARGE, "
+                        + "LIST_TIMED_ITEMS, ADD_TIMED_ITEM, REMOVE_TIMED_ITEM (attach/detach TimedItem services that "
+                        + "auto-bill by duration of stay alongside a room facility charge's fixed fees; id = the "
+                        + "room facility charge id, timedItemId = the TimedItem to attach for ADD_TIMED_ITEM, "
+                        + "id/linkId identify the attachment to remove for REMOVE_TIMED_ITEM). "
                         + "Always confirm with the user before creating, updating, or retiring records.")
                 .add("input_schema", Json.createObjectBuilder()
                         .add("type", "object")
@@ -784,11 +788,19 @@ public class AnthropicApiService implements Serializable {
                                         .add("enum", Json.createArrayBuilder()
                                                 .add("LIST_CATEGORIES").add("GET_CATEGORY").add("POST_CATEGORY").add("PUT_CATEGORY").add("DELETE_CATEGORY")
                                                 .add("LIST_ROOMS").add("GET_ROOM").add("POST_ROOM").add("PUT_ROOM").add("DELETE_ROOM")
-                                                .add("LIST_CHARGES").add("GET_CHARGE").add("POST_CHARGE").add("PUT_CHARGE").add("DELETE_CHARGE"))
+                                                .add("LIST_CHARGES").add("GET_CHARGE").add("POST_CHARGE").add("PUT_CHARGE").add("DELETE_CHARGE")
+                                                .add("LIST_TIMED_ITEMS").add("ADD_TIMED_ITEM").add("REMOVE_TIMED_ITEM"))
                                         .add("description", "Operation to perform."))
                                 .add("id", Json.createObjectBuilder()
                                         .add("type", "string")
-                                        .add("description", "Record id. Required for PUT and DELETE methods."))
+                                        .add("description", "Record id. Required for PUT and DELETE methods. "
+                                                + "For LIST_TIMED_ITEMS/ADD_TIMED_ITEM/REMOVE_TIMED_ITEM this is the room facility charge id."))
+                                .add("timedItemId", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "TimedItem id to attach. Required for ADD_TIMED_ITEM."))
+                                .add("linkId", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "RoomFacilityTimedItem attachment id to remove. Required for REMOVE_TIMED_ITEM."))
                                 .add("name", Json.createObjectBuilder()
                                         .add("type", "string")
                                         .add("description", "Name of the record. Required for POST methods."))
@@ -2345,11 +2357,13 @@ public class AnthropicApiService implements Serializable {
                     String query          = toolInput.containsKey("query")                          ? toolInput.getString("query", "")                          : "";
                     String size           = toolInput.containsKey("size")                           ? toolInput.getString("size", "")                           : "";
                     String retireComments = toolInput.containsKey("retireComments")                 ? toolInput.getString("retireComments", "")                 : "";
+                    String timedItemId    = toolInput.containsKey("timedItemId")                    ? toolInput.getString("timedItemId", "")                    : "";
+                    String linkId         = toolInput.containsKey("linkId")                         ? toolInput.getString("linkId", "")                         : "";
                     return callInwardRoomsApi(method, id, name, code, desc, roomCategoryId, roomId,
                             departmentId, filled, svgChildView, roomCharge, maintCharge, linenCharge, nursingCharge,
                             moCharge, moAfterCharge, adminCharge, medCareCharge,
                             durationHours, overShoot, durationDays,
-                            query, size, retireComments, hmisBaseUrl, hmisApiKey);
+                            query, size, retireComments, timedItemId, linkId, hmisBaseUrl, hmisApiKey);
                 }
                 case "manage_bed_board_svg": {
                     String method        = toolInput.getString("method", "GET_SITE");
@@ -3872,7 +3886,7 @@ public class AnthropicApiService implements Serializable {
             String roomCharge, String maintananceCharge, String linenCharge, String nursingCharge,
             String moCharge, String moChargeForAfterDuration, String adminstrationCharge, String medicalCareCharge,
             String timedItemFeeDurationHours, String timedItemFeeOverShootHours, String timedItemFeeDurationDaysForMoCharge,
-            String query, String size, String retireComments,
+            String query, String size, String retireComments, String timedItemId, String linkId,
             String hmisBaseUrl, String hmisApiKey) {
 
         if (hmisBaseUrl == null || hmisBaseUrl.trim().isEmpty()) {
@@ -4066,6 +4080,34 @@ public class AnthropicApiService implements Serializable {
                 case "DELETE_CHARGE": {
                     if (id == null || id.isEmpty()) return "Error: id is required for DELETE_CHARGE.";
                     StringBuilder url = new StringBuilder(baseUrl).append("/api/inward/room-facility-charges/").append(id);
+                    if (retireComments != null && !retireComments.isEmpty()) url.append("?retireComments=").append(java.net.URLEncoder.encode(retireComments, java.nio.charset.StandardCharsets.UTF_8));
+                    request = HttpRequest.newBuilder().uri(URI.create(url.toString()))
+                            .timeout(Duration.ofSeconds(15)).header("Finance", hmisApiKey)
+                            .DELETE().build();
+                    break;
+                }
+                case "LIST_TIMED_ITEMS": {
+                    if (id == null || id.isEmpty()) return "Error: id (room facility charge id) is required for LIST_TIMED_ITEMS.";
+                    request = HttpRequest.newBuilder().uri(URI.create(baseUrl + "/api/inward/room-facility-charges/" + id + "/timed-items"))
+                            .timeout(Duration.ofSeconds(15)).header("Finance", hmisApiKey).GET().build();
+                    break;
+                }
+                case "ADD_TIMED_ITEM": {
+                    if (id == null || id.isEmpty()) return "Error: id (room facility charge id) is required for ADD_TIMED_ITEM.";
+                    if (timedItemId == null || timedItemId.isEmpty()) return "Error: timedItemId is required for ADD_TIMED_ITEM.";
+                    java.util.Map<String, Object> bodyMap = new java.util.LinkedHashMap<>();
+                    bodyMap.put("timedItemId", Long.parseLong(timedItemId));
+                    String bodyJson = new com.google.gson.Gson().toJson(bodyMap);
+                    request = HttpRequest.newBuilder().uri(URI.create(baseUrl + "/api/inward/room-facility-charges/" + id + "/timed-items"))
+                            .timeout(Duration.ofSeconds(15)).header("Finance", hmisApiKey)
+                            .header("Content-Type", "application/json")
+                            .POST(HttpRequest.BodyPublishers.ofString(bodyJson)).build();
+                    break;
+                }
+                case "REMOVE_TIMED_ITEM": {
+                    if (id == null || id.isEmpty()) return "Error: id (room facility charge id) is required for REMOVE_TIMED_ITEM.";
+                    if (linkId == null || linkId.isEmpty()) return "Error: linkId is required for REMOVE_TIMED_ITEM.";
+                    StringBuilder url = new StringBuilder(baseUrl).append("/api/inward/room-facility-charges/").append(id).append("/timed-items/").append(linkId);
                     if (retireComments != null && !retireComments.isEmpty()) url.append("?retireComments=").append(java.net.URLEncoder.encode(retireComments, java.nio.charset.StandardCharsets.UTF_8));
                     request = HttpRequest.newBuilder().uri(URI.create(url.toString()))
                             .timeout(Duration.ofSeconds(15)).header("Finance", hmisApiKey)
@@ -5912,6 +5954,9 @@ public class AnthropicApiService implements Serializable {
           .append("POST_CATEGORY / POST_ROOM / POST_CHARGE to create new records. ")
           .append("PUT_CATEGORY / PUT_ROOM / PUT_CHARGE to update. ")
           .append("DELETE_CATEGORY / DELETE_ROOM / DELETE_CHARGE to soft-retire. ")
+          .append("LIST_TIMED_ITEMS / ADD_TIMED_ITEM / REMOVE_TIMED_ITEM manage the TimedItem services attached to a ")
+          .append("room facility charge so they auto-bill by duration of stay alongside its fixed fees ")
+          .append("(id = room facility charge id; timedItemId required for ADD_TIMED_ITEM; linkId required for REMOVE_TIMED_ITEM). ")
           .append("Always confirm with the user before POST, PUT, or DELETE — these changes affect live inward room billing.\n\n");
         sb.append("### manage_bed_board_svg\n");
         sb.append("Read and set the graphical bed-board SVG drawings used by the Inpatient Bed Board page. ")
@@ -6596,7 +6641,10 @@ public class AnthropicApiService implements Serializable {
                     {"GET",    "/inward/room-facility-charges/{id}", "Fetch one room facility charge"},
                     {"POST",   "/inward/room-facility-charges",    "Create room facility charge. Body: name (required), roomId, roomCategoryId, departmentId, charge fields, timedItemFee fields"},
                     {"PUT",    "/inward/room-facility-charges/{id}", "Update room facility charge"},
-                    {"DELETE", "/inward/room-facility-charges/{id}", "Soft-retire room facility charge"}
+                    {"DELETE", "/inward/room-facility-charges/{id}", "Soft-retire room facility charge"},
+                    {"GET",    "/inward/room-facility-charges/{id}/timed-items", "List TimedItems attached to a room facility charge"},
+                    {"POST",   "/inward/room-facility-charges/{id}/timed-items", "Attach a TimedItem. Body: timedItemId (required)"},
+                    {"DELETE", "/inward/room-facility-charges/{id}/timed-items/{linkId}", "Soft-retire a TimedItem attachment"}
                 });
 
         appendModule(sb, "Inward - Item Requests", "/itemrequests",

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -778,7 +778,8 @@ public class AnthropicApiService implements Serializable {
                         + "LIST_TIMED_ITEMS, ADD_TIMED_ITEM, REMOVE_TIMED_ITEM (attach/detach TimedItem services that "
                         + "auto-bill by duration of stay alongside a room facility charge's fixed fees; id = the "
                         + "room facility charge id, timedItemId = the TimedItem to attach for ADD_TIMED_ITEM, "
-                        + "id/linkId identify the attachment to remove for REMOVE_TIMED_ITEM). "
+                        + "id/linkId identify the attachment to remove for REMOVE_TIMED_ITEM; retireComments is "
+                        + "optional for REMOVE_TIMED_ITEM). "
                         + "Always confirm with the user before creating, updating, or retiring records.")
                 .add("input_schema", Json.createObjectBuilder()
                         .add("type", "object")

--- a/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
+++ b/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
@@ -225,6 +225,14 @@ public class CapabilityStatementResource {
                         + "timedItemFeeDurationDaysForMoCharge.",
                         "API Key",
                         "GET", "POST", "PUT", "DELETE"))
+                .add(resource("Inward Room Facility Timed Items", "/api/inward/room-facility-charges/{id}/timed-items",
+                        "Manage the list of TimedItem services attached to a room facility charge (backs the "
+                        + "'Timed Items' section of /inward/inward_room_facility.xhtml), so they auto-bill "
+                        + "based on duration of stay alongside the fixed room charges. "
+                        + "POST body: timedItemId (required). A TimedItem cannot be attached twice while active "
+                        + "(409 conflict). DELETE soft-retires the attachment, not the TimedItem itself.",
+                        "API Key",
+                        "GET", "POST", "DELETE"))
                 .add(resource("Item Requests", "/api/itemrequests",
                         "External systems submit item/service requests (meals like Breakfast/Lunch/Dinner as "
                         + "InwardService items, and stock items like Water Bottle/Tea/Milk/Sugar) against a patient's "

--- a/src/main/java/com/divudi/ws/inward/InwardRoomFacilityChargeApi.java
+++ b/src/main/java/com/divudi/ws/inward/InwardRoomFacilityChargeApi.java
@@ -12,11 +12,15 @@ import com.divudi.core.entity.WebUser;
 import com.divudi.core.entity.inward.Room;
 import com.divudi.core.entity.inward.RoomCategory;
 import com.divudi.core.entity.inward.RoomFacilityCharge;
+import com.divudi.core.entity.inward.RoomFacilityTimedItem;
+import com.divudi.core.entity.inward.TimedItem;
 import com.divudi.core.entity.inward.TimedItemFee;
 import com.divudi.core.facade.DepartmentFacade;
 import com.divudi.core.facade.RoomCategoryFacade;
 import com.divudi.core.facade.RoomFacade;
 import com.divudi.core.facade.RoomFacilityChargeFacade;
+import com.divudi.core.facade.RoomFacilityTimedItemFacade;
+import com.divudi.core.facade.TimedItemFacade;
 import com.divudi.core.facade.TimedItemFeeFacade;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -78,6 +82,12 @@ public class InwardRoomFacilityChargeApi {
 
     @EJB
     private TimedItemFeeFacade timedItemFeeFacade;
+
+    @EJB
+    private RoomFacilityTimedItemFacade roomFacilityTimedItemFacade;
+
+    @EJB
+    private TimedItemFacade timedItemFacade;
 
     private static final Gson gson = new GsonBuilder()
             .setDateFormat("yyyy-MM-dd HH:mm:ss")
@@ -406,6 +416,158 @@ public class InwardRoomFacilityChargeApi {
     }
 
     // =========================================================================
+    // Timed Items (RoomFacilityTimedItem) — issue #23147
+    // =========================================================================
+
+    /**
+     * List active Timed Items attached to a room facility charge.
+     * GET /api/inward/room-facility-charges/{id}/timed-items
+     */
+    @GET
+    @Path("/{id}/timed-items")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response listTimedItems(@PathParam("id") Long id) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+            RoomFacilityCharge charge = roomFacilityChargeFacade.find(id);
+            if (charge == null || charge.isRetired()) {
+                return errorResponse("Room facility charge not found: " + id, 404);
+            }
+
+            Map<String, Object> params = new HashMap<>();
+            params.put("rfc", charge);
+            List<RoomFacilityTimedItem> links = roomFacilityTimedItemFacade.findByJpql(
+                    "select r from RoomFacilityTimedItem r where r.roomFacilityCharge = :rfc and r.retired = false order by r.id",
+                    params);
+
+            List<Map<String, Object>> payload = new ArrayList<>();
+            if (links != null) {
+                for (RoomFacilityTimedItem link : links) {
+                    payload.add(toTimedItemDto(link));
+                }
+            }
+            return successResponse(payload);
+
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    /**
+     * Attach a Timed Item to a room facility charge.
+     * POST /api/inward/room-facility-charges/{id}/timed-items
+     * Body: { "timedItemId" (required) }
+     */
+    @POST
+    @Path("/{id}/timed-items")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response addTimedItem(@PathParam("id") Long id, String requestBody) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+            RoomFacilityCharge charge = roomFacilityChargeFacade.find(id);
+            if (charge == null || charge.isRetired()) {
+                return errorResponse("Room facility charge not found: " + id, 404);
+            }
+
+            Map<?, ?> body;
+            try {
+                body = gson.fromJson(requestBody, Map.class);
+            } catch (JsonSyntaxException e) {
+                return errorResponse("Invalid JSON format: " + e.getMessage(), 400);
+            }
+            if (body == null) {
+                return errorResponse("Request body is required", 400);
+            }
+
+            Long timedItemId = asLong(body.get("timedItemId"));
+            if (timedItemId == null) {
+                return errorResponse("timedItemId is required", 400);
+            }
+            TimedItem timedItem = timedItemFacade.find(timedItemId);
+            if (timedItem == null || timedItem.isRetired()) {
+                return errorResponse("Timed Item not found: " + timedItemId, 400);
+            }
+
+            Map<String, Object> params = new HashMap<>();
+            params.put("rfc", charge);
+            params.put("ti", timedItem);
+            List<RoomFacilityTimedItem> existing = roomFacilityTimedItemFacade.findByJpql(
+                    "select r from RoomFacilityTimedItem r where r.roomFacilityCharge = :rfc and r.timedItem = :ti and r.retired = false",
+                    params);
+            if (existing != null && !existing.isEmpty()) {
+                return errorResponse("This Timed Item is already attached to this room facility charge", 409);
+            }
+
+            RoomFacilityTimedItem link = new RoomFacilityTimedItem();
+            link.setRoomFacilityCharge(charge);
+            link.setTimedItem(timedItem);
+            link.setCreater(user);
+            link.setCreatedAt(new Date());
+            roomFacilityTimedItemFacade.create(link);
+
+            return Response.status(201).entity(gson.toJson(successData(toTimedItemDto(link)))).build();
+
+        } catch (IllegalArgumentException e) {
+            return errorResponse(e.getMessage(), 400);
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    /**
+     * Soft-retire a Timed Item attachment.
+     * DELETE /api/inward/room-facility-charges/{id}/timed-items/{linkId}?retireComments=reason
+     */
+    @DELETE
+    @Path("/{id}/timed-items/{linkId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response removeTimedItem(@PathParam("id") Long id, @PathParam("linkId") Long linkId) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+            RoomFacilityCharge charge = roomFacilityChargeFacade.find(id);
+            if (charge == null || charge.isRetired()) {
+                return errorResponse("Room facility charge not found: " + id, 404);
+            }
+
+            RoomFacilityTimedItem link = roomFacilityTimedItemFacade.find(linkId);
+            if (link == null || link.getRoomFacilityCharge() == null
+                    || !link.getRoomFacilityCharge().getId().equals(charge.getId())) {
+                return errorResponse("Timed Item attachment not found: " + linkId, 404);
+            }
+            if (link.isRetired()) {
+                return errorResponse("Timed Item attachment is already retired: " + linkId, 400);
+            }
+
+            link.setRetired(true);
+            link.setRetiredAt(new Date());
+            link.setRetirer(user);
+            String retireComments = param("retireComments");
+            if (retireComments != null && !retireComments.trim().isEmpty()) {
+                link.setRetireComments(retireComments.trim());
+            }
+            roomFacilityTimedItemFacade.edit(link);
+
+            Map<String, Object> resp = new LinkedHashMap<>();
+            resp.put("id", link.getId());
+            resp.put("retired", true);
+            return successResponse(resp);
+
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    // =========================================================================
     // Helpers
     // =========================================================================
 
@@ -491,6 +653,22 @@ public class InwardRoomFacilityChargeApi {
         } else {
             row.put("timedItemFee", null);
         }
+        return row;
+    }
+
+    private Map<String, Object> toTimedItemDto(RoomFacilityTimedItem link) {
+        Map<String, Object> row = new LinkedHashMap<>();
+        row.put("id", link.getId());
+        if (link.getTimedItem() != null) {
+            Map<String, Object> ti = new LinkedHashMap<>();
+            ti.put("id", link.getTimedItem().getId());
+            ti.put("name", link.getTimedItem().getName());
+            row.put("timedItem", ti);
+        } else {
+            row.put("timedItem", null);
+        }
+        row.put("createdAt", link.getCreatedAt());
+        row.put("retired", link.isRetired());
         return row;
     }
 


### PR DESCRIPTION
## Decisions made without approval

This was run via `dev-issue-unattended`, so the following judgment call was made without a live approval gate — please double-check it first:

- **Placement**: added the new endpoints as sub-resources on the existing `InwardRoomFacilityChargeApi` class (`/api/inward/room-facility-charges/{id}/timed-items`) rather than a new top-level API class. This matches the existing `/{id}/svg` sub-resource pattern already used elsewhere in this codebase (`InwardRoomApi`, `InstitutionApi`, `DepartmentApi`), and the `RoomFacilityTimedItem` join entity has no independent lifecycle outside its parent `RoomFacilityCharge`.

## Summary

Closes #23147.

The existing `/api/inward/room-facility-charges` API (documented in `API_INWARD_ROOM.md`) covered `RoomFacilityCharge` base fields and the `timedItemFee` duration/overshoot config, but not the list of individually-attached `TimedItem` services shown at the bottom of `inward/inward_room_facility.xhtml` (backed by `RoomFacilityChargeController.addTimedItem()`/`removeTimedItem()`). This PR closes that gap with three new endpoints:

- `GET /api/inward/room-facility-charges/{id}/timed-items` — list active attachments
- `POST /api/inward/room-facility-charges/{id}/timed-items` — attach a `TimedItem` (`timedItemId` in body); 409 if already attached
- `DELETE /api/inward/room-facility-charges/{id}/timed-items/{linkId}?retireComments=` — soft-retire an attachment (never a hard delete of the attachment or the underlying `TimedItem`)

Business rules mirror `RoomFacilityChargeController` exactly (same duplicate-active-attachment guard, same soft-retire semantics).

## Also updated

- `CapabilityStatementResource` — new capability entry for the sub-resource
- `AnthropicApiService` — `manage_inward_rooms` AI Chat tool gets `LIST_TIMED_ITEMS` / `ADD_TIMED_ITEM` / `REMOVE_TIMED_ITEM` methods (tool schema + handler + system-prompt docs), following the existing pattern for that tool
- `developer_docs/api/using-apis/API_INWARD_ROOM.md` — new §4 documenting the sub-resource, plus an added step in the "Typical Workflow" example

No entity, controller, or database schema changes — this is purely a new REST surface over the existing `RoomFacilityTimedItem` join entity, so no DDL/migration is involved.

## Testing

Verified end-to-end on local Payara against real dev data (no mock/synthetic records): `RoomFacilityCharge` id `136273` ("Room 100 wom") + `TimedItem` id `13839292` ("Nebulization Test 22316"). Confirmed via curl + DB:

- `GET` list before/after attach/detach
- `POST` attach → 201, duplicate attach → 409
- `DELETE` → 200 soft-retire, DB shows `RETIRED=1` + `RETIRECOMMENTS` set (no hard delete), re-DELETE → 400 already retired
- Error paths: unknown charge id → 404, unknown/retired `timedItemId` → 400, missing `timedItemId` → 400, missing/invalid API key → 401
- `/api/capabilities` shows the new resource entry

Full verification log posted as a comment on #23147.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Room facility charges can now display associated timed-item services.
  * Timed items can be attached with validation, ownership checks, and duplicate protection.
  * Existing timed-item associations can be retired without deleting historical records.
  * API responses clearly report validation, ownership, and conflict errors.

* **Documentation**
  * Added API guidance for requests, responses, workflows, and association behavior.
  * Added capability information for the new timed-item operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->