### PR TITLE
fix(pharmacy): clear Transfer Receive list on navigation

### DIFF
--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -1505,6 +1505,11 @@ public class SearchController implements Serializable {
         settledBillType = null;
         total = 0.0;
         pharmacyBillSearch.setSaleBillDtos(null);
+        // Transfer Receive list (pharmacy_transfer_issued_list.xhtml) — was never cleared here,
+        // so the previous search results stayed on screen until the user searched again on
+        // every navigation into the page (menu.xhtml, disbursement_index.xhtml, home.xhtml all
+        // call makeListNull() as their actionListener before navigating here). See issue #23117.
+        transferIssuedListDtos = new ArrayList<>();
     }
 
     public String navigateToSearchOpdBillsOfLoggedDepartment() {


### PR DESCRIPTION
## Summary

Fixes #23117 — the Transfer Receive page (`pharmacy/pharmacy_transfer_issued_list.xhtml`) kept showing the previous search's results when navigated to fresh, until the user ran a new search.

## Root cause

`searchController.transferIssuedListDtos` is the `@SessionScoped` field the page's `p:dataTable` binds to. Every navigation entry point into this page (`resources/ezcomp/menu.xhtml`, `pharmacy/disbursement_index.xhtml`, `home.xhtml`) already wires `actionListener="#{searchController.makeListNull()}"` before the `faces-redirect` — this is the project's established reset pattern (see the `jsf-ajax` skill: initialization belongs in the navigation action, not `f:viewAction`, since `SearchController` is `@SessionScoped`). But `makeListNull()` clears about a dozen other search-result fields (`bills`, `pharmacyPurchaseOrderDtos`, `aceptPaymentBills`, etc.) and simply never included `transferIssuedListDtos` — so the reset call already firing on every navigation had no effect for this specific page.

## Fix

One line: `makeListNull()` now also resets `transferIssuedListDtos` to a fresh empty list, consistent with how every other field in that method is handled.

## Decisions made without approval

This was run via `dev-issue-unattended`. One judgment call worth flagging:

- **Live UI reproduction was not completed.** The root cause was fully confirmed by code inspection alone (grep across all 3 navigation entry points into this page, plus reading `makeListNull()`'s body and the `fetchTransferIssuedListDtos()` methods that populate the field) — this falls under the skill's step 2a carve-out for skipping live reproduction when a bug's root cause is already confirmed from code + history. I did attempt a live Playwright pass afterward for extra confidence, but the only local test account available (`buddhika`, permanently bound to the "Inward" department per the `WEBUSER` table) has **zero** historical inbound pharmacy transfers in the local DB — Inward has never been the `toDepartment` of any `PHARMACY_ISSUE`/`PHARMACY_DIRECT_ISSUE` bill — so there was no real "previous search result" to reproduce the stale-display bug against, or to visually confirm now clears, under this login. Reaching a department that does have pending receives (Main Pharmacy, OPD Pharmacy) would need a second department's credentials this run doesn't have.
- What *was* verified live: the page loads cleanly (empty state, no exceptions) from a fresh navigation and after Search/Fully Received/Yet to Receive, with no new errors in `server.log`.

## Testing

- `mvn package` — 207 existing tests pass, no new failures.
- Deployed locally, exercised the Receive page's Search / Fully Received / Yet to Receive buttons — no errors in `server.log`.
- Root cause and fix verified by code inspection as described above; full behavioral repro constrained by local test-account department, noted above rather than skipped silently.

Closes #23117

🤖 Generated with [Claude Code](https://claude.com/claude-code)