### PR TITLE
Wire shared admission search into Add Timed Services

### DIFF
--- a/src/main/webapp/inward/inward_timed_service_consume.xhtml
+++ b/src/main/webapp/inward/inward_timed_service_consume.xhtml
@@ -6,7 +6,8 @@
                 xmlns:f="http://xmlns.jcp.org/jsf/core"
                 xmlns="http://www.w3.org/1999/xhtml"
                 xmlns:p="http://primefaces.org/ui"
-                xmlns:in="http://xmlns.jcp.org/jsf/composite/inward">
+                xmlns:in="http://xmlns.jcp.org/jsf/composite/inward"
+                xmlns:admcc="http://xmlns.jcp.org/jsf/composite/ezcomp/inpatient">
 
 
     <ui:define name="content">
@@ -37,43 +38,17 @@
 
 
                             <h:outputLabel value="Type Patient Name or BHT : "/>
-                            <p:autoComplete  
-                                widgetVar="aPt" 
-                                id="acPt" 
-                                forceSelection="true" 
+                            <admcc:admission_search
+                                widgetVar="aPt"
+                                inputId="acPt"
                                 value="#{inwardTimedItemController.current.patientEncounter}"
-                                completeMethod="#{admissionController.completePatient}" 
-                                var="myItem" 
-                                itemValue="#{myItem}" 
-                                itemLabel="#{myItem.bhtNo}" 
-                                size="40" 
-                                required="true" 
-                                class="m-2" 
-                                requiredMessage="Please enter patient details">
-
-                                <p:column headerText="PHN" style="padding: 6px; width: 8em;">
-                                    <h:outputLabel value="#{myItem.patient.phn}"/>
-                                </p:column>
-                                <p:column headerText="BHT No" style="padding: 6px; width: 8em;">
-                                    <h:outputLabel value="#{myItem.bhtNo}"/>
-                                </p:column>
-                                <p:column headerText="Patient" style="padding: 6px; width: 400px;;">
-                                    <h:outputLabel value="#{myItem.patient.person.nameWithTitle}"/>
-                                </p:column>
-                                <p:column headerText="Room" style="padding: 6px; width: 8em;">
-                                    <h:outputLabel value="#{myItem.currentPatientRoom.roomFacilityCharge.name}"/>
-                                </p:column>
-                                <p:column headerText="Discharged" style="padding: 6px; width: 10em;">
-                                    <div class="d-flex justify-content-center">
-                                        <span class="#{myItem.discharged ? 'discharged-badge' : 'not-discharged-badge'}">
-                                            #{myItem.discharged ? 'Discharged' : 'Not Discharged'}
-                                        </span>
-                                    </div>
-                                </p:column>
-
-                            </p:autoComplete> 
-                            <p:commandButton 
-                                value="Select" 
+                                completeMethod="#{admissionController.completePatient}"
+                                continueClientId="formTimedServiceConsume:btnSelect"
+                                required="true"
+                                requiredMessage="Please enter patient details" />
+                            <p:commandButton
+                                id="btnSelect"
+                                value="Select"
                                 ajax="false" >
                             </p:commandButton>
 

--- a/src/main/webapp/resources/ezcomp/inpatient/admission_search.xhtml
+++ b/src/main/webapp/resources/ezcomp/inpatient/admission_search.xhtml
@@ -13,8 +13,10 @@
                       method-signature="java.util.List completeMethod(java.lang.String)" />
         <!-- The ALREADY-RESOLVED, real rendered client id (e.g. "bill:btnSelect") of the page's
              existing "Continue" button. This composite will document.getElementById(...) and
-             .click() it when auto-advancing on an exact single-match. -->
-        <cc:attribute name="continueClientId" required="true" type="java.lang.String" />
+             .click() it when auto-advancing on an exact single-match. Optional: some pages have
+             no separate Continue step (selecting the item itself, via itemSelectUpdate, is the
+             whole "advance" action) - leave unset/blank in that case, and no click is attempted. -->
+        <cc:attribute name="continueClientId" type="java.lang.String" default="" />
         <cc:attribute name="widgetVar" type="java.lang.String" default="acAdmissionSearch" />
         <cc:attribute name="inputId" type="java.lang.String" default="acAdmissionSearch" />
         <!-- Passed straight through to the inner p:ajax event="itemSelect" update="...".
@@ -24,6 +26,8 @@
         <cc:attribute name="itemSelectUpdate" type="java.lang.String" default="" />
         <cc:attribute name="placeholder" type="java.lang.String"
                       default="Type patient name, BHT number, MRN, or PHN..." />
+        <cc:attribute name="required" type="java.lang.Boolean" default="false" />
+        <cc:attribute name="requiredMessage" type="java.lang.String" default="Please select a patient" />
     </cc:interface>
 
     <!-- IMPLEMENTATION -->
@@ -41,6 +45,8 @@
             itemValue="#{myItem}"
             itemLabel="#{myItem.bhtNo}"
             placeholder="#{cc.attrs.placeholder}"
+            required="#{cc.attrs.required}"
+            requiredMessage="#{cc.attrs.requiredMessage}"
             minQueryLength="2"
             style="width: 100%;"
             inputStyleClass="form-control form-control-lg">


### PR DESCRIPTION
## Summary

Part of #23165's rollout — wires `admcc:admission_search` (from pilot PR #23176) into `inward/inward_timed_service_consume.xhtml` (Inward → Services & Items → Add Timed Services).

**Note:** this PR also touches the shared `resources/ezcomp/inpatient/admission_search.xhtml` composite: this page's original `p:autoComplete` had `required="true"` (blocking the plain "Select" postback until a patient is chosen). Added optional `required`/`requiredMessage` pass-through attributes to the composite to preserve that validation — previously not exposed. Purely additive; should merge cleanly regardless of ordering against the other PRs in this batch (#23178–#23186).

- Same `completeMethod` (`admissionController.completePatient`), no filter-semantics change.

## Test plan

Verified with Playwright against local Payara + MySQL:
- [x] Scanning an exact PHN with one matching admission auto-advances to "Manage Inward Timed Services" with full patient details, no click.
- [x] No console or server-log errors during the pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)