### PR TITLE
Barcode-friendly admission search with auto-select (pilot: Edit Admission Details, Direct Issue to BHTs)

### DIFF
--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -1545,7 +1545,8 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         HashMap hm = new HashMap();
         sql = "select c from Admission c"
                 + " where ((c.bhtNo) like :q or"
-                + " (c.patient.person.name) like :q ) "
+                + " (c.patient.person.name) like :q or"
+                + " (c.patient.code) like :q ) "
                 + " order by c.bhtNo";
         hm.put("q", "%" + query.toUpperCase() + "%");
         suggestions = getFacade().findByJpql(sql, hm);
@@ -1559,7 +1560,8 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         HashMap hm = new HashMap();
         sql = "select c from Admission c"
                 + " where ((c.bhtNo) like :q or"
-                + " (c.patient.person.name) like :q ) "
+                + " (c.patient.person.name) like :q or"
+                + " (c.patient.code) like :q ) "
                 + " and c.paymentFinalized=true"
                 + " order by c.bhtNo";
         hm.put("q", "%" + query.toUpperCase() + "%");
@@ -1593,7 +1595,8 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
                     + " ( c.paymentFinalized is null or c.paymentFinalized=false )"
                     + " and ( ((c.bhtNo) like :q )"
                     + " or ((c.patient.person.name) like :q ) "
-                    + " or ((c.patient.phn =:phn ))) order by c.bhtNo";
+                    + " or ((c.patient.phn =:phn )) "
+                    + " or ((c.patient.code) like :q )) order by c.bhtNo";
 
             h.put("q", "%" + query.toUpperCase() + "%");
             h.put("phn", query.toUpperCase());
@@ -1614,6 +1617,7 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
                 + " and ( ((c.bhtNo) like :q ) "
                 + " or ((c.patient.person.name) like :q ) "
                 + " or ((c.patient.phn =:phn )) "
+                + " or ((c.patient.code) like :q ) "
                 + " or ((c.patient.person.phone) like :q ) "
                 + " or ((c.patient.person.mobile) like :q ) ) ";
         HashMap h = new HashMap();
@@ -1727,7 +1731,8 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
                     + " where c.retired=false "
                     + " and c.paymentFinalized=true "
                     + " and ((c.bhtNo) like :q "
-                    + " or (c.patient.person.name) like :q)"
+                    + " or (c.patient.person.name) like :q "
+                    + " or (c.patient.code) like :q)"
                     + "  order by c.bhtNo";
             ////// // System.out.println(sql);
             //      h.put("btp", BillType.InwardPaymentBill);

--- a/src/main/java/com/divudi/bean/inward/BhtEditController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtEditController.java
@@ -506,7 +506,7 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
             sql = "select c from Admission c where "
                     + " c.retired=false "
                     //                    + " and c.discharged=false "
-                    + " and ((c.bhtNo) like '%" + query.toUpperCase() + "%' or (c.patient.person.name) like '%" + query.toUpperCase() + "%') "
+                    + " and ((c.bhtNo) like '%" + query.toUpperCase() + "%' or (c.patient.person.name) like '%" + query.toUpperCase() + "%' or (c.patient.code) like '%" + query.toUpperCase() + "%') "
                     + " order by c.bhtNo ";
             suggestions = getFacade().findByJpql(sql);
         }

--- a/src/main/webapp/inward/inward_edit_bht.xhtml
+++ b/src/main/webapp/inward/inward_edit_bht.xhtml
@@ -69,7 +69,7 @@
                                                                        var="ins"
                                                                        itemLabel="#{ins.name}"
                                                                        itemValue="#{ins}" />
-                                                        <p:ajax listener="#{bhtEditController.onInstitutionChange}" update="acPt pnlPatientPreview btnSelect" />
+                                                        <p:ajax listener="#{bhtEditController.onInstitutionChange}" update="admissionSearch pnlPatientPreview btnSelect" />
                                                     </p:selectOneMenu>
                                                 </div>
                                             </div>
@@ -81,6 +81,7 @@
                                                         Patient Search
                                                     </h:outputLabel>
                                                     <admcc:admission_search
+                                                        id="admissionSearch"
                                                         widgetVar="aPt"
                                                         inputId="acPt"
                                                         value="#{bhtEditController.current}"

--- a/src/main/webapp/inward/inward_edit_bht.xhtml
+++ b/src/main/webapp/inward/inward_edit_bht.xhtml
@@ -11,12 +11,13 @@
                 xmlns:c="http://java.sun.com/jsp/jstl/core"
                 xmlns:bill="http://xmlns.jcp.org/jsf/composite/inward"
                 xmlns:cc_credit="http://xmlns.jcp.org/jsf/composite/inward/creditCompany"
