### PR TITLE
Wire shared admission search into Add Estimated Professional Fee

### DIFF
--- a/src/main/webapp/inward/inward_bill_professional_estimate.xhtml
+++ b/src/main/webapp/inward/inward_bill_professional_estimate.xhtml
@@ -6,7 +6,8 @@
                 xmlns:p="http://primefaces.org/ui"
                 xmlns:f="http://xmlns.jcp.org/jsf/core"
                 xmlns="http://www.w3.org/1999/xhtml"
-                xmlns:in="http://xmlns.jcp.org/jsf/composite/inward">
+                xmlns:in="http://xmlns.jcp.org/jsf/composite/inward"
+                xmlns:admcc="http://xmlns.jcp.org/jsf/composite/ezcomp/inpatient">
 
 
 
@@ -40,38 +41,12 @@
 
                             <h:outputLabel value="Type Patient Name or BHT : "/>
 
-                            <p:autoComplete 
-                                widgetVar="aPt2"  
-                                id="acPt2" 
-                                forceSelection="true" 
-                                value="#{inwardProfessionalBillController.current.patientEncounter}" 
+                            <admcc:admission_search
+                                widgetVar="aPt2"
+                                inputId="acPt2"
+                                value="#{inwardProfessionalBillController.current.patientEncounter}"
                                 completeMethod="#{admissionController.completePatient}"
-                                var="apt2" 
-                                itemLabel="#{apt2.bhtNo}"
-                                itemValue="#{apt2}" 
-                                size="30"  
-                                class="mx-2">
-
-                                <p:column headerText="PHN" style="padding: 6px; width: 8em;">
-                                    <h:outputLabel value="#{apt2.patient.phn}"/>
-                                </p:column>
-                                <p:column headerText="BHT No" style="padding: 6px; width: 8em;">
-                                    <h:outputLabel value="#{apt2.bhtNo}"/>
-                                </p:column>
-                                <p:column headerText="Patient" style="padding: 6px; width: 400px;;">
-                                    <h:outputLabel value="#{apt2.patient.person.nameWithTitle}"/>
-                                </p:column>
-                                <p:column headerText="Room" style="padding: 6px; width: 8em;">
-                                    <h:outputLabel value="#{apt2.currentPatientRoom.roomFacilityCharge.name}"/>
-                                </p:column>
-                                <p:column headerText="Discharged" style="padding: 6px; width: 10em;">
-                                    <div class="d-flex justify-content-center">
-                                            <span class="#{apt2.discharged ? 'discharged-badge' : 'not-discharged-badge'}">
-                                                #{apt2.discharged ? 'Discharged' : 'Not Discharged'}
-                                            </span>
-                                        </div>
-                                </p:column>
-                            </p:autoComplete>
+                                continueClientId="form:btnSelect" />
 
                             <p:commandButton
                                 id="btnSelect"


### PR DESCRIPTION
## Summary

Part of #23165's rollout — wires `admcc:admission_search` (from pilot PR #23176) into `inward/inward_bill_professional_estimate.xhtml` (Inward → Services & Items → Add Estimated Professional Fee).

- Replaces the page's own hand-copied `p:autoComplete` block with the shared composite. Same `completeMethod` (`admissionController.completePatient`), no filter-semantics change. No institution filter on this page, so no AJAX-target fix needed.

## Test plan

Verified with Playwright against local Payara + MySQL:
- [x] Scanning an exact PHN with one matching admission auto-advances to "Inward Estimated Professional Charges" with no click.
- [x] No console or server-log errors during the pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)