### PR TITLE
fix(ci): allow development to merge into new QA/staging infra branches

### DIFF
--- a/.github/workflows/branch_merge_validation.yml
+++ b/.github/workflows/branch_merge_validation.yml
@@ -7,6 +7,7 @@ on:
       - '*-prod'
       - 'staging'
       - 'hims-qa*'
+      - 'rh-local-staging'
 
 jobs:
   check-branch:
@@ -27,14 +28,19 @@ jobs:
               echo "❌ Merging from $SOURCE to $TARGET is not allowed. If this is a hot-fix, please check if branch name ends with '-hotfix'."
               exit 1
             fi
-          elif [[ "$TARGET" == "hims-qa1" || "$TARGET" == "hims-qa2" || "$TARGET" == "hims-qa3" ]]; then
+          elif [[ "$TARGET" == "hims-qa1" || "$TARGET" == "hims-qa2" || "$TARGET" == "hims-qa3" || "$TARGET" == "hims-qa4" || "$TARGET" == "hims-qa1-migrated" || "$TARGET" == "hims-qa2-migrated" || "$TARGET" == "hims-qa3-migrated" || "$TARGET" == "hims-qa4-migrated" ]]; then
             if [[ "$SOURCE" != "development" ]]; then
               echo "❌ Only development can merge to $TARGET (qa restriction)."
               exit 1
             fi
           elif [[ "$TARGET" == "staging" ]]; then
-            if [[ "$SOURCE" != "hims-qa1" && "$SOURCE" != "hims-qa2" && "$SOURCE" != "hims-qa3" ]]; then
-              echo "❌ Only hims-qa1, hims-qa2 and hims-qa3 can merge to $TARGET (staging restriction)."
+            if [[ "$SOURCE" != "hims-qa1" && "$SOURCE" != "hims-qa2" && "$SOURCE" != "hims-qa3" && "$SOURCE" != "hims-qa4" && "$SOURCE" != "hims-qa1-migrated" && "$SOURCE" != "hims-qa2-migrated" && "$SOURCE" != "hims-qa3-migrated" && "$SOURCE" != "hims-qa4-migrated" && "$SOURCE" != "development" ]]; then
+              echo "❌ Only the hims-qa branches or development can merge to $TARGET (staging restriction)."
+              exit 1
+            fi
+          elif [[ "$TARGET" == "rh-local-staging" ]]; then
+            if [[ "$SOURCE" != "development" ]]; then
+              echo "❌ Only development can merge to $TARGET (rh-local-staging restriction)."
               exit 1
             fi
           fi


### PR DESCRIPTION
## Summary
- Branch Merge Validation workflow only recognized `hims-qa1/2/3` and `staging` as merge targets, and only `hims-qa1/2/3` as valid sources into `staging`.
- This blocked syncing `development` into the new infra QA branches (`hims-qa1-4-migrated`), `staging` directly, and `rh-local-staging` — all currently needed to trigger CI/CD to the new infra.

## Changes
- Added `hims-qa4` and all four `hims-qaN-migrated` branches as valid `development` merge targets.
- Added `development` as a valid source into `staging` (alongside the existing `hims-qa1/2/3`).
- Added `rh-local-staging` as a new valid `development` merge target, and added it to the workflow's trigger filter.

## Test plan
- [ ] Confirm `check-branch` passes on the pending sync PRs targeting `hims-qa1-4-migrated`, `staging`, and `rh-local-staging` once this merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added `rh-local-staging` as a supported pull-request target branch.
  - Expanded QA validation to include migrated QA branches.
  - Updated staging merge rules to support regular and migrated QA branches, plus `development`.
  - Restricted merges into `rh-local-staging` to `development` only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->