### PR TITLE
fix(pharmacy): correct GRN return value lookup in supplier bill settlement

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/SupplierPaymentController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/SupplierPaymentController.java
@@ -514,7 +514,7 @@ public class SupplierPaymentController implements Serializable {
             BillItem availableBillItem = new BillItem();
             availableBillItem.setSearialNo(generatedSerialNumber++);
             availableBillItem.setReferenceBill(b);
-            double returned = Math.abs(getCreditBean().getGrnReturnValue(getCurrentBillItem().getReferenceBill(), billTypesListReturn));
+            double returned = Math.abs(getCreditBean().getGrnReturnValue(b, billTypesListReturn));
             availableBillItem.getReferenceBill().setTmpReturnTotal(returned);
             fillNetValueForBillItems(availableBillItem);
             billItems.add(availableBillItem);


### PR DESCRIPTION
## Decisions made without approval

This was run unattended via `dev-issue-unattended` — one judgment call, low ambiguity:

- **Fix location**: root cause traced to `SupplierPaymentController.fillInstitutionBillsToSettle()` computing each GRN's already-returned amount via `getCurrentBillItem().getReferenceBill()` instead of the loop variable `b`. Since `currentBillItem` is nulled by `makeNull()` at the top of the method and never repopulated inside the loop, this always passed a `null` reference bill into `CreditBean.getGrnReturnValue`, which silently returns `0.0` on no match / null param (via `findDoubleByJpql`'s catch-and-return-0 behavior). The fix swaps in `b`, matching the pattern already used correctly at the method's other two call sites (`SupplierPaymentController.java` lines ~2054, ~2992) and in the non-buggy sibling helper `fillNetValueForBillItems`. No architectural ambiguity — a same-file, same-pattern one-line correction — so no stop was warranted.

## Problem

On **Settle Bills by Supplier** (`/dealerPayment/bill_dealor_all.xhtml`), a GRN return amount that had already been accounted for kept reappearing as outstanding **"To Pay"**, even after the supplier had been paid in full.

## Root cause

`fillInstitutionBillsToSettle()` builds one `BillItem` per unpaid GRN and needs to look up how much of that specific GRN has already been returned to the supplier (`CreditBean.getGrnReturnValue(refBill, returnTypes)`). Instead of passing the GRN it's currently iterating (`b`), it passed `getCurrentBillItem().getReferenceBill()` — a leftover, never-populated `BillItem` created by a lazy getter after `makeNull()` clears the field. That object's `referenceBill` is always `null`, so the return-value query always misses and silently resolves to `0.0`. With the return amount always zero, "Receivable Value" (`GRN Value + Return Value + Paid Value`) never subtracted what had already been returned — so a return that was already settled kept showing up as still owed.

This bug has been present since the method was introduced (commit `932466ee18e`, Feb 2025).

## Fix

One-line change: use the loop variable `b` (the actual GRN bill) instead of the stale `getCurrentBillItem().getReferenceBill()`.

## Verification (local dev, real data — not synthetic)

Found an existing supplier with a real, previously-unpaid GRN that already had a partial return recorded and no prior payment.

**Before payment (after the fix deployed):**

| GRN Value | Return Value | Paid Value | Receivable Value |
|---|---|---|---|
| -107.50 | 43.00 | 0.00 | **-64.50** |

(Return Value correctly non-zero, Receivable already nets out the return — before the fix this would have shown Return Value `0.00` and Receivable `-107.50`, ignoring the return entirely.)

Settled the bill for 64.50 through the normal Settle Bills by Supplier flow (Payment Voucher generated, "Bill Saved").

**After payment, re-searching the same supplier:**

| GRN Value | Return Value | Paid Value | Receivable Value |
|---|---|---|---|
| -107.50 | 43.00 | 64.50 | **0.00** |

The return no longer reappears as outstanding. Confirmed directly in the database: the GRN's `PAIDAMOUNT=64.50`, `BALANCE=0`; the new `SUPPLIER_PAYMENT` bill item correctly references the GRN with `NETVALUE=-64.50`. No errors in the server log during the flow.

Closes #23208

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected supplier payment calculations to account for returned amounts on the bill currently being processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->