### PR TITLE
Wire shared admission search into Change Patient for Admission

### DIFF
--- a/src/main/webapp/inward/inward_change_patient.xhtml
+++ b/src/main/webapp/inward/inward_change_patient.xhtml
@@ -61,10 +61,10 @@
 
                                             <div class="row mb-3">
                                                 <div class="col-12">
-                                                    <h:outputLabel styleClass="form-label fw-bold text-dark mb-2">
-                                                        <i class="fa-solid fa-user me-2 text-primary"></i>
-                                                        Patient Search
-                                                    </h:outputLabel>
+                                                    <h:panelGroup layout="block" styleClass="form-label fw-bold text-dark mb-2">
+                                                        <h:outputText styleClass="fa-solid fa-user me-2 text-primary" />
+                                                        <h:outputText value="Patient Search" />
+                                                    </h:panelGroup>
                                                     <admcc:admission_search
                                                         id="admissionSearch"
                                                         widgetVar="acAdmission"

--- a/src/main/webapp/inward/inward_change_patient.xhtml
+++ b/src/main/webapp/inward/inward_change_patient.xhtml
@@ -6,7 +6,8 @@
                 xmlns:f="http://xmlns.jcp.org/jsf/core"
                 xmlns="http://www.w3.org/1999/xhtml"
                 xmlns:p="http://primefaces.org/ui"
-                xmlns:common="http://xmlns.jcp.org/jsf/composite/ezcomp/common">
+                xmlns:common="http://xmlns.jcp.org/jsf/composite/ezcomp/common"
+                xmlns:admcc="http://xmlns.jcp.org/jsf/composite/ezcomp/inpatient">
 
     <ui:define name="content">
         <h:panelGroup id="panChangePatient">
@@ -53,67 +54,25 @@
                                                                        var="ins"
                                                                        itemLabel="#{ins.name}"
                                                                        itemValue="#{ins}" />
-                                                        <p:ajax listener="#{admissionPatientChangeController.onInstitutionChange}" update="acAdmission pnlPatientPreview" />
+                                                        <p:ajax listener="#{admissionPatientChangeController.onInstitutionChange}" update="admissionSearch pnlPatientPreview" />
                                                     </p:selectOneMenu>
                                                 </div>
                                             </div>
 
                                             <div class="row mb-3">
                                                 <div class="col-12">
-                                                    <h:outputLabel for="acAdmission" styleClass="form-label fw-bold text-dark mb-2">
+                                                    <h:outputLabel styleClass="form-label fw-bold text-dark mb-2">
                                                         <i class="fa-solid fa-user me-2 text-primary"></i>
                                                         Patient Search
                                                     </h:outputLabel>
-                                                    <p:autoComplete
+                                                    <admcc:admission_search
+                                                        id="admissionSearch"
                                                         widgetVar="acAdmission"
-                                                        id="acAdmission"
-                                                        forceSelection="true"
+                                                        inputId="acAdmission"
                                                         value="#{admissionPatientChangeController.current}"
                                                         completeMethod="#{admissionPatientChangeController.completeAdmissionByInstitution}"
-                                                        var="adm"
-                                                        itemValue="#{adm}"
-                                                        itemLabel="#{adm.bhtNo}"
-                                                        placeholder="Type patient name, BHT number, or PHN..."
-                                                        minQueryLength="2"
-                                                        style="width: 100%;"
-                                                        inputStyleClass="form-control form-control-lg">
-                                                        <p:ajax event="itemSelect" update="pnlPatientPreview" />
-                                                        <p:column headerText="PHN" style="padding: 8px; min-width: 100px;">
-                                                            <div class="d-flex align-items-center">
-                                                                <i class="fa-solid fa-id-card me-2 text-info"></i>
-                                                                <strong>#{adm.patient.phn}</strong>
-                                                            </div>
-                                                        </p:column>
-                                                        <p:column headerText="BHT No" style="padding: 8px; min-width: 120px;">
-                                                            <div class="d-flex align-items-center">
-                                                                <i class="fa-solid fa-hospital me-2 text-warning"></i>
-                                                                <strong class="text-primary">#{adm.bhtNo}</strong>
-                                                            </div>
-                                                        </p:column>
-                                                        <p:column headerText="Patient Name" style="padding: 8px; min-width: 250px;">
-                                                            <div class="d-flex align-items-center">
-                                                                <i class="fa-solid fa-user me-2 text-success"></i>
-                                                                <span class="fw-medium">#{adm.patient.person.nameWithTitle}</span>
-                                                            </div>
-                                                        </p:column>
-                                                        <p:column headerText="Room" style="padding: 8px; min-width: 150px;">
-                                                            <h:panelGroup rendered="#{adm.currentPatientRoom ne null}">
-                                                                <div class="d-flex align-items-center">
-                                                                    <i class="fa-solid fa-bed me-2 text-secondary"></i>
-                                                                    <span>#{adm.currentPatientRoom.roomFacilityCharge.name}</span>
-                                                                </div>
-                                                            </h:panelGroup>
-                                                            <h:panelGroup rendered="#{adm.currentPatientRoom eq null}">
-                                                                <span class="text-muted">
-                                                                    <i class="fa-solid fa-question-circle me-1"></i>No room assigned
-                                                                </span>
-                                                            </h:panelGroup>
-                                                        </p:column>
-                                                        <p:column headerText="Status" style="padding: 8px; min-width: 120px;">
-                                                            <p:badge value="Discharged" styleClass="ui-badge-danger" rendered="#{adm.discharged}" />
-                                                            <p:badge value="Active" styleClass="ui-badge-success" rendered="#{!adm.discharged}" />
-                                                        </p:column>
-                                                    </p:autoComplete>
+                                                        continueClientId="formChangePatient:btnLoadAdmission"
+                                                        itemSelectUpdate=":formChangePatient:pnlPatientPreview" />
                                                 </div>
                                             </div>
 


### PR DESCRIPTION
## Summary

Part of #23165's rollout — wires `admcc:admission_search` (from pilot PR #23176) into `inward/inward_change_patient.xhtml` (Inward → Admissions → Change Patient for Admission).

- Replaces the page's own hand-copied `p:autoComplete` block with the shared composite. Same `completeMethod` (`admissionPatientChangeController.completeAdmissionByInstitution`), no filter-semantics change.
- Fixes the Institution-change AJAX (`update="acAdmission pnlPatientPreview"` → `update="admissionSearch pnlPatientPreview"`) — same class of stale-search-box bug fixed on the pilot page in #23176.

## Test plan

Verified with Playwright against local Payara + MySQL:
- [x] Scanning an exact PHN with one matching admission auto-advances with no click.
- [x] No console or server-log errors during the pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved admission searching when changing institutions.
  * Updated patient previews and the Continue button to refresh correctly after selecting an admission.
  * Replaced the previous admission autocomplete with an enhanced search experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->