### PR TITLE
feat(skills): add /merge-gate skill for PR pre-merge regression gating

### DIFF
--- a/.claude/skills/merge-gate/SKILL.md
+++ b/.claude/skills/merge-gate/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: merge-gate
+description: >
+  Gate one or more open PRs before merge: CI check, then a code-level
+  regression/business-rule review, then (only if that's clean) end-to-end
+  Playwright verification of the PR's own workflow(s) plus two fixed
+  baseline checks. Use when asked to "gate PR(s) for merge", "run
+  merge-gate on #N", "check these PRs are safe to merge", or before merging
+  any PR that touches shared/core code (API, billing, pharmacy) where a
+  regression could silently break unrelated functions.
+argument-hint: "<pr-number> [pr-number...]"
+---
+
+# Merge Gate (HMIS)
+
+Full design rationale: `developer_docs/git/2026-08-22-merge-gate-skill-design.md`.
+
+This exists because a past API-improvement PR shipped an NPE that broke
+**all** API functions, and neither CodeRabbit nor manual review caught it
+before merge. This skill adds a code-level review pass plus a live
+end-to-end sweep — including two fixed baseline checks unrelated to the
+PR's own scope — as a safety net for that class of regression.
+
+**This skill never merges anything.** It ends with a report telling you
+which PRs are ready for *your* final review and merge.
+
+## Arguments
+
+- `$0`, `$1`, ... — one or more **PR numbers** (not issue numbers). If a
+  number given doesn't resolve to an open PR, say so and ask for the
+  correct PR number rather than guessing which PR closes an issue.
+
+## Multi-PR handling
+
+Process PRs **sequentially**, one fully through the pipeline (or blocked)
+before starting the next — only one branch/deployment can be live on local
+Payara at a time. Keep a running outcome table and print the final report
+after the last PR.
+
+## Pipeline (per PR)
+
+### 0. CI gate
+
+```bash
+gh pr checks <PR>
+```
+
+- Failing → record `BLOCKED-CI`, stop this PR, move to the next.
+- Pending → `ScheduleWakeup` ~270s (same cadence as `dev-issue` §14), recheck
+  once. Still not green → `BLOCKED-CI`, stop this PR.
+- Passing → continue.
+
+### 1. Fetch and checkout
+
+```bash
+git fetch origin
+gh pr checkout <PR>
+```
+
+Then restore `persistence.xml` to local JNDI (`jdbc/coop` /
+`jdbc/ruhunuAudit`) per CLAUDE.md, left **unstaged**.
+
+### Phase 1 — Code-level regression review
+
+Invoke the `code-review` skill against this PR at **high** effort with
+`--comment`, so findings post directly to the PR (reuses the existing
+review engine instead of duplicating its logic).
+
+Classify the findings it returns:
+
+| Category | Effect |
+|---|---|
+| correctness, regression, business-rule violation | **Blocking.** Comments are already posted by `--comment`; summarize in chat; record `BLOCKED-REVIEW`; stop this PR — do not run Phase 2/3. |
+| style, simplification, efficiency, reuse-only | **Non-blocking.** Note in chat, continue to Phase 2 regardless. |
+
+No findings at all → continue to Phase 2.
+
+### Phase 2 — Identify affected workflows
+
+```bash
+gh pr diff <PR> --name-only
+```
+
+Use the `Explore` agent to map the changed files (controllers, services,
+entities, XHTML, REST resources) to the user-facing pages/flows that
+exercise them. Produce a short concrete list (e.g. "GRN receipt flow",
+"Stock Transfer approval"). Only pause for `AskUserQuestion` if the mapping
+is genuinely ambiguous (e.g. a shared utility touched by many unrelated
+flows) — don't ask when the diff makes the affected flow obvious.
+
+### 2a. Build and local redeploy
+
+Per `playwright-e2e` §0a / `dev-issue` §6:
+
+```powershell
+$env:JAVA_HOME="C:\Program Files\Eclipse Adoptium\jdk-11.0.23.9-hotspot"
+& "D:\Program Files\NetBeans-18\netbeans\java\maven\bin\mvn.cmd" clean package -DskipTests
+& "D:\Payara\bin\asadmin.bat" redeploy --name rh "D:\Development\2024\hmis\target\rh-3.0.0.war"
+```
+
+Check the server log for deployment errors before proceeding.
+
+### Phase 3 — End-to-end verification
+
+Run via the `playwright-e2e` skill (login, department selection, AJAX-aware
+waits, DB verification per its workflow doc). For **every** PR that reaches
+this phase, run all three of the following — the two baseline checks are
+fixed and always run, regardless of what the PR touches, because the
+motivating incident broke core flows unrelated to the changed code:
+
+1. **PR-specific workflow(s)** from Phase 2, using real test data (pick
+   department/records the same way `dev-issue` §4 does — confirm with
+   `AskUserQuestion` rather than guessing).
+2. **Fixed baseline A — pharmacy retail sale → COGS variance.** Make a
+   pharmacy retail sale, then open Reports → Inventory Reports → Cost Of
+   Good Sold (`/reports/inventoryReports/cost_of_goods_sold`) and confirm
+   no unexplained variance. This report's Process button can silently no-op
+   or show stale results — poll for AJAX/query completion twice, a few
+   seconds apart, before reading the grid (see the project's COGS-report
+   testing-gotcha memory).
+3. **Fixed baseline B — OPD sale → Cashier Details.** Log into an OPD
+   department, make an OPD sale, then open Reports → **Cashier Reports** →
+   Cashier Details (`/reports/cashier_reports/cashier_detailed`) and
+   confirm the sale appears correctly for the cashier/shift used.
+
+A failure in any of the three (PR workflow or either baseline) is a real
+bug the gate caught: capture evidence (screenshots, DB query output) into
+the project `tmp/` folder, record `BLOCKED-E2E`, and stop this PR. Do not
+attempt a fix inline — report it and discuss next steps (per CLAUDE.md
+"discuss uncertainties"); fixing is separate `dev-issue` work.
+
+All three pass → record `PASSED`.
+
+## Final report
+
+After all PRs are processed, print a table:
+
+| PR # | Outcome | Workflows tested | Notes/links |
+|---|---|---|---|
+
+For every `PASSED` row, say it's ready for the user's final review and
+merge. For blocked rows, link the PR comment (Phase 1) or the evidence
+captured (Phase 3). Never merge, approve, or request changes on the user's
+behalf.
+
+## Hygiene
+
+- Restore `persistence.xml` to local JNDI after every PR's checkout, left
+  unstaged — repeat for each PR in the batch, not just the first.
+- Screenshots/evidence go to the project `tmp/` folder (never system
+  `/tmp/`), per CLAUDE.md.
+
+## Required permissions
+
+Same as `playwright-e2e` (full `mcp__playwright__*` set, Maven +
+`asadmin`, `mysql` read access) plus `gh` for PR checkout/checks/diff and
+the `Agent` tool for the Phase 2 `Explore` dispatch.

--- a/.claude/skills/merge-gate/SKILL.md
+++ b/.claude/skills/merge-gate/SKILL.md
@@ -54,8 +54,14 @@ gh pr checks <PR>
 
 ```bash
 git fetch origin
+git checkout -- src/main/resources/META-INF/persistence.xml
 gh pr checkout <PR>
 ```
+
+The `git checkout --` discards the previous PR's uncommitted local-JNDI edit
+first — skip it and the branch switch can fail or behave inconsistently
+whenever the committed `persistence.xml` differs between branches. Safe
+no-op on the very first PR (nothing to discard).
 
 Then restore `persistence.xml` to local JNDI (`jdbc/coop` /
 `jdbc/ruhunuAudit`) per CLAUDE.md, left **unstaged**.
@@ -98,7 +104,11 @@ $env:JAVA_HOME="C:\Program Files\Eclipse Adoptium\jdk-11.0.23.9-hotspot"
 & "D:\Payara\bin\asadmin.bat" redeploy --name rh "D:\Development\2024\hmis\target\rh-3.0.0.war"
 ```
 
-Check the server log for deployment errors before proceeding.
+Check the server log for deployment errors before proceeding. **If `mvn
+clean package` fails, `asadmin redeploy` fails, or the server log shows
+deployment errors, stop this PR here**: capture the failure output, record
+`BLOCKED-BUILD`, and move to the next PR — don't attempt Phase 3 against a
+stale or undeployed build.
 
 ### Phase 3 — End-to-end verification
 
@@ -125,9 +135,12 @@ motivating incident broke core flows unrelated to the changed code:
 
 A failure in any of the three (PR workflow or either baseline) is a real
 bug the gate caught: capture evidence (screenshots, DB query output) into
-the project `tmp/` folder, record `BLOCKED-E2E`, and stop this PR. Do not
-attempt a fix inline — report it and discuss next steps (per CLAUDE.md
-"discuss uncertainties"); fixing is separate `dev-issue` work.
+the project `tmp/` folder, record `BLOCKED-E2E`, and stop this PR. Redact
+patient identifiers, credentials, tokens, and other sensitive fields from
+that evidence before it leaves `tmp/` (referenced in chat, posted to a PR
+comment, etc.) — same rule as `dev-issue` §2a/§10. Do not attempt a fix
+inline — report it and discuss next steps (per CLAUDE.md "discuss
+uncertainties"); fixing is separate `dev-issue` work.
 
 All three pass → record `PASSED`.
 
@@ -138,17 +151,20 @@ After all PRs are processed, print a table:
 | PR # | Outcome | Workflows tested | Notes/links |
 |---|---|---|---|
 
-For every `PASSED` row, say it's ready for the user's final review and
-merge. For blocked rows, link the PR comment (Phase 1) or the evidence
-captured (Phase 3). Never merge, approve, or request changes on the user's
-behalf.
+Outcome is one of `PASSED`, `BLOCKED-CI`, `BLOCKED-REVIEW`, `BLOCKED-BUILD`,
+`BLOCKED-E2E`. For every `PASSED` row, say it's ready for the user's final
+review and merge. For blocked rows, link the PR comment (Phase 1), the
+build/deploy failure output (2a), or the evidence captured (Phase 3). Never
+merge, approve, or request changes on the user's behalf.
 
 ## Hygiene
 
-- Restore `persistence.xml` to local JNDI after every PR's checkout, left
-  unstaged — repeat for each PR in the batch, not just the first.
+- Discard and restore `persistence.xml` to local JNDI around every PR's
+  checkout (see step 1), left unstaged — repeat for each PR in the batch,
+  not just the first.
 - Screenshots/evidence go to the project `tmp/` folder (never system
-  `/tmp/`), per CLAUDE.md.
+  `/tmp/`), per CLAUDE.md — redacted of patient/sensitive data before they
+  leave `tmp/`.
 
 ## Required permissions
 

--- a/developer_docs/git/2026-08-22-merge-gate-skill-design.md
+++ b/developer_docs/git/2026-08-22-merge-gate-skill-design.md
@@ -1,0 +1,170 @@
+# `/merge-gate` Skill — Design Spec
+
+Date: 2026-08-22
+Status: Approved
+
+## Motivation
+
+An API improvement PR shipped an NPE that broke all API functions. CodeRabbit
+review and the developer's own manual review both missed it. There is no
+existing gate that combines (a) a focused code-level regression/business-rule
+review and (b) live end-to-end verification before a PR is considered
+mergeable. This skill closes that gap.
+
+## Goal
+
+Given one or more PR numbers, run each through: CI check → code-level review
+→ (if clean) end-to-end Playwright verification, including two fixed
+baseline regression checks that exercise core billing/reporting paths
+regardless of what the PR touches → a final merge-readiness report. The
+skill never merges — the developer always does the final review and clicks
+merge.
+
+## Non-goals
+
+- Not a replacement for `review-pr` (handling reviewer/bot comment threads
+  on an already-open review cycle) — that's a separate, later step.
+- Not a general test-automation framework — it drives the existing
+  `code-review` and `playwright-e2e` skills rather than reimplementing them.
+- Does not auto-fix bugs found during E2E — a bug found here is reported and
+  the PR is blocked; fixing it is separate `dev-issue` work.
+
+## Skill location
+
+`.claude/skills/merge-gate/SKILL.md`
+
+Not mirrored to `.codex/skills/` — this skill depends on the `Agent`
+(Explore) tool, `playwright-e2e`'s full `mcp__playwright__*` tool set, and
+`ScheduleWakeup`-style polling, matching the existing pattern where
+`dev-issue`, `dev-issue-unattended`, `playwright-e2e`, and `start-issue` are
+Claude-only and not present under `.codex/skills/`.
+
+## Invocation
+
+`/merge-gate <pr-number> [pr-number...]`
+
+Arguments are PR numbers directly (not issue numbers). If the user supplies
+an issue number by mistake, note the PR/issue distinction and ask them to
+give the PR number, rather than guessing which PR closes it.
+
+## Per-PR pipeline
+
+Multiple PRs are processed **sequentially** — one PR goes all the way
+through (or is blocked) before the next starts — because only one
+branch/deployment can be live on local Payara at a time.
+
+### Step 0 — CI gate
+
+```bash
+gh pr checks <PR>
+```
+
+- Failing → report and stop this PR (`BLOCKED-CI`). Do not proceed to Phase 1.
+- Pending → wait once via `ScheduleWakeup` (~270s, same cadence as
+  `dev-issue` §14) and recheck. Still pending/failing → stop this PR
+  (`BLOCKED-CI`).
+- Passing → proceed to Phase 1.
+
+### Step 1 — Fetch and checkout
+
+```bash
+git fetch origin
+gh pr checkout <PR>
+```
+
+Restore `persistence.xml` to local JNDI (`jdbc/coop` /
+`jdbc/ruhunuAudit`) per CLAUDE.md, unstaged.
+
+### Phase 1 — Code-level review
+
+Invoke the existing `code-review` skill against this PR at **high** effort
+with `--comment`, so it posts findings directly to the PR (per the design
+discussion — this avoids duplicating review logic in the new skill and
+keeps it in sync with future improvements to `code-review`).
+
+Classify returned findings:
+
+- **Blocking categories**: correctness, regression, business-rule
+  violation. Any finding in these categories → the comments are already
+  posted by `code-review --comment`; report the summary in chat; **stop
+  this PR here** (`BLOCKED-REVIEW`). Do not proceed to Phase 2.
+- **Non-blocking categories**: style, simplification, efficiency,
+  reuse-only suggestions. Note them in chat but continue to Phase 2
+  regardless.
+
+If `code-review` finds nothing at all, proceed to Phase 2.
+
+### Phase 2 — Identify affected workflows
+
+Use the `Explore` agent against the PR's changed files (`gh pr diff <PR>
+--name-only` as the starting point) to map changed
+controllers/services/endpoints/XHTML to the user-facing pages/flows that
+exercise that code. Produce a short, concrete list (e.g. "GRN receipt
+flow", "Stock Transfer approval"). No user confirmation pause unless the
+mapping is genuinely ambiguous (e.g. a shared utility touched by many
+unrelated flows) — in that case, ask via `AskUserQuestion` which flow(s) to
+prioritize.
+
+### Step 2a — Build and local redeploy
+
+Per `playwright-e2e` §0a / `dev-issue` §6:
+
+```powershell
+$env:JAVA_HOME="C:\Program Files\Eclipse Adoptium\jdk-11.0.23.9-hotspot"
+& "D:\Program Files\NetBeans-18\netbeans\java\maven\bin\mvn.cmd" clean package -DskipTests
+& "D:\Payara\bin\asadmin.bat" redeploy --name rh "D:\Development\2024\hmis\target\rh-3.0.0.war"
+```
+
+Check the server log for deployment errors before proceeding.
+
+### Phase 3 — End-to-end verification (Playwright)
+
+Run via the `playwright-e2e` skill workflow (login, department selection,
+AJAX-aware waits, DB verification). For **every** PR that reaches this
+phase, test:
+
+1. **PR-specific workflow(s)** identified in Phase 2 — exercise the actual
+   changed behavior with real data (department/records chosen the same way
+   `dev-issue` §4 does, via `AskUserQuestion` if not obvious from the diff).
+2. **Fixed baseline check A — Pharmacy retail sale → COGS variance.**
+   Make a pharmacy retail sale, then open Reports → Inventory Reports →
+   Cost Of Good Sold (`/reports/inventoryReports/cost_of_goods_sold`) and
+   confirm no unexplained variance. Apply the known testing gotcha: this
+   report's Process button can silently no-op or show stale results — poll
+   AJAX/query completion twice a few seconds apart before reading the grid
+   (see `feedback_cogs_report_testing_gotcha` memory).
+3. **Fixed baseline check B — OPD sale → Cashier Details.**
+   Log into an OPD department, make an OPD sale, then open Reports →
+   Cashier Reports → Cashier Details
+   (`/reports/cashier_reports/cashier_detailed`) and confirm the sale
+   appears correctly for the cashier/shift used.
+
+These two baseline checks run regardless of what the PR touches, because
+the motivating incident (API NPE) broke core flows unrelated to the
+changed code — the goal is catching exactly that class of global breakage.
+
+A failure at this phase (PR workflow OR either baseline check) means a real
+bug was found: report it with evidence (screenshots/DB query results) and
+stop this PR (`BLOCKED-E2E`). Do not attempt to fix it inline — flag for
+discussion per CLAUDE.md "discuss uncertainties"; fixing is separate
+`dev-issue` work.
+
+### Step 4 — Record outcome
+
+One of: `PASSED`, `BLOCKED-CI`, `BLOCKED-REVIEW`, `BLOCKED-E2E`, with a
+one-line reason and links (PR comment URL, screenshots) for anything
+blocked.
+
+## Final report (after all PRs processed)
+
+A table: PR # | outcome | workflows tested | notes/links. For `PASSED`
+PRs: "ready for your final review to merge." The skill never merges or
+approves — that's always the user's call, matching every other skill's
+convention (`dev-issue` §15, `review-pr`).
+
+## Hygiene
+
+- `persistence.xml` restored to local JNDI after each PR's checkout, left
+  unstaged (CLAUDE.md rule), for every PR in the batch.
+- Temporary screenshots go to the project `tmp/` folder, same as
+  `playwright-e2e`/`dev-issue` conventions.

--- a/developer_docs/git/2026-08-22-merge-gate-skill-design.md
+++ b/developer_docs/git/2026-08-22-merge-gate-skill-design.md
@@ -69,11 +69,15 @@ gh pr checks <PR>
 
 ```bash
 git fetch origin
+git checkout -- src/main/resources/META-INF/persistence.xml
 gh pr checkout <PR>
 ```
 
-Restore `persistence.xml` to local JNDI (`jdbc/coop` /
-`jdbc/ruhunuAudit`) per CLAUDE.md, unstaged.
+The `git checkout --` discards the previous PR's uncommitted local-JNDI
+edit before switching branches — otherwise the branch switch can fail or
+behave inconsistently whenever the committed `persistence.xml` differs
+between branches. Safe no-op on the first PR. Restore `persistence.xml` to
+local JNDI (`jdbc/coop` / `jdbc/ruhunuAudit`) per CLAUDE.md, unstaged.
 
 ### Phase 1 — Code-level review
 
@@ -115,7 +119,11 @@ $env:JAVA_HOME="C:\Program Files\Eclipse Adoptium\jdk-11.0.23.9-hotspot"
 & "D:\Payara\bin\asadmin.bat" redeploy --name rh "D:\Development\2024\hmis\target\rh-3.0.0.war"
 ```
 
-Check the server log for deployment errors before proceeding.
+Check the server log for deployment errors before proceeding. If `mvn
+clean package` fails, `asadmin redeploy` fails, or the server log shows
+deployment errors, stop this PR here: capture the failure output, record
+`BLOCKED-BUILD`, and move to the next PR — do not attempt Phase 3 against a
+stale or undeployed build.
 
 ### Phase 3 — End-to-end verification (Playwright)
 
@@ -145,15 +153,17 @@ changed code — the goal is catching exactly that class of global breakage.
 
 A failure at this phase (PR workflow OR either baseline check) means a real
 bug was found: report it with evidence (screenshots/DB query results) and
-stop this PR (`BLOCKED-E2E`). Do not attempt to fix it inline — flag for
-discussion per CLAUDE.md "discuss uncertainties"; fixing is separate
-`dev-issue` work.
+stop this PR (`BLOCKED-E2E`). Redact patient identifiers, credentials,
+tokens, and other sensitive fields from that evidence before it leaves
+`tmp/` (chat, PR comment, etc.) — same rule as `dev-issue` §2a/§10. Do not
+attempt to fix it inline — flag for discussion per CLAUDE.md "discuss
+uncertainties"; fixing is separate `dev-issue` work.
 
 ### Step 4 — Record outcome
 
-One of: `PASSED`, `BLOCKED-CI`, `BLOCKED-REVIEW`, `BLOCKED-E2E`, with a
-one-line reason and links (PR comment URL, screenshots) for anything
-blocked.
+One of: `PASSED`, `BLOCKED-CI`, `BLOCKED-REVIEW`, `BLOCKED-BUILD`,
+`BLOCKED-E2E`, with a one-line reason and links (PR comment URL,
+screenshots) for anything blocked.
 
 ## Final report (after all PRs processed)
 
@@ -164,7 +174,8 @@ convention (`dev-issue` §15, `review-pr`).
 
 ## Hygiene
 
-- `persistence.xml` restored to local JNDI after each PR's checkout, left
-  unstaged (CLAUDE.md rule), for every PR in the batch.
+- `persistence.xml` discarded and restored to local JNDI around each PR's
+  checkout (CLAUDE.md rule), for every PR in the batch, not just the first.
 - Temporary screenshots go to the project `tmp/` folder, same as
-  `playwright-e2e`/`dev-issue` conventions.
+  `playwright-e2e`/`dev-issue` conventions, redacted of patient/sensitive
+  data before they leave `tmp/`.


### PR DESCRIPTION
## Why

A recent API-improvement PR shipped an NPE that broke **all** API functions. Neither CodeRabbit review nor manual review caught it before merge. There was no gate combining a focused code-level regression/business-rule review with a live end-to-end sweep before a PR is considered mergeable.

## What

Adds `.claude/skills/merge-gate/SKILL.md` — a new skill invoked as `/merge-gate <pr-number> [pr-number...]`.

Per PR, sequentially:
1. **CI gate** — `gh pr checks`; stop (`BLOCKED-CI`) if red/still-pending after one recheck.
2. **Phase 1 — code-level review** — reuses the existing `code-review` skill at high effort with `--comment` (posts findings straight to the PR). Blocks only on **correctness / regression / business-rule violation** findings (`BLOCKED-REVIEW`); style/simplification/efficiency findings are reported but don't block.
3. **Phase 2 — affected-workflow discovery** — maps the PR's changed files to the real pages/flows that exercise them (`Explore` agent), for Playwright to target.
4. **Build + local redeploy**, then **Phase 3 — E2E verification** via the `playwright-e2e` skill:
   - The PR-specific workflow(s) from Phase 2.
   - **Fixed baseline A** (every PR, regardless of scope): pharmacy retail sale → Reports → Inventory Reports → Cost Of Good Sold → confirm no variance.
   - **Fixed baseline B** (every PR): log into an OPD department, make an OPD sale → Reports → Cashier Reports → Cashier Details → confirm it appears correctly.

   The two baseline checks run unconditionally because the motivating incident broke core flows unrelated to the changed code — the goal is catching exactly that class of global regression.
5. Any E2E failure → `BLOCKED-E2E`, evidence captured, reported for discussion (not auto-fixed).
6. Final output: a PASSED/BLOCKED-* table per PR. **The skill never merges** — passed PRs are reported as ready for the developer's own final review and merge.

Also adds `developer_docs/git/2026-08-22-merge-gate-skill-design.md` with the full design rationale from the brainstorming session that produced this.

## Testing

This is a new operational skill (Markdown workflow definition, no application code) — matches the existing lightweight pattern used by `dev-issue`, `playwright-e2e`, `review-pr`, etc. in this repo, none of which carry automated tests. No source/build changes; JSF/Java compilation is unaffected.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `/merge-gate` workflow for sequential pull request validation.
  - Supports CI checks, code review, local redeployment, affected-workflow testing, and Playwright verification.
  - Provides a final status report with evidence for any blocked checks.

- **Documentation**
  - Added guidance covering supported arguments, execution rules, required permissions, checkout hygiene, baseline checks, and local configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->