### PR TITLE
fix(pharmacy): show stock qty for both departments on transfer request approval

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
@@ -349,6 +349,26 @@ public class TransferRequestController implements Serializable {
         return getAvailableQtyAtOrderingStore(bi) < bi.getQty();
     }
 
+    private final Map<BillItem, Double> availableQtyAtRequestingDepartmentCache = new WeakHashMap<>();
+
+    public double getAvailableQtyAtRequestingDepartment(BillItem bi) {
+        if (bi == null || bi.getItem() == null
+                || getTransferRequestBillPre() == null
+                || getTransferRequestBillPre().getFromDepartment() == null) {
+            return 0.0;
+        }
+        return availableQtyAtRequestingDepartmentCache.computeIfAbsent(bi, this::calculateAvailableQtyAtRequestingDepartment);
+    }
+
+    private double calculateAvailableQtyAtRequestingDepartment(BillItem bi) {
+        Item item = bi.getItem();
+        double stock = stockService.findDepartmentStock(getTransferRequestBillPre().getFromDepartment(), item);
+        if ((item instanceof Ampp || item instanceof Vmpp) && item.getDblValue() > 0) {
+            return stock / item.getDblValue();
+        }
+        return stock;
+    }
+
     // Value of the stock already available at the Ordering Store, priced at the
     // same config-selected transfer rate (see determineTransferRate) already
     // shown in the row's Transfer Rate/Transfer Value columns.

--- a/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
@@ -353,8 +353,8 @@ public class TransferRequestController implements Serializable {
 
     public double getAvailableQtyAtRequestingDepartment(BillItem bi) {
         if (bi == null || bi.getItem() == null
-                || getTransferRequestBillPre() == null
-                || getTransferRequestBillPre().getFromDepartment() == null) {
+                || transferRequestBillPre == null
+                || transferRequestBillPre.getFromDepartment() == null) {
             return 0.0;
         }
         return availableQtyAtRequestingDepartmentCache.computeIfAbsent(bi, this::calculateAvailableQtyAtRequestingDepartment);
@@ -362,7 +362,7 @@ public class TransferRequestController implements Serializable {
 
     private double calculateAvailableQtyAtRequestingDepartment(BillItem bi) {
         Item item = bi.getItem();
-        double stock = stockService.findDepartmentStock(getTransferRequestBillPre().getFromDepartment(), item);
+        double stock = stockService.findDepartmentStock(transferRequestBillPre.getFromDepartment(), item);
         if ((item instanceof Ampp || item instanceof Vmpp) && item.getDblValue() > 0) {
             return stock / item.getDblValue();
         }

--- a/src/main/webapp/pharmacy/pharmacy_transfer_request_approval.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_request_approval.xhtml
@@ -95,6 +95,13 @@
                                         </p:inputText>
                                     </p:column>
 
+                                    <p:column headerText="Available Qty (Requesting Department)" class="text-end" width="10em">
+                                        <h:outputText
+                                            value="#{transferRequestController.getAvailableQtyAtRequestingDepartment(bi)}">
+                                            <f:convertNumber pattern="#,##0.#"/>
+                                        </h:outputText>
+                                    </p:column>
+
                                     <p:column headerText="Available Qty (Ordering Store)" class="text-end" width="10em">
                                         <h:outputText
                                             value="#{transferRequestController.getAvailableQtyAtOrderingStore(bi)}"


### PR DESCRIPTION
## What changed

Issue #22907 was reopened after @Irani96's "Not fix" comment on the original
fix (PR #22952, merged): that PR added a "Total Drug Amount" column priced
off the Ordering Store's (to-department's) stock, but the reporter needed
plain stock-quantity visibility for the **requesting** department too, as a
pure stock overview for the pharmacist (independent of the requested
transfer qty).

This PR adds that missing piece:

- **`TransferRequestController.java`** — new `getAvailableQtyAtRequestingDepartment(BillItem)`
  getter (+ cache), mirroring the existing `getAvailableQtyAtOrderingStore()`
  pattern but sourced from `transferRequestBillPre.getFromDepartment()`
  instead of `toDepartment`.
- **`pharmacy_transfer_request_approval.xhtml`** — new **"Available Qty
  (Requesting Department)"** column, placed before the existing "Available
  Qty (Ordering Store)" column. The existing Ordering Store qty/amount/rate/value
  columns from #22952 are unchanged.

Resulting column order: Item → Pack Size → Qty → **Available Qty (Requesting
Department)** *(new)* → Available Qty (Ordering Store) → Total Drug Amount
(Ordering Store) → Transfer Rate → Transfer Value.

## Verification (local Payara, DB-checked)

Tested against pending transfer request **OP/MP/26/000025** (Main Pharmacy →
OPD Pharmacy, item "Amoxicillin 250mg capsules", qty 10 requested), logged in
as a Main Pharmacy user (the requesting department, which does its own
maker-checker approval per the existing code comment in
`saveTransferRequestPreBillAndBillItems()`):

- New **Available Qty (Requesting Department)** rendered **2,237** — Main
  Pharmacy's own stock for the item.
- Existing **Available Qty (Ordering Store)** rendered **149** — OPD
  Pharmacy's stock, unchanged.
- Cross-checked both numbers directly against the DB (`SUM(STOCK.STOCK)`
  across the item's `Amp` batches, grouped by department) — exact match for
  both departments.
- The pending request bill was left untouched (not approved) during
  verification.

![Both-department stock qty columns](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/22907-after-both-department-stock-columns.png)

Closes #22907

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transfer request approvals now display the available quantity for each item in the requesting department.
  * Quantities are shown with up to one decimal place and account for applicable pack conversions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->