+                xmlns:admcc="http://xmlns.jcp.org/jsf/composite/ezcomp/inpatient"
                 >
 
 
     <ui:define name="content">
         <h:panelGroup id="panSearch2">
-            <h:form>
+            <h:form id="frmBhtEdit">
                 <h:panelGroup class="row" rendered="#{not bhtEditController.admissionEditFormReady}">
                     <div class="col-12">
                         <p:panel styleClass="shadow-sm">
@@ -75,60 +76,17 @@
 
                                             <div class="row mb-3">
                                                 <div class="col-12">
-                                                    <h:outputLabel for="acPt" styleClass="form-label fw-bold text-dark mb-2">
+                                                    <h:outputLabel styleClass="form-label fw-bold text-dark mb-2">
                                                         <i class="fa-solid fa-user me-2 text-primary"></i>
                                                         Patient Search
                                                     </h:outputLabel>
-                                                    <p:autoComplete
+                                                    <admcc:admission_search
                                                         widgetVar="aPt"
-                                                        id="acPt"
-                                                        forceSelection="true"
+                                                        inputId="acPt"
                                                         value="#{bhtEditController.current}"
                                                         completeMethod="#{bhtEditController.completePatientByInstitution}"
-                                                        var="myItem"
-                                                        itemValue="#{myItem}"
-                                                        itemLabel="#{myItem.bhtNo}"
-                                                        placeholder="Type patient name, BHT number, or PHN..."
-                                                        minQueryLength="2"
-                                                        style="width: 100%;"
-                                                        inputStyleClass="form-control form-control-lg">
-                                                        <p:ajax event="itemSelect" update="pnlPatientPreview btnSelect" />
-                                                        <p:column headerText="PHN" style="padding: 8px; min-width: 100px;">
-                                                            <div class="d-flex align-items-center">
-                                                                <i class="fa-solid fa-id-card me-2 text-info"></i>
-                                                                <strong>#{myItem.patient.phn}</strong>
-                                                            </div>
-                                                        </p:column>
-                                                        <p:column headerText="BHT No" style="padding: 8px; min-width: 120px;">
-                                                            <div class="d-flex align-items-center">
-                                                                <i class="fa-solid fa-hospital me-2 text-warning"></i>
-                                                                <strong class="text-primary">#{myItem.bhtNo}</strong>
-                                                            </div>
-                                                        </p:column>
-                                                        <p:column headerText="Patient Name" style="padding: 8px; min-width: 250px;">
-                                                            <div class="d-flex align-items-center">
-                                                                <i class="fa-solid fa-user me-2 text-success"></i>
-                                                                <span class="fw-medium">#{myItem.patient.person.nameWithTitle}</span>
-                                                            </div>
-                                                        </p:column>
-                                                        <p:column headerText="Room" style="padding: 8px; min-width: 150px;">
-                                                            <h:panelGroup rendered="#{myItem.currentPatientRoom ne null}">
-                                                                <div class="d-flex align-items-center">
-                                                                    <i class="fa-solid fa-bed me-2 text-secondary"></i>
-                                                                    <span>#{myItem.currentPatientRoom.roomFacilityCharge.name}</span>
-                                                                </div>
-                                                            </h:panelGroup>
-                                                            <h:panelGroup rendered="#{myItem.currentPatientRoom eq null}">
-                                                                <span class="text-muted">
-                                                                    <i class="fa-solid fa-question-circle me-1"></i>No room assigned
-                                                                </span>
-                                                            </h:panelGroup>
-                                                        </p:column>
-                                                        <p:column headerText="Status" style="padding: 8px; min-width: 120px;">
-                                                            <p:badge value="Discharged" styleClass="ui-badge-danger" rendered="#{myItem.discharged}" />
-                                                            <p:badge value="Active" styleClass="ui-badge-success" rendered="#{!myItem.discharged}" />
-                                                        </p:column>
-                                                    </p:autoComplete>
+                                                        continueClientId="frmBhtEdit:btnSelect"
+                                                        itemSelectUpdate=":frmBhtEdit:pnlPatientPreview :frmBhtEdit:btnSelect" />
                                                 </div>
                                             </div>
 

