### PR TITLE
Wire shared admission search into BHT Issue Request (Pharmacy)

### DIFF
--- a/src/main/webapp/resources/ezcomp/inpatient/admission_search.xhtml
+++ b/src/main/webapp/resources/ezcomp/inpatient/admission_search.xhtml
@@ -13,8 +13,10 @@
                       method-signature="java.util.List completeMethod(java.lang.String)" />
         <!-- The ALREADY-RESOLVED, real rendered client id (e.g. "bill:btnSelect") of the page's
              existing "Continue" button. This composite will document.getElementById(...) and
-             .click() it when auto-advancing on an exact single-match. -->
-        <cc:attribute name="continueClientId" required="true" type="java.lang.String" />
+             .click() it when auto-advancing on an exact single-match. Optional: some pages have
+             no separate Continue step (selecting the item itself, via itemSelectUpdate, is the
+             whole "advance" action) - leave unset/blank in that case, and no click is attempted. -->
+        <cc:attribute name="continueClientId" type="java.lang.String" default="" />
         <cc:attribute name="widgetVar" type="java.lang.String" default="acAdmissionSearch" />
         <cc:attribute name="inputId" type="java.lang.String" default="acAdmissionSearch" />
         <!-- Passed straight through to the inner p:ajax event="itemSelect" update="...".
@@ -24,6 +26,8 @@
         <cc:attribute name="itemSelectUpdate" type="java.lang.String" default="" />
         <cc:attribute name="placeholder" type="java.lang.String"
                       default="Type patient name, BHT number, MRN, or PHN..." />
+        <cc:attribute name="required" type="java.lang.Boolean" default="false" />
+        <cc:attribute name="requiredMessage" type="java.lang.String" default="Please select a patient" />
     </cc:interface>
 
     <!-- IMPLEMENTATION -->
@@ -41,6 +45,8 @@
             itemValue="#{myItem}"
             itemLabel="#{myItem.bhtNo}"
             placeholder="#{cc.attrs.placeholder}"
+            required="#{cc.attrs.required}"
+            requiredMessage="#{cc.attrs.requiredMessage}"
             minQueryLength="2"
             style="width: 100%;"
             inputStyleClass="form-control form-control-lg">

--- a/src/main/webapp/ward/ward_pharmacy_bht_issue_request_bill.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_bht_issue_request_bill.xhtml
@@ -8,7 +8,8 @@
       xmlns:phi="http://xmlns.jcp.org/jsf/composite/pharmacy"
       xmlns:ph="http://xmlns.jcp.org/jsf/composite/pharmacy"
       xmlns:bill="http://xmlns.jcp.org/jsf/composite/inward"
-      xmlns:phprint="http://xmlns.jcp.org/jsf/composite/pharmacy/print">
+      xmlns:phprint="http://xmlns.jcp.org/jsf/composite/pharmacy/print"
+      xmlns:admcc="http://xmlns.jcp.org/jsf/composite/ezcomp/inpatient">
 
     <h:body>
 
@@ -122,40 +123,12 @@
                                                      placeholder="Select a pharmacy department first" />
                                     </h:panelGroup>
                                     <h:panelGroup rendered="#{pharmacyRequestForBhtController.department ne null}">
-                                    <p:autoComplete
+                                    <admcc:admission_search
                                         widgetVar="aPt2"
-                                        id="acPt2"
-                                        forceSelection="true"
+                                        inputId="acPt2"
                                         value="#{pharmacyRequestForBhtController.patientEncounter}"
                                         completeMethod="#{admissionController.completePatient}"
-                                        var="apt2"
-                                        itemLabel="#{apt2.bhtNo}"
-                                        itemValue="#{apt2}"
-                                        size="30"
-                                        class="col-md-12 my-1"
-                                        inputStyleClass="form-control"
-                                        >
-                                        <p:column headerText="PHN" style="padding: 6px; width: 8em;">
-                                            <h:outputLabel value="#{apt2.patient.phn}"/>
-                                        </p:column>
-                                        <p:column headerText="BHT No" style="padding: 6px; width: 8em;">
-                                            <h:outputLabel value="#{apt2.bhtNo}"/>
-                                        </p:column>
-                                        <p:column headerText="Patient" style="padding: 6px; width: 400px;;">
-                                            <h:outputLabel value="#{apt2.patient.person.nameWithTitle}"/>
-                                        </p:column>
-                                        <p:column headerText="Room" style="padding: 6px; width: 8em;">
-                                            <h:outputLabel value="#{apt2.currentPatientRoom.roomFacilityCharge.name}"/>
-                                        </p:column>
-                                        <p:column headerText="Discharged" style="padding: 6px; width: 10em;">
-                                            <div class="d-flex justify-content-center">
-                                                <span class="#{apt2.discharged ? 'discharged-badge' : 'not-discharged-badge'}">
-                                                    #{apt2.discharged ? 'Discharged' : 'Not Discharged'}
-                                                </span>
-                                            </div>
-                                        </p:column>
-                                        <p:ajax event="itemSelect" process="acPt2" update="@form" />
-                                    </p:autoComplete>
+                                        itemSelectUpdate="@form" />
                                     </h:panelGroup>
                                 </div>
 


### PR DESCRIPTION
## Summary

Part of #23165's rollout — wires `admcc:admission_search` (from pilot PR #23176) into `ward/ward_pharmacy_bht_issue_request_bill.xhtml` (Pharmacy/Inward → BHT Issue Requests).

**Note:** this PR also touches the shared `resources/ezcomp/inpatient/admission_search.xhtml` composite, since this page needed one small enhancement not required by prior pages:

- This page has no separate "Continue" button — selecting the patient (`itemSelectUpdate="@form"`) *is* the whole advance action. Made the composite's `continueClientId` attribute optional (was `required="true"`) instead of adding a page-specific special case. When left unset, the composite's auto-click step is simply skipped — same-as-before behavior for every page already wired to a `continueClientId`.
- If another PR in this rollout batch (#23178–#23185) merges first, this composite diff should apply cleanly since it's purely additive (relaxing a `required` constraint, no removed/changed lines those other PRs touch).

## Test plan

Verified with Playwright against local Payara + MySQL:
- [x] Selected a pharmacy department, then scanned an exact PHN with one matching admission — auto-advanced straight to "BHT Issue Request for - Main Pharmacy" with full patient details, no click.
- [x] A pre-existing, unrelated PrimeFaces widget-init console error fires on this page at load time (reproducible before the composite even renders, and on other unrelated pages too) — not something this change introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)