### PR TITLE
Require approval before final bill can be viewed, printed, emailed, or confirmed

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -1927,6 +1927,40 @@ actually proves the WAR builds and packages the fix correctly. Verified while
 testing issue #22984 (caught an `outputLabel for=` component-id mismatch this
 way in seconds instead of a multi-minute rebuild).
 
+## 75. Inpatient discharge chain has a strict, undocumented order — and Physical Discharge requires the Final Bill to already exist
+
+To reach "Create Final Bill" on `inward_bill_intrim.xhtml` for a fresh test
+admission, the discharge steps on `admission_profile.xhtml` must run in this
+exact order — doing them out of order produces a visible error banner, not a
+silent failure:
+
+1. **Room discharge** (Room Management → "Discharge from Room") — must
+   happen before Nursing Discharge.
+2. **Nursing Discharge** (`inward_nursing_discharge.xhtml`, "Confirm Nursing
+   Discharge") and **Clinical Discharge** — both must complete before the
+   Interim Bill's own "Discharge" button will accept the bill.
+3. **Interim Bill → Discharge** (sets `PATIENTENCOUNTER.DISCHARGED=1`) —
+   only after step 2. Attempting it earlier shows "Nursing discharge must be
+   completed before the bill can be settled."
+4. **Create Final Bill** — only after step 3.
+5. **Physical Discharge** — counter-intuitively, this can only be confirmed
+   **after** the Final Bill already exists; attempting it earlier errors with
+   "administrative discharge (final bill) has not been completed."
+
+Verify each stage against `PATIENTENCOUNTER` (`NURSINGDISCHARGED`,
+`CLINICALLYDISCHARGED`, `DISCHARGED`, `PHYSICALDISCHARGED`) before moving to
+the next — see §32 below for why the UI alone can't be trusted here.
+
+A native `confirm()` dialog handled via `browser_handle_dialog(accept:true)`
+immediately returns a "Loading..." page title — that is not proof the
+server-side action succeeded. The actual result (success or an error banner)
+only appears in the *next* `browser_snapshot`/reload. Always re-snapshot (or
+re-query the DB) after handling the dialog before assuming the step passed;
+in one session `NURSINGDISCHARGED` stayed `0` for several tool calls after
+the dialog was accepted, because the click had actually been rejected
+server-side (wrong order) but nothing in the dialog-handling response showed
+that.
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.

--- a/src/main/java/com/divudi/bean/inward/InwardSearch.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSearch.java
@@ -769,8 +769,54 @@ public class InwardSearch implements Serializable {
             JsfUtil.addErrorMessage("Cannot confirm a cancelled bill");
             return;
         }
+        if (!newConfirmed.isApprovedFinalBill()) {
+            JsfUtil.addErrorMessage("Cannot confirm an unapproved bill");
+            return;
+        }
         setAsConfirmedFinalBillInternal(newConfirmed);
         JsfUtil.addSuccessMessage("Final Bill Version Confirmed");
+        finalBillVersions = null;
+    }
+
+    /**
+     * Navigates to the approval page for the given final bill version,
+     * mirroring {@link #prepareEmailFinalBillVersion(Bill)}'s use of the
+     * shared {@link #bill} session field for the target page.
+     */
+    public String navigateToApproveFinalBill(Bill b) {
+        if (b == null) {
+            JsfUtil.addErrorMessage("No bill selected");
+            return "";
+        }
+        bill = b;
+        return "/inward/inward_final_bill_approve?faces-redirect=true";
+    }
+
+    /**
+     * User-facing action to approve a final bill version. Approval is a
+     * prerequisite for confirming a version ({@link #setAsConfirmedFinalBill})
+     * and for emailing it ({@link #emailFinalBillVersionInternal}). Privilege
+     * checks are done in the XHTML via {@code rendered}, not here.
+     */
+    public void approveFinalBillVersion(Bill b) {
+        if (b == null) {
+            JsfUtil.addErrorMessage("No bill selected");
+            return;
+        }
+        if (b.isApprovedFinalBill()) {
+            JsfUtil.addErrorMessage("Bill already approved");
+            return;
+        }
+        b.setApprovedFinalBill(true);
+        b.setFinalBillApprover(sessionController.getLoggedUser());
+        b.setFinalBillApprovedAt(new Date());
+        getBillFacade().edit(b);
+
+        auditService.logEncounterAudit(b.getPatientEncounter(), "Final Bill Version Approved",
+                null, b.getId(), sessionController.getLoggedUser(),
+                "Bill", b.getId());
+
+        JsfUtil.addSuccessMessage("Final Bill Approved");
         finalBillVersions = null;
     }
 
