### PR TITLE
Wire shared admission search into Admit Room

### DIFF
--- a/src/main/webapp/inward/admit_room.xhtml
+++ b/src/main/webapp/inward/admit_room.xhtml
@@ -8,12 +8,13 @@
                 xmlns:p="http://primefaces.org/ui"
                 xmlns:common="http://xmlns.jcp.org/jsf/composite/ezcomp/common"
                 xmlns:in="http://xmlns.jcp.org/jsf/composite/inward"
-                xmlns:na="http://xmlns.jcp.org/jsf/composite/template">
+                xmlns:na="http://xmlns.jcp.org/jsf/composite/template"
+                xmlns:admcc="http://xmlns.jcp.org/jsf/composite/ezcomp/inpatient">
 
 
     <ui:define name="content">
-        <h:form>
-            
+        <h:form id="frmAdmitRoom">
+
             <h:panelGroup rendered="#{!webUserController.hasPrivilege('WatingRoomAdmitPatient')}">
                 <na:not_authorize />
             </h:panelGroup>
@@ -68,67 +69,25 @@
                                                                var="ins"
                                                                itemLabel="#{ins.name}"
                                                                itemValue="#{ins}" />
-                                                <p:ajax listener="#{roomChangeController.onInstitutionChange}" update="acPtAdmit pnlPatientPreviewAdmit" />
+                                                <p:ajax listener="#{roomChangeController.onInstitutionChange}" update="admissionSearch pnlPatientPreviewAdmit" />
                                             </p:selectOneMenu>
                                         </div>
                                     </div>
 
                                     <div class="row mb-3">
                                         <div class="col-12">
-                                            <h:outputLabel for="acPtAdmit" styleClass="form-label fw-bold text-dark mb-2">
+                                            <h:outputLabel styleClass="form-label fw-bold text-dark mb-2">
                                                 <i class="fa-solid fa-user me-2 text-primary"></i>
                                                 Patient Search
                                             </h:outputLabel>
-                                            <p:autoComplete
+                                            <admcc:admission_search
+                                                id="admissionSearch"
                                                 widgetVar="aPtAdmit"
-                                                id="acPtAdmit"
-                                                forceSelection="true"
+                                                inputId="acPtAdmit"
                                                 value="#{roomChangeController.selectedAdmission}"
                                                 completeMethod="#{roomChangeController.completePatientFromWaitingRoomByInstitution}"
-                                                var="myItem"
-                                                itemLabel="#{myItem.bhtNo}"
-                                                itemValue="#{myItem}"
-                                                placeholder="Type patient name, BHT number, or PHN..."
-                                                minQueryLength="2"
-                                                style="width: 100%;"
-                                                inputStyleClass="form-control form-control-lg">
-                                                <p:ajax event="itemSelect" update="pnlPatientPreviewAdmit" />
-                                                <p:column headerText="PHN" style="padding: 8px; min-width: 100px;">
-                                                    <div class="d-flex align-items-center">
-                                                        <i class="fa-solid fa-id-card me-2 text-info"></i>
-                                                        <strong>#{myItem.patient.phn}</strong>
-                                                    </div>
-                                                </p:column>
-                                                <p:column headerText="BHT No" style="padding: 8px; min-width: 120px;">
-                                                    <div class="d-flex align-items-center">
-                                                        <i class="fa-solid fa-hospital me-2 text-warning"></i>
-                                                        <strong class="text-primary">#{myItem.bhtNo}</strong>
-                                                    </div>
-                                                </p:column>
-                                                <p:column headerText="Patient Name" style="padding: 8px; min-width: 250px;">
-                                                    <div class="d-flex align-items-center">
-                                                        <i class="fa-solid fa-user me-2 text-success"></i>
-                                                        <span class="fw-medium">#{myItem.patient.person.nameWithTitle}</span>
-                                                    </div>
-                                                </p:column>
-                                                <p:column headerText="Room" style="padding: 8px; min-width: 150px;">
-                                                    <h:panelGroup rendered="#{myItem.currentPatientRoom ne null}">
-                                                        <div class="d-flex align-items-center">
-                                                            <i class="fa-solid fa-bed me-2 text-secondary"></i>
-                                                            <span>#{myItem.currentPatientRoom.roomFacilityCharge.name}</span>
-                                                        </div>
-                                                    </h:panelGroup>
-                                                    <h:panelGroup rendered="#{myItem.currentPatientRoom eq null}">
-                                                        <span class="text-muted">
-                                                            <i class="fa-solid fa-question-circle me-1"></i>No room assigned
-                                                        </span>
-                                                    </h:panelGroup>
-                                                </p:column>
-                                                <p:column headerText="Status" style="padding: 8px; min-width: 120px;">
-                                                    <p:badge value="Discharged" styleClass="ui-badge-danger" rendered="#{myItem.discharged}" />
-                                                    <p:badge value="Active" styleClass="ui-badge-success" rendered="#{!myItem.discharged}" />
-                                                </p:column>
-                                            </p:autoComplete>
+                                                continueClientId="frmAdmitRoom:btnContinueAdmit"
+                                                itemSelectUpdate=":frmAdmitRoom:pnlPatientPreviewAdmit" />
                                         </div>
                                     </div>
 
@@ -178,6 +137,7 @@
                                     <div class="row">
                                         <div class="col-12 text-center">
                                             <p:commandButton
+                                                id="btnContinueAdmit"
                                                 ajax="false"
                                                 value="Continue"
                                                 icon="fa-solid fa-arrow-right"


### PR DESCRIPTION
## Summary

Part of #23165's rollout — wires `admcc:admission_search` (from pilot PR #23176) into `inward/admit_room.xhtml` (Inward → Room → Admit Room).

- Replaces the page's own hand-copied `p:autoComplete` block with the shared composite. Same `completeMethod` (`roomChangeController.completePatientFromWaitingRoomByInstitution`), no filter-semantics change.
- The page's `<h:form>` and Continue button had no explicit `id` — added `id="frmAdmitRoom"` / `id="btnContinueAdmit"` so the composite can target them for auto-advance.
- Fixes the Institution-change AJAX (`update="acPtAdmit pnlPatientPreviewAdmit"` → `update="admissionSearch pnlPatientPreviewAdmit"`) — same class of stale-search-box bug fixed on the pilot page in #23176.

## Test plan

Verified with Playwright against local Payara + MySQL:
- [x] Search returns "No results found" correctly for a non-matching query, no errors (this page filters to waiting-room-only admissions, so the local test patient doesn't match — confirmed the 0-result path works cleanly).
- [x] No console or server-log errors during the pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)