### PR TITLE
fix(pharmacy): clear Transfer Requests to Approve list on navigation

### DIFF
--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -4678,6 +4678,11 @@ public class SearchController implements Serializable {
         billedDepartment = null;
         visitType = null;
         methodType = null;
+        // Transfer Requests to Approve list (pharmacy_transfer_request_list_to_approve.xhtml) —
+        // navigateToTransferRequestApprove() calls makeNull() before navigating here, but this
+        // field was never included, so the previous search's results stayed on screen until the
+        // user searched again. See issue #23116.
+        transferRequestsToApproveDtos = null;
     }
 
     public void resetTotals() {


### PR DESCRIPTION
## Summary

Fixes #23116 — the Transfer Requests to Approve page (`pharmacy/pharmacy_transfer_request_list_to_approve.xhtml`) kept showing the previous search's results when navigated to fresh, until the user ran a new search.

## Root cause

Same pattern as #23117, different reset method. `searchController.transferRequestsToApproveDtos` is the `@SessionScoped` field the page's table binds to. The "Approve Requests" button in `disbursement_index.xhtml` fires an `actionListener="#{searchController.makeListNull()}"` and then an `action="#{searchController.navigateToTransferRequestApprove()}"`, which itself calls `makeNull()` (a *different*, older reset method) before redirecting. Neither `makeListNull()` nor `makeNull()` ever included `transferRequestsToApproveDtos` — so despite two reset calls firing on every navigation into this page, the field was never actually cleared.

## Fix

One line: `makeNull()` — the reset method actually called by `navigateToTransferRequestApprove()` — now also resets `transferRequestsToApproveDtos` to `null`, consistent with how the ~20 other fields in that method are handled.

## Decisions made without approval

This was run via `dev-issue-unattended`.

- **Live UI reproduction was not completed**, for the same reason as #23117: the root cause was fully confirmed by code inspection (the navigation method, its reset method, and the population method `fillPharmacyTransferRequestsToApprove()`, which per an existing code comment filters `b.fromDepartment` = the session/logged department — i.e. requests *created by* the current department, finalized but not yet approved). The only local test account (`buddhika`, permanently bound to "Inward") has zero historical pharmacy transfer request activity of any kind in the local DB (confirmed via direct query) — same constraint as #23117. What *was* verified live: the page loads cleanly and Search works with no server errors.

## Testing

- `mvn package` — 207 existing tests pass, no new failures.
- Deployed locally, exercised the Approve Requests page's Search button — no errors in `server.log`.
- Root cause and fix verified by code inspection; full behavioral repro constrained by local test-account department, as documented above.

Closes #23116

🤖 Generated with [Claude Code](https://claude.com/claude-code)