@@ -990,6 +1036,10 @@ public class InwardSearch implements Serializable {
         if (b.getBillType() != BillType.InwardFinalBill
                 || b.getBillTypeAtomic() != BillTypeAtomic.INWARD_FINAL_BILL) {
             JsfUtil.addErrorMessage("Selected bill is not a Final Bill");
+            return false;
+        }
+        if (!b.isApprovedFinalBill()) {
+            JsfUtil.addErrorMessage("Cannot email an unapproved Final Bill");
             return false;
         }
         if (emailRecipient == null || emailRecipient.trim().isEmpty()) {

--- a/src/main/java/com/divudi/bean/inward/InwardSearch.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSearch.java
@@ -769,7 +769,7 @@ public class InwardSearch implements Serializable {
             JsfUtil.addErrorMessage("Cannot confirm a cancelled bill");
             return;
         }
-        if (!newConfirmed.isApprovedFinalBill()) {
+        if (newConfirmed.getApproveAt() == null) {
             JsfUtil.addErrorMessage("Cannot confirm an unapproved bill");
             return;
         }
@@ -797,19 +797,24 @@ public class InwardSearch implements Serializable {
      * prerequisite for confirming a version ({@link #setAsConfirmedFinalBill})
      * and for emailing it ({@link #emailFinalBillVersionInternal}). Privilege
      * checks are done in the XHTML via {@code rendered}, not here.
+     *
+     * Reuses the generic {@code Bill.approveUser}/{@code approveAt} fields
+     * (same pair GRN/PO/Petty Cash/etc. approval already uses) rather than a
+     * final-bill-specific field, following the existing codebase convention
+     * that approval state is a plain {@code approveAt != null} check scoped
+     * by {@code billType}/{@code billTypeAtomic} at each call site.
      */
     public void approveFinalBillVersion(Bill b) {
         if (b == null) {
             JsfUtil.addErrorMessage("No bill selected");
             return;
         }
-        if (b.isApprovedFinalBill()) {
+        if (b.getApproveAt() != null) {
             JsfUtil.addErrorMessage("Bill already approved");
             return;
         }
-        b.setApprovedFinalBill(true);
-        b.setFinalBillApprover(sessionController.getLoggedUser());
-        b.setFinalBillApprovedAt(new Date());
+        b.setApproveUser(sessionController.getLoggedUser());
+        b.setApproveAt(new Date());
         getBillFacade().edit(b);
 
         auditService.logEncounterAudit(b.getPatientEncounter(), "Final Bill Version Approved",
@@ -1038,7 +1043,7 @@ public class InwardSearch implements Serializable {
             JsfUtil.addErrorMessage("Selected bill is not a Final Bill");
             return false;
         }
-        if (!b.isApprovedFinalBill()) {
+        if (b.getApproveAt() == null) {
             JsfUtil.addErrorMessage("Cannot email an unapproved Final Bill");
             return false;
         }

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -115,6 +115,7 @@ public enum Privileges {
     InwardFinalBillSetConfirmed("Inward Final Bill Set As Confirmed"),
     InwardFinalBillRetire("Inward Final Bill Retire"),
     InwardFinalBillEmail("Inward Final Bill Email"),
+    InwardFinalBillApprove("Inward Final Bill Approve"),
     InwardSaveProvisionalFinalBill("Inward Save Provisional Final Bill"),
     InwardReport("Inward Report"),
     // Inpatient Dashboard - Reports Panel individual button privileges (issue: admission_profile.xhtml Reports panel)
@@ -1677,6 +1678,7 @@ public enum Privileges {
             case InwardFinalBillSetConfirmed:
             case InwardFinalBillRetire:
             case InwardFinalBillEmail:
+            case InwardFinalBillApprove:
             case InwardSaveProvisionalFinalBill:
             case InwardLaboratory:
             case InwardLaboratoryBarcodeGeneration:

--- a/src/main/java/com/divudi/core/entity/Bill.java
+++ b/src/main/java/com/divudi/core/entity/Bill.java
@@ -373,12 +373,6 @@ public class Bill implements Serializable, RetirableEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private Bill previousVersion;           // the bill this version was created from; null for the first version; display-only, not used in any query
 
-    private boolean approvedFinalBill;
-    @ManyToOne(fetch = FetchType.LAZY)
-    private WebUser finalBillApprover;
-    @Temporal(javax.persistence.TemporalType.TIMESTAMP)
-    private Date finalBillApprovedAt;
-
     @Transient
     private double tmpReturnTotal;
     @Transient
@@ -2142,30 +2136,6 @@ public class Bill implements Serializable, RetirableEntity {
 
     public void setPreviousVersion(Bill previousVersion) {
         this.previousVersion = previousVersion;
-    }
-
-    public boolean isApprovedFinalBill() {
-        return approvedFinalBill;
-    }
-
-    public void setApprovedFinalBill(boolean approvedFinalBill) {
-        this.approvedFinalBill = approvedFinalBill;
-    }
-
-    public WebUser getFinalBillApprover() {
-        return finalBillApprover;
-    }
-
-    public void setFinalBillApprover(WebUser finalBillApprover) {
-        this.finalBillApprover = finalBillApprover;
-    }
-
-    public Date getFinalBillApprovedAt() {
-        return finalBillApprovedAt;
-    }
-
-    public void setFinalBillApprovedAt(Date finalBillApprovedAt) {
-        this.finalBillApprovedAt = finalBillApprovedAt;
     }
 
     public List<Bill> getForwardReferenceBills() {

--- a/src/main/java/com/divudi/core/entity/Bill.java
+++ b/src/main/java/com/divudi/core/entity/Bill.java
@@ -373,6 +373,12 @@ public class Bill implements Serializable, RetirableEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private Bill previousVersion;           // the bill this version was created from; null for the first version; display-only, not used in any query
 
+    private boolean approvedFinalBill;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private WebUser finalBillApprover;
+    @Temporal(javax.persistence.TemporalType.TIMESTAMP)
+    private Date finalBillApprovedAt;
+
     @Transient
     private double tmpReturnTotal;
     @Transient
@@ -2136,6 +2142,30 @@ public class Bill implements Serializable, RetirableEntity {
 
     public void setPreviousVersion(Bill previousVersion) {
         this.previousVersion = previousVersion;
+    }
+
+    public boolean isApprovedFinalBill() {
+        return approvedFinalBill;
+    }
+
+    public void setApprovedFinalBill(boolean approvedFinalBill) {
+        this.approvedFinalBill = approvedFinalBill;
+    }
+
+    public WebUser getFinalBillApprover() {
+        return finalBillApprover;
+    }
+
+    public void setFinalBillApprover(WebUser finalBillApprover) {
+        this.finalBillApprover = finalBillApprover;
+    }
+
+    public Date getFinalBillApprovedAt() {
+        return finalBillApprovedAt;
+    }
+
+    public void setFinalBillApprovedAt(Date finalBillApprovedAt) {
+        this.finalBillApprovedAt = finalBillApprovedAt;
     }
 
     public List<Bill> getForwardReferenceBills() {

--- a/src/main/webapp/inward/inward_final_bill_approve.xhtml
+++ b/src/main/webapp/inward/inward_final_bill_approve.xhtml
@@ -1,0 +1,90 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:bi="http://xmlns.jcp.org/jsf/composite/inward/bill">
+
+    <h:body>
+
+        <ui:composition template="/resources/template/template.xhtml">
+
+            <ui:define name="content">
+                <h:form id="formApproveFinalBill">
+
+                    <p:panel rendered="#{webUserController.hasPrivilege('InwardFinalBillApprove') and inwardSearch.bill ne null}">
+
+                        <f:facet name="header">
+                            <div class="d-flex justify-content-between">
+                                <div class="d-flex">
+                                    <h:outputText styleClass="fas fa-gavel"></h:outputText>
+                                    <h:outputLabel value="Approve Final Bill" class="mx-4"></h:outputLabel>
+                                    <h:outputLabel value="#{inwardSearch.bill.deptId}" styleClass="text-muted"></h:outputLabel>
+                                </div>
+                                <div class="d-flex gap-2">
+                                    <p:commandButton
+                                        ajax="false"
+                                        icon="fas fa-list"
+                                        class="ui-button-secondary"
+                                        value="Back to Final Bills"
+                                        action="/inward/inward_final_bill_list?faces-redirect=true"
+                                        title="Back to Final Bills">
+                                    </p:commandButton>
+                                </div>
+                            </div>
+                        </f:facet>
+
+                        <p:panel rendered="#{inwardSearch.bill.approvedFinalBill}" class="mb-3">
+                            <h:outputText value="This bill has already been approved." styleClass="text-success" />
+                        </p:panel>
+
+                        <p:panel class="mt-3">
+                            <f:facet name="header">
+                                <h:outputLabel value="Final Bill (Read Only)"></h:outputLabel>
+                            </f:facet>
+
+                            <bi:finalBill bill="#{inwardSearch.bill}" />
+
+                        </p:panel>
+
+                        <div class="d-flex gap-2 mt-3">
+                            <p:commandButton
+                                ajax="false"
+                                icon="fa fa-gavel"
+                                class="ui-button-primary"
+                                value="Approve"
+                                title="Approve #{inwardSearch.bill.deptId}"
+                                actionListener="#{inwardSearch.approveFinalBillVersion(inwardSearch.bill)}"
+                                action="/inward/inward_final_bill_list?faces-redirect=true"
+                                rendered="#{not inwardSearch.bill.approvedFinalBill}">
+                                <p:confirm header="Confirm Approval" message="Approve final bill #{inwardSearch.bill.deptId}? Once approved it can be viewed, printed, emailed, and confirmed." icon="pi pi-exclamation-triangle" />
+                            </p:commandButton>
+
+                            <p:commandButton
+                                ajax="false"
+                                icon="fa fa-arrow-left"
+                                class="ui-button-secondary"
+                                value="Back to Final Bills"
+                                action="/inward/inward_final_bill_list?faces-redirect=true"
+                                title="Back to Final Bills">
+                            </p:commandButton>
+                        </div>
+
+                    </p:panel>
+
+                    <p:panel rendered="#{inwardSearch.bill eq null}">
+                        <h:outputText value="No final bill selected." styleClass="text-danger" />
+                    </p:panel>
+
+                    <p:confirmDialog global="true" showEffect="fade" hideEffect="fade">
+                        <p:commandButton value="Yes" type="button" styleClass="ui-confirmdialog-yes ui-button-success" icon="pi pi-check" />
+                        <p:commandButton value="No" type="button" styleClass="ui-confirmdialog-no ui-button-secondary" icon="pi pi-times" />
+                    </p:confirmDialog>
+
+                </h:form>
+            </ui:define>
+        </ui:composition>
+    </h:body>
+</html>

--- a/src/main/webapp/inward/inward_final_bill_approve.xhtml
+++ b/src/main/webapp/inward/inward_final_bill_approve.xhtml
@@ -36,7 +36,7 @@
                             </div>
                         </f:facet>
 
-                        <p:panel rendered="#{inwardSearch.bill.approvedFinalBill}" class="mb-3">
+                        <p:panel rendered="#{inwardSearch.bill.approveAt ne null}" class="mb-3">
                             <h:outputText value="This bill has already been approved." styleClass="text-success" />
                         </p:panel>
 
@@ -58,7 +58,7 @@
                                 title="Approve #{inwardSearch.bill.deptId}"
                                 actionListener="#{inwardSearch.approveFinalBillVersion(inwardSearch.bill)}"
                                 action="/inward/inward_final_bill_list?faces-redirect=true"
-                                rendered="#{not inwardSearch.bill.approvedFinalBill}">
+                                rendered="#{inwardSearch.bill.approveAt eq null}">
                                 <p:confirm header="Confirm Approval" message="Approve final bill #{inwardSearch.bill.deptId}? Once approved it can be viewed, printed, emailed, and confirmed." icon="pi pi-exclamation-triangle" />
                             </p:commandButton>
 

--- a/src/main/webapp/inward/inward_final_bill_email.xhtml
+++ b/src/main/webapp/inward/inward_final_bill_email.xhtml
@@ -13,7 +13,7 @@
             <ui:define name="content">
                 <h:form id="formEmailFinalBill" enctype="multipart/form-data">
 
-                    <p:panel rendered="#{webUserController.hasPrivilege('InwardFinalBillEmail') and inwardSearch.bill ne null and inwardSearch.bill.approvedFinalBill and inwardSearch.bill.billType eq 'InwardFinalBill' and inwardSearch.bill.billTypeAtomic eq 'INWARD_FINAL_BILL'}">
+                    <p:panel rendered="#{webUserController.hasPrivilege('InwardFinalBillEmail') and inwardSearch.bill ne null and inwardSearch.bill.approveAt ne null and inwardSearch.bill.billType eq 'InwardFinalBill' and inwardSearch.bill.billTypeAtomic eq 'INWARD_FINAL_BILL'}">
 
                         <f:facet name="header">
                             <div class="d-flex justify-content-between">

--- a/src/main/webapp/inward/inward_final_bill_email.xhtml
+++ b/src/main/webapp/inward/inward_final_bill_email.xhtml
@@ -13,7 +13,7 @@
             <ui:define name="content">
                 <h:form id="formEmailFinalBill" enctype="multipart/form-data">
 
-                    <p:panel rendered="#{webUserController.hasPrivilege('InwardFinalBillEmail') and inwardSearch.bill ne null and inwardSearch.bill.billType eq 'InwardFinalBill' and inwardSearch.bill.billTypeAtomic eq 'INWARD_FINAL_BILL'}">
+                    <p:panel rendered="#{webUserController.hasPrivilege('InwardFinalBillEmail') and inwardSearch.bill ne null and inwardSearch.bill.approvedFinalBill and inwardSearch.bill.billType eq 'InwardFinalBill' and inwardSearch.bill.billTypeAtomic eq 'INWARD_FINAL_BILL'}">
 
                         <f:facet name="header">
                             <div class="d-flex justify-content-between">

--- a/src/main/webapp/inward/inward_final_bill_list.xhtml
+++ b/src/main/webapp/inward/inward_final_bill_list.xhtml
@@ -91,10 +91,10 @@
                                 </p:column>
 
                                 <p:column headerText="Status">
-                                    <p:tag value="Pending Approval" severity="warning" rendered="#{not b.approvedFinalBill}" />
-                                    <p:tag value="Confirmed" severity="success" rendered="#{b.approvedFinalBill and b.confirmedFinalBill}" />
-                                    <p:tag value="Cancelled" severity="danger" rendered="#{b.approvedFinalBill and not b.confirmedFinalBill and b.cancelled}" />
-                                    <p:tag value="Available" severity="secondary" rendered="#{b.approvedFinalBill and not b.confirmedFinalBill and not b.cancelled}" />
+                                    <p:tag value="Pending Approval" severity="warning" rendered="#{b.approveAt eq null}" />
+                                    <p:tag value="Confirmed" severity="success" rendered="#{b.approveAt ne null and b.confirmedFinalBill}" />
+                                    <p:tag value="Cancelled" severity="danger" rendered="#{b.approveAt ne null and not b.confirmedFinalBill and b.cancelled}" />
+                                    <p:tag value="Available" severity="secondary" rendered="#{b.approveAt ne null and not b.confirmedFinalBill and not b.cancelled}" />
                                 </p:column>
 
                                 <p:column headerText="Actions" width="420">
@@ -106,7 +106,7 @@
                                         value="Approve"
                                         title="Review and Approve #{b.deptId}"
                                         action="#{inwardSearch.navigateToApproveFinalBill(b)}"
-                                        rendered="#{not b.approvedFinalBill and webUserController.hasPrivilege('InwardFinalBillApprove')}">
+                                        rendered="#{b.approveAt eq null and webUserController.hasPrivilege('InwardFinalBillApprove')}">
                                     </p:commandButton>
 
                                     <p:commandButton
@@ -116,7 +116,7 @@
                                         value="View / Print"
                                         title="View #{b.deptId}"
                                         action="/inward/inward_reprint_bill_final?faces-redirect=true"
-                                        rendered="#{b.approvedFinalBill}">
+                                        rendered="#{b.approveAt ne null}">
                                         <f:setPropertyActionListener
                                             value="#{b}"
                                             target="#{inwardSearch.bill}">
@@ -130,7 +130,7 @@
                                         value="Set as Confirmed"
                                         title="Set as Confirmed #{b.deptId}"
                                         actionListener="#{inwardSearch.setAsConfirmedFinalBill(b)}"
-                                        rendered="#{b.approvedFinalBill and not b.cancelled and not b.confirmedFinalBill and webUserController.hasPrivilege('InwardFinalBillSetConfirmed')}">
+                                        rendered="#{b.approveAt ne null and not b.cancelled and not b.confirmedFinalBill and webUserController.hasPrivilege('InwardFinalBillSetConfirmed')}">
                                         <p:confirm header="Confirm" message="Set bill #{b.deptId} as the Confirmed Final Bill?" icon="pi pi-exclamation-triangle" />
                                     </p:commandButton>
 
@@ -162,7 +162,7 @@
                                         value="Email"
                                         title="Email #{b.deptId}"
                                         action="#{inwardSearch.prepareEmailFinalBillVersion(b)}"
-                                        rendered="#{b.approvedFinalBill and webUserController.hasPrivilege('InwardFinalBillEmail')}">
+                                        rendered="#{b.approveAt ne null and webUserController.hasPrivilege('InwardFinalBillEmail')}">
                                     </p:commandButton>
 
                                 </p:column>

--- a/src/main/webapp/inward/inward_final_bill_list.xhtml
+++ b/src/main/webapp/inward/inward_final_bill_list.xhtml
@@ -91,12 +91,23 @@
                                 </p:column>
 
                                 <p:column headerText="Status">
-                                    <p:tag value="Confirmed" severity="success" rendered="#{b.confirmedFinalBill}" />
-                                    <p:tag value="Cancelled" severity="danger" rendered="#{not b.confirmedFinalBill and b.cancelled}" />
-                                    <p:tag value="Available" severity="secondary" rendered="#{not b.confirmedFinalBill and not b.cancelled}" />
+                                    <p:tag value="Pending Approval" severity="warning" rendered="#{not b.approvedFinalBill}" />
+                                    <p:tag value="Confirmed" severity="success" rendered="#{b.approvedFinalBill and b.confirmedFinalBill}" />
+                                    <p:tag value="Cancelled" severity="danger" rendered="#{b.approvedFinalBill and not b.confirmedFinalBill and b.cancelled}" />
+                                    <p:tag value="Available" severity="secondary" rendered="#{b.approvedFinalBill and not b.confirmedFinalBill and not b.cancelled}" />
                                 </p:column>
 
                                 <p:column headerText="Actions" width="420">
+
+                                    <p:commandButton
+                                        ajax="false"
+                                        icon="fa fa-gavel"
+                                        class="ui-button-primary me-1"
+                                        value="Approve"
+                                        title="Review and Approve #{b.deptId}"
+                                        action="#{inwardSearch.navigateToApproveFinalBill(b)}"
+                                        rendered="#{not b.approvedFinalBill and webUserController.hasPrivilege('InwardFinalBillApprove')}">
+                                    </p:commandButton>
 
                                     <p:commandButton
                                         ajax="false"
@@ -104,7 +115,8 @@
                                         class="ui-button-info me-1"
                                         value="View / Print"
                                         title="View #{b.deptId}"
-                                        action="/inward/inward_reprint_bill_final?faces-redirect=true">
+                                        action="/inward/inward_reprint_bill_final?faces-redirect=true"
+                                        rendered="#{b.approvedFinalBill}">
                                         <f:setPropertyActionListener
                                             value="#{b}"
                                             target="#{inwardSearch.bill}">
@@ -118,7 +130,7 @@
                                         value="Set as Confirmed"
                                         title="Set as Confirmed #{b.deptId}"
                                         actionListener="#{inwardSearch.setAsConfirmedFinalBill(b)}"
-                                        rendered="#{not b.cancelled and not b.confirmedFinalBill and webUserController.hasPrivilege('InwardFinalBillSetConfirmed')}">
+                                        rendered="#{b.approvedFinalBill and not b.cancelled and not b.confirmedFinalBill and webUserController.hasPrivilege('InwardFinalBillSetConfirmed')}">
                                         <p:confirm header="Confirm" message="Set bill #{b.deptId} as the Confirmed Final Bill?" icon="pi pi-exclamation-triangle" />
                                     </p:commandButton>
 
@@ -150,7 +162,7 @@
                                         value="Email"
                                         title="Email #{b.deptId}"
                                         action="#{inwardSearch.prepareEmailFinalBillVersion(b)}"
-                                        rendered="#{webUserController.hasPrivilege('InwardFinalBillEmail')}">
+                                        rendered="#{b.approvedFinalBill and webUserController.hasPrivilege('InwardFinalBillEmail')}">
                                     </p:commandButton>
 
                                 </p:column>

--- a/src/main/webapp/inward/inward_reprint_bill_final.xhtml
+++ b/src/main/webapp/inward/inward_reprint_bill_final.xhtml
@@ -15,8 +15,8 @@
 
             <ui:define name="content">
                 <h:form>
-                    <p:panel rendered="#{inwardSearch.patient.person ne null and inwardSearch.bill ne null and inwardSearch.bill.approvedFinalBill}">
-                        <p:panel styleClass="alignTop" rendered="#{inwardSearch.patient.person ne null and inwardSearch.bill ne null and inwardSearch.bill.approvedFinalBill}" class="">
+                    <p:panel rendered="#{inwardSearch.patient.person ne null and inwardSearch.bill ne null and inwardSearch.bill.approveAt ne null}">
+                        <p:panel styleClass="alignTop" rendered="#{inwardSearch.patient.person ne null and inwardSearch.bill ne null and inwardSearch.bill.approveAt ne null}" class="">
                             <f:facet name="header">
                                 <div class="d-flex justify-content-between">
                                     <div class="d-flex">
@@ -1045,7 +1045,7 @@
 
                     </p:panel>
 
-                    <p:panel rendered="#{inwardSearch.patient.person ne null and inwardSearch.bill ne null and not inwardSearch.bill.approvedFinalBill}">
+                    <p:panel rendered="#{inwardSearch.patient.person ne null and inwardSearch.bill ne null and inwardSearch.bill.approveAt eq null}">
                         <h:outputText value="This final bill has not been approved yet and cannot be viewed or printed." styleClass="text-danger" />
                     </p:panel>
                 </h:form>

--- a/src/main/webapp/inward/inward_reprint_bill_final.xhtml
+++ b/src/main/webapp/inward/inward_reprint_bill_final.xhtml
@@ -15,8 +15,8 @@
 
             <ui:define name="content">
                 <h:form>
-                    <p:panel rendered="#{inwardSearch.patient.person ne null}">
-                        <p:panel styleClass="alignTop" rendered="#{inwardSearch.patient.person ne null}" class="">
+                    <p:panel rendered="#{inwardSearch.patient.person ne null and inwardSearch.bill ne null and inwardSearch.bill.approvedFinalBill}">
+                        <p:panel styleClass="alignTop" rendered="#{inwardSearch.patient.person ne null and inwardSearch.bill ne null and inwardSearch.bill.approvedFinalBill}" class="">
                             <f:facet name="header">
                                 <div class="d-flex justify-content-between">
                                     <div class="d-flex">
@@ -1043,6 +1043,10 @@
 
                         <h:outputStylesheet library="css" name="printing.css" ></h:outputStylesheet>
 
+                    </p:panel>
+
+                    <p:panel rendered="#{inwardSearch.patient.person ne null and inwardSearch.bill ne null and not inwardSearch.bill.approvedFinalBill}">
+                        <h:outputText value="This final bill has not been approved yet and cannot be viewed or printed." styleClass="text-danger" />
                     </p:panel>
                 </h:form>
             </ui:define>


### PR DESCRIPTION
## Summary

- Adds an approval gate to inpatient final bills (issue #23173). Every final bill version now starts unapproved and must be reviewed and approved by a privileged user (`InwardFinalBillApprove`) before it can be viewed/printed, emailed, or set as the confirmed version.
- Closes a pre-existing gap where the View/Print page (`inward_reprint_bill_final.xhtml`) had no privilege check at all.
- **No new `Bill` fields/columns.** Reuses the existing `Bill.approveUser`/`Bill.approveAt` pair already used by GRN, Purchase Order, Direct Purchase, Stock Transfer, Stock Take, and Petty Cash approval — following the codebase's established convention that "approved" means `approveAt` is non-null, scoped by `billType`/`billTypeAtomic` at each call site. No DDL/migration needed.
- New privilege `InwardFinalBillApprove`.
- New read-only review page `inward_final_bill_approve.xhtml` (reuses the existing `bi:finalBill` composite, no print/email/edit controls) with a single Approve action.
- `inward_final_bill_list.xhtml`: new "Pending Approval" status tag; while unapproved, View/Print, Set as Confirmed, and Email are replaced by a single Approve button (visible only to privileged users); Create New Version and Retire remain unchanged (no approval gate).
- Approval never carries over — creating a new version always starts unapproved again (a fresh `Bill` row has `approveAt = null`).

## Testing performed

Tested end-to-end against local Payara + local `coop` DB using Playwright, with a real admission (BHT/57241) driven through Room Discharge → Nursing/Clinical Discharge → Interim Bill Discharge → Create Final Bill → Approve:

- **Pending state**: Manage Final Bills list showed "Pending Approval" status and only the Approve button (plus Create New Version) for a privileged user — View/Print, Set as Confirmed, and Email were correctly absent.
- **Approve page**: read-only bill review rendered correctly with only an Approve action; confirmation dialog showed the expected message.
- **After approval**: DB confirmed `approveUser_ID`/`approveAt` set on the bill; list page updated to show the real status (`Confirmed`/`Available`) with View/Print, Set as Confirmed, and Email all restored; View/Print rendered the full bill correctly.
- **New version isolation**: created a second version via "Create New Version" — confirmed via DB it started with `approveAt = null` independent of the first version's approval.
- **Negative test — privilege gate**: revoked `InwardFinalBillApprove` for the test user and confirmed the Approve button disappeared from the pending row, and direct navigation to `inward_final_bill_approve.xhtml` rendered blank (privilege-gated panel, no content leak).
- Re-verified end-to-end after switching from dedicated fields to the reused `approveUser`/`approveAt` fields — same behavior, no new columns.

Screenshots published to the wiki: [Inpatient — Final Bill Versions § Approving a Version](https://github.com/hmislk/hmis/wiki/Inpatient-Final-Bill-Versions#approving-a-version).

## Test plan

- [x] Fresh final bill version starts unapproved and is view/print/email/confirm-blocked
- [x] Approve page renders read-only content and persists approval correctly
- [x] Post-approval, all previously-blocked actions work
- [x] New versions never inherit approval
- [x] Non-privileged user cannot see or reach the Approve action
- [x] No schema change — reuses existing `approveUser`/`approveAt` columns