### PR TITLE
Wire shared admission search into Store BHT Issue

### DIFF
--- a/src/main/webapp/store/store_retail_sale_bht.xhtml
+++ b/src/main/webapp/store/store_retail_sale_bht.xhtml
@@ -7,7 +7,8 @@
       xmlns:f="http://xmlns.jcp.org/jsf/core"
       xmlns:bil="http://xmlns.jcp.org/jsf/composite/bill"
       xmlns:in="http://xmlns.jcp.org/jsf/composite/inward"
-      xmlns:st="http://xmlns.jcp.org/jsf/composite/store/inward">
+      xmlns:st="http://xmlns.jcp.org/jsf/composite/store/inward"
+      xmlns:admcc="http://xmlns.jcp.org/jsf/composite/ezcomp/inpatient">
 
     <h:body>
 
@@ -29,40 +30,13 @@
 
                             <p:panel header="Patient Detail" rendered="#{storeSaleBhtController.patientEncounter eq null}" class="w-100">                                        
                                 <h:outputLabel value="Type Patient Name or BHT"/>
-                                <p:autoComplete 
-                                    widgetVar="aPt2"  
-                                    id="acPt2" 
-                                    forceSelection="true" 
-                                    value="#{storeSaleBhtController.patientEncounter}" 
+                                <admcc:admission_search
+                                    widgetVar="aPt2"
+                                    inputId="acPt2"
+                                    value="#{storeSaleBhtController.patientEncounter}"
                                     completeMethod="#{admissionController.completePatient}"
-                                    var="apt2" 
-                                    itemLabel="#{apt2.bhtNo}"
-                                    itemValue="#{apt2}" 
-                                    size="30"  
-                                    style="width: 400px;
-                                    margin-left: 10px">
-
-                                    <p:column headerText="PHN" style="padding: 6px; width: 8em;">
-                                        <h:outputLabel value="#{apt2.patient.phn}"/>
-                                    </p:column>
-                                    <p:column headerText="BHT No" style="padding: 6px; width: 8em;">
-                                        <h:outputLabel value="#{apt2.bhtNo}"/>
-                                    </p:column>
-                                    <p:column headerText="Patient" style="padding: 6px; width: 400px;;">
-                                        <h:outputLabel value="#{apt2.patient.person.nameWithTitle}"/>
-                                    </p:column>
-                                    <p:column headerText="Room" style="padding: 6px; width: 8em;">
-                                        <h:outputLabel value="#{apt2.currentPatientRoom.roomFacilityCharge.name}"/>
-                                    </p:column>
-                                    <p:column headerText="Discharged" style="padding: 6px; width: 10em;">
-                                        <div class="d-flex justify-content-center">
-                                            <span class="#{apt2.discharged ? 'discharged-badge' : 'not-discharged-badge'}">
-                                                #{apt2.discharged ? 'Discharged' : 'Not Discharged'}
-                                            </span>
-                                        </div>
-                                    </p:column>
-                                    <p:ajax event="itemSelect" process="acPt2" update="#{p:resolveFirstComponentWithId('gpDetail',view).clientId}" />
-                                </p:autoComplete>  
+                                    continueClientId="bill:btnSelect"
+                                    itemSelectUpdate="#{p:resolveFirstComponentWithId('gpDetail',view).clientId}" />
                                 <p:commandButton 
                                     value="Select" 
                                     ajax="false" 


### PR DESCRIPTION
## Summary

Part of #23165's rollout — wires `admcc:admission_search` (from pilot PR #23176) into `store/store_retail_sale_bht.xhtml` (Store → BHT Issue → Inward Billing).

- Replaces the page's own hand-copied `p:autoComplete` block with the shared composite. Same `completeMethod` (`admissionController.completePatient`), no filter-semantics change.
- Preserves the existing `p:resolveFirstComponentWithId('gpDetail', view).clientId` expression as the `itemSelectUpdate` target.

## Test plan

Verified with Playwright against local Payara + MySQL:
- [x] Scanning an exact PHN with one matching admission auto-advances with no click.
- [x] No console or server-log errors during the interaction (a pre-existing, unrelated PrimeFaces widget-init console error fires on page load before the composite renders — reproducible on other unrelated pages too, not something this change introduced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)