### PR TITLE
Wire shared admission search into Add Surgery

### DIFF
--- a/src/main/webapp/theater/surgery_add.xhtml
+++ b/src/main/webapp/theater/surgery_add.xhtml
@@ -7,7 +7,8 @@
                 xmlns:f="http://xmlns.jcp.org/jsf/core"
                 xmlns="http://www.w3.org/1999/xhtml"
                 xmlns:in="http://xmlns.jcp.org/jsf/composite/inward"
-                xmlns:common="http://xmlns.jcp.org/jsf/composite/ezcomp/common">
+                xmlns:common="http://xmlns.jcp.org/jsf/composite/ezcomp/common"
+                xmlns:admcc="http://xmlns.jcp.org/jsf/composite/ezcomp/inpatient">
 
     <ui:define name="content">
 
@@ -26,28 +27,10 @@
                     </f:facet>
 
                     <h:outputLabel value="Type Patient Name or BHT : " class="mx-2"/>
-                    <p:autoComplete
-                        forceSelection="true"
+                    <admcc:admission_search
                         value="#{surgeryBillController.surgeryBill.patientEncounter}"
                         completeMethod="#{admissionController.completePatient}"
-                        var="apt2"
-                        itemLabel="#{apt2.patient.person.name}"
-                        itemValue="#{apt2}"
-                        size="40"
-                        class="m-2">
-                        <p:column headerText="PHN" style="padding: 6px; width: 8em;">
-                            <h:outputLabel value="#{apt2.patient.phn}"/>
-                        </p:column>
-                        <p:column headerText="BHT No" style="padding: 6px; width: 8em;">
-                            <h:outputLabel value="#{apt2.bhtNo}"/>
-                        </p:column>
-                        <p:column headerText="Patient" style="padding: 6px; width: 400px;">
-                            <h:outputLabel value="#{apt2.patient.person.nameWithTitle}"/>
-                        </p:column>
-                        <p:column headerText="Room" style="padding: 6px; width: 8em;">
-                            <h:outputLabel value="#{apt2.currentPatientRoom.roomFacilityCharge.name}"/>
-                        </p:column>
-                    </p:autoComplete>
+                        continueClientId="form:btnSelect" />
                     <p:commandButton value="Select" ajax="false" id="btnSelect"/>
                 </p:panel>
 


### PR DESCRIPTION
## Summary

Part of #23165's rollout — wires `admcc:admission_search` (from pilot PR #23176) into `theater/surgery_add.xhtml` (Theatre → Add Surgeries, the direct-add variant).

- Replaces the page's own hand-copied `p:autoComplete` block with the shared composite. Same `completeMethod` (`admissionController.completePatient`), no filter-semantics change.
- Same `itemLabel` standardization (shows BHT number instead of patient name) as the sibling `patient_surgery.xhtml` PR in this batch (#23184), for consistency.

## Test plan

Verified with Playwright: this page shares the session-scoped `surgeryBillController` with `patient_surgery.xhtml`, so state carried over during testing and confirmed the same value binding renders correctly (Add Surgery — BHT + full patient details). Structurally identical composite wiring to `patient_surgery.xhtml`, which was tested fresh end-to-end (exact-match auto-advance, no console/server errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)