### PR TITLE
chore(skills): improve demonstrate-issues based on 2026-08-20 session findings

### DIFF
--- a/.claude/skills/demonstrate-issues/SKILL.md
+++ b/.claude/skills/demonstrate-issues/SKILL.md
@@ -19,7 +19,8 @@ allowed-tools: Read, Glob, Grep, Bash, PowerShell, mcp__playwright__browser_navi
   mcp__playwright__browser_snapshot, mcp__playwright__browser_take_screenshot,
   mcp__playwright__browser_console_messages, mcp__playwright__browser_network_requests,
   mcp__playwright__browser_evaluate, mcp__playwright__browser_resize,
-  mcp__playwright__browser_tabs, mcp__playwright__browser_close
+  mcp__playwright__browser_tabs, mcp__playwright__browser_close,
+  mcp__playwright__browser_handle_dialog
 ---
 
 # Demonstrate Issues (HMIS)
@@ -123,6 +124,13 @@ happened yet) from "see this, X is broken" (the actual cue). Narration that
 describes what's coming next is not itself a capture cue — wait for the
 concrete bug before recording anything.
 
+The same non-capture handling applies to plain navigation/setup
+instructions interspersed between demos — "go to inpatient dashboard",
+"click room details", "now click admit" — where the user is just directing
+the browser to the next thing worth showing, with no bug implied. Follow
+the instruction, but don't treat it as a capture cue on its own; wait for
+the user to actually point out a problem.
+
 If a capture already happened and the user later clarifies that demo #N was not
 meant as a bug report (e.g. "no error in this page yet, just gathering
 facts"), treat that as an explicit instruction to drop the prior capture —
@@ -130,6 +138,33 @@ whether that clarification arrives in the very next message or a later one:
 acknowledge it ("Dropping demo #N — noted as context only") and exclude it
 from the investigation/filing phases. Don't carry the ambiguity forward and
 make the user re-resolve it during investigation.
+
+### Native JS dialogs mid-demo
+
+If a demo step triggers a native `confirm()`/`alert()` (e.g. clicking an
+"Accept" or "Delete" button that pops a browser-native confirmation), the
+page blocks until the dialog is resolved. Don't guess whether to accept or
+dismiss — pause and ask the user explicitly which one they want, especially
+if their reply is short or ambiguous. Once they've said which, call
+`browser_handle_dialog` with `accept: true` or `accept: false` accordingly.
+
+### When an element-targeted screenshot won't crop cleanly
+
+`browser_take_screenshot`'s `element`/`target` params can return the wrong
+region for a specific gridcell/badge/small element — most often after the
+page has scrolled or re-rendered and the accessibility-tree ref has gone
+stale. If that happens, fall back to a full-page screenshot and crop it
+manually (e.g. PowerShell `System.Drawing`) using coordinates read off the
+page's own layout description.
+
+When computing crop coordinates this way, remember the screenshot PNG is in
+**device pixels**, not the CSS pixels the accessibility snapshot reports
+element positions in — on a machine with a >1x device pixel ratio the two
+disagree by that ratio (e.g. a 2000px-wide described layout can produce a
+3455px-wide PNG, a ~1.73x factor). Derive the scale as
+`image_width / described_css_width` and multiply your target CSS
+coordinates by it before cropping, or the crop will land on the wrong
+region.
 
 **HARD STOP** — do not read application code, form a root-cause hypothesis,
 or otherwise start investigating any demo until the end signal in step 4.
@@ -164,7 +199,14 @@ evidence/attachments after redaction) — together for the user's review.
 
 Default is **one GitHub issue per demonstrated bug**, but if two demos seem
 to share a root cause (or one demo should split into two issues), ask the
-user before filing rather than deciding unilaterally.
+user before filing rather than deciding unilaterally. If the user asks for
+every demo in the batch to be filed as a single combined issue, structure it
+as one issue with a `## Part N` section per demo — each section keeping its
+own full template (summary, environment, repro, expected/actual, root
+cause, evidence) so the parts stay independently actionable/closeable via
+checkboxes despite sharing one issue number. Ask the user if it's unclear
+whether they want this per-section structure or a single merged narrative
+instead.
 
 **HARD STOP** — do not file anything until the user confirms the exact
 final body and attachments for this batch.


### PR DESCRIPTION
## Summary

Documents 5 gaps between the `demonstrate-issues` skill's current instructions and what a real 2026-08-20 session (which filed #23145) actually needed. Skill documentation only — no application code touched, no build/deploy/DB verification required.

## Decisions made without approval

- **No functional ambiguity to resolve here** — all 5 changes were directly specified by issue #23146's own "Suggested fix" for each gap, so this PR implements those verbatim rather than interpreting anything new. The one small judgment call: reordered the new "Native JS dialogs" subsection to sit after the existing "drop a prior capture" paragraph rather than splitting it, so the step-3 flow reads in a more natural order (this is presentation only, doesn't change any instruction's content).

## Changes

1. Added `mcp__playwright__browser_handle_dialog` to `allowed-tools`, plus a new "Native JS dialogs mid-demo" subsection: pause and ask the user explicitly which to choose (accept/dismiss) rather than guessing from a short/ambiguous reply.
2. New "When an element-targeted screenshot won't crop cleanly" subsection: documents the full-page-screenshot + manual-crop fallback for when `element`/`target` params return the wrong region (stale ref after scroll/re-render).
3. Same subsection also documents the CSS-pixel vs. device-pixel scale gotcha (e.g. `image_width / described_css_width` ratio) that has to be applied before cropping, or the crop lands on the wrong region.
4. Step 6 ("Discuss before filing") now has an explicit third grouping option: file every demo in the batch as one combined issue with `## Part N` sections, alongside the existing one-issue-per-demo default and the merge/split cases.
5. "Forward-looking narration vs a firm bug cue" now also names plain navigation/setup instructions ("go to X", "click Y") as a third category that doesn't trigger a capture on its own — same handling as scene-setting narration.

## Test plan

Documentation-only change (`.claude/skills/demonstrate-issues/SKILL.md`) — no build or runtime verification applicable. Reviewed the rendered instructions read correctly in order and don't contradict the existing hard-stop structure.

- [x] Diff reviewed for correctness against each of #23146's 5 numbered gaps
- [x] No application code (`src/`) touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