--- a/src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml
+++ b/src/main/webapp/inward/pharmacy_bill_issue_bht.xhtml
@@ -7,7 +7,8 @@
                 xmlns:f="http://xmlns.jcp.org/jsf/core"
                 xmlns:phe="http://xmlns.jcp.org/jsf/composite/pharmacy/inward"
                 xmlns:phi="http://xmlns.jcp.org/jsf/composite/pharmacy"
-                xmlns:bill="http://xmlns.jcp.org/jsf/composite/inward">
+                xmlns:bill="http://xmlns.jcp.org/jsf/composite/inward"
+                xmlns:admcc="http://xmlns.jcp.org/jsf/composite/ezcomp/inpatient">
 
     <ui:define name="content">
         <h:form id="bill">
@@ -80,57 +81,13 @@
                                                     <i class="fa-solid fa-user me-2 text-primary"></i>
                                                     Patient Search
                                                 </label>
-                                                <p:autoComplete
+                                                <admcc:admission_search
                                                     widgetVar="aPtNative"
-                                                    id="acPtNative"
-                                                    forceSelection="true"
+                                                    inputId="acPtNative"
                                                     value="#{inpatientDirectIssueNativeSqlController.patientEncounter}"
                                                     completeMethod="#{admissionController.completePatient}"
-                                                    var="apt"
-                                                    itemLabel="#{apt.bhtNo}"
-                                                    itemValue="#{apt}"
-                                                    placeholder="Type patient name, BHT number, or PHN..."
-                                                    minQueryLength="2"
-                                                    maxResults="20"
-                                                    style="width: 100%;"
-                                                    inputStyleClass="form-control form-control-lg"
-                                                    onkeydown="if(event.which===13){var w=PF('aPtNative');if(!w.panel||!w.panel.is(':visible')){event.preventDefault();document.getElementById('bill:btnSelect').click();}}">
-                                                    <p:column headerText="PHN" style="padding: 8px; min-width: 100px;">
-                                                        <div class="d-flex align-items-center">
-                                                            <i class="fa-solid fa-id-card me-2 text-info"></i>
-                                                            <strong>#{apt.patient.phn}</strong>
-                                                        </div>
-                                                    </p:column>
-                                                    <p:column headerText="BHT No" style="padding: 8px; min-width: 120px;">
-                                                        <div class="d-flex align-items-center">
-                                                            <i class="fa-solid fa-hospital me-2 text-warning"></i>
-                                                            <strong class="text-primary">#{apt.bhtNo}</strong>
-                                                        </div>
-                                                    </p:column>
-                                                    <p:column headerText="Patient Name" style="padding: 8px; min-width: 250px;">
-                                                        <div class="d-flex align-items-center">
-                                                            <i class="fa-solid fa-user me-2 text-success"></i>
-                                                            <span class="fw-medium">#{apt.patient.person.nameWithTitle}</span>
-                                                        </div>
-                                                    </p:column>
-                                                    <p:column headerText="Room" style="padding: 8px; min-width: 150px;">
-                                                        <h:panelGroup rendered="#{apt.currentPatientRoom ne null}">
-                                                            <div class="d-flex align-items-center">
-                                                                <i class="fa-solid fa-bed me-2 text-secondary"></i>
-                                                                <span>#{apt.currentPatientRoom.roomFacilityCharge.name}</span>
-                                                            </div>
-                                                        </h:panelGroup>
-                                                        <h:panelGroup rendered="#{apt.currentPatientRoom eq null}">
-                                                            <span class="text-muted">
-                                                                <i class="fa-solid fa-question-circle me-1"></i>No room assigned
-                                                            </span>
-                                                        </h:panelGroup>
-                                                    </p:column>
-                                                    <p:column headerText="Status" style="padding: 8px; min-width: 120px;">
-                                                        <p:badge value="Discharged" styleClass="ui-badge-danger" rendered="#{apt.discharged}" />
-                                                        <p:badge value="Active" styleClass="ui-badge-success" rendered="#{!apt.discharged}" />
-                                                    </p:column>
-                                                </p:autoComplete>
+                                                    continueClientId="bill:btnSelect"
+                                                    placeholder="Type patient name, BHT number, MRN, or PHN..." />
                                             </div>
                                             <div class="col-12 col-md-3">
                                                 <p:commandButton

