### PR TITLE
Fix OPD Billing NPE and Select Department screen being skipped after login

### DIFF
--- a/src/main/java/com/divudi/bean/common/SessionController.java
+++ b/src/main/java/com/divudi/bean/common/SessionController.java
@@ -2707,7 +2707,9 @@ public class SessionController implements Serializable, HttpSessionListener {
     }
 
     public UserPreference getDepartmentPreference() {
-        //System.out.println("getting departmentPreference = " + departmentPreference);
+        if (departmentPreference == null) {
+            departmentPreference = getApplicationPreference();
+        }
         return departmentPreference;
     }
 

--- a/src/main/java/com/divudi/bean/common/SessionController.java
+++ b/src/main/java/com/divudi/bean/common/SessionController.java
@@ -947,18 +947,16 @@ public class SessionController implements Serializable, HttpSessionListener {
     }
 
     public Department getDepartment() {
-        if (department == null) {
-            // Fall back to the logged user's own department when nothing has
-            // been cached yet (e.g. sessions established via loginForRequests()
-            // that set loggedUser but never call setDepartment()). The null
-            // check here was previously inverted, NPE-ing whenever loggedUser
-            // was null instead of guarding against it (CodeRabbit #23175).
-            if (loggedUser != null) {
-                if (loggedUser.getDepartment() != null) {
-                    department = loggedUser.getDepartment();
-                }
-            }
-        }
+        // Intentionally no fallback to loggedUser.getDepartment() here: this
+        // getter backs the interactive login "Select Department" screen
+        // (template.xhtml renders it while sessionController.department is
+        // null), and loginActionWithoutDepartment() deliberately resets
+        // department to null so that screen shows. Auto-populating from the
+        // WebUser's persisted department would silently skip that screen for
+        // any returning user. Callers on API/loginForRequests() sessions that
+        // need a fallback (which never call setDepartment()) should use
+        // getLoggedUser().getDepartment() directly, as PatientInvestigationController
+        // already does.
         return department;
     }
 

--- a/src/main/java/com/divudi/bean/inward/PatientTransferController.java
+++ b/src/main/java/com/divudi/bean/inward/PatientTransferController.java
@@ -1060,7 +1060,15 @@ public class PatientTransferController implements Serializable {
         // Same target-department constraint as loadPendingReturnsForWard() —
         // without it, a user with WardAcceptTheatreReturn could accept a
         // return bound for a different ward's department (CodeRabbit #23175).
+        // Falls back to the logged-in WebUser's own department for sessions
+        // established via loginForRequests(), which set loggedUser but never
+        // call sessionController.setDepartment() — getDepartment() itself must
+        // stay non-populating so it doesn't skip the interactive department
+        // selection screen for ordinary logins.
         Department userDepartment = sessionController.getDepartment();
+        if (userDepartment == null && sessionController.getLoggedUser() != null) {
+            userDepartment = sessionController.getLoggedUser().getDepartment();
+        }
         Department targetDepartment = req.getToRoomFacilityCharge() != null
                 ? req.getToRoomFacilityCharge().getDepartment() : null;
         if (userDepartment == null || userDepartment.getId() == null


### PR DESCRIPTION
## Summary
Two related regressions, both traced back to today's `028129f117` commit (part of PR #23175):

- Closes #23201 — NullPointerException navigating to OPD Billing
- Closes #23202 — Select Department screen skipped after login, landing straight on Home

## Root cause
`028129f117` gave `SessionController.getDepartment()` a *mutating* fallback: on first read, if
`department` was null, it auto-populated from the logged-in `WebUser`'s persisted department.
That getter backs `template.xhtml`'s own check for whether to render the **Select Department**
screen (`sessionController.department eq null`) — so evaluating that condition silently filled in
the department and skipped the screen for any user who'd logged in before. Skipping department
selection then left session state (department preference, etc.) incomplete, which surfaced
separately as a `NullPointerException` in `OpdBillController.getPaymentMethod()` via
`SessionController.getDepartmentPreference()`.

## Fix
- `SessionController.getDepartment()` (#23202) — reverted to a plain, non-mutating accessor.
  The one legitimate need for a loggedUser fallback (API sessions from `loginForRequests()`,
  which never call `setDepartment()`) is now handled locally in
  `PatientTransferController.acceptReturnToWardForAdmission()` via
  `getLoggedUser().getDepartment()` — the same pattern `PatientInvestigationController` already
  uses for API-session department lookups — instead of living in the shared getter.
- `SessionController.getDepartmentPreference()` (#23201) — made null-safe by falling back to
  `getApplicationPreference()`, matching the existing `departmentPreference == null →
  institutionPreference` fallback already used in `selectDepartment()`, and matching every other
  `isPartialPaymentOfOpdBillsAllowed()` call site in the codebase which already uses the
  null-safe `getApplicationPreference()`.

## Files changed
- `src/main/java/com/divudi/bean/common/SessionController.java`
- `src/main/java/com/divudi/bean/inward/PatientTransferController.java`

## Test plan
- [x] Confirmed locally: login now shows the Select Department screen again instead of skipping
      to Home.
- [x] Confirmed: OPD Billing navigates without the NullPointerException.
- [ ] Verify `PatientTransferController.acceptReturnToWardForAdmission()` still correctly rejects
      a theatre return bound for a different ward, for both interactive and `loginForRequests()`
      sessions.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved the department selected during a session instead of automatically replacing it.
  - Added a fallback to the logged-in user’s department when processing returns to a ward.
  - Improved department preference handling by using the application default when no department-specific preference is available.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->