### PR TITLE
fix(pharmacy): set explicit width for Item column in BHT pharmacy bill issue

### DIFF
--- a/src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml
+++ b/src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml
@@ -432,7 +432,7 @@
                                     <p:column headerText="#" width="2em">
                                         <h:outputText value="#{s+1}"></h:outputText>
                                     </p:column>
-                                    <p:column headerText="Item" style="min-width: 20em;">
+                                    <p:column headerText="Item" style="width: 26em;">
                                         <h:outputText value="#{bid.itemName}"></h:outputText>
                                         <p:commandButton
                                             rendered="#{!bid.fromPackage}"


### PR DESCRIPTION
## Summary
- The "Item" column in the Bill Items table on the Inward Pharmacy Bill Issue (BHT) page (`pharmacy_bill_issue_bht.xhtml`) only had `min-width: 20em;`, unlike the other columns which use fixed widths.
- Changed it to an explicit `width: 26em;` so item names render consistently and readably, matching the fix already applied to the Pharmacy Transfer Request Approval page (#23162).

## Test plan
- [ ] Open Inward > a BHT with an in-progress pharmacy issue > Pharmacy Bill Issue page.
- [ ] Add bill items with long item names and confirm the Item column renders at a consistent, readable width.
- [ ] JSF-only change (XHTML style attribute) — no Java compilation required.

Closes #23168

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the pharmacy bill items table layout by widening the Item column for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->