### PR TITLE
hotfix(pharmacy): stop null costRate aborting stock-take adjustments

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyStockTakeController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyStockTakeController.java
@@ -3800,9 +3800,12 @@ public class PharmacyStockTakeController implements Serializable {
         adjustmentBill.setBackwardReferenceBill(physicalCountBill);
         physicalCountBill.setForwardReferenceBill(adjustmentBill);
         billFacade.create(adjustmentBill);
+        int expectedLines = 0;
+        int appliedLines = 0;
         for (BillItem bi : physicalCountBill.getBillItems()) {
             double variance = bi.getAdjustedValue();
             if (variance == 0) continue;
+            expectedLines++;
             BillItem abi = new BillItem();
             abi.setBill(adjustmentBill);
             abi.setItem(bi.getItem());
@@ -3834,8 +3837,17 @@ public class PharmacyStockTakeController implements Serializable {
             if (stock != null) {
                 double targetQty = apbi.getAfterAdjustmentValue();
                 boolean ok = pharmacyBean.resetStock(apbi, stock, targetQty, dept);
+                if (ok) {
+                    appliedLines++;
+                } else {
+                    LOGGER.log(Level.SEVERE, "[StockTake] resetStock returned false - quantity NOT applied. refItemId={0}, stockId={1}, target={2}",
+                            new Object[]{bi.getId(), stock.getId(), targetQty});
+                }
                 LOGGER.log(Level.INFO, "[StockTake] Posted adjustment line. adjItemId={0}, refItemId={1}, stockId={2}, before={3}, after={4}, variance={5}, resetOk={6}",
                         new Object[]{abi.getId(), bi.getId(), stock.getId(), apbi.getBeforeAdjustmentValue(), apbi.getAfterAdjustmentValue(), variance, ok});
+            } else {
+                LOGGER.log(Level.SEVERE, "[StockTake] No linked Stock row - quantity NOT applied. refItemId={0}, item={1}",
+                        new Object[]{bi.getId(), bi.getItem() != null ? bi.getItem().getName() : "null"});
             }
         }
         physicalCountBill.setApproveUser(sessionController.getLoggedUser());
@@ -3846,7 +3858,15 @@ public class PharmacyStockTakeController implements Serializable {
                 new Object[]{physicalCountBill.getId(), adjustmentBill.getId(), adjustmentBill.getBillItems() != null ? adjustmentBill.getBillItems().size() : 0});
         this.printPreview = true;
         this.comments = null;
-        JsfUtil.addSuccessMessage("Physical count approved");
+        if (appliedLines != expectedLines) {
+            LOGGER.log(Level.SEVERE, "[StockTake] Approval INCOMPLETE. pcBillId={0}, expectedLines={1}, appliedLines={2}",
+                    new Object[]{physicalCountBill.getId(), expectedLines, appliedLines});
+            JsfUtil.addErrorMessage("Physical count approved, but only " + appliedLines + " of " + expectedLines
+                    + " lines were applied to stock. " + (expectedLines - appliedLines)
+                    + " line(s) were NOT updated - please re-check before closing the stock take.");
+        } else {
+            JsfUtil.addSuccessMessage("Physical count approved. " + appliedLines + " stock line(s) updated.");
+        }
     }
 
     public void rejectPhysicalCount() {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyStockTakeController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyStockTakeController.java
@@ -27,6 +27,7 @@ import com.divudi.core.facade.PharmaceuticalBillItemFacade;
 import com.divudi.core.facade.StockFacade;
 import com.divudi.core.util.CommonFunctions;
 import com.divudi.core.util.JsfUtil;
+import javax.faces.context.FacesContext;
 import com.divudi.ejb.BillNumberGenerator;
 import com.divudi.ejb.PharmacyBean;
 import com.divudi.service.pharmacy.StockTakeApprovalService;
@@ -1576,6 +1577,13 @@ public class PharmacyStockTakeController implements Serializable {
                     snapshotBillDisplay.getNetTotal(), Boolean.FALSE);
         }
 
+        // doApprovalLogic() may have queued a warning that some lines were not applied
+        // to stock. Without this the redirect below discards it and the operator is told
+        // nothing - which is how the Southern Lanka partial adjustments went unnoticed.
+        FacesContext fc = FacesContext.getCurrentInstance();
+        if (fc != null) {
+            fc.getExternalContext().getFlash().setKeepMessages(true);
+        }
         return "/pharmacy/pharmacy_stock_take_print?faces-redirect=true";
     }
 

