### PR TITLE
Wire shared admission search into Surgery Workbench

### DIFF
--- a/src/main/webapp/theater/patient_surgery.xhtml
+++ b/src/main/webapp/theater/patient_surgery.xhtml
@@ -7,7 +7,8 @@
                 xmlns:f="http://xmlns.jcp.org/jsf/core"
                 xmlns="http://www.w3.org/1999/xhtml"
                 xmlns:in="http://xmlns.jcp.org/jsf/composite/inward"
-                xmlns:common="http://xmlns.jcp.org/jsf/composite/ezcomp/common">
+                xmlns:common="http://xmlns.jcp.org/jsf/composite/ezcomp/common"
+                xmlns:admcc="http://xmlns.jcp.org/jsf/composite/ezcomp/inpatient">
 
 
     <ui:define name="content">
@@ -39,37 +40,10 @@
                     </f:facet>
 
                     <h:outputLabel value="Type Patient Name or BHT : " class="mx-2"/>
-                    <p:autoComplete
-                        forceSelection="true"
+                    <admcc:admission_search
                         value="#{surgeryBillController.surgeryBill.patientEncounter}"
                         completeMethod="#{admissionController.completePatient}"
-                        var="apt2"
-                        itemLabel="#{apt2.patient.person.name}"
-                        itemValue="#{apt2}"
-                        size="40"
-                        class="m-2" >
-
-                        <p:column headerText="PHN" style="padding: 6px; width: 8em;">
-                            <h:outputLabel value="#{apt2.patient.phn}"/>
-                        </p:column>
-                        <p:column headerText="BHT No" style="padding: 6px; width: 8em;">
-                            <h:outputLabel value="#{apt2.bhtNo}"/>
-                        </p:column>
-                        <p:column headerText="Patient" style="padding: 6px; width: 400px;;">
-                            <h:outputLabel value="#{apt2.patient.person.nameWithTitle}"/>
-                        </p:column>
-                        <p:column headerText="Room" style="padding: 6px; width: 8em;">
-                            <h:outputLabel value="#{apt2.currentPatientRoom.roomFacilityCharge.name}"/>
-                        </p:column>
-                        <p:column headerText="Discharged" style="padding: 6px; width: 10em;">
-                            <div class="d-flex justify-content-center">
-                                <span class="#{apt2.discharged ? 'discharged-badge' : 'not-discharged-badge'}">
-                                    #{apt2.discharged ? 'Discharged' : 'Not Discharged'}
-                                </span>
-                            </div>
-                        </p:column>
-
-                    </p:autoComplete>
+                        continueClientId="form:btnSelect" />
 
                     <p:commandButton
                         value="Select"


### PR DESCRIPTION
## Summary

Part of #23165's rollout — wires `admcc:admission_search` (from pilot PR #23176) into `theater/patient_surgery.xhtml` (Theatre → Add Surgeries).

- Replaces the page's own hand-copied `p:autoComplete` block with the shared composite. Same `completeMethod` (`admissionController.completePatient`), no filter-semantics change.
- Minor consistency note: the closed input's label now shows BHT number (via the composite's standard `itemLabel`) instead of patient name, matching every other admission-search page in the app.

## Test plan

Verified with Playwright against local Payara + MySQL:
- [x] Scanning an exact PHN with one matching admission auto-advances to "Surgery Workbench" with no click.
- [x] No console or server-log errors during the pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)