### PR TITLE
feat(inward): per-patient Theatre Status page and ward-side theatre return acceptance

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -1927,6 +1927,20 @@ actually proves the WAR builds and packages the fix correctly. Verified while
 testing issue #22984 (caught an `outputLabel for=` component-id mismatch this
 way in seconds instead of a multi-minute rebuild).
 
+## 75. `isXxx(arg)` boolean methods with a parameter don't resolve via the JSF EL property-getter convention — drop the `is` prefix
+
+A boolean bean method named `isHasPendingTheatreReturnForAdmission(Admission admission)` and called from EL as
+`#{bean.hasPendingTheatreReturnForAdmission(admissionController.current)}` (mirroring how existing no-arg booleans like
+`isHasPendingRequestsForDepartment()` are already referenced as `hasPendingRequestsForDepartment` elsewhere in the same
+page) throws `javax.el.MethodNotFoundException` at render time — caught immediately by a Playwright pass (500 error
+page) rather than silently misbehaving. The JavaBean `isXxx()`/`getXxx()` → property-name stripping is an EL
+*property-access* convention (`#{bean.propertyName}`, zero arguments only); once the call includes an argument list,
+EL falls back to literal method-name resolution and looks for a method named exactly `hasPendingTheatreReturnForAdmission`,
+not `isHasPendingTheatreReturnForAdmission`. **Fix**: for any boolean helper method that takes a parameter, name it
+*without* the `is` prefix (`hasPendingTheatreReturnForAdmission(Admission)`), matching how the call site will
+naturally read in EL — reserve the `is`/`get` prefix convention for genuine no-arg property getters. Verified while
+testing issue #23166 (theatre transfer per-patient page).
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.

