### PR TITLE
fix(pharmacy): include Direct Purchase Cancellation in movement out report

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySummaryReportController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySummaryReportController.java
@@ -979,6 +979,7 @@ public class PharmacySummaryReportController implements Serializable {
                 BillTypeAtomic.PHARMACY_ISSUE,
                 BillTypeAtomic.PHARMACY_ISSUE_CANCELLED,
                 BillTypeAtomic.PHARMACY_ISSUE_RETURN,
+                BillTypeAtomic.PHARMACY_DIRECT_PURCHASE_CANCELLED,
                 BillTypeAtomic.PHARMACY_DIRECT_PURCHASE_REFUND
         );
     }

--- a/src/main/java/com/divudi/service/BillService.java
+++ b/src/main/java/com/divudi/service/BillService.java
@@ -2751,6 +2751,12 @@ public class BillService {
         // norm). An earlier version of this query special-cased this bill type to skip negation,
         // which was backwards and displayed real returns with a negative out-quantity - see #21833.
         //
+        // Direct Purchase Cancellation follows the identical convention: PharmacyBillSearch.
+        // pharmacyPurchaseCancel() -> pharmacyCancelBillItemsReduceStock() calls
+        // PharmaceuticalBillItem.invertValue(), which negates qty relative to the original
+        // (positive) Direct Purchase pbi.qty - so the plain negation below is already correct
+        // for it too, no CASE WHEN needed.
+        //
         // Pending (not yet approved) Direct Purchase Return bills are excluded below: pbi.qty is
         // only sign-flipped to the correct negative-for-out value at approval time
         // (DirectPurchaseReturnWorkflowController.completeApproval() -> updateStock()); before


### PR DESCRIPTION
## Summary

Fixes #21833. The reporter (@Irani96) confirmed the original fix (PR #22307, #22688, #22690) as "not fix" on 2026-08-19 with screenshots showing a Direct Purchase-related bill still missing from the report for a given day.

## Root cause

`getPharmacyMovementOutBillTypes()` in `PharmacySummaryReportController` included `PHARMACY_DIRECT_PURCHASE_REFUND` (supplier return) but was missing `PHARMACY_DIRECT_PURCHASE_CANCELLED` (cancelling a completed Direct Purchase). Both represent stock leaving — a cancellation reverses the stock a Direct Purchase brought in, the same as a return does.

The reporter's screenshot showed a bill filtered under "Pharmacy Direct Purchase" bill type (which groups both `PHARMACY_DIRECT_PURCHASE` and `PHARMACY_DIRECT_PURCHASE_CANCELLED` under `BillType.PharmacyPurchaseBill`) with a **negative** net value (-20.00) — the signature of a cancelled purchase, not a plain purchase. That's exactly the row this report was silently dropping.

## Decisions made without approval

- **Confirmed the sign convention before trusting the existing `sum(pbi.qty) * -1` formula**, rather than assuming it would work like it does for other bill types — a previous fix for this same issue (#22688) got this backwards for `PHARMACY_DIRECT_PURCHASE_REFUND` and had to be corrected. Traced the actual writer (`PharmacyBillSearch.pharmacyPurchaseCancel()` → `pharmacyCancelBillItemsReduceStock()` → `PharmaceuticalBillItem.invertValue()`) and confirmed it negates `pbi.qty` relative to the original (positive) Direct Purchase quantity — matching the documented convention in `PharmacyAsyncReportService.java`'s Item Movement Summary report ("Quantities should be minus, values should be plus" for `PHARMACY_DIRECT_PURCHASE_CANCELLED`, identical to `PHARMACY_DIRECT_PURCHASE_REFUND`). No `CASE WHEN` special-case needed, unlike the earlier REFUND bug.
- **Left `PHARMACY_DIRECT_PURCHASE` (the plain purchase, not cancellation) out of scope** — confirmed still intentional per the original fix's reasoning; it's a stock-IN transaction that belongs to procurement/IN reports, not this OUT report.
- **Did not touch `PHARMACY_GRN_CANCELLED` / `PHARMACY_GRN_RETURN`** — those aren't in this report's bill-type list either, but the issue and reporter's evidence are scoped to Direct Purchase only; that looked out of scope for this fix.

## Verification

Local DB already had a real cancelled Direct Purchase bill (Galle Co-op, Main Pharmacy, bill `MPPURCAN/16`, Yanker Suction Set, -5 units / -6500 purchase value) from before this fix — reused it instead of creating new data.

- Confirmed via direct SQL simulation of the fixed JPQL that the "By Item" aggregate now returns the item with the correct **positive** out-quantity (5) and correct net value (-6500).
- Confirmed via SQL that the bill now matches the "By Bill" view's WHERE clause (previously excluded).
- Confirmed end-to-end in the actual running app (screenshot below) — "YANKER SUCTION SET" now appears in the By Item view with Qty 5, Net -6,500.00.

![By Item view showing YANKER SUCTION SET now included](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/21833-movement-out-report-direct-purchase-cancelled-fixed.png)

Note: the "By Bill" view on this report has a pre-existing, unrelated N+1 performance issue (documented in `developer_docs/testing/playwright-e2e-workflow.md` §52) that made it too slow to screenshot directly for a full day/institution scope — not something this fix touches or introduces.

## Test plan

- [x] Verified fix via direct SQL simulation of the JPQL query
- [x] Verified end-to-end in the browser against real local data (Galle Co-op)
- [x] Confirmed `PHARMACY_DIRECT_PURCHASE_CANCELLED` now appears in "Included Pharmacy Bill Types" list on the report page
- [x] `mvn compile` passes with JDK 11

🤖 Generated with [Claude Code](https://claude.ai/code)