### PR TITLE
feat(collecting-centre): show reference bill details on CC repayment reprint page

### DIFF
--- a/src/main/webapp/collecting_centre/cc_repayment_bill_reprint.xhtml
+++ b/src/main/webapp/collecting_centre/cc_repayment_bill_reprint.xhtml
@@ -35,7 +35,7 @@
                                         disabled="#{collectingCentrePaymentController.currentPaymentBill.cancelled}"
                                         icon="fa fa-times">
                                     </p:commandButton>
-                                    
+
                                     <p:commandButton 
                                         class="ui-button-warning"
                                         ajax="false"
@@ -43,7 +43,7 @@
                                         action="/collecting_centre/collecting_centre_repayment_bill_search?faces-redirect=true"
                                         icon="fa fa-long-arrow-left">
                                     </p:commandButton>
-                                    
+
                                 </div>
                             </div>
 
@@ -68,6 +68,8 @@
                                     </p:panel>
                                 </p:panelGrid>
 
+
+
                             </div>
 
                             <div class="col-md-6">
@@ -76,6 +78,63 @@
                                 </h:panelGroup>
                             </div>
 
+                        </div>
+
+                        <div class="mt-3">
+                            <p:panel header="" >
+                                <f:facet name="header">
+                                    <div class="d-flex justify-content-between">
+                                        <h:outputLabel value="Reference Bill Details" class="mt-2"/>
+                                        <p:commandButton 
+                                            class="mx-2 ui-button-success" 
+                                            icon="fas fa-file-excel"
+                                            ajax="false" 
+                                            value="Export Excel">
+                                            <p:dataExporter type="xlsx" target="referenceBillDetails" fileName="CC Payment Reference Bill Details" />
+                                        </p:commandButton>
+                                    </div>
+                                </f:facet>
+                                <p:dataTable 
+                                    value="#{billBeanController.fetchBillItems(collectingCentrePaymentController.currentPaymentBill)}"
+                                    var="bip" 
+                                    rowIndexVar="i"
+                                    style="margin: auto; padding: 1%; width: 100%; margin-right: 10%; " 
+                                    paginator="true" 
+                                    rows="20"
+                                    id="referenceBillDetails"
+                                    paginatorPosition="bottom"
+                                    paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                    rowsPerPageTemplate="20,50,100">
+
+                                    <p:column style="text-align: center; margin-left: 10%; padding: 6px;" width="3em;" headerText="#">
+                                        <h:outputLabel value="#{i+1}"/>
+                                    </p:column>
+
+                                    <p:column style="text-align: left; padding: 6px;" headerText="Bill No" width="12em;">
+                                        <h:outputLabel value="#{bip.referenceBill.deptId}"/>
+                                    </p:column>
+
+                                    <p:column style="text-align: left; padding: 6px;" headerText="Bill At" width="12em;">
+                                        <h:outputLabel value="#{bip.referenceBill.createdAt}">
+                                            <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                        </h:outputLabel>
+                                    </p:column>
+
+                                    <p:column style="text-align: left; padding: 6px;" width="8em;" headerText="Ref. Number">
+                                        <h:outputLabel value="#{bip.referenceBill.referenceNumber}"/>
+                                    </p:column>
+
+                                    <p:column style="text-align: left; padding: 6px;" headerText="Patient Name">
+                                        <h:outputLabel value="#{bip.referenceBill.patient.person.nameWithTitle}"/>
+                                    </p:column>
+
+                                    <p:column style="text-align: right; width: 8em; padding: 6px;" headerText="Amount">
+                                        <h:outputLabel value="#{bip.netValue}" class="d-flex justify-content-end mx-2">
+                                            <f:convertNumber pattern="#,##0.00" />
+                                        </h:outputLabel>
+                                    </p:column>
+                                </p:dataTable>
+                            </p:panel>
                         </div>
                     </p:panel>
                 </h:form>

--- a/src/main/webapp/collecting_centre/cc_repayment_bill_reprint.xhtml
+++ b/src/main/webapp/collecting_centre/cc_repayment_bill_reprint.xhtml
@@ -84,7 +84,7 @@
                             <p:panel header="" >
                                 <f:facet name="header">
                                     <div class="d-flex justify-content-between">
-                                        <h:outputLabel value="Reference Bill Details" class="mt-2"/>
+                                        <h:outputText value="Reference Bill Details" class="mt-2"/>
                                         <p:commandButton 
                                             class="mx-2 ui-button-success" 
                                             icon="fas fa-file-excel"
@@ -107,31 +107,31 @@
                                     rowsPerPageTemplate="20,50,100">
 
                                     <p:column style="text-align: center; margin-left: 10%; padding: 6px;" width="3em;" headerText="#">
-                                        <h:outputLabel value="#{i+1}"/>
+                                        <h:outputText value="#{i+1}"/>
                                     </p:column>
 
                                     <p:column style="text-align: left; padding: 6px;" headerText="Bill No" width="12em;">
-                                        <h:outputLabel value="#{bip.referenceBill.deptId}"/>
+                                        <h:outputText value="#{bip.referenceBill.deptId}"/>
                                     </p:column>
 
                                     <p:column style="text-align: left; padding: 6px;" headerText="Bill At" width="12em;">
-                                        <h:outputLabel value="#{bip.referenceBill.createdAt}">
+                                        <h:outputText value="#{bip.referenceBill.createdAt}">
                                             <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
-                                        </h:outputLabel>
+                                        </h:outputText>
                                     </p:column>
 
                                     <p:column style="text-align: left; padding: 6px;" width="8em;" headerText="Ref. Number">
-                                        <h:outputLabel value="#{bip.referenceBill.referenceNumber}"/>
+                                        <h:outputText value="#{bip.referenceBill.referenceNumber}"/>
                                     </p:column>
 
                                     <p:column style="text-align: left; padding: 6px;" headerText="Patient Name">
-                                        <h:outputLabel value="#{bip.referenceBill.patient.person.nameWithTitle}"/>
+                                        <h:outputText value="#{bip.referenceBill.patient.person.nameWithTitle}"/>
                                     </p:column>
 
                                     <p:column style="text-align: right; width: 8em; padding: 6px;" headerText="Amount">
-                                        <h:outputLabel value="#{bip.netValue}" class="d-flex justify-content-end mx-2">
+                                        <h:outputText value="#{bip.netValue}" class="d-flex justify-content-end mx-2">
                                             <f:convertNumber pattern="#,##0.00" />
-                                        </h:outputLabel>
+                                        </h:outputText>
                                     </p:column>
                                 </p:dataTable>
                             </p:panel>


### PR DESCRIPTION
## Summary
- Adds a "Reference Bill Details" panel to the CC payment bill reprint page (`cc_repayment_bill_reprint.xhtml`) that lists the original reference bills covered by the CC repayment bill (Bill No, Bill At, Reference Number, Patient Name, Amount).
- Adds an "Export Excel" button on the new panel to export the reference bill list.
- Minor whitespace cleanup around existing action buttons.

Closes #23160

## Test plan
- [ ] Open a CC repayment bill's reprint page and confirm the Reference Bill Details panel lists the correct reference bills and amounts for that repayment
- [ ] Confirm Export Excel produces a correct spreadsheet of the reference bill list
- [ ] Confirm existing Print / To Cancel / Back actions on the page still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Reference Bill Details” panel showing related bill items, bill metadata, patient information, and amounts.
  * Added pagination for related bill records.
  * Added Excel export support for bill details.

* **Style**
  * Improved spacing and layout around existing elements.
  * Improved display consistency for panel titles and table values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->