### PR TITLE
fix(pharmacy): correct GRN Summary Report stock amount, filters, and PDF columns

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
@@ -210,6 +210,8 @@ public class PharmacyController implements Serializable {
     private List<BillItem> directPurchase;
     private List<PharmacyItemPurchaseDTO> directPurchaseDtos;
     private List<Bill> bills;
+    // GRN Summary Report "Stock Amount" column — bill.id -> summed BillItemFinanceDetails.valueAtPurchaseRate. See #23170.
+    private Map<Long, BigDecimal> grnStockAmountsByBillId;
     List<ItemTransactionSummeryRow> itemTransactionSummeryRows;
     private int managePharamcyReportIndex = -1;
     double persentage;
@@ -2505,7 +2507,33 @@ public class PharmacyController implements Serializable {
         filters.put("Payment Method", paymentMethod != null ? paymentMethod.getLabel() : "All");
         filters.put("Supplier", fromInstitution != null ? fromInstitution.getName() : "All");
         filters.put("report type", reportType != null ? reportType : "All");
-       
+
+
+        return filters;
+    }
+
+    /**
+     * Filters map for the standalone GRN Summary Report page
+     * (reports/inventoryReports/grn_summary_report.xhtml), which only exposes
+     * From/To Date, Institution, Site, Department/Store, Payment Mode and
+     * Purchase Type as inputs. {@link #getFiltersForGRNDetailReport()} lists
+     * fields (Department Type, Category, Dosage Form, Supplier) that belong to
+     * the older combined GRN/Direct Purchase report (grn.xhtml) and are not
+     * present on this page — using it here showed those as "All" on every PDF
+     * and Excel export regardless of what the user actually filtered by. See
+     * issue #23170.
+     */
+    public Map<String, Object> getFiltersForGRNSummaryReport() {
+        SimpleDateFormat sdf = new SimpleDateFormat(sessionController.getApplicationPreference().getLongDateTimeFormat());
+        Map<String, Object> filters = new LinkedHashMap<>();
+
+        filters.put("From Date", fromDate != null ? sdf.format(fromDate) : "None");
+        filters.put("To Date", toDate != null ? sdf.format(toDate) : "None");
+        filters.put("Institution", institution != null ? institution.getName() : "All Institutions");
+        filters.put("Site", site != null ? site.getName() : "All Sites");
+        filters.put("Department/Store", dept != null ? dept.getName() : "All Departments");
+        filters.put("Payment Mode", paymentMethod != null ? paymentMethod.getLabel() : "All Modes");
+        filters.put("Purchase Type", "grn".equals(purchaseType) ? "GRN" : "direct".equals(purchaseType) ? "Direct Purchase" : "All Types");
 
         return filters;
     }
@@ -10614,6 +10642,66 @@ public class PharmacyController implements Serializable {
         } catch (Exception e) {
             JsfUtil.addErrorMessage(e, " Something Went Worng!");
         }
+
+        loadGrnStockAmounts();
+    }
+
+    /**
+     * Batch-computes the "Stock Amount" (value at purchase rate) for each bill
+     * currently loaded into {@link #bills}, summed from BillItemFinanceDetails.
+     * <p>
+     * Bill-level BillFinanceDetails.totalPurchaseValue is only populated via the
+     * GRN Costing workflow (see GrnCostingController) or the GRN BFD backfill
+     * service, so most GRNs never carry an aggregate on the bill itself. Summing
+     * from the line-level finance details (already populated at GRN receipt time
+     * for every bill item) avoids depending on that separate workflow having run.
+     * See issue #23170.
+     */
+    private void loadGrnStockAmounts() {
+        grnStockAmountsByBillId = new HashMap<>();
+        if (bills == null || bills.isEmpty()) {
+            return;
+        }
+        List<Long> billIds = new ArrayList<>();
+        for (Bill b : bills) {
+            if (b.getId() != null) {
+                billIds.add(b.getId());
+            }
+        }
+        if (billIds.isEmpty()) {
+            return;
+        }
+        String stockAmountJpql = "SELECT bi.bill.id, SUM(bi.billItemFinanceDetails.valueAtPurchaseRate) "
+                + " FROM BillItem bi "
+                + " WHERE bi.bill.id IN :billIds AND bi.retired = false "
+                + " GROUP BY bi.bill.id";
+        Map<String, Object> stockAmountParams = new HashMap<>();
+        stockAmountParams.put("billIds", billIds);
+        try {
+            List<Object[]> rows = getBillItemFacade().findObjectsArrayByJpql(stockAmountJpql, stockAmountParams, TemporalType.TIMESTAMP);
+            if (rows != null) {
+                for (Object[] row : rows) {
+                    if (row[0] != null && row[1] != null) {
+                        grnStockAmountsByBillId.put((Long) row[0], (BigDecimal) row[1]);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            Logger.getLogger(PharmacyController.class.getName()).log(Level.SEVERE, "Error computing GRN stock amounts", e);
+        }
+    }
+
+    /**
+     * "Stock Amount" for a single bill row on the GRN Summary Report — see
+     * {@link #loadGrnStockAmounts()}. Falls back to zero when nothing was
+     * posted to stock (e.g. cancelled bills with no surviving bill items).
+     */
+    public BigDecimal getGrnStockAmount(Bill bill) {
+        if (bill == null || bill.getId() == null || grnStockAmountsByBillId == null) {
+            return BigDecimal.ZERO;
+        }
+        BigDecimal amt = grnStockAmountsByBillId.get(bill.getId());
+        return amt != null ? amt : BigDecimal.ZERO;
     }
 
     public Double calculateTotalGrnAmount() {
@@ -11230,16 +11318,172 @@ public class PharmacyController implements Serializable {
         }
     }
     
+    /**
+     * PDF export for the standalone GRN Summary Report page
+     * (reports/inventoryReports/grn_summary_report.xhtml). Columns mirror that
+     * page's on-screen table exactly and filters are scoped to just the inputs
+     * that page actually exposes. See issue #23170.
+     * <p>
+     * NOT used by the older combined GRN/Direct Purchase report (grn.xhtml) —
+     * that page keeps using {@link #exportGRNAndDirectPurchaseSummaryReportToPDF()}
+     * unchanged, since its own on-screen "summary" table has a different,
+     * narrower column set that method already matches.
+     */
+    public void exportGRNSummaryReportToPDF() {
+        FacesContext context = FacesContext.getCurrentInstance();
+        ExternalContext externalContext = context.getExternalContext();
+
+        List<Bill> rows = getBills();
+        if (rows == null || rows.isEmpty()) {
+            JsfUtil.addErrorMessage("No data available to export");
+            return;
+        }
+
+        String fileName = "GRN_Summary_Report_"
+                + fromDateFormatted() + "_to_" + toDateFormatted() + ".pdf";
+
+        SimpleDateFormat sdf = new SimpleDateFormat(sessionController.getApplicationPreference().getLongDateTimeFormat());
+        SimpleDateFormat sdfDateOnly = new SimpleDateFormat(sessionController.getApplicationPreference().getLongDateFormat());
+        com.itextpdf.text.Font bodyFontSmall =
+                com.itextpdf.text.FontFactory.getFont(com.itextpdf.text.FontFactory.HELVETICA, 6);
+        String institutionName = sessionController.getInstitution() != null ? sessionController.getInstitution().getName() : "";
+        com.itextpdf.text.Document document = null;
+        OutputStream out = null;
+
+        try {
+            externalContext.responseReset();
+            externalContext.setResponseContentType("application/pdf");
+            externalContext.setResponseHeader("Content-Disposition", "attachment; filename=\"" + fileName + "\"");
+
+            out = externalContext.getResponseOutputStream();
+
+            document = new com.itextpdf.text.Document(com.itextpdf.text.PageSize.A4.rotate(), 10f, 10f, 12f, 12f);
+            com.itextpdf.text.pdf.PdfWriter.getInstance(document, out);
+            document.open();
+
+            if (!institutionName.isEmpty()) {
+                document.add(new Paragraph(institutionName,
+                        FontFactory.getFont(FontFactory.HELVETICA_BOLD, 18)));
+            }
+            document.add(new Paragraph("GRN Summary Report",
+                    FontFactory.getFont(FontFactory.HELVETICA_BOLD, 16)));
+            document.add(new Paragraph("Generated On: " + sdf.format(new Date()),
+                    FontFactory.getFont(FontFactory.HELVETICA, 12)));
+            document.add(new Paragraph(" "));
+
+            Map<String, Object> filters = getFiltersForGRNSummaryReport();
+            PdfPTable infoTable = createInfoTablePdfExport(sdf, filters);
+            if (infoTable != null) {
+                document.add(infoTable);
+            }
+
+            com.itextpdf.text.pdf.PdfPTable table = new com.itextpdf.text.pdf.PdfPTable(12);
+            table.setWidthPercentage(100);
+            table.setWidths(new float[]{0.6f, 1.3f, 1.2f, 1.2f, 1.1f, 1.2f, 1.8f, 1.1f, 1f, 1f, 1f, 1.1f});
+
+            String[] headers = {
+                "S.No", "GRN No", "Purchase Type", "GRN Date", "Invoice No", "Invoice Date",
+                "Vendor Name", "Payment Mode", "Amount", "Dis. Amount", "Stock Amount", "Status"
+            };
+
+            for (String header : headers) {
+                com.itextpdf.text.pdf.PdfPCell cell =
+                        new com.itextpdf.text.pdf.PdfPCell(
+                                new com.itextpdf.text.Phrase(header,
+                                        com.itextpdf.text.FontFactory.getFont(
+                                                com.itextpdf.text.FontFactory.HELVETICA_BOLD, 7)));
+                cell.setBackgroundColor(com.itextpdf.text.BaseColor.LIGHT_GRAY);
+                table.addCell(cell);
+            }
+
+            BigDecimal totalDiscount = BigDecimal.ZERO;
+            BigDecimal totalStockAmount = BigDecimal.ZERO;
+
+            int index = 1;
+            for (Bill f : rows) {
+                BigDecimal stockAmount = getGrnStockAmount(f);
+                totalDiscount = totalDiscount.add(BigDecimal.valueOf(f.getDiscount()));
+                totalStockAmount = totalStockAmount.add(stockAmount);
+
+                table.addCell(numCell(index++, bodyFontSmall));
+                table.addCell(textCell(f.getDeptId(), bodyFontSmall));
+                table.addCell(textCell(f.getBillTypeAtomic() != null ? f.getBillTypeAtomic().getLabel() : "-", bodyFontSmall));
+                table.addCell(textCell(f.getCreatedAt() != null ? sdfDateOnly.format(f.getCreatedAt()) : "-", bodyFontSmall));
+                table.addCell(textCell(f.getInvoiceNumber(), bodyFontSmall));
+                table.addCell(textCell(f.getInvoiceDate() != null ? sdfDateOnly.format(f.getInvoiceDate()) : "-", bodyFontSmall));
+                table.addCell(textCell((f.getBillTypeAtomic() == BillTypeAtomic.PHARMACY_GRN_RETURN || f.getBillTypeAtomic() == BillTypeAtomic.PHARMACY_DIRECT_PURCHASE_REFUND)
+                        ? (f.getToInstitution() != null ? f.getToInstitution().getName() : "-")
+                        : (f.getFromInstitution() != null ? f.getFromInstitution().getName() : "-"), bodyFontSmall));
+                table.addCell(textCell(f.getPaymentMethod() != null ? f.getPaymentMethod().getLabel() : "-", bodyFontSmall));
+                table.addCell(numCell(f.getNetTotal(), bodyFontSmall));
+                table.addCell(numCell(f.getDiscount(), bodyFontSmall));
+                table.addCell(numCell(stockAmount.doubleValue(), bodyFontSmall));
+                table.addCell(textCell(grnSummaryStatusLabel(f), bodyFontSmall));
+            }
+
+            com.itextpdf.text.pdf.PdfPCell footerCell =
+                    new com.itextpdf.text.pdf.PdfPCell(
+                            new com.itextpdf.text.Phrase("Total",
+                                    com.itextpdf.text.FontFactory.getFont(
+                                            com.itextpdf.text.FontFactory.HELVETICA_BOLD, 8)));
+            footerCell.setColspan(8);
+            footerCell.setBackgroundColor(com.itextpdf.text.BaseColor.LIGHT_GRAY);
+            footerCell.setHorizontalAlignment(com.itextpdf.text.Element.ALIGN_CENTER);
+            table.addCell(footerCell);
+
+            table.addCell(numCell(calculateTotalGrnAmount(), bodyFontSmall));
+            table.addCell(numCell(totalDiscount.doubleValue(), bodyFontSmall));
+            table.addCell(numCell(totalStockAmount.doubleValue(), bodyFontSmall));
+            com.itextpdf.text.pdf.PdfPCell blankStatusFooterCell = new com.itextpdf.text.pdf.PdfPCell(new com.itextpdf.text.Phrase(""));
+            blankStatusFooterCell.setBackgroundColor(com.itextpdf.text.BaseColor.LIGHT_GRAY);
+            table.addCell(blankStatusFooterCell);
+
+            document.add(table);
+
+        } catch (Exception e) {
+            Logger.getLogger(PharmacyController.class.getName()).log(Level.SEVERE, "Error generating GRN Summary Report PDF", e);
+        } finally {
+            if (document != null && document.isOpen()) {
+                document.close();
+            }
+            context.responseComplete();
+        }
+    }
+
+    /**
+     * Same "Status" logic as the on-screen GRN Summary Report table
+     * (grn_summary_report.xhtml) — kept here so the PDF export matches it.
+     */
+    private String grnSummaryStatusLabel(Bill bill) {
+        if (bill == null || bill.getBillTypeAtomic() == null) {
+            return "-";
+        }
+        BillTypeAtomic bta = bill.getBillTypeAtomic();
+        if (bta == BillTypeAtomic.PHARMACY_GRN_CANCELLED || bta == BillTypeAtomic.PHARMACY_DIRECT_PURCHASE_CANCELLED) {
+            return "Cancelled";
+        }
+        if (bta == BillTypeAtomic.PHARMACY_GRN_RETURN || bta == BillTypeAtomic.PHARMACY_DIRECT_PURCHASE_REFUND) {
+            return "Returned";
+        }
+        if ((bta == BillTypeAtomic.PHARMACY_GRN && bill.isCompleted()) || bta == BillTypeAtomic.PHARMACY_DIRECT_PURCHASE) {
+            return "Approved";
+        }
+        if (bta == BillTypeAtomic.PHARMACY_GRN && !bill.isCompleted()) {
+            return "Pending Approval";
+        }
+        return "-";
+    }
+
     // PostProcessor for grn and direct purchase summary report excel export
     public void postProcessGRNAndDirectPurchaseReportExcel(Object document) {
-        postProcessGRNAndDirectPurchaseReportExcel(document, "GRN and Direct Purchase Report");
+        postProcessGRNAndDirectPurchaseReportExcel(document, "GRN and Direct Purchase Report", getFiltersForGRNDetailReport());
     }
 
     public void postProcessGRNSummaryReportExcel(Object document) {
-        postProcessGRNAndDirectPurchaseReportExcel(document, "GRN Summary Report");
+        postProcessGRNAndDirectPurchaseReportExcel(document, "GRN Summary Report", getFiltersForGRNSummaryReport());
     }
 
-    private void postProcessGRNAndDirectPurchaseReportExcel(Object document, String reportTitle) {
+    private void postProcessGRNAndDirectPurchaseReportExcel(Object document, String reportTitle, Map<String, Object> filters) {
         if (document == null) {
             Logger.getLogger(PharmacyController.class.getName()).log(Level.SEVERE, "Document is null in postProcessBillWiseItemMovementReportExcel");
             return;
@@ -11256,8 +11500,6 @@ public class PharmacyController implements Serializable {
 
         workbook.setSheetName(0, reportTitle);
         sheet.shiftRows(0, sheet.getLastRowNum(), 7);
-
-        Map<String, Object> filters = getFiltersForGRNDetailReport();
 
         if (filters != null && !filters.isEmpty()) {
             addMetaDataToExcelSheet(workbook, sheet, 0, reportTitle, filters);

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
@@ -11499,12 +11499,30 @@ public class PharmacyController implements Serializable {
         }
 
         workbook.setSheetName(0, reportTitle);
-        sheet.shiftRows(0, sheet.getLastRowNum(), 7);
 
+        // Reserve exactly enough rows for the metadata block below: institution row +
+        // title row + ceil(filterCount / 3) filter rows (addMetaDataToExcelSheet packs
+        // 3 label/value pairs per row) + 1 blank spacer row (reused as the "Generated
+        // On" row) + 1 trailing blank spacer before the report's own header row.
+        // This used to be a hardcoded 7, tuned for exactly the GRN Summary Report's 7
+        // filters — with the GRN/Direct Purchase Report's 11 filters (one more filter
+        // row), the fixed rowIndex=5 for "Generated On" silently overwrote the last
+        // filter row's Supplier/report-type values instead of landing on the blank
+        // spacer. Computing both from the actual filter count keeps this correct for
+        // either caller. See issue #23170 (CodeRabbit review on PR #23195).
+        int filterCount = (filters != null) ? filters.size() : 0;
+        int filterRows = (int) Math.ceil(filterCount / 3.0);
+        int metadataContentRows = 2 + filterRows; // institution + title + filter rows
+        int shiftAmount = metadataContentRows + 2; // + blank spacer (Generated On) + trailing blank
+        sheet.shiftRows(0, sheet.getLastRowNum(), shiftAmount);
+
+        int rowIndex = 0;
         if (filters != null && !filters.isEmpty()) {
-            addMetaDataToExcelSheet(workbook, sheet, 0, reportTitle, filters);
+            // addMetaDataToExcelSheet() returns the row index just past its own
+            // trailing blank spacer row; back up one row to write "Generated On" into
+            // that spacer row instead of appending a whole extra row after it.
+            rowIndex = addMetaDataToExcelSheet(workbook, sheet, 0, reportTitle, filters) - 1;
         }
-        int rowIndex = 5;
         SimpleDateFormat sdf = new SimpleDateFormat(sessionController.getApplicationPreference().getLongDateTimeFormat());
         // Add "Generated On" row with current date and time
         Row generatedOnRow = sheet.createRow(rowIndex++);

--- a/src/main/webapp/reports/inventoryReports/grn_summary_report.xhtml
+++ b/src/main/webapp/reports/inventoryReports/grn_summary_report.xhtml
@@ -212,6 +212,13 @@
                                 ajax="false"
                                 action="#{pharmacyController.generateGrnReport()}"/>
                             <p:commandButton
+                                value="Print"
+                                icon="fas fa-print"
+                                class="ui-button mx-1"
+                                ajax="false"
+                                action="grn_summary_view?faces-redirect=true"
+                                rendered="#{not empty pharmacyController.bills}"/>
+                            <p:commandButton
                                 value="Download"
                                 icon="fas fa-file-excel"
                                 class="ui-button-success mx-1"
@@ -227,7 +234,7 @@
                                 icon="fas fa-file-pdf"
                                 class="ui-button-danger mx-1"
                                 ajax="false"
-                                action="#{pharmacyController.exportGRNAndDirectPurchaseSummaryReportToPDF()}"
+                                action="#{pharmacyController.exportGRNSummaryReportToPDF()}"
                                 rendered="#{not empty pharmacyController.bills}"/>
                         </h:panelGroup>
 
@@ -286,7 +293,7 @@
                                     </h:outputText>
                                 </p:column>
                                 <p:column headerText="Stock Amount" styleClass="text-end">
-                                    <h:outputText value="#{bill.billFinanceDetails != null ? bill.billFinanceDetails.totalPurchaseValue : 0}">
+                                    <h:outputText value="#{pharmacyController.getGrnStockAmount(bill)}">
                                         <f:convertNumber pattern="#,##0.00"/>
                                     </h:outputText>
                                 </p:column>


### PR DESCRIPTION
## Summary

Fixes all 5 checklist items in #23170:
- [x] Print is missing
- [x] GRN Stock Amount isn't displayed
- [x] Downloaded PDF showed unwanted filters (Department Type, Category, Dosage Form, Supplier)
- [x] Downloaded PDF table columns didn't match the on-screen report
- [x] Downloaded Excel showed unwanted filters (Department Type, Category, Dosage Form)

## Decisions made without approval

This was run via `dev-issue-unattended`, so these calls were made without a live human review beforehand:

1. **Stock Amount computed on the fly instead of fixing upstream population.** `bill.billFinanceDetails.totalPurchaseValue` is only populated by the separate GRN Costing workflow (`GrnCostingController`) or the `PharmacyGrnBifdBackfillService` backfill — not at normal GRN completion. Confirmed via DB query that every recent completed GRN has a `BillFinanceDetails` row but `totalPurchaseValue = NULL`. Rather than changing GRN completion logic across multiple controllers (a much larger, riskier change) or running a data backfill against existing bills (explicitly out of scope for unattended runs), the report now computes "Stock Amount" directly from `BillItemFinanceDetails.valueAtPurchaseRate` — already populated per line item at GRN receipt time for every bill in the DB I checked — batched into one grouped JPQL query per report run.
2. **Left `exportGRNAndDirectPurchaseSummaryReportToPDF()` and `getFiltersForGRNDetailReport()` untouched**, adding new dedicated `exportGRNSummaryReportToPDF()` / `getFiltersForGRNSummaryReport()` methods instead. The old methods are still used by `grn.xhtml`'s own "summary" `reportType` view, which has a different (narrower) column set and a real "Department Type/Category/Dosage Form/Supplier" filter UI of its own — changing them in place would have broken that page.
3. **Print button reuses the existing `grn_summary_view.xhtml` print page** (already built, unpaginated, used by `grn.xhtml`'s own "To Print" button) rather than adding a new print view or wiring `p:printer` directly to the paginated on-screen table (which would only print the current page of results). Its "Back to Report" button still points to `grn.xhtml`, not `grn_summary_report.xhtml` — `PharmacyController` is `@SessionScoped`, so filters/results survive either navigation path; only the return destination differs.

## Root cause detail

- The old `bill.billFinanceDetails != null ? ... : 0` EL check never actually detected a missing aggregate, because `Bill.getBillFinanceDetails()` auto-vivifies a new (empty) `BillFinanceDetails` on first access — the check was always true, but `totalPurchaseValue` on that empty object defaulted to `null`, which `f:convertNumber` renders as blank. Root cause was upstream: the aggregate is simply never populated by the normal GRN flow.
- `getFiltersForGRNDetailReport()` (shared by 13+ call sites) is the correct, full filter set for the older `grn.xhtml` report, which really does have Department Type/Category/Dosage Form/Supplier inputs. `grn_summary_report.xhtml` is a newer, simpler standalone page that was wired to reuse it and the old PDF export by mistake.

## Testing

Verified end-to-end against local Payara + MySQL (`coop` DB), Inward department, GRN Summary Report page, date range covering 44 real GRN/Direct Purchase bills:
- Stock Amount column shows real computed values matching `BillItemFinanceDetails` data (spot-checked one bill against the DB directly).
- PDF export: columns now match the on-screen table exactly; filters section shows only From/To Date, Institution, Site, Department/Store, Payment Mode, Purchase Type.
- Excel export: filters section shows the same scoped set (verified by inspecting the generated `.xlsx` shared-strings XML directly — no "Department Type"/"Category"/"Dosage Form"/"Supplier" present).
- Print button navigates to the existing print page showing all 44 matching rows (unpaginated), with working Print/Back buttons.
- `mvn package` — 207 existing tests pass, no new failures.
- No new errors in `server.log` during the test pass.

Screenshots and full verification notes posted on #23170.

Closes #23170

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Print access for the GRN Summary report.
  * Added a dedicated PDF export matching the summary view, including filters, purchase type, payment mode, status, discounts, and stock amounts.
  * Added stock amount details for each bill in the GRN Summary.
  * Enhanced Excel exports to preserve selected filters and support dedicated GRN Summary output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->