--- a/src/main/webapp/resources/ezcomp/inpatient/admission_search.xhtml
+++ b/src/main/webapp/resources/ezcomp/inpatient/admission_search.xhtml
@@ -1,0 +1,92 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:p="http://primefaces.org/ui">
+
+    <!-- INTERFACE -->
+    <cc:interface>
+        <cc:attribute name="value" required="true" />
+        <cc:attribute name="completeMethod" required="true"
+                      method-signature="java.util.List completeMethod(java.lang.String)" />
+        <!-- The ALREADY-RESOLVED, real rendered client id (e.g. "bill:btnSelect") of the page's
+             existing "Continue" button. This composite will document.getElementById(...) and
+             .click() it when auto-advancing on an exact single-match. -->
+        <cc:attribute name="continueClientId" required="true" type="java.lang.String" />
+        <cc:attribute name="widgetVar" type="java.lang.String" default="acAdmissionSearch" />
+        <cc:attribute name="inputId" type="java.lang.String" default="acAdmissionSearch" />
+        <!-- Passed straight through to the inner p:ajax event="itemSelect" update="...".
+             Since this composite is itself a NamingContainer, if the calling page needs to
+             update components OUTSIDE the composite, it must pass ABSOLUTE search expressions
+             (leading ':', e.g. ":frmBhtEdit:pnlPatientPreview :frmBhtEdit:btnSelect"). -->
+        <cc:attribute name="itemSelectUpdate" type="java.lang.String" default="" />
+        <cc:attribute name="placeholder" type="java.lang.String"
+                      default="Type patient name, BHT number, MRN, or PHN..." />
+    </cc:interface>
+
+    <!-- IMPLEMENTATION -->
+    <cc:implementation>
+        <h:outputScript library="js" name="admission-search.js" target="head" />
+
+        <p:autoComplete
+            widgetVar="#{cc.attrs.widgetVar}"
+            id="#{cc.attrs.inputId}"
+            forceSelection="true"
+            autoHighlight="true"
+            value="#{cc.attrs.value}"
+            completeMethod="#{cc.attrs.completeMethod}"
+            var="myItem"
+            itemValue="#{myItem}"
+            itemLabel="#{myItem.bhtNo}"
+            placeholder="#{cc.attrs.placeholder}"
+            minQueryLength="2"
+            style="width: 100%;"
+            inputStyleClass="form-control form-control-lg">
+            <p:ajax event="query" oncomplete="HmisAdmissionSearch.onQueryComplete('#{cc.attrs.widgetVar}', '#{cc.attrs.continueClientId}')" />
+            <p:ajax event="itemSelect" update="#{cc.attrs.itemSelectUpdate}" oncomplete="HmisAdmissionSearch.onItemSelectComplete('#{cc.attrs.continueClientId}')" />
+            <p:column headerText="PHN" style="padding: 8px; min-width: 100px;">
+                <div class="d-flex align-items-center">
+                    <i class="fa-solid fa-id-card me-2 text-info"></i>
+                    <strong class="hmis-adm-phn">#{myItem.patient.phn}</strong>
+                </div>
+            </p:column>
+            <p:column headerText="BHT No" style="padding: 8px; min-width: 120px;">
+                <div class="d-flex align-items-center">
+                    <i class="fa-solid fa-hospital me-2 text-warning"></i>
+                    <strong class="text-primary hmis-adm-bht">#{myItem.bhtNo}</strong>
+                </div>
+            </p:column>
+            <p:column headerText="MRN" style="padding: 8px; min-width: 100px;">
+                <div class="d-flex align-items-center">
+                    <i class="fa-solid fa-hashtag me-2 text-secondary"></i>
+                    <strong class="hmis-adm-mrn">#{myItem.patient.code}</strong>
+                </div>
+            </p:column>
+            <p:column headerText="Patient Name" style="padding: 8px; min-width: 250px;">
+                <div class="d-flex align-items-center">
+                    <i class="fa-solid fa-user me-2 text-success"></i>
+                    <span class="fw-medium">#{myItem.patient.person.nameWithTitle}</span>
+                </div>
+            </p:column>
+            <p:column headerText="Room" style="padding: 8px; min-width: 150px;">
+                <h:panelGroup rendered="#{myItem.currentPatientRoom ne null}">
+                    <div class="d-flex align-items-center">
+                        <i class="fa-solid fa-bed me-2 text-secondary"></i>
+                        <span>#{myItem.currentPatientRoom.roomFacilityCharge.name}</span>
+                    </div>
+                </h:panelGroup>
+                <h:panelGroup rendered="#{myItem.currentPatientRoom eq null}">
+                    <span class="text-muted">
+                        <i class="fa-solid fa-question-circle me-1"></i>No room assigned
+                    </span>
+                </h:panelGroup>
+            </p:column>
+            <p:column headerText="Status" style="padding: 8px; min-width: 120px;">
+                <p:badge value="Discharged" styleClass="ui-badge-danger" rendered="#{myItem.discharged}" />
+                <p:badge value="Active" styleClass="ui-badge-success" rendered="#{!myItem.discharged}" />
+            </p:column>
+        </p:autoComplete>
+    </cc:implementation>
+</html>

