### PR TITLE
fix(pharmacy): guard GRN Receive/Save against double-submit item duplication

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnCostingController.java
@@ -2772,7 +2772,14 @@ public class GrnCostingController implements Serializable {
         }
     }
 
-    public String navigateToResiveCostingWithSaveApprove() {
+    // synchronized: a double-click/double-submit on the "Receive" button (ajax="false",
+    // no confirm() dialog) can race two calls through this session-scoped bean before
+    // either finishes rebuilding currentGrnBillPre, interleaving generateBillComponent()'s
+    // appends to getBillItems() across both calls and leaving some PO lines duplicated
+    // in the in-memory draft while others are untouched (same bug class as
+    // PurchaseOrderController.approve() / finalizeGrnWithSaveApprove() / issue #22194,
+    // but this entry point was never covered).
+    public synchronized String navigateToResiveCostingWithSaveApprove() {
         // Check for billId parameter (from DTO-based page)
         String billIdParam = JsfUtil.getRequestParameter("billId");
         if (billIdParam != null && !billIdParam.isEmpty()) {
@@ -2954,7 +2961,10 @@ public class GrnCostingController implements Serializable {
         }
     }
 
-    public void requestWithSaveApprove() {
+    // synchronized: the Save button (ajax="false", no confirm() dialog) has no
+    // double-click guard - see navigateToResiveCostingWithSaveApprove() above for the
+    // same bug class this closes.
+    public synchronized void requestWithSaveApprove() {
         if (!isAuthorized("REQUEST_WITH_SAVE_APPROVE", "PharmacyGrnSave")) {
             return;
         }

--- a/src/main/java/com/divudi/bean/pharmacy/GrnCostingNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/GrnCostingNativeSqlController.java
@@ -257,7 +257,12 @@ public class GrnCostingNativeSqlController implements Serializable {
         insTotal = 0;
     }
 
-    public String navigateToResiveCostingWithSaveApprove() {
+    // synchronized: same double-click double-submit guard as finalize/approve below
+    // (issue #22194) - the "Receive" button (ajax="false", no confirm()) had no guard,
+    // letting two racing calls interleave generateBillComponent()'s appends and
+    // duplicate some PO lines in the in-memory draft (issue GRN item duplication,
+    // Ruhunu prod, 2026-08-21).
+    public synchronized String navigateToResiveCostingWithSaveApprove() {
         // Check for billId parameter (from DTO-based receive list)
         String billIdParam = JsfUtil.getRequestParameter("billId");
         if (billIdParam != null && !billIdParam.isEmpty()) {
@@ -406,7 +411,9 @@ public class GrnCostingNativeSqlController implements Serializable {
     // ==================================================================
     // Save / Finalize / Approve
     // ==================================================================
-    public void requestWithSaveApprove() {
+    // synchronized: the Save button has no double-click guard - see
+    // navigateToResiveCostingWithSaveApprove() above for the same bug class this closes.
+    public synchronized void requestWithSaveApprove() {
         if (!isAuthorized("REQUEST_WITH_SAVE_APPROVE", "PharmacyGrnSave")) {
             return;
         }


### PR DESCRIPTION
## Summary
- `GrnCostingController.navigateToResiveCostingWithSaveApprove()` ("Receive" button) and `requestWithSaveApprove()` ("Save" button) on the legacy GRN costing page had no `synchronized` guard, unlike the sibling Finalize/Approve actions already fixed for issue #22194.
- A double-click / double-submit races two calls through the shared `@SessionScoped` bean, interleaving `generateBillComponent()`'s appends and leaving some PO lines duplicated in the in-memory GRN draft while others are untouched.
- Mirrored the same fix in `GrnCostingNativeSqlController` (the newer "native" GRN costing page), which had the identical gap.

## Context
Investigated a Ruhunu production report (2026-08-21) of a Main Laboratory user seeing GRN line items tripled on the "Goods Receive with Save/Approve" screen (e.g. Norfloxacin x3, Piperacillin Tazobactam x3) while other lines on the same screen were unaffected — the classic signature of an unguarded concurrent-request race, not a clean logical bug.

Confirmed via direct query against the `ruhunu` production DB that nothing was ever persisted for the affected items that day — the duplication was purely in-memory (pre-Save), so no data correction is needed for this incident. Payara logs for the period show no exceptions, consistent with a silent client-side race rather than a server-side error.

This is a different code path from the PO-Approval duplication fixed by PR #21815/#21821 — that fix (`PurchaseOrderController.approve()`) is confirmed still `synchronized` and intact on `ruhunu-prod`. This PR closes a separate, previously-uncovered entry point in the GRN Receive/Save flow.

## Test plan
- [x] `mvn compile` passes
- [ ] Manually verify Receive → Save → Finalize → Approve flow still works end-to-end on a test PO
- [ ] Port to `ruhunu-prod` via `/hotfix-deploy` once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate GRN costing submissions caused by repeated or concurrent actions.
  * Improved reliability when saving, approving, and navigating GRN costing records.
  * Ensured draft item processing and updates are handled consistently during submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->