### PR TITLE
fix(pharmacy): set explicit width for Item Name column in transfer request approval

### DIFF
--- a/src/main/webapp/pharmacy/pharmacy_transfer_request_approval.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_transfer_request_approval.xhtml
@@ -57,7 +57,7 @@
                                     id="itemList"
                                     editable="true" >
 
-                                    <p:column headerText="Item Name">
+                                    <p:column headerText="Item Name" width="20em">
                                         <h:outputText
                                             id="item"
                                             value="#{bi.item.name}" />


### PR DESCRIPTION
## Summary
- The "Item Name" column in the Bill Items table on the Pharmacy Transfer Request Approval page had no explicit width, unlike every other column in the table.
- Added `width="20em"` to the "Item Name" `p:column`, matching the fixed-width pattern already used by the Pack Size, Qty, Available Qty, Transfer Rate, and other columns in the same table.

## Change
- `src/main/webapp/pharmacy/pharmacy_transfer_request_approval.xhtml` — added `width="20em"` to the Item Name column.

This is an XHTML-only markup change, no Java changes.

## Test plan
- [x] JSF-only change (no compilation needed per project guidelines)
- [ ] Load Pharmacy > Disbursement > Transfer Request Approval page and confirm the Item Name column renders at a consistent width alongside the other columns, with long item names readable.

Closes #23162

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Set a fixed width for the “Item Name” column in pharmacy transfer request approvals to improve table layout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->