--- a/src/main/java/com/divudi/ejb/PharmacyBean.java
+++ b/src/main/java/com/divudi/ejb/PharmacyBean.java
@@ -1844,11 +1844,12 @@ public class PharmacyBean {
 
         // Record itemBatch rates
         if (fetchedStock.getItemBatch() != null) {
-            Double costRate = fetchedStock.getItemBatch().getCostRate();
+            Double costRateObj = fetchedStock.getItemBatch().getCostRate();
+            double costRate = costRateObj != null ? costRateObj : 0.0;
             double purchaseRate = fetchedStock.getItemBatch().getPurcahseRate();
             double retailSaleRate = fetchedStock.getItemBatch().getRetailsaleRate();
 
-            sh.setCostRate(costRate != null ? costRate : 0.0);
+            sh.setCostRate(costRate);
             sh.setPurchaseRate(fetchedStock.getItemBatch().getPurcahseRate());
             sh.setRetailRate(fetchedStock.getItemBatch().getRetailsaleRate());
             sh.setWholesaleRate(fetchedStock.getItemBatch().getWholesaleRate());
@@ -1970,11 +1971,12 @@ public class PharmacyBean {
 
         // Record itemBatch rates
         if (fetchedStock.getItemBatch() != null) {
-            Double costRate = fetchedStock.getItemBatch().getCostRate();
+            Double costRateObj = fetchedStock.getItemBatch().getCostRate();
+            double costRate = costRateObj != null ? costRateObj : 0.0;
             double purchaseRate = fetchedStock.getItemBatch().getPurcahseRate();
             double retailSaleRate = fetchedStock.getItemBatch().getRetailsaleRate();
 
-            sh.setCostRate(costRate != null ? costRate : 0.0);
+            sh.setCostRate(costRate);
             sh.setPurchaseRate(fetchedStock.getItemBatch().getPurcahseRate());
             sh.setRetailRate(fetchedStock.getItemBatch().getRetailsaleRate());
             sh.setWholesaleRate(fetchedStock.getItemBatch().getWholesaleRate());


### PR DESCRIPTION
Deploy hotfix for the Southern Lanka instance staff are currently using.

Cherry-pick of the two commits from #23212 (already green against `development`) onto `southernlanka-stg-migrated`. Merges clean — **2 files, 35 insertions**, no entity or schema changes.

## Why this is needed now

The 2026-08-17/19 stock take (snapshot bill `10174939`, 8,789 stock rows) left **235 counted stock rows never written back**, while the variance report kept showing the correct variance. The pharmacy has been trading on wrong stock for three days.

`PharmacyBean.addToStockHistory()` null-guards the boxed `ItemBatch.costRate` once, then unboxes the same reference raw 17 lines later:

```java
Double costRate = fetchedStock.getItemBatch().getCostRate();
sh.setCostRate(costRate != null ? costRate : 0.0);                             // guarded
...
sh.setInstitutionBatchStockValueAtCostRate(institutionBatchStock * costRate);  // NPE
```

Confirmed in this server's own log:

```
Caused by: java.lang.NullPointerException
	at com.divudi.ejb.PharmacyBean.addToStockHistory(PharmacyBean.java:1868)
	at com.divudi.ejb.PharmacyBean.resetStock(PharmacyBean.java:910)
```

`resetStock()` commits the stock write *before* calling `addToStockHistory()`, so the NPE escapes the loop in `doApprovalLogic()` and abandons every remaining item in that upload — earlier items stay committed, and the operator is told "Physical count approved".

Of the **3,420 successfully adjusted** stocks only **2** have a NULL `costRate`; of the **235 missed**, **212** do. The database holds 10,414 such batches.

## Blocking the recovery

This must ship before the data can be corrected: `POST /api/pharmacy_adjustments/stock_quantity` calls the same `resetStock()`, so for 212 of the 235 affected rows it would commit the stock write and *then* throw HTTP 500, leaving a half-applied state with no audit bill.

## Changes

1. `PharmacyBean` — unbox `costRate` once into a primitive, matching the pattern the `addToStockHistory(..., Staff)` overload in the same class already uses. Applied to both affected methods.
2. `PharmacyStockTakeController.doApprovalLogic()` — count lines actually applied, honour `resetStock()`'s previously-ignored boolean return, warn when applied != expected, and keep that warning across the `faces-redirect` (raised by CodeRabbit on #23212).

## Testing

`mvn compile` — BUILD SUCCESS on this base. Root cause reproduced from the production log and confirmed statistically against the production dataset.

After deploy: smoke-test one null-`costRate` item through the API, then apply the 228 correctable rows with per-item verification of `stock.stock` and a new `stockhistory` row. 7 further rows whose corrected value would go negative are being reported to SLH rather than changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)