--- a/src/main/java/com/divudi/bean/common/SessionController.java
+++ b/src/main/java/com/divudi/bean/common/SessionController.java
@@ -948,7 +948,12 @@ public class SessionController implements Serializable, HttpSessionListener {
 
     public Department getDepartment() {
         if (department == null) {
-            if (loggedUser == null) {
+            // Fall back to the logged user's own department when nothing has
+            // been cached yet (e.g. sessions established via loginForRequests()
+            // that set loggedUser but never call setDepartment()). The null
+            // check here was previously inverted, NPE-ing whenever loggedUser
+            // was null instead of guarding against it (CodeRabbit #23175).
+            if (loggedUser != null) {
                 if (loggedUser.getDepartment() != null) {
                     department = loggedUser.getDepartment();
                 }

--- a/src/main/java/com/divudi/bean/inward/InwardReservationController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardReservationController.java
@@ -2,6 +2,7 @@ package com.divudi.bean.inward;
 
 import com.divudi.bean.common.ConfigOptionApplicationController;
 import com.divudi.bean.common.SessionController;
+import com.divudi.bean.common.WebUserController;
 import com.divudi.core.data.AppointmentStatus;
 import com.divudi.core.data.DepartmentType;
 import com.divudi.core.data.dto.ReservationDTO;
@@ -13,6 +14,7 @@ import com.divudi.core.entity.inward.Reservation;
 import com.divudi.core.facade.PatientEncounterFacade;
 import com.divudi.core.facade.ReservationFacade;
 import com.divudi.core.util.CommonFunctions;
+import com.divudi.core.util.JsfUtil;
 
 import java.io.Serializable;
 import java.time.LocalDateTime;
@@ -58,6 +60,8 @@ public class InwardReservationController implements Serializable {
     ////////////////////////////
     @Inject
     private SessionController sessionController;
+    @Inject
+    private WebUserController webUserController;
     @Inject
     ConfigOptionApplicationController configOptionApplicationController;
 
@@ -395,6 +399,13 @@ public class InwardReservationController implements Serializable {
     // -----------------------------------------------------------------------
 
     public String navigateToTheatreScheduleCalendar() {
+        // Server-side enforcement to match the rendered guard on the menu/
+        // button entry points — the UI-only check alone doesn't stop a
+        // direct navigation (CodeRabbit #23175).
+        if (!webUserController.hasPrivilege("TheatreAcceptPatient") && !webUserController.hasPrivilege("TheatreSendPatient")) {
+            JsfUtil.addErrorMessage("You are not authorized to view the Theatre Schedule.");
+            return "";
+        }
         currentReservationDTO = null;
         fromDate = CommonFunctions.getStartOfDay();
         Long noOfMonths = configOptionApplicationController.getLongValueByKey(

--- a/src/main/java/com/divudi/bean/inward/PatientTransferController.java
+++ b/src/main/java/com/divudi/bean/inward/PatientTransferController.java
@@ -1057,6 +1057,18 @@ public class PatientTransferController implements Serializable {
             JsfUtil.addErrorMessage("No pending theatre return found for this patient.");
             return;
         }
+        // Same target-department constraint as loadPendingReturnsForWard() —
+        // without it, a user with WardAcceptTheatreReturn could accept a
+        // return bound for a different ward's department (CodeRabbit #23175).
+        Department userDepartment = sessionController.getDepartment();
+        Department targetDepartment = req.getToRoomFacilityCharge() != null
+                ? req.getToRoomFacilityCharge().getDepartment() : null;
+        if (userDepartment == null || userDepartment.getId() == null
+                || targetDepartment == null || targetDepartment.getId() == null
+                || !userDepartment.getId().equals(targetDepartment.getId())) {
+            JsfUtil.addErrorMessage("This theatre return belongs to a different ward.");
+            return;
+        }
         acceptReturnToWard(req);
         loadTheatreStatusForAdmission(admission);
     }

--- a/src/main/java/com/divudi/bean/inward/PatientTransferController.java
+++ b/src/main/java/com/divudi/bean/inward/PatientTransferController.java
@@ -81,6 +81,12 @@ public class PatientTransferController implements Serializable {
     private List<PatientTransferRequest> inTheatreRequests;
     private List<PatientTransferRequest> pendingReturnRequests;
 
+    // Focused single-admission theatre status view — the active theatre
+    // transfer and any pending return-to-ward request for one admission,
+    // used by the per-patient Theatre Status page (#23166)
+    private PatientTransferRequest currentTheatreRequest;
+    private PatientTransferRequest currentTheatreReturnRequest;
+
     public List<Admission> completePatientByInstitution(String query) {
         return admissionController.completePatientNotFinalizedByInstitution(query, getInstitution());
     }
@@ -926,6 +932,141 @@ public class PatientTransferController implements Serializable {
                 + "ORDER BY b.createdAt";
         List<Bill> result = billFacade.findByJpql(jpql, params);
         return result != null ? result : new ArrayList<>();
+    }
+
+    /**
+     * Focused single-admission theatre status flow launched from the
+     * Inpatient Dashboard / Nursing WorkBench — shows the live theatre
+     * workflow milestones for just this admission instead of the
+     * department-wide theatre worklists (#23166, mirrors the
+     * navigateToPatientAcceptForAdmission pattern from #22420).
+     */
+    public String navigateToTheatreStatus(Admission admission) {
+        if (admission == null) {
+            JsfUtil.addErrorMessage("No patient selected.");
+            return "";
+        }
+        current = admission;
+        loadTheatreStatusForAdmission(admission);
+        return "/inward/inward_theatre_status?faces-redirect=true";
+    }
+
+    /**
+     * Loads the active theatre transfer and any pending return-to-ward
+     * request scoped to a single admission (#23166).
+     */
+    private void loadTheatreStatusForAdmission(Admission admission) {
+        if (admission == null) {
+            currentTheatreRequest = null;
+            currentTheatreReturnRequest = null;
+            return;
+        }
+        currentTheatreRequest = findActiveSendToTheatreRequest(admission);
+        currentTheatreReturnRequest = findPendingReturnRequestForAdmission(admission);
+    }
+
+    /**
+     * Finds the PENDING RETURN_TO_WARD request for a single admission, if
+     * any — mirrors findActiveSendToTheatreRequest (#23166).
+     */
+    public PatientTransferRequest findPendingReturnRequestForAdmission(Admission admission) {
+        if (admission == null) {
+            return null;
+        }
+        HashMap<String, Object> params = new HashMap<>();
+        params.put("admission", admission);
+        params.put("type", TheatreTransferType.RETURN_TO_WARD);
+        params.put("status", TransferRequestStatus.PENDING);
+        String jpql = "SELECT r FROM PatientTransferRequest r "
+                + "WHERE r.admission = :admission "
+                + "AND r.theatreTransferType = :type "
+                + "AND r.status = :status "
+                + "AND r.retired = false "
+                + "ORDER BY r.createdAt DESC";
+        List<PatientTransferRequest> results = patientTransferRequestFacade.findByJpql(jpql, params, 1);
+        return (results != null && !results.isEmpty()) ? results.get(0) : null;
+    }
+
+    /**
+     * True when there is a PENDING theatre return request for this admission
+     * (#23166). Named without the "is" prefix (unlike the no-arg
+     * isHasPendingTheatreRequestsForDepartment()-style booleans elsewhere in
+     * this class) because JSF EL only applies the isXxx()/getXxx() JavaBean
+     * property convention to no-argument property access — a parameterized
+     * call like #{bean.hasPendingTheatreReturnForAdmission(x)} resolves by
+     * the literal method name, not the "is"-stripped property name.
+     */
+    public boolean hasPendingTheatreReturnForAdmission(Admission admission) {
+        return findPendingReturnRequestForAdmission(admission) != null;
+    }
+
+    /**
+     * Accept from the single-admission focused theatre status view (#23166)
+     * — delegates to acceptInTheatre() then refreshes the admission-scoped
+     * theatre status instead of the department-wide worklists.
+     */
+    public void acceptInTheatreForAdmission(PatientTransferRequest req) {
+        Admission admission = req != null ? req.getAdmission() : current;
+        acceptInTheatre(req);
+        loadTheatreStatusForAdmission(admission);
+    }
+
+    /**
+     * Mark In Theatre from the single-admission focused theatre status view
+     * (#23166) — delegates to markInTheatre() then refreshes the
+     * admission-scoped theatre status.
+     */
+    public void markInTheatreForAdmission(PatientTransferRequest req) {
+        Admission admission = req != null ? req.getAdmission() : current;
+        markInTheatre(req);
+        loadTheatreStatusForAdmission(admission);
+    }
+
+    /**
+     * Mark Procedure Completed from the single-admission focused theatre
+     * status view (#23166) — delegates to markProcedureCompleted() then
+     * refreshes the admission-scoped theatre status.
+     */
+    public void markProcedureCompletedForAdmission(PatientTransferRequest req) {
+        Admission admission = req != null ? req.getAdmission() : current;
+        markProcedureCompleted(req);
+        loadTheatreStatusForAdmission(admission);
+    }
+
+    /**
+     * Return To Ward from the single-admission focused theatre status view
+     * (#23166) — delegates to returnToWard() then refreshes the
+     * admission-scoped theatre status.
+     */
+    public void returnToWardForAdmission(PatientTransferRequest req) {
+        Admission admission = req != null ? req.getAdmission() : current;
+        returnToWard(req);
+        loadTheatreStatusForAdmission(admission);
+    }
+
+    /**
+     * Accept Return To Ward from the single-admission focused theatre status
+     * view (#23166). Takes an Admission (not a request) since this is also
+     * called directly from the Inpatient Dashboard / Nursing WorkBench
+     * buttons, which only have the Admission in scope, not the return
+     * request object.
+     */
+    public void acceptReturnToWardForAdmission(Admission admission) {
+        PatientTransferRequest req = findPendingReturnRequestForAdmission(admission);
+        if (req == null) {
+            JsfUtil.addErrorMessage("No pending theatre return found for this patient.");
+            return;
+        }
+        acceptReturnToWard(req);
+        loadTheatreStatusForAdmission(admission);
+    }
+
+    public PatientTransferRequest getCurrentTheatreRequest() {
+        return currentTheatreRequest;
+    }
+
+    public PatientTransferRequest getCurrentTheatreReturnRequest() {
+        return currentTheatreReturnRequest;
     }
 
     public List<Bill> getSurgeryBillsForCurrentAdmission() {

--- a/src/main/java/com/divudi/bean/inward/TheatreDashboardController.java
+++ b/src/main/java/com/divudi/bean/inward/TheatreDashboardController.java
@@ -1,6 +1,7 @@
 package com.divudi.bean.inward;
 
 import com.divudi.bean.common.SessionController;
+import com.divudi.bean.common.WebUserController;
 import com.divudi.core.data.DepartmentType;
 import com.divudi.core.data.inward.TheatreOccupancyStatus;
 import com.divudi.core.data.inward.TheatreTransferType;
@@ -9,6 +10,7 @@ import com.divudi.core.entity.inward.PatientTransferRequest;
 import com.divudi.core.entity.inward.RoomFacilityCharge;
 import com.divudi.core.facade.PatientTransferRequestFacade;
 import com.divudi.core.facade.RoomFacilityChargeFacade;
+import com.divudi.core.util.JsfUtil;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -29,6 +31,8 @@ public class TheatreDashboardController implements Serializable {
     @Inject
     private SessionController sessionController;
     @Inject
+    private WebUserController webUserController;
+    @Inject
     private PatientTransferController patientTransferController;
 
     @EJB
@@ -43,6 +47,13 @@ public class TheatreDashboardController implements Serializable {
     private List<PatientTransferRequest> todaysList;
 
     public String navigateToTheatreDashboard() {
+        // Server-side enforcement to match the rendered guard on the menu/
+        // button entry points — the UI-only check alone doesn't stop a
+        // direct navigation (CodeRabbit #23175).
+        if (!webUserController.hasPrivilege("TheatreAcceptPatient") && !webUserController.hasPrivilege("TheatreSendPatient")) {
+            JsfUtil.addErrorMessage("You are not authorized to view the Theatre Dashboard.");
+            return "";
+        }
         loadAll();
         return "/theater/theatre_dashboard?faces-redirect=true";
     }

--- a/src/main/webapp/inward/admission_profile.xhtml
+++ b/src/main/webapp/inward/admission_profile.xhtml
@@ -867,11 +867,25 @@
                                     <p:commandButton
                                         id="btnTheatreDashboard"
                                         rendered="#{webUserController.hasPrivilege('TheatreAcceptPatient') or webUserController.hasPrivilege('TheatreSendPatient')}"
-                                        value="Theatre Dashboard"
+                                        value="Theatre Status"
                                         ajax="false"
-                                        action="#{theatreDashboardController.navigateToTheatreDashboard()}"
+                                        action="#{patientTransferController.navigateToTheatreStatus(admissionController.current)}"
                                         icon="fa fa-columns"
                                         class="w-100 ui-button-secondary">
+                                    </p:commandButton>
+                                </div>
+                                <div class="col-6">
+                                    <p:commandButton
+                                        id="btnAcceptTheatreReturn"
+                                        rendered="#{webUserController.hasPrivilege('WardAcceptTheatreReturn')}"
+                                        value="Accept Return from Theatre"
+                                        ajax="false"
+                                        disabled="#{not patientTransferController.hasPendingTheatreReturnForAdmission(admissionController.current)}"
+                                        action="#{patientTransferController.acceptReturnToWardForAdmission(admissionController.current)}"
+                                        icon="fa fa-undo"
+                                        title="Accept theatre return for #{admissionController.current.bhtNo}"
+                                        onclick="if (!confirm('Accept this patient back from theatre?')) return false;"
+                                        class="w-100 ui-button-success">
                                     </p:commandButton>
                                 </div>
                                 <div class="col-6">

--- a/src/main/webapp/inward/inward_theatre_status.xhtml
+++ b/src/main/webapp/inward/inward_theatre_status.xhtml
@@ -1,0 +1,254 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/resources/template/template.xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:p="http://primefaces.org/ui">
+
+    <ui:define name="content">
+        <h:form id="theatreStatusForm">
+            <p:panel class="my-3">
+                <f:facet name="header">
+                    <div class="d-flex justify-content-between">
+                        <div>
+                            <h:outputText styleClass="fa fa-procedures fa-lg"/>
+                            <p:outputLabel value="Theatre Status" class="m-2"/>
+                        </div>
+                        <div class="d-flex gap-2">
+                            <p:commandButton
+                                id="btnBackToDashboard"
+                                value="Inpatient Dashboard"
+                                icon="fa fa-id-card"
+                                ajax="false"
+                                class="ui-button-secondary"
+                                rendered="#{admissionController.current ne null and admissionController.current.id ne null}"
+                                action="#{admissionController.navigateToAdmissionProfilePage}"/>
+                        </div>
+                    </div>
+                </f:facet>
+
+                <!-- Patient Identity Banner -->
+                <div class="d-flex flex-wrap gap-4 align-items-center p-3 mb-3 rounded" style="background:#f0f4f8; border-left:6px solid #0d6efd;">
+                    <div>
+                        <div class="text-muted small">Name</div>
+                        <div class="fs-4 fw-bold"><h:outputText value="#{patientTransferController.current.patient.person.nameWithTitle}"/></div>
+                    </div>
+                    <div>
+                        <div class="text-muted small">Age</div>
+                        <div class="fs-4 fw-bold"><h:outputText value="#{patientTransferController.current.patient.person.ageAsString}"/></div>
+                    </div>
+                    <div>
+                        <div class="text-muted small">Sex</div>
+                        <div class="fs-4 fw-bold"><h:outputText value="#{patientTransferController.current.patient.person.sex}"/></div>
+                    </div>
+                    <div>
+                        <div class="text-muted small">BHT No</div>
+                        <div class="fs-4 fw-bold"><h:outputText value="#{patientTransferController.current.bhtNo}"/></div>
+                    </div>
+                </div>
+
+                <!-- ==================================================================== -->
+                <!-- State (a): Active SEND_TO_THEATRE request                              -->
+                <!-- ==================================================================== -->
+                <h:panelGroup layout="block" id="activeTheatreRequestPanel"
+                              rendered="#{patientTransferController.currentTheatreRequest ne null}"
+                              styleClass="card mb-3">
+                    <div class="card-header d-flex justify-content-between align-items-center">
+                        <span class="fw-bold">
+                            <i class="fa fa-heartbeat me-1 text-danger"/>
+                            Current Theatre Request
+                        </span>
+                        <span class="badge bg-secondary">
+                            <h:outputText value="#{patientTransferController.currentTheatreRequest.theatreOccupancyStatus}"/>
+                        </span>
+                    </div>
+                    <div class="card-body">
+
+                        <!-- 5-step visual stepper: Sent → Received → In OT → Done → Returned -->
+                        <div style="display:flex;align-items:center;gap:0;padding:6px 0;max-width:420px;">
+                            <div title="Sent to Theatre"
+                                 style="width:26px;height:26px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:0.7rem;font-weight:700;flex-shrink:0;
+                                        background:#{patientTransferController.theatreStepBg(patientTransferController.currentTheatreRequest.theatreOccupancyStatus,1)};
+                                        color:#{patientTransferController.theatreStepColor(patientTransferController.currentTheatreRequest.theatreOccupancyStatus,1)};">1</div>
+                            <div style="flex:1;height:2px;min-width:8px;background:#{patientTransferController.theatreLineBg(patientTransferController.currentTheatreRequest.theatreOccupancyStatus,1)};"/>
+                            <div title="Received in Theatre"
+                                 style="width:26px;height:26px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:0.7rem;font-weight:700;flex-shrink:0;
+                                        background:#{patientTransferController.theatreStepBg(patientTransferController.currentTheatreRequest.theatreOccupancyStatus,2)};
+                                        color:#{patientTransferController.theatreStepColor(patientTransferController.currentTheatreRequest.theatreOccupancyStatus,2)};">2</div>
+                            <div style="flex:1;height:2px;min-width:8px;background:#{patientTransferController.theatreLineBg(patientTransferController.currentTheatreRequest.theatreOccupancyStatus,2)};"/>
+                            <div title="In Theatre — Procedure Active"
+                                 style="width:26px;height:26px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:0.7rem;font-weight:700;flex-shrink:0;
+                                        background:#{patientTransferController.theatreStepBg(patientTransferController.currentTheatreRequest.theatreOccupancyStatus,3)};
+                                        color:#{patientTransferController.theatreStepColor(patientTransferController.currentTheatreRequest.theatreOccupancyStatus,3)};">3</div>
+                            <div style="flex:1;height:2px;min-width:8px;background:#{patientTransferController.theatreLineBg(patientTransferController.currentTheatreRequest.theatreOccupancyStatus,3)};"/>
+                            <div title="Procedure Completed"
+                                 style="width:26px;height:26px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:0.7rem;font-weight:700;flex-shrink:0;
+                                        background:#{patientTransferController.theatreStepBg(patientTransferController.currentTheatreRequest.theatreOccupancyStatus,4)};
+                                        color:#{patientTransferController.theatreStepColor(patientTransferController.currentTheatreRequest.theatreOccupancyStatus,4)};">4</div>
+                            <div style="flex:1;height:2px;min-width:8px;background:#{patientTransferController.theatreLineBg(patientTransferController.currentTheatreRequest.theatreOccupancyStatus,4)};"/>
+                            <div title="Returned to Ward"
+                                 style="width:26px;height:26px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:0.7rem;font-weight:700;flex-shrink:0;
+                                        background:#{patientTransferController.theatreStepBg(patientTransferController.currentTheatreRequest.theatreOccupancyStatus,5)};
+                                        color:#{patientTransferController.theatreStepColor(patientTransferController.currentTheatreRequest.theatreOccupancyStatus,5)};">5</div>
+                        </div>
+                        <div class="small text-muted mb-3">Sent → Received → In OT → Done → Returned</div>
+
+                        <div class="row g-3 mb-3">
+                            <div class="col-6 col-md-3">
+                                <div class="text-muted small">Theatre Room</div>
+                                <div class="fw-bold"><h:outputText value="#{patientTransferController.currentTheatreRequest.toRoomFacilityCharge.name}"/></div>
+                            </div>
+                            <div class="col-6 col-md-3">
+                                <div class="text-muted small">Surgery</div>
+                                <div class="fw-bold">
+                                    <h:outputText value="#{patientTransferController.currentTheatreRequest.surgeryBill.procedure.item.name}"
+                                                   rendered="#{patientTransferController.currentTheatreRequest.surgeryBill ne null}"/>
+                                    <h:outputText value="—" rendered="#{patientTransferController.currentTheatreRequest.surgeryBill eq null}"/>
+                                </div>
+                            </div>
+                            <div class="col-6 col-md-3">
+                                <div class="text-muted small">Sent At</div>
+                                <div class="fw-bold">
+                                    <h:outputText value="#{patientTransferController.currentTheatreRequest.initiatedAt}">
+                                        <f:convertDateTime pattern="dd MMM yyyy HH:mm"/>
+                                    </h:outputText>
+                                </div>
+                            </div>
+                            <h:panelGroup layout="block" styleClass="col-6 col-md-3"
+                                          rendered="#{patientTransferController.currentTheatreRequest.procedureStartAt ne null}">
+                                <div class="text-muted small">OT Duration</div>
+                                <div class="fw-bold"><h:outputText value="#{patientTransferController.formatOtDuration(patientTransferController.currentTheatreRequest)}"/></div>
+                            </h:panelGroup>
+                        </div>
+
+                        <!-- Exactly one contextual action button, chosen by theatreOccupancyStatus -->
+                        <div class="d-flex gap-2">
+                            <p:commandButton
+                                id="btnAcceptInTheatre"
+                                value="Accept in Theatre"
+                                icon="fa fa-check-circle"
+                                ajax="false"
+                                class="ui-button-success"
+                                title="Accept in theatre for #{patientTransferController.current.bhtNo}"
+                                rendered="#{webUserController.hasPrivilege('TheatreAcceptPatient')
+                                            and patientTransferController.currentTheatreRequest.theatreOccupancyStatus ne null
+                                            and patientTransferController.currentTheatreRequest.theatreOccupancyStatus.name() == 'SENT_TO_THEATRE'}"
+                                action="#{patientTransferController.acceptInTheatreForAdmission(patientTransferController.currentTheatreRequest)}"
+                                onclick="if (!confirm('Accept this patient in theatre?')) return false;"/>
+                            <p:commandButton
+                                id="btnMarkInTheatre"
+                                value="Mark In Theatre"
+                                icon="fa fa-play"
+                                ajax="false"
+                                class="ui-button-warning"
+                                title="Mark in theatre for #{patientTransferController.current.bhtNo}"
+                                rendered="#{webUserController.hasPrivilege('TheatreAcceptPatient')
+                                            and patientTransferController.currentTheatreRequest.theatreOccupancyStatus ne null
+                                            and patientTransferController.currentTheatreRequest.theatreOccupancyStatus.name() == 'RECEIVED_IN_THEATRE'}"
+                                action="#{patientTransferController.markInTheatreForAdmission(patientTransferController.currentTheatreRequest)}"
+                                onclick="if (!confirm('Mark patient as In Theatre?')) return false;"/>
+                            <p:commandButton
+                                id="btnProcedureDone"
+                                value="Proc. Done"
+                                icon="fa fa-check"
+                                ajax="false"
+                                class="ui-button-success"
+                                title="Mark procedure done for #{patientTransferController.current.bhtNo}"
+                                rendered="#{webUserController.hasPrivilege('TheatreReturnPatient')
+                                            and patientTransferController.currentTheatreRequest.theatreOccupancyStatus ne null
+                                            and patientTransferController.currentTheatreRequest.theatreOccupancyStatus.name() == 'IN_THEATRE'}"
+                                action="#{patientTransferController.markProcedureCompletedForAdmission(patientTransferController.currentTheatreRequest)}"
+                                onclick="if (!confirm('Mark procedure as completed?')) return false;"/>
+                            <p:commandButton
+                                id="btnReturnToWard"
+                                value="Return to Ward"
+                                icon="fa fa-arrow-left"
+                                ajax="false"
+                                class="ui-button-info"
+                                title="Return to ward for #{patientTransferController.current.bhtNo}"
+                                rendered="#{webUserController.hasPrivilege('TheatreReturnPatient')
+                                            and patientTransferController.currentTheatreRequest.theatreOccupancyStatus ne null
+                                            and patientTransferController.currentTheatreRequest.theatreOccupancyStatus.name() == 'PROCEDURE_COMPLETED'}"
+                                action="#{patientTransferController.returnToWardForAdmission(patientTransferController.currentTheatreRequest)}"
+                                onclick="if (!confirm('Initiate return to ward?')) return false;"/>
+                        </div>
+                    </div>
+                </h:panelGroup>
+
+                <!-- ==================================================================== -->
+                <!-- State (b): Pending RETURN_TO_WARD request                              -->
+                <!-- ==================================================================== -->
+                <h:panelGroup layout="block" id="pendingReturnRequestPanel"
+                              rendered="#{patientTransferController.currentTheatreReturnRequest ne null}"
+                              styleClass="card mb-3">
+                    <div class="card-header">
+                        <span class="fw-bold">
+                            <i class="fa fa-arrow-left me-1 text-info"/>
+                            Pending Return to Ward
+                        </span>
+                    </div>
+                    <div class="card-body">
+                        <div class="row g-3 mb-3">
+                            <div class="col-6 col-md-3">
+                                <div class="text-muted small">From</div>
+                                <div class="fw-bold">
+                                    <h:outputText value="#{patientTransferController.currentTheatreReturnRequest.fromPatientRoom.roomFacilityCharge.name}"
+                                                   rendered="#{patientTransferController.currentTheatreReturnRequest.fromPatientRoom ne null}"/>
+                                    <h:outputText value="—" rendered="#{patientTransferController.currentTheatreReturnRequest.fromPatientRoom eq null}"/>
+                                </div>
+                            </div>
+                            <div class="col-6 col-md-3">
+                                <div class="text-muted small">To</div>
+                                <div class="fw-bold"><h:outputText value="#{patientTransferController.currentTheatreReturnRequest.toRoomFacilityCharge.name}"/></div>
+                            </div>
+                            <div class="col-6 col-md-3">
+                                <div class="text-muted small">Initiated At</div>
+                                <div class="fw-bold">
+                                    <h:outputText value="#{patientTransferController.currentTheatreReturnRequest.initiatedAt}">
+                                        <f:convertDateTime pattern="dd MMM yyyy HH:mm"/>
+                                    </h:outputText>
+                                </div>
+                            </div>
+                        </div>
+
+                        <p:commandButton
+                            id="btnAcceptReturnToWard"
+                            value="Accept Return to Ward"
+                            icon="fa fa-check"
+                            ajax="false"
+                            class="ui-button-success"
+                            title="Accept return to ward for #{patientTransferController.current.bhtNo}"
+                            rendered="#{webUserController.hasPrivilege('WardAcceptTheatreReturn')}"
+                            action="#{patientTransferController.acceptReturnToWardForAdmission(patientTransferController.current)}"
+                            onclick="if (!confirm('Accept this patient back from theatre?')) return false;"/>
+                    </div>
+                </h:panelGroup>
+
+                <!-- ==================================================================== -->
+                <!-- State (c): Empty state — no active theatre transfer                    -->
+                <!-- ==================================================================== -->
+                <h:panelGroup layout="block" id="noTheatreTransferPanel"
+                              rendered="#{patientTransferController.currentTheatreRequest eq null and patientTransferController.currentTheatreReturnRequest eq null}"
+                              styleClass="text-center text-muted py-4">
+                    <i class="fa fa-info-circle me-1"/>
+                    <p:outputLabel value="No active theatre transfer for this patient."/>
+                    <div class="mt-3">
+                        <p:commandButton
+                            id="btnSendToTheatre"
+                            value="Send to Theatre"
+                            icon="fa fa-procedures"
+                            ajax="false"
+                            class="ui-button-primary"
+                            title="Send to theatre for #{patientTransferController.current.bhtNo}"
+                            rendered="#{webUserController.hasPrivilege('TheatreSendPatient')}"
+                            action="#{patientTransferController.navigateToSendToTheatre(patientTransferController.current)}"/>
+                    </div>
+                </h:panelGroup>
+
+            </p:panel>
+        </h:form>
+    </ui:define>
+
+</ui:composition>

--- a/src/main/webapp/nurse/index.xhtml
+++ b/src/main/webapp/nurse/index.xhtml
@@ -463,7 +463,7 @@
                                                             value="Theatre Status"
                                                             icon="fa fa-procedures"
                                                             ajax="false"
-                                                            rendered="#{webUserController.hasPrivilege('TheatreAcceptPatient') or webUserController.hasPrivilege('TheatreSendPatient')}"
+                                                            rendered="#{(webUserController.hasPrivilege('TheatreAcceptPatient') or webUserController.hasPrivilege('TheatreSendPatient')) and admissionController.current ne null}"
                                                             action="#{patientTransferController.navigateToTheatreStatus(admissionController.current)}"
                                                             class="w-100 ui-button-warning">
                                                         </p:commandButton>

--- a/src/main/webapp/nurse/index.xhtml
+++ b/src/main/webapp/nurse/index.xhtml
@@ -460,12 +460,24 @@
                                                     <div class="d-grid gap-3">
                                                         <p:commandButton
                                                             id="btnNurseTheatreDashboard"
-                                                            value="Theatre Dashboard"
+                                                            value="Theatre Status"
                                                             icon="fa fa-procedures"
                                                             ajax="false"
                                                             rendered="#{webUserController.hasPrivilege('TheatreAcceptPatient') or webUserController.hasPrivilege('TheatreSendPatient')}"
-                                                            action="#{theatreDashboardController.navigateToTheatreDashboard()}"
+                                                            action="#{patientTransferController.navigateToTheatreStatus(admissionController.current)}"
                                                             class="w-100 ui-button-warning">
+                                                        </p:commandButton>
+                                                        <p:commandButton
+                                                            id="btnNurseAcceptTheatreReturn"
+                                                            value="Accept Return from Theatre"
+                                                            icon="fa fa-undo"
+                                                            ajax="false"
+                                                            rendered="#{webUserController.hasPrivilege('WardAcceptTheatreReturn')}"
+                                                            disabled="#{not patientTransferController.hasPendingTheatreReturnForAdmission(admissionController.current)}"
+                                                            action="#{patientTransferController.acceptReturnToWardForAdmission(admissionController.current)}"
+                                                            title="Accept theatre return for #{admissionController.current.bhtNo}"
+                                                            onclick="if (!confirm('Accept this patient back from theatre?')) return false;"
+                                                            class="w-100 ui-button-success">
                                                         </p:commandButton>
                                                         <p:commandButton
                                                             id="btnNurseSendToTheatre"

--- a/src/main/webapp/resources/ezcomp/menu.xhtml
+++ b/src/main/webapp/resources/ezcomp/menu.xhtml
@@ -751,6 +751,26 @@
                         rendered="#{webUserController.hasPrivilege('InwardReport')}" >
                     </p:menuitem>
 
+                    <p:menuitem
+                        ajax="false"
+                        id="smTheatreDashboard"
+                        value="Theatre Dashboard"
+                        title="Theatre Dashboard"
+                        icon="fa fa-procedures"
+                        rendered="#{webUserController.hasPrivilege('TheatreAcceptPatient') or webUserController.hasPrivilege('TheatreSendPatient')}"
+                        action="#{theatreDashboardController.navigateToTheatreDashboard()}">
+                    </p:menuitem>
+
+                    <p:menuitem
+                        ajax="false"
+                        id="smTheatreSchedule"
+                        value="Theatre Schedule"
+                        title="Theatre Schedule"
+                        icon="fa fa-calendar-alt"
+                        rendered="#{webUserController.hasPrivilege('TheatreAcceptPatient') or webUserController.hasPrivilege('TheatreSendPatient')}"
+                        action="#{inwardReservationController.navigateToTheatreScheduleCalendar()}">
+                    </p:menuitem>
+
                 </p:submenu>
 
                 <!--            Collecting Centre Section-->


### PR DESCRIPTION
## What this does

Fixes the page-scoping violation described in #23166: pages linked from a specific patient's Inpatient Dashboard should manage only that patient, but "Theatre Dashboard" opened the hospital-wide worklist.

- **New per-patient Theatre Status page** (`inward_theatre_status.xhtml`), scoped to a single admission's active theatre transfer — mirrors the #22420 focused-view pattern (`navigateToPatientAcceptForAdmission` → `inward_patient_accept_single.xhtml`). Reuses the existing milestone stepper markup and `theatreStepBg`/`theatreStepColor`/`theatreLineBg`/`formatOtDuration` helpers, and the existing core theatre mutators (`acceptInTheatre`, `markInTheatre`, `markProcedureCompleted`, `returnToWard`, `acceptReturnToWard`) via new admission-scoped wrappers that reload only this admission's state.
- Inpatient Dashboard and Nursing WorkBench Operation Theatre panels now link to this new page (relabeled **"Theatre Status"**) instead of the hospital-wide Theatre Dashboard.
- New **"Accept Return from Theatre"** button on both dashboards, so ward staff can accept a theatre return without going through the global Theatre Dashboard. Enabled/disabled via a new `hasPendingTheatreReturnForAdmission(Admission)` check.
- The existing hospital-wide **Theatre Dashboard** and **Theatre Schedule** are unchanged, but now linked from the **Inpatient** menu instead of only being reachable from a single patient's screen.
- No new privileges — reuses `TheatreSendPatient`, `TheatreAcceptPatient`, `TheatreReturnPatient`, `WardAcceptTheatreReturn`.
- No schema changes.

## Testing performed

Full end-to-end Playwright pass against a real local admission (BHT/56757, Galle Co-Operative Hospital, local Payara + `coop` DB):

1. Sent BHT/56757 to Operating Theatre 1 from the Inpatient Dashboard.
2. Opened **Theatre Status** — confirmed it shows only this patient (not other admissions), stepper at step 1.
3. Progressed **Accept in Theatre → Mark In Theatre → Proc. Done → Return to Ward** entirely from the new page, confirming the stepper and button set update correctly at each step.
4. Accepted the return via the new **Accept Return from Theatre** button on the Inpatient Dashboard (and confirmed the button/state is correct on Nursing WorkBench too).
5. Confirmed the global **Theatre Dashboard** reflects the same final state throughout, and BHT/56757 drops out of all its worklists once the return is accepted — same underlying data, no separate sync logic needed.
6. Verified the DB directly (`PATIENTTRANSFERREQUEST`) — both the `SEND_TO_THEATRE` and `RETURN_TO_WARD` rows show correct final status/timestamps.
7. Confirmed the new "Theatre Dashboard"/"Theatre Schedule" menu items render under the Inpatient submenu.

Screenshots and full verification write-up: [Inpatient — Sending a Patient to Theatre](https://github.com/hmislk/hmis/wiki/Inpatient-Sending-a-Patient-to-Theatre)

Issue comment with the same evidence: https://github.com/hmislk/hmis/issues/23166#issuecomment-5360338050

![Theatre Status — awaiting acceptance](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23166-01-theatre-status-awaiting-acceptance.png)

![Inpatient Dashboard — Operation Theatre panel](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23166-03-inpatient-dashboard-theatre-panel.png)

## Notes for reviewers

- A JSF EL gotcha surfaced during verification and is fixed + documented: parameterized boolean methods must not use the `isXxx()` naming convention (EL only strips `is`/`get` for zero-arg property access). Recorded in `developer_docs/testing/playwright-e2e-workflow.md` §75.

Closes #23166

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added admission-specific Theatre Status views with transfer progress, patient details, contextual actions, and empty-state guidance.
  * Added “Accept Return from Theatre” actions with permission controls, pending-state handling, and confirmation.
  * Added Theatre Dashboard and Theatre Schedule navigation to inpatient menus.
  * Added theatre workflow actions for accepting patients, tracking progress, completing procedures, and returning patients to the ward.
* **Bug Fixes**
  * Restricted theatre dashboards and schedules to authorized users.
  * Prevented accepting theatre returns for the wrong ward.
  * Fixed errors when retrieving department information in certain sessions.
* **Documentation**
  * Documented the required inpatient discharge sequence and server-side verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->