### PR TITLE
fix(pharmacy): resolve BHT request department from patient's ward, not session

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyRequestForBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyRequestForBhtController.java
@@ -1073,8 +1073,8 @@ public class PharmacyRequestForBhtController implements Serializable {
         // From: ward (patient's current room department)
         Department fromDept = getPatientEncounter().getCurrentPatientRoom().getRoomFacilityCharge().getDepartment();
 
-        getPreBill().setDepartment(sessionController.getDepartment());
-        getPreBill().setInstitution(sessionController.getInstitution());
+        getPreBill().setDepartment(fromDept);
+        getPreBill().setInstitution(fromDept.getInstitution());
 
         getPreBill().setFromDepartment(fromDept);
         getPreBill().setFromInstitution(fromDept.getInstitution());
@@ -1085,7 +1085,7 @@ public class PharmacyRequestForBhtController implements Serializable {
         getPreBill().setBillTypeAtomic(bta);
         getPreBill().setBillType(bt);
         getPreBill().setComments(comment);
-        String deptId = getBillNumberBean().departmentBillNumberGeneratorYearly(sessionController.getDepartment(), bta);
+        String deptId = getBillNumberBean().departmentBillNumberGeneratorYearly(fromDept, bta);
         getPreBill().setDeptId(deptId);
         getPreBill().setInsId(deptId);
         if (getPreBill().getId() == null) {
@@ -1731,6 +1731,9 @@ public class PharmacyRequestForBhtController implements Serializable {
         if (wardDept == null || wardDept.getId() == null || pharmacy == null || pharmacy.getId() == null) {
             return;
         }
+        if (pharmacy.getDepartmentType() != DepartmentType.Pharmacy) {
+            return;
+        }
         String pharmacyId = String.valueOf(pharmacy.getId());
         configOptionApplicationController.saveShortTextOption(lastPharmacyKey(wardDept), pharmacyId);
 
@@ -1767,7 +1770,11 @@ public class PharmacyRequestForBhtController implements Serializable {
             return null;
         }
         String id = configOptionApplicationController.getShortTextValueByKey(lastPharmacyKey(wardDept), "");
-        return findDepartmentById(id);
+        Department d = findDepartmentById(id);
+        if (d == null || d.getDepartmentType() != DepartmentType.Pharmacy) {
+            return null;
+        }
+        return d;
     }
 
     /**
@@ -1785,7 +1792,7 @@ public class PharmacyRequestForBhtController implements Serializable {
 
         // Default first, if any.
         Department defaultPharmacy = getDefaultRequestedPharmacy();
-        if (defaultPharmacy != null) {
+        if (defaultPharmacy != null && defaultPharmacy.getDepartmentType() == DepartmentType.Pharmacy) {
             result.add(defaultPharmacy);
         }
 
@@ -1793,7 +1800,7 @@ public class PharmacyRequestForBhtController implements Serializable {
         if (csv != null && !csv.trim().isEmpty()) {
             for (String token : csv.split(",")) {
                 Department d = findDepartmentById(token.trim());
-                if (d != null && !result.contains(d)) {
+                if (d != null && d.getDepartmentType() == DepartmentType.Pharmacy && !result.contains(d)) {
                     result.add(d);
                 }
                 if (result.size() >= MAX_RECENT_PHARMACIES) {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyRequestForBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyRequestForBhtController.java
@@ -1073,6 +1073,11 @@ public class PharmacyRequestForBhtController implements Serializable {
         // From: ward (patient's current room department)
         Department fromDept = getPatientEncounter().getCurrentPatientRoom().getRoomFacilityCharge().getDepartment();
 
+        if (fromDept == null || fromDept.getInstitution() == null) {
+            JsfUtil.addErrorMessage("Please set the department and institution for the patient's current room.");
+            return false;
+        }
+
         getPreBill().setDepartment(fromDept);
         getPreBill().setInstitution(fromDept.getInstitution());
 


### PR DESCRIPTION
## What

Fixes #23167 — "Request from Pharmacy" created a bill with `department`/`toDepartment` reversed whenever the operator was logged into a non-ward department (e.g. a pharmacy) instead of the patient's actual ward, making the request invisible to any pharmacy's "Issue for Requests" queue forever, with no error shown.

## Root cause

`PharmacyRequestForBhtController.persistBhtRequest(...)` (the live save path behind **Settle Request**) already resolved the patient's actual ward into a local `fromDept` variable and used it correctly for `bill.fromDepartment` — but set `bill.department` (and generated the bill number) from `sessionController.getDepartment()` instead of reusing `fromDept`. A copy-paste-style inconsistency: when the operator happened to be logged into the ward, `fromDept == session dept` and nothing looked wrong.

## Fix

1. `persistBhtRequest(...)`: use `fromDept` (not the session department) for `bill.department`, `bill.institution`, and the bill-number generator.
2. Hardened the "Recent:" pharmacy quick-pick (`getRecentRequestedPharmacies`, `getDefaultRequestedPharmacy`, `rememberRequestedPharmacyForWard`) to only ever read/write departments where `departmentType == Pharmacy`, matching the existing filter convention already used by the free-text autocomplete on the same field (`DepartmentController.completeDeptPharmacy`). The quick-pick was already letting a ward (Inward) get offered/recorded as if it were a target pharmacy — a direct, self-perpetuating symptom of the same root cause, confirmed via a poisoned `ConfigOption` (`Recent Requested Pharmacies For Ward 486` = `485,486`) found in the local dev DB.

## Verification (local Payara, DB-verified, screenshots on the issue)

- **Reproduced live before the fix**: creating a request for BHT/56755 (ward: Inward) while logged into Main Pharmacy produced bill `13988723` with `DEPARTMENT_ID=485` (Main Pharmacy), `TODEPARTMENT_ID=486` (Inward) — backwards, never visible in any Issue for Requests queue. (Cancelled as test cleanup afterward.)
- **After the fix**, repeating the exact same steps (still logged into Main Pharmacy) produced bill `Inward//26/038087` with `DEPARTMENT_ID=486` (Inward), `TODEPARTMENT_ID=485` (Main Pharmacy) — correct — and it appears in Main Pharmacy's "Issue for Requests" (Search Not Issued) queue.
- **Quick-pick self-heal confirmed**: reopening the request page from either session now shows only genuine pharmacies in "Recent:" — "Inward" no longer offered.
- **Regression check**: repeated the same request creation from the *correct* (Inward) session — bill came out identical to pre-fix behavior (`DEPARTMENT_ID=486`, `TODEPARTMENT_ID=485`), confirming no change to the already-working path.

Full before/after screenshots and DB evidence: https://github.com/hmislk/hmis/issues/23167#issuecomment-5360266171

![Recent quick-pick no longer offers Inward](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23167-01-recent-chips-inward-removed.png)
![Request bill correctly attributed to Inward despite Main Pharmacy session](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23167-02-request-correct-from-wrong-session.png)
![Request visible in Issue for Requests queue](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23167-03-visible-in-issue-for-requests-queue.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * BHT request bills now use the patient ward’s department and institution for accurate ownership.
  * Department numbers are generated from the patient’s ward department.
  * Pharmacy selections now include only departments classified as Pharmacy.
  * Invalid stored pharmacy selections are filtered out and prevented from being saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->