### PR TITLE
Wire shared admission search into Issue Discharge Medicines

### DIFF
--- a/src/main/webapp/inward/pharmacy_discharge_medicine_issue.xhtml
+++ b/src/main/webapp/inward/pharmacy_discharge_medicine_issue.xhtml
@@ -7,7 +7,8 @@
                 xmlns:f="http://xmlns.jcp.org/jsf/core"
                 xmlns:phe="http://xmlns.jcp.org/jsf/composite/pharmacy/inward"
                 xmlns:phi="http://xmlns.jcp.org/jsf/composite/pharmacy"
-                xmlns:bill="http://xmlns.jcp.org/jsf/composite/inward">
+                xmlns:bill="http://xmlns.jcp.org/jsf/composite/inward"
+                xmlns:admcc="http://xmlns.jcp.org/jsf/composite/ezcomp/inpatient">
 
     <ui:define name="content">
         <h:form id="bill" >
@@ -60,61 +61,17 @@
 
                                         <div class="row align-items-end">
                                             <div class="col-12 col-md-9 mb-3 mb-md-0">
-                                                <h:outputLabel for="acPt2" styleClass="form-label fw-bold text-dark mb-2">
+                                                <h:outputLabel styleClass="form-label fw-bold text-dark mb-2">
                                                     <i class="fa-solid fa-user me-2 text-primary"></i>
                                                     <h:outputText value="Patient Search" />
                                                 </h:outputLabel>
-                                                <p:autoComplete
+                                                <admcc:admission_search
                                                     widgetVar="aPt2"
-                                                    id="acPt2"
-                                                    forceSelection="true"
+                                                    inputId="acPt2"
                                                     value="#{pharmacySaleBhtController.patientEncounter}"
                                                     completeMethod="#{admissionController.completePatient}"
-                                                    var="apt2"
-                                                    itemLabel="#{apt2.bhtNo}"
-                                                    itemValue="#{apt2}"
-                                                    placeholder="Type patient name, BHT number, or PHN..."
-                                                    minQueryLength="2"
-                                                    maxResults="25"
-                                                    scrollHeight="250"
-                                                    style="width: 100%;"
-                                                    inputStyleClass="form-control form-control-lg">
-                                                    <p:column headerText="PHN" style="padding: 8px; min-width: 100px;">
-                                                        <div class="d-flex align-items-center">
-                                                            <i class="fa-solid fa-id-card me-2 text-info"></i>
-                                                            <strong>#{apt2.patient.phn}</strong>
-                                                        </div>
-                                                    </p:column>
-                                                    <p:column headerText="BHT No" style="padding: 8px; min-width: 120px;">
-                                                        <div class="d-flex align-items-center">
-                                                            <i class="fa-solid fa-hospital me-2 text-warning"></i>
-                                                            <strong class="text-primary">#{apt2.bhtNo}</strong>
-                                                        </div>
-                                                    </p:column>
-                                                    <p:column headerText="Patient Name" style="padding: 8px; min-width: 250px;">
-                                                        <div class="d-flex align-items-center">
-                                                            <i class="fa-solid fa-user me-2 text-success"></i>
-                                                            <span class="fw-medium">#{apt2.patient.person.nameWithTitle}</span>
-                                                        </div>
-                                                    </p:column>
-                                                    <p:column headerText="Room" style="padding: 8px; min-width: 150px;">
-                                                        <h:panelGroup rendered="#{apt2.currentPatientRoom ne null}">
-                                                            <div class="d-flex align-items-center">
-                                                                <i class="fa-solid fa-bed me-2 text-secondary"></i>
-                                                                <span>#{apt2.currentPatientRoom.roomFacilityCharge.name}</span>
-                                                            </div>
-                                                        </h:panelGroup>
-                                                        <h:panelGroup rendered="#{apt2.currentPatientRoom eq null}">
-                                                            <span class="text-muted">
-                                                                <i class="fa-solid fa-question-circle me-1"></i>No room assigned
-                                                            </span>
-                                                        </h:panelGroup>
-                                                    </p:column>
-                                                    <p:column headerText="Status" style="padding: 8px; min-width: 120px;">
-                                                        <p:badge value="Discharged" styleClass="ui-badge-danger" rendered="#{apt2.discharged}" />
-                                                        <p:badge value="Active" styleClass="ui-badge-success" rendered="#{!apt2.discharged}" />
-                                                    </p:column>
-                                                </p:autoComplete>
+                                                    continueClientId="bill:btnSelect"
+                                                    placeholder="Type patient name, BHT number, MRN, or PHN..." />
                                             </div>
                                             <div class="col-12 col-md-3">
                                                 <p:commandButton


### PR DESCRIPTION
## Summary

Part of #23165's rollout — wires `admcc:admission_search` (from pilot PR #23176) into `inward/pharmacy_discharge_medicine_issue.xhtml` (Pharmacy → Inpatient Medication Management → Issue Discharge Medicines).

- Replaces the page's own hand-copied `p:autoComplete` block with the shared composite. Same `completeMethod` (`admissionController.completePatient`), no filter-semantics change.

## Test plan

Verified with Playwright against local Payara + MySQL:
- [x] Scanning an exact PHN with one matching admission auto-advances to the discharge-medicine issue screen with no click.
- [x] No console or server-log errors during the pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)