--- a/src/main/webapp/resources/js/admission-search.js
+++ b/src/main/webapp/resources/js/admission-search.js
@@ -1,0 +1,47 @@
+var HmisAdmissionSearch = (function () {
+    var pending = {};
+
+    function normalize(text) {
+        return (text || '').replace(/\s+/g, '').toUpperCase();
+    }
+
+    function onQueryComplete(widgetVar, continueClientId) {
+        var widget = PF(widgetVar);
+        if (!widget || !widget.items || widget.items.length !== 1) {
+            return;
+        }
+        var query = normalize(widget.input.val());
+        if (!query) {
+            return;
+        }
+        var row = widget.items.eq(0);
+        var phn = normalize(row.find('.hmis-adm-phn').text());
+        var bht = normalize(row.find('.hmis-adm-bht').text());
+        var mrn = normalize(row.find('.hmis-adm-mrn').text());
+        if (query === phn || query === bht || (mrn && query === mrn)) {
+            pending[widgetVar] = continueClientId;
+            row.trigger('click');
+        }
+    }
+
+    function onItemSelectComplete(continueClientId) {
+        var advanced = false;
+        Object.keys(pending).forEach(function (widgetVar) {
+            if (pending[widgetVar] === continueClientId) {
+                delete pending[widgetVar];
+                advanced = true;
+            }
+        });
+        if (advanced) {
+            var btn = document.getElementById(continueClientId);
+            if (btn) {
+                btn.click();
+            }
+        }
+    }
+
+    return {
+        onQueryComplete: onQueryComplete,
+        onItemSelectComplete: onItemSelectComplete
+    };
+})();


### PR DESCRIPTION
## Summary

Pilot of #23165 — a shared admission-search UI mechanism so staff can scan a
patient's PHN/BHT/MRN barcode and get taken straight to the right admission
when the scan matches exactly one record, without changing any page's
existing active/discharged/finalized filter semantics.

- New shared composite `resources/ezcomp/inpatient/admission_search.xhtml` +
  `resources/js/admission-search.js`: wraps the existing `p:autoComplete`
  admission search, detects an exact PHN/BHT/MRN match against the single
  returned suggestion, and auto-triggers the page's own "Continue" action.
  Ambiguous (2+ matches) or free-text (partial name/phone) queries behave
  exactly as before — dropdown shown, manual pick required, no auto-advance.
- MRN (`patient.code`) added as a searchable OR-clause to the
  `AdmissionController` query methods that were missing it
  (`completePatientNotFinalizedByInstitution`, `completePatientDishcargedNotFinalized`,
  `completePatientAll`, `completePatientFinaled`, `completePatientPaymentFinalized`,
  and `BhtEditController`'s local `completePatientAll`) — purely additive,
  no discharged/active/finalized filter logic touched.
- Piloted on `inward/inward_edit_bht.xhtml` (Inward → Admissions → Edit
  Admission Details) and `inward/pharmacy_bill_issue_bht.xhtml` (Pharmacy →
  Inpatient Medication Management → Direct Issue to BHTs). The remaining
  ~18 admission-search pages are tracked as follow-up in #23165, not part
  of this PR.

## Test plan

Verified end-to-end against local Payara + MySQL with Playwright (see
[issue comment](https://github.com/hmislk/hmis/issues/23165#issuecomment-5361062061)
for screenshots):

- [x] Scanning an exact PHN with exactly one matching admission auto-advances
      on both pilot pages with no click (tested with a real local-DB
      admission, PHN → BHT → patient details verified against MySQL).
- [x] A query matching 2+ admissions (tested with a patient who has two
      active admissions) shows the dropdown; manual selection still sets
      the correct admission and does not auto-advance.
- [x] Manual "Continue" still works and lands on the correct admission after
      a manual pick from an ambiguous list.
- [x] No new errors in `server.log` or the browser console during the pass.
- [x] `mvn clean package` — build green, all existing tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Patient and admission searches now match patient codes across inpatient workflows.
  - Added a reusable admission search with PHN, BHT, MRN, patient, room, and discharge-status details.
  - Searches can automatically select unique matches and continue to the next step.

- **Improvements**
  - Updated BHT editing and pharmacy billing screens with a consistent admission-search experience.
  - Improved searching by phone, birth-health, and medical-record identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->