### PR TITLE
fix(pharmacy): stop null costRate aborting stock-take adjustments

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyStockTakeController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyStockTakeController.java
@@ -3800,9 +3800,12 @@ public class PharmacyStockTakeController implements Serializable {
         adjustmentBill.setBackwardReferenceBill(physicalCountBill);
         physicalCountBill.setForwardReferenceBill(adjustmentBill);
         billFacade.create(adjustmentBill);
+        int expectedLines = 0;
+        int appliedLines = 0;
         for (BillItem bi : physicalCountBill.getBillItems()) {
             double variance = bi.getAdjustedValue();
             if (variance == 0) continue;
+            expectedLines++;
             BillItem abi = new BillItem();
             abi.setBill(adjustmentBill);
             abi.setItem(bi.getItem());
@@ -3834,8 +3837,17 @@ public class PharmacyStockTakeController implements Serializable {
             if (stock != null) {
                 double targetQty = apbi.getAfterAdjustmentValue();
                 boolean ok = pharmacyBean.resetStock(apbi, stock, targetQty, dept);
+                if (ok) {
+                    appliedLines++;
+                } else {
+                    LOGGER.log(Level.SEVERE, "[StockTake] resetStock returned false - quantity NOT applied. refItemId={0}, stockId={1}, target={2}",
+                            new Object[]{bi.getId(), stock.getId(), targetQty});
+                }
                 LOGGER.log(Level.INFO, "[StockTake] Posted adjustment line. adjItemId={0}, refItemId={1}, stockId={2}, before={3}, after={4}, variance={5}, resetOk={6}",
                         new Object[]{abi.getId(), bi.getId(), stock.getId(), apbi.getBeforeAdjustmentValue(), apbi.getAfterAdjustmentValue(), variance, ok});
+            } else {
+                LOGGER.log(Level.SEVERE, "[StockTake] No linked Stock row - quantity NOT applied. refItemId={0}, item={1}",
+                        new Object[]{bi.getId(), bi.getItem() != null ? bi.getItem().getName() : "null"});
             }
         }
         physicalCountBill.setApproveUser(sessionController.getLoggedUser());
@@ -3846,7 +3858,15 @@ public class PharmacyStockTakeController implements Serializable {
                 new Object[]{physicalCountBill.getId(), adjustmentBill.getId(), adjustmentBill.getBillItems() != null ? adjustmentBill.getBillItems().size() : 0});
         this.printPreview = true;
         this.comments = null;
-        JsfUtil.addSuccessMessage("Physical count approved");
+        if (appliedLines != expectedLines) {
+            LOGGER.log(Level.SEVERE, "[StockTake] Approval INCOMPLETE. pcBillId={0}, expectedLines={1}, appliedLines={2}",
+                    new Object[]{physicalCountBill.getId(), expectedLines, appliedLines});
+            JsfUtil.addErrorMessage("Physical count approved, but only " + appliedLines + " of " + expectedLines
+                    + " lines were applied to stock. " + (expectedLines - appliedLines)
+                    + " line(s) were NOT updated - please re-check before closing the stock take.");
+        } else {
+            JsfUtil.addSuccessMessage("Physical count approved. " + appliedLines + " stock line(s) updated.");
+        }
     }
 
     public void rejectPhysicalCount() {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyStockTakeController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyStockTakeController.java
@@ -27,6 +27,7 @@ import com.divudi.core.facade.PharmaceuticalBillItemFacade;
 import com.divudi.core.facade.StockFacade;
 import com.divudi.core.util.CommonFunctions;
 import com.divudi.core.util.JsfUtil;
+import javax.faces.context.FacesContext;
 import com.divudi.ejb.BillNumberGenerator;
 import com.divudi.ejb.PharmacyBean;
 import com.divudi.service.pharmacy.StockTakeApprovalService;
@@ -1576,6 +1577,13 @@ public class PharmacyStockTakeController implements Serializable {
                     snapshotBillDisplay.getNetTotal(), Boolean.FALSE);
         }
 
+        // doApprovalLogic() may have queued a warning that some lines were not applied
+        // to stock. Without this the redirect below discards it and the operator is told
+        // nothing - which is how the Southern Lanka partial adjustments went unnoticed.
+        FacesContext fc = FacesContext.getCurrentInstance();
+        if (fc != null) {
+            fc.getExternalContext().getFlash().setKeepMessages(true);
+        }
         return "/pharmacy/pharmacy_stock_take_print?faces-redirect=true";
     }
 

--- a/src/main/java/com/divudi/ejb/PharmacyBean.java
+++ b/src/main/java/com/divudi/ejb/PharmacyBean.java
@@ -1844,11 +1844,12 @@ public class PharmacyBean {
 
         // Record itemBatch rates
         if (fetchedStock.getItemBatch() != null) {
-            Double costRate = fetchedStock.getItemBatch().getCostRate();
+            Double costRateObj = fetchedStock.getItemBatch().getCostRate();
+            double costRate = costRateObj != null ? costRateObj : 0.0;
             double purchaseRate = fetchedStock.getItemBatch().getPurcahseRate();
             double retailSaleRate = fetchedStock.getItemBatch().getRetailsaleRate();
 
-            sh.setCostRate(costRate != null ? costRate : 0.0);
+            sh.setCostRate(costRate);
             sh.setPurchaseRate(fetchedStock.getItemBatch().getPurcahseRate());
             sh.setRetailRate(fetchedStock.getItemBatch().getRetailsaleRate());
             sh.setWholesaleRate(fetchedStock.getItemBatch().getWholesaleRate());
@@ -1970,11 +1971,12 @@ public class PharmacyBean {
 
         // Record itemBatch rates
         if (fetchedStock.getItemBatch() != null) {
-            Double costRate = fetchedStock.getItemBatch().getCostRate();
+            Double costRateObj = fetchedStock.getItemBatch().getCostRate();
+            double costRate = costRateObj != null ? costRateObj : 0.0;
             double purchaseRate = fetchedStock.getItemBatch().getPurcahseRate();
             double retailSaleRate = fetchedStock.getItemBatch().getRetailsaleRate();
 
-            sh.setCostRate(costRate != null ? costRate : 0.0);
+            sh.setCostRate(costRate);
             sh.setPurchaseRate(fetchedStock.getItemBatch().getPurcahseRate());
             sh.setRetailRate(fetchedStock.getItemBatch().getRetailsaleRate());
             sh.setWholesaleRate(fetchedStock.getItemBatch().getWholesaleRate());


### PR DESCRIPTION
## Problem

A full pharmacy stock take at Southern Lanka (snapshot bill `10174939`, 8,789 stock rows) left **235 counted stock rows never written back** to the `stock` table, while the variance report kept showing the correct variance — so the loss was invisible for two days.

## Root cause

`PharmacyBean.addToStockHistory(PharmaceuticalBillItem, Stock, Department)` reads the **boxed** `ItemBatch.costRate` and correctly null-guards it once:

```java
Double costRate = fetchedStock.getItemBatch().getCostRate();
sh.setCostRate(costRate != null ? costRate : 0.0);   // guarded
```

…then unboxes the same reference raw a few lines later:

```java
sh.setInstitutionBatchStockValueAtCostRate(institutionBatchStock * costRate);  // NPE
sh.setTotalBatchStockValueAtCostRate(totalBatchStock * costRate);              // NPE
```

Any batch with a NULL `costRate` throws. Confirmed in the production log:

```
Caused by: java.lang.NullPointerException
	at com.divudi.ejb.PharmacyBean.addToStockHistory(PharmacyBean.java:1868)
	at com.divudi.ejb.PharmacyBean.resetStock(PharmacyBean.java:910)
```

### Why it loses data silently

`resetStock()` commits the stock write **before** calling `addToStockHistory()`:

```java
stock.setStock(qty);
getStockFacade().editAndCommit(stock);    // already committed
addToStockHistory(ph, stock, department); // throws here
```

The NPE escapes the per-item loop in `PharmacyStockTakeController.doApprovalLogic()`, abandoning every remaining item in that upload. Items processed earlier stay committed → partial application, no error shown to the operator. The operator re-uploaded the failing chunk 11 times; it failed identically every time because the offending batch is deterministic.

## Evidence

Of the **3,420 successfully adjusted** stocks only **2** have a NULL `costRate`; of the **235 missed**, **212 (90%)** do. The database has 10,414 batches with a NULL `costRate`.

| Chunk | Variance lines | Actually applied | Missed |
|---|---|---|---|
| PHA//6 + PHA//7 | 223 | 186 | 37 |
| PHA//14 + PHA//15 | 220 | 46 | 174 |
| PHA//9 … PHA//34 | 211 → 25 | 188 | 24 |
| other 22 chunks | — | complete | 0 |
| | | **TOTAL** | **235** |

## Changes

1. **`PharmacyBean`** — unbox `costRate` once into a primitive, matching the pattern the `addToStockHistory(..., Staff)` overload in the same class already uses correctly (line ~2091). Applied to both `addToStockHistory(..., Department)` and `addToStockHistoryForCosting()`, which carried the identical latent bug.
2. **`PharmacyStockTakeController.doApprovalLogic()`** — stop hiding the failure: count lines actually applied, honour `resetStock()`'s boolean return (previously captured and only logged, never checked), and warn the operator when the applied count does not match the number of variance lines.

Note this also fixes `POST /api/pharmacy_adjustments/stock_quantity`, which calls the same `resetStock()` and fails the same way for any NULL-`costRate` batch.

## Testing

`mvn compile` — BUILD SUCCESS. Root cause reproduced from production logs and confirmed statistically against the production dataset (see table above).

## Follow-ups (not in this PR)

- Restructure the approval loop so one bad line cannot abandon the rest (needs the transaction semantics verified first).
- Backfill/default the 10,414 NULL `costRate` batches.
- Double-submit guard on the approve button — four chunk pairs were each submitted twice in the same second.
- Have the variance report reconcile against live `Stock` so a non-applied line is visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stock adjustment approvals now preserve incomplete-application warnings after redirect.
  * Improved messaging for successful approvals, failed stock updates, and missing stock references.
  * Prevented stock history calculations from failing when batch cost rates are unavailable by safely handling missing values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->