### PR TITLE
fix(pharmacy): Stock Transfer Report Ref Bill No link opens the wrong bill

### DIFF
--- a/src/main/webapp/reports/inventoryReports/stock_transfer_report.xhtml
+++ b/src/main/webapp/reports/inventoryReports/stock_transfer_report.xhtml
@@ -786,7 +786,7 @@
                                     <p:column headerText="Ref Bill No" width="6em">
                                         <p:commandLink ajax="false" value="#{i.billItem.bill.backwardReferenceBill.deptId}"
                                                        action="/pharmacy/pharmacy_reprint_transfer_request">
-                                            <f:setPropertyActionListener value="#{i.billItem.bill}"
+                                            <f:setPropertyActionListener value="#{i.billItem.bill.backwardReferenceBill}"
                                                                          target="#{pharmacyBillSearch.bill}"/>
                                         </p:commandLink>
                                     </p:column>


### PR DESCRIPTION
## Summary

Fixes #23129 — in the Stock Transfer Report's Detail view, the "Ref Bill No" column's link text showed the correct referenced bill number, but clicking it opened the wrong bill (the row's own bill instead of the one referenced).

## Root cause

Already fully identified in the issue body (from the #23112 investigation):

```xhtml
<p:commandLink ajax="false" value="#{i.billItem.bill.backwardReferenceBill.deptId}"
               action="/pharmacy/pharmacy_reprint_transfer_request">
    <f:setPropertyActionListener value="#{i.billItem.bill}"
                                 target="#{pharmacyBillSearch.bill}"/>
</p:commandLink>
```

Link text = `i.billItem.bill.backwardReferenceBill.deptId` (correct), but the action listener passed `i.billItem.bill` (the row's own bill) instead of `i.billItem.bill.backwardReferenceBill` (the bill the link text actually names).

## Fix

One-line change: pass `i.billItem.bill.backwardReferenceBill` instead of `i.billItem.bill`.

## Decisions made without approval

None — the issue body already specified the exact fix; this PR applies it as described and verifies it.

## Testing

Verified end-to-end against local Payara + MySQL (Inventory Reports → Stock Transfer Report, Detail type, Aug 2026 date range, OPD Pharmacy):
- Row with link text "TI/COOP/26/000401" (a Cancellation bill's backward reference, which happens to be the original Issue bill) now opens `Bill No: TI/COOP/26/000401` — matching the link, not the Cancellation bill's own number (`MPPHTICAN/4`) as before.
- Row with link text "MP/OP/26/000192" (an Issue bill's backward reference, the actual Transfer Request) now opens `Bill No: MP/OP/26/000192`, with the "Cancel Request" button correctly enabled and scoped to that real Request bill — confirming the #23112 Cancel guard now acts on the right bill.
- `mvn package` — 207 existing tests pass (XHTML-only change).
- No new errors in `server.log`.

Screenshots posted on #23129.

Closes #23129

🤖 Generated with [Claude Code](https://claude.com/claude-code)