### PR TITLE
fix(pharmacy): clear Transfer Issue (requests-to-issue) list on navigation

### DIFF
--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -1505,6 +1505,11 @@ public class SearchController implements Serializable {
         settledBillType = null;
         total = 0.0;
         pharmacyBillSearch.setSaleBillDtos(null);
+        // Transfer Issue list (pharmacy_transfer_request_list.xhtml) — the "Issue for Requests"
+        // navigation button fires this as its actionListener before navigating, but this field
+        // was never included, so the previous search's results stayed on screen until the user
+        // searched again. See issue #23115.
+        transferRequestDtos = null;
     }
 
     public String navigateToSearchOpdBillsOfLoggedDepartment() {


### PR DESCRIPTION
## Summary

Fixes #23115 — the Transfer Issue page (`pharmacy/pharmacy_transfer_request_list.xhtml`, the "Issue for Requests" list) kept showing the previous search's results when navigated to fresh, until the user ran a new search.

## Root cause

Third occurrence of the same pattern found in this batch (#23117 Transfer Receive, #23116 Transfer Requests to Approve). The "Issue for Requests" button in `disbursement_index.xhtml` fires `actionListener="#{searchController.makeListNull()}"` before `action="#{transferIssueController.navigateToListPharmacyIssueRequests}"` (which itself does no state reset — it's a bare one-line navigation string). `searchController.transferRequestDtos` is the `@SessionScoped` field this page's table binds to, populated only by `createRequestTableDto()` (the Search button's action) — and `makeListNull()` never included it.

## Fix

One line: `makeListNull()` now also resets `transferRequestDtos` to `null`.

## Decisions made without approval

This was run via `dev-issue-unattended`.

- **Live UI reproduction was not completed**, same reason as #23117/#23116: root cause fully confirmed by code inspection (navigation button, its actionListener, the navigation method, and the population method `createRequestTableDto()`, which filters `b.toDepartment` = session department). The local test account (`buddhika`, bound to "Inward") has zero historical activity as a `toDepartment` for `PHARMACY_TRANSFER_REQUEST` bills — same constraint as the other two issues in this batch. What *was* verified live: the page loads cleanly and Search works with no server errors.

## Testing

- `mvn package` — 207 existing tests pass, no new failures.
- Deployed locally, exercised the Transfer Issue page's Search button — no errors in `server.log`.
- Root cause and fix verified by code inspection; full behavioral repro constrained by local test-account department, as documented above.

Closes #23115

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cleared previous transfer-request search results when navigating, preventing stale results from remaining visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->