### PR TITLE
feat(inward): charge timed services per minute, per day or one time (#23206)

### DIFF
--- a/developer_docs/api/using-apis/API_INWARD_ROOM.md
+++ b/developer_docs/api/using-apis/API_INWARD_ROOM.md
@@ -191,7 +191,8 @@ GET /api/inward/room-facility-charges?query=&roomId=&roomCategoryId=&size=
         "id": 5,
         "durationHours": 24.0,
         "overShootHours": 6.0,
-        "durationDaysForMoCharge": 0
+        "durationDaysForMoCharge": 0,
+        "durationUnit": "HOUR"
       }
     }
   ]
@@ -224,7 +225,8 @@ Returns a single room facility charge or 404 if not found / retired.
   "medicalCareCharge": 0.0,
   "timedItemFeeDurationHours": 24.0,
   "timedItemFeeOverShootHours": 6.0,
-  "timedItemFeeDurationDaysForMoCharge": 0
+  "timedItemFeeDurationDaysForMoCharge": 0,
+  "timedItemFeeDurationUnit": "HOUR"
 }
 ```
 
@@ -242,9 +244,10 @@ Returns a single room facility charge or 404 if not found / retired.
 | moChargeForAfterDuration | No | MO charge for after-duration |
 | adminstrationCharge | No | Administration charge per block |
 | medicalCareCharge | No | Medical care charge per block |
-| timedItemFeeDurationHours | No | Block duration in hours |
-| timedItemFeeOverShootHours | No | Over-shoot hours for last block |
+| timedItemFeeDurationHours | No | Block duration, counted in `timedItemFeeDurationUnit` |
+| timedItemFeeOverShootHours | No | Over-shoot for last block, in the same unit |
 | timedItemFeeDurationDaysForMoCharge | No | Duration days for MO charge calculation |
+| timedItemFeeDurationUnit | No | `ONE_TIME`, `MINUTE`, `HOUR` or `DAY` — what the two values above are counted in. Defaults to `HOUR`; `ONE_TIME` charges the block once regardless of the stay |
 
 ### PUT — Update
 

--- a/developer_docs/api/using-apis/API_INWARD_ROOM.md
+++ b/developer_docs/api/using-apis/API_INWARD_ROOM.md
@@ -244,7 +244,7 @@ Returns a single room facility charge or 404 if not found / retired.
 | moChargeForAfterDuration | No | MO charge for after-duration |
 | adminstrationCharge | No | Administration charge per block |
 | medicalCareCharge | No | Medical care charge per block |
-| timedItemFeeDurationHours | No | Block duration, counted in `timedItemFeeDurationUnit` |
+| timedItemFeeDurationHours | Yes, unless the unit is `ONE_TIME` | Block duration, counted in `timedItemFeeDurationUnit`. Must be greater than 0 — a time-based block of 0 bills nothing for every stay, so it is rejected with 400 |
 | timedItemFeeOverShootHours | No | Over-shoot for last block, in the same unit |
 | timedItemFeeDurationDaysForMoCharge | No | Duration days for MO charge calculation |
 | timedItemFeeDurationUnit | No | `ONE_TIME`, `MINUTE`, `HOUR` or `DAY` — what the two values above are counted in. Defaults to `HOUR`; `ONE_TIME` charges the block once regardless of the stay |

--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -1975,6 +1975,44 @@ not `isHasPendingTheatreReturnForAdmission`. **Fix**: for any boolean helper met
 naturally read in EL — reserve the `is`/`get` prefix convention for genuine no-arg property getters. Verified while
 testing issue #23166 (theatre transfer per-patient page).
 
+## 77. `p:autoComplete` with `<p:column>` children renders suggestions as a `<table>` of `<tr data-item-label>`, not `<li>` — a `li`-only selector reports "no matches" on a working autocomplete
+
+`.ui-autocomplete-panel li` is the right selector only for a plain autocomplete. As soon as the component declares
+`<p:column>` children (the multi-column suggestion form used by the timed-service, admission and item pickers), the
+panel renders a `<table class="ui-autocomplete-items ui-autocomplete-table">` whose rows are
+`<tr id="<clientId>_item_N" data-item-value="…" data-item-label="…">`. Querying only `li` returns an empty list, which
+looks exactly like "the server found nothing" and sends you off debugging the `completeMethod`'s JPQL. Diagnose by
+reading the actual AJAX response (`browser_network_request` → `response-body`) — if the partial response contains the
+rows, the query is fine and only the selector is wrong. **Fix**: select `tr[id^="<clientId>_item_"]` (or query both
+`tr, li`), and click the row by `data-item-label`. Verified while testing issue #23206.
+
+## 78. Typing into an input that a `p:ajax` just re-rendered prepends to the restored model value — set the dropdown first, then the numbers, and always confirm in the DB
+
+A `p:ajax` on a `p:selectOneMenu` with `update="txtDuration txtOverShoot"` re-renders those inputs *from the server-side
+model*. Clearing them client-side beforehand is undone by that re-render, so a later `pressSequentially('1')` lands in a
+field that once again reads `0.0` and produces **`10.0`**, not `1`. Nothing errors and the page looks right at a glance —
+the wrong value only shows up in the database. **Fix**: choose the dropdown value *first*, let the AJAX settle, then fill
+the dependent inputs; and verify every configuration value with a `SELECT` after saving rather than trusting the form.
+Related: `p:datePicker` ignores a direct `input.value = '…'` assignment (it re-formats from its own internal model) —
+drive it with `PF('widgetVar').setDate(new Date(...))`, resolving the widget via
+`Object.keys(PrimeFaces.widgets).find(k => PrimeFaces.widgets[k].id === '<clientId>')` when the page sets no
+`widgetVar`. Verified while testing issue #23206.
+
+## 79. Capturing a `p:growl` message in a screenshot: suppress its auto-hide timer, don't race it
+
+§68 says snapshot immediately — but with `life="3000"` even a single `browser_take_screenshot` round-trip usually misses
+it. Reading the DOM inside one `browser_evaluate` (click, `await` ~900ms, read `#growl_container.innerText`) proves the
+message *arrived*, and `getBoundingClientRect()` on `.ui-growl-item-container` proves it was actually on screen — but
+neither produces a screenshot. To capture one, suppress only the fade timer before triggering the action:
+
+```js
+window.__origSetTimeout = window.setTimeout;
+window.setTimeout = function (fn, delay) { return delay >= 2500 ? 0 : window.__origSetTimeout.apply(window, arguments); };
+```
+
+The real growl then stays rendered for the screenshot (nothing about the message is faked — only the dismissal is
+deferred). Reload the page afterwards to drop the patch. Verified while testing issue #23206.
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -2215,12 +2215,14 @@ public class BhtSummeryController implements Serializable {
         }
         TimedItemFee timedFee = pr.getRoomFacilityCharge().getTimedItemFee();
         double liveEquivalent = facilityRoomCharge * getInwardBean().calCount(timedFee, pr.getAdmittedAt(), pr.getDischargedAt());
-        // RoomFacilityCharge.roomCharge is a rate per TimedItemFee.durationHours block (see
+        // RoomFacilityCharge.roomCharge is a rate per TimedItemFee block (see
         // InwardBeanController.calCount: charge = roomCharge * count, where count is the number
-        // of durationHours-sized blocks between admittedAt/dischargedAt). Room-charge TimedItemFee
+        // of blocks between admittedAt/dischargedAt). Room-charge TimedItemFee
         // configs are conventionally 24-hour ("per day") blocks, so we use the actual configured
-        // durationHours here (falling back to 24.0 if unset) rather than hardcoding 24.
-        double blockHours = (timedFee != null && timedFee.getDurationHours() > 0) ? timedFee.getDurationHours() : 24.0;
+        // block length here (falling back to 24.0 if unset) rather than hardcoding 24.
+        // getDurationInHours() honours the configured duration unit, so a block defined in
+        // minutes or days converts to hours instead of being read as a raw hour count.
+        double blockHours = (timedFee != null && timedFee.getDurationInHours() > 0) ? timedFee.getDurationInHours() : 24.0;
         double includedEquivalent = facilityRoomCharge * (pr.getIncludedRoomDurationHours() / blockHours);
         return Math.max(0.0, liveEquivalent - includedEquivalent);
     }
@@ -5626,8 +5628,15 @@ public class BhtSummeryController implements Serializable {
         Date dischargedAt = pr.getDischargedAt() != null ? pr.getDischargedAt() : new Date();
 
         long totalMinutes = CommonFunctions.calculateDurationMin(pr.getAdmittedAt(), dischargedAt);
-        double slotMinutes = tif.getDurationHours() * 60.0;
-        double overshootMinutes = tif.getOverShootHours() * 60.0;
+
+        // A one-time charge is billed as a single slot regardless of the stay,
+        // matching what calCount() returns for it.
+        if (tif.isOneTime()) {
+            return new RoomDurationBreakdown(totalMinutes, 0, 0, totalMinutes, 0, false, 1);
+        }
+
+        double slotMinutes = tif.getDurationMinutes();
+        double overshootMinutes = tif.getOverShootMinutes();
 
         if (slotMinutes == 0) {
             return new RoomDurationBreakdown(totalMinutes, slotMinutes, 0, totalMinutes, overshootMinutes, false, 0);

--- a/src/main/java/com/divudi/bean/inward/InwardBeanController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardBeanController.java
@@ -3337,6 +3337,14 @@ public class InwardBeanController implements Serializable {
         }
 
         double duration = tif.getDurationMinutes();
+
+        // Same guard calCount already applies. Persisted data can still carry a
+        // time-based fee with no duration set, and dividing by it below yields
+        // Infinity — which casts to a huge block count and overcharges the bill.
+        if (duration <= 0) {
+            return 0;
+        }
+
         double consumeTimeM = 0L;
 
         if (admittedAt == null) {

--- a/src/main/java/com/divudi/bean/inward/InwardBeanController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardBeanController.java
@@ -3323,8 +3323,16 @@ public class InwardBeanController implements Serializable {
 
     public double calCountWithoutOverShoot(TimedItemFee tif, Date admittedAt, Date dischargedAt) {
 
+        // No fee configured at all counts the same as a fee with no duration set:
+        // nothing to bill. RoomFacilityCharge.timedItemFee is a nullable mapping,
+        // so this is reachable from the room paths, and a missing configuration
+        // should not break the page that is rendering the bill.
+        if (tif == null) {
+            return 0;
+        }
+
         // A one-time fee is charged once for the whole service, however long it ran.
-        if (tif != null && tif.isOneTime()) {
+        if (tif.isOneTime()) {
             return 1;
         }
 
@@ -3424,9 +3432,17 @@ public class InwardBeanController implements Serializable {
 
     public double calCount(TimedItemFee tif, Date admittedDate, Date dischargedDate) {
 
+        // No fee configured at all counts the same as a fee with no duration set:
+        // nothing to bill. RoomFacilityCharge.timedItemFee is a nullable mapping,
+        // so this is reachable from the room paths, and a missing configuration
+        // should not break the page that is rendering the bill.
+        if (tif == null) {
+            return 0;
+        }
+
         // A one-time fee is charged once for the whole service, however long it
         // ran — no block counting, and no dependency on elapsed time at all.
-        if (tif != null && tif.isOneTime()) {
+        if (tif.isOneTime()) {
             return 1;
         }
 

--- a/src/main/java/com/divudi/bean/inward/InwardBeanController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardBeanController.java
@@ -3323,7 +3323,12 @@ public class InwardBeanController implements Serializable {
 
     public double calCountWithoutOverShoot(TimedItemFee tif, Date admittedAt, Date dischargedAt) {
 
-        double duration = tif.getDurationHours() * 60;
+        // A one-time fee is charged once for the whole service, however long it ran.
+        if (tif != null && tif.isOneTime()) {
+            return 1;
+        }
+
+        double duration = tif.getDurationMinutes();
         double consumeTimeM = 0L;
 
         if (admittedAt == null) {
@@ -3419,8 +3424,14 @@ public class InwardBeanController implements Serializable {
 
     public double calCount(TimedItemFee tif, Date admittedDate, Date dischargedDate) {
 
-        double duration = tif.getDurationHours() * 60;
-        double overShoot = tif.getOverShootHours() * 60;
+        // A one-time fee is charged once for the whole service, however long it
+        // ran — no block counting, and no dependency on elapsed time at all.
+        if (tif != null && tif.isOneTime()) {
+            return 1;
+        }
+
+        double duration = tif.getDurationMinutes();
+        double overShoot = tif.getOverShootMinutes();
         //  double tempFee = tif.getFee();
         double consumeTime = 0;
 

--- a/src/main/java/com/divudi/bean/inward/InwardTimedItemController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardTimedItemController.java
@@ -710,9 +710,19 @@ public class InwardTimedItemController implements Serializable {
         if (getCurrent().getToTime() == null) {
             getCurrent().setToTime(new Date());
         }
+        // Price from the Start Time the user entered on this page, not from the
+        // date of admission. Both are stored on the item, but only fromTime is
+        // what the service actually ran for — and it is what the row's Update
+        // button (finalizeService) re-prices against, so pricing from the
+        // admission date made Add and Update disagree. A per-minute service made
+        // that glaring: a six-minute run on a two-week-old admission billed every
+        // minute since admission.
+        Date chargeFrom = getCurrent().getFromTime() != null
+                ? getCurrent().getFromTime()
+                : getCurrent().getPatientEncounter().getDateOfAdmission();
         double value = getInwardBean().calTotalTimedChargeForItem(
                 (TimedItem) getCurrent().getItem(),
-                getCurrent().getPatientEncounter().getDateOfAdmission(),
+                chargeFrom,
                 getCurrent().getToTime(),
                 getCurrent().getPatientEncounter().isForiegner());
         getCurrent().setServiceValue(value);

--- a/src/main/java/com/divudi/bean/inward/RoomFacilityChargeController.java
+++ b/src/main/java/com/divudi/bean/inward/RoomFacilityChargeController.java
@@ -11,6 +11,7 @@ package com.divudi.bean.inward;
 import com.divudi.bean.common.SessionController;
 import com.divudi.core.data.DepartmentType;
 import com.divudi.core.data.inward.RoomFacility;
+import com.divudi.core.data.inward.TimedItemDurationUnit;
 import com.divudi.core.entity.Institution;
 import com.divudi.core.entity.inward.AdmissionType;
 import com.divudi.core.entity.inward.RoomFacilityCharge;
@@ -302,9 +303,16 @@ public class RoomFacilityChargeController implements Serializable {
             current = new RoomFacilityCharge();
 
             TimedItemFee tmp = new TimedItemFee();
+            // Hour blocks are what every room charge configured before duration
+            // units existed used, so a new one starts there too.
+            tmp.setDurationUnit(TimedItemDurationUnit.HOUR);
             current.setTimedItemFee(tmp);
         }
         return current;
+    }
+
+    public TimedItemDurationUnit[] getDurationUnits() {
+        return TimedItemDurationUnit.values();
     }
 
     public void setCurrent(RoomFacilityCharge current) {

--- a/src/main/java/com/divudi/bean/inward/RoomOccupancyController.java
+++ b/src/main/java/com/divudi/bean/inward/RoomOccupancyController.java
@@ -184,6 +184,26 @@ public class RoomOccupancyController implements Serializable {
         return roomFacilityCharges;
     }
 
+    /**
+     * What a full day in this room costs, for the vacant-room list. The room
+     * charge is per configured block, and the block can be defined in minutes,
+     * hours or days — so it is scaled by however many blocks fit in 24 hours. A
+     * one-time charge is not time-based and is shown as-is.
+     */
+    public double getDailyEquivalentRoomCharge(RoomFacilityCharge charge) {
+        if (charge == null || charge.getTimedItemFee() == null || charge.getRoomCharge() == null) {
+            return 0.0;
+        }
+        if (charge.getTimedItemFee().isOneTime()) {
+            return charge.getRoomCharge();
+        }
+        double blockHours = charge.getTimedItemFee().getDurationInHours();
+        if (blockHours <= 0) {
+            return 0.0;
+        }
+        return charge.getRoomCharge() * (24.0 / blockHours);
+    }
+
     public void setRoomFacilityCharges(List<RoomFacilityCharge> roomFacilityCharges) {
         this.roomFacilityCharges = roomFacilityCharges;
     }

--- a/src/main/java/com/divudi/bean/inward/TimedItemFeeController.java
+++ b/src/main/java/com/divudi/bean/inward/TimedItemFeeController.java
@@ -10,6 +10,7 @@ package com.divudi.bean.inward;
 
 import com.divudi.bean.common.SessionController;
 
+import com.divudi.core.data.inward.TimedItemDurationUnit;
 import com.divudi.core.entity.Department;
 import com.divudi.core.entity.inward.TimedItem;
 import com.divudi.core.entity.inward.TimedItemFee;
@@ -76,6 +77,11 @@ public class TimedItemFeeController implements Serializable {
         }
         if (currentFee == null) {
             JsfUtil.addErrorMessage("Please select a charge");
+            return;
+        }
+        if (!currentFee.isOneTime() && currentFee.getDurationHours() <= 0) {
+            JsfUtil.addErrorMessage("Duration must be greater than 0 for a "
+                    + currentFee.getDurationUnit().getLabel() + " fee.");
             return;
         }
         currentFee.setItem(currentIx);
@@ -243,8 +249,15 @@ public class TimedItemFeeController implements Serializable {
         if (currentFee == null) {
             currentFee = new TimedItemFee();
             currentFee.setBooleanValue(true);
+            // Hour is what every fee created before duration units existed used,
+            // so a new fee starts there too unless the user picks another unit.
+            currentFee.setDurationUnit(TimedItemDurationUnit.HOUR);
         }
         return currentFee;
+    }
+
+    public TimedItemDurationUnit[] getDurationUnits() {
+        return TimedItemDurationUnit.values();
     }
 
     public void setCurrentFee(TimedItemFee currentFee) {

--- a/src/main/java/com/divudi/bean/inward/TimedItemFeeController.java
+++ b/src/main/java/com/divudi/bean/inward/TimedItemFeeController.java
@@ -160,6 +160,15 @@ public class TimedItemFeeController implements Serializable {
             JsfUtil.addErrorMessage("Please Enter Fee Name.");
             return;
         }
+        // Same guard as saveCharge(). It matters more here: the row's Duration input
+        // is disabled while the row is a One Time Fee, and a disabled input submits
+        // nothing — so switching a row to a time-based unit could otherwise save a
+        // duration of 0, which prices every block at zero.
+        if (!tif.isOneTime() && tif.getDurationHours() <= 0) {
+            JsfUtil.addErrorMessage("Duration must be greater than 0 for a "
+                    + tif.getDurationUnit().getLabel() + " fee.");
+            return;
+        }
         tif.setEditedAt(new Date());
         tif.setCreater(getSessionController().getLoggedUser());
         getTimedItemFeeFacade().edit(tif);

--- a/src/main/java/com/divudi/core/data/dto/timeditem/TimedItemFeeCreateRequestDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/timeditem/TimedItemFeeCreateRequestDTO.java
@@ -5,6 +5,8 @@
  */
 package com.divudi.core.data.dto.timeditem;
 
+import com.divudi.core.data.inward.TimedItemDurationUnit;
+
 /**
  * DTO for adding a fee to a TimedItem.
  *
@@ -15,18 +17,19 @@ public class TimedItemFeeCreateRequestDTO {
     private String name; // required
     private double fee; // required, >= 0
     private double ffee; // optional, defaults to fee if 0
-    private double durationHours; // required for tiered billing
+    private double durationHours; // required for tiered billing, except for ONE_TIME
     private double overShootHours;
     private long durationDaysForMoCharge;
     private int sortOrder;
     private boolean repeating;
+    private TimedItemDurationUnit durationUnit; // optional, defaults to HOUR
 
     public TimedItemFeeCreateRequestDTO() {
     }
 
     public boolean isValid() {
         return name != null && !name.trim().isEmpty()
-                && durationHours > 0
+                && (durationHours > 0 || durationUnit == TimedItemDurationUnit.ONE_TIME)
                 && fee >= 0;
     }
 
@@ -92,5 +95,13 @@ public class TimedItemFeeCreateRequestDTO {
 
     public void setRepeating(boolean repeating) {
         this.repeating = repeating;
+    }
+
+    public TimedItemDurationUnit getDurationUnit() {
+        return durationUnit;
+    }
+
+    public void setDurationUnit(TimedItemDurationUnit durationUnit) {
+        this.durationUnit = durationUnit;
     }
 }

--- a/src/main/java/com/divudi/core/data/dto/timeditem/TimedItemFeeDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/timeditem/TimedItemFeeDTO.java
@@ -5,6 +5,8 @@
  */
 package com.divudi.core.data.dto.timeditem;
 
+import com.divudi.core.data.inward.TimedItemDurationUnit;
+
 /**
  * DTO representing a single TimedItemFee.
  *
@@ -22,6 +24,7 @@ public class TimedItemFeeDTO {
     private int sortOrder;
     private boolean repeating;
     private boolean retired;
+    private TimedItemDurationUnit durationUnit;
 
     public TimedItemFeeDTO() {
     }
@@ -104,5 +107,13 @@ public class TimedItemFeeDTO {
 
     public void setRetired(boolean retired) {
         this.retired = retired;
+    }
+
+    public TimedItemDurationUnit getDurationUnit() {
+        return durationUnit;
+    }
+
+    public void setDurationUnit(TimedItemDurationUnit durationUnit) {
+        this.durationUnit = durationUnit;
     }
 }

--- a/src/main/java/com/divudi/core/data/dto/timeditem/TimedItemFeeUpdateRequestDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/timeditem/TimedItemFeeUpdateRequestDTO.java
@@ -5,6 +5,8 @@
  */
 package com.divudi.core.data.dto.timeditem;
 
+import com.divudi.core.data.inward.TimedItemDurationUnit;
+
 /**
  * DTO for updating an existing TimedItemFee. All fields optional — only non-null/non-sentinel values are applied.
  *
@@ -20,6 +22,7 @@ public class TimedItemFeeUpdateRequestDTO {
     private Long durationDaysForMoCharge;
     private Integer sortOrder;
     private Boolean repeating;
+    private TimedItemDurationUnit durationUnit;
 
     public TimedItemFeeUpdateRequestDTO() {
     }
@@ -28,7 +31,7 @@ public class TimedItemFeeUpdateRequestDTO {
         boolean hasValidName = name != null && !name.trim().isEmpty();
         return hasValidName || fee != null || ffee != null || durationHours != null
                 || overShootHours != null || durationDaysForMoCharge != null
-                || sortOrder != null || repeating != null;
+                || sortOrder != null || repeating != null || durationUnit != null;
     }
 
     public String getName() {
@@ -93,5 +96,13 @@ public class TimedItemFeeUpdateRequestDTO {
 
     public void setRepeating(Boolean repeating) {
         this.repeating = repeating;
+    }
+
+    public TimedItemDurationUnit getDurationUnit() {
+        return durationUnit;
+    }
+
+    public void setDurationUnit(TimedItemDurationUnit durationUnit) {
+        this.durationUnit = durationUnit;
     }
 }

--- a/src/main/java/com/divudi/core/data/inward/TimedItemDurationUnit.java
+++ b/src/main/java/com/divudi/core/data/inward/TimedItemDurationUnit.java
@@ -1,0 +1,49 @@
+package com.divudi.core.data.inward;
+
+/**
+ * The unit a {@code TimedItemFee.durationHours} value is expressed in, i.e. how
+ * a timed service (or a room facility charge) turns elapsed time into a billed
+ * block count.
+ * <p>
+ * {@code durationHours} keeps its historical name for database compatibility;
+ * with a unit attached it is really "duration value", and the unit says whether
+ * that value counts minutes, hours or days. {@link #ONE_TIME} ignores the value
+ * entirely and charges the fee exactly once.
+ * <p>
+ * A null unit on an existing row means {@link #HOUR} — that is what every row
+ * created before this enum existed was implicitly using.
+ */
+public enum TimedItemDurationUnit {
+
+    ONE_TIME,
+    MINUTE,
+    HOUR,
+    DAY;
+
+    /** Minutes in one unit. Meaningless for {@link #ONE_TIME}, which is not time-based. */
+    public double getMinutesPerUnit() {
+        switch (this) {
+            case MINUTE:
+                return 1.0;
+            case DAY:
+                return 60.0 * 24.0;
+            case HOUR:
+            default:
+                return 60.0;
+        }
+    }
+
+    public String getLabel() {
+        switch (this) {
+            case ONE_TIME:
+                return "One Time Fee";
+            case MINUTE:
+                return "Per Minute";
+            case DAY:
+                return "Per Day";
+            case HOUR:
+            default:
+                return "Per Hour";
+        }
+    }
+}

--- a/src/main/java/com/divudi/core/entity/inward/TimedItemFee.java
+++ b/src/main/java/com/divudi/core/entity/inward/TimedItemFee.java
@@ -4,9 +4,13 @@
  */
 package com.divudi.core.entity.inward;
 
+import com.divudi.core.data.inward.TimedItemDurationUnit;
 import com.divudi.core.entity.Fee;
 import java.io.Serializable;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.Transient;
 
 
 /**
@@ -21,6 +25,13 @@ public class TimedItemFee extends Fee implements Serializable {
     private long durationDaysForMoCharge;
     private int sortOrder = 0;
     private boolean repeating = false;
+    /**
+     * The unit durationHours/overShootHours are expressed in. Null on every row
+     * created before this field existed, which is why {@link #getDurationUnit()}
+     * reads it as HOUR — the behaviour those rows have always had.
+     */
+    @Enumerated(EnumType.STRING)
+    private TimedItemDurationUnit durationUnit;
 
     public void setDurationHours(Integer durationHours) {
         this.durationHours = durationHours;
@@ -68,5 +79,67 @@ public class TimedItemFee extends Fee implements Serializable {
 
     public void setRepeating(boolean repeating) {
         this.repeating = repeating;
+    }
+
+    /**
+     * Never null: rows saved before this field existed are hour-based, so that
+     * is what an unset unit means. Defaulting on read (rather than leaving null
+     * to every caller) also keeps the configuration dropdowns from showing a
+     * legacy fee as whatever option happens to be listed first.
+     * <p>
+     * The entity hierarchy uses field access (see the {@code @Id} on
+     * {@code Fee.id}), so this default is not written back to the column until
+     * something actually sets the unit.
+     */
+    public TimedItemDurationUnit getDurationUnit() {
+        return durationUnit == null ? TimedItemDurationUnit.HOUR : durationUnit;
+    }
+
+    public void setDurationUnit(TimedItemDurationUnit durationUnit) {
+        this.durationUnit = durationUnit;
+    }
+
+    /**
+     * True when this fee is charged once for the whole service, regardless of
+     * how long it ran.
+     */
+    @Transient
+    public boolean isOneTime() {
+        return getDurationUnit() == TimedItemDurationUnit.ONE_TIME;
+    }
+
+    /**
+     * Length of one billable block in minutes. This is the single place elapsed
+     * time is converted into block size, so every calculation (room charges,
+     * interim bill, final bill, timed service consume) reads the same number.
+     * Zero for a one-time fee, which is not time-based.
+     */
+    @Transient
+    public double getDurationMinutes() {
+        if (isOneTime()) {
+            return 0;
+        }
+        return durationHours * getDurationUnit().getMinutesPerUnit();
+    }
+
+    /**
+     * Length of one billable block in hours, for callers that reason in hours
+     * (e.g. package room-duration variance).
+     */
+    @Transient
+    public double getDurationInHours() {
+        return getDurationMinutes() / 60.0;
+    }
+
+    /**
+     * Grace period in minutes before an incomplete block is charged as a whole
+     * block. Expressed in the same unit as the block length.
+     */
+    @Transient
+    public double getOverShootMinutes() {
+        if (isOneTime()) {
+            return 0;
+        }
+        return overShootHours * getDurationUnit().getMinutesPerUnit();
     }
 }

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -1789,6 +1789,7 @@ public class AnthropicApiService implements Serializable {
                         "Manage timed item master data (room rent, oxygen, ICU time, etc.) and their tiered fee slots. "
                         + "TimedItems are consumed by the inward timed service page to bill patients for duration-based charges. "
                         + "Fees are ordered by sortOrder; each fee defines a durationHours block with an optional overShootHours grace window. "
+                        + "durationUnit says what durationHours/overShootHours are counted in (ONE_TIME, MINUTE, HOUR, DAY) and defaults to HOUR. "
                         + "Methods for items: LIST, GET, POST, PUT, DELETE, ACTIVATE, DEACTIVATE. "
                         + "Methods for fees: LIST_FEES, POST_FEE, PUT_FEE, DELETE_FEE. "
                         + "Always confirm with the user before creating, updating, or retiring records.")
@@ -1840,10 +1841,13 @@ public class AnthropicApiService implements Serializable {
                                         .add("description", "Foreigner fee amount. Optional; defaults to fee if omitted."))
                                 .add("durationHours", Json.createObjectBuilder()
                                         .add("type", "string")
-                                        .add("description", "Block duration in hours this fee tier covers. Required for POST_FEE (must be > 0)."))
+                                        .add("description", "Block duration this fee tier covers, counted in durationUnit. Required for POST_FEE unless durationUnit is ONE_TIME (must be > 0)."))
+                                .add("durationUnit", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "ONE_TIME, MINUTE, HOUR or DAY — the unit durationHours/overShootHours are counted in. Optional; defaults to HOUR. ONE_TIME charges the fee once regardless of duration."))
                                 .add("overShootHours", Json.createObjectBuilder()
                                         .add("type", "string")
-                                        .add("description", "Grace hours beyond durationHours before the next tier applies. Optional."))
+                                        .add("description", "Grace period beyond durationHours, in the same durationUnit, before the next tier applies. Optional."))
                                 .add("durationDaysForMoCharge", Json.createObjectBuilder()
                                         .add("type", "string")
                                         .add("description", "Duration days for monthly charge calculation. Optional."))
@@ -2487,12 +2491,13 @@ public class AnthropicApiService implements Serializable {
                     String durationDays = toolInput.containsKey("durationDaysForMoCharge") ? toolInput.getString("durationDaysForMoCharge", "") : "";
                     String sortOrder    = toolInput.containsKey("sortOrder")         ? toolInput.getString("sortOrder", "")         : "";
                     String repeating    = toolInput.containsKey("repeating")         ? toolInput.getString("repeating", "")         : "";
+                    String durationUnit = toolInput.containsKey("durationUnit")      ? toolInput.getString("durationUnit", "")      : "";
                     String query        = toolInput.containsKey("query")             ? toolInput.getString("query", "")             : "";
                     String size         = toolInput.containsKey("size")              ? toolInput.getString("size", "")              : "";
                     String retireComments = toolInput.containsKey("retireComments")  ? toolInput.getString("retireComments", "")    : "";
                     return callTimedItemsApi(method, id, feeId, name, code, deptType, chargeType,
                             departmentId, institutionId, categoryId, inactive,
-                            fee, ffee, durationHrs, overShoot, durationDays, sortOrder, repeating,
+                            fee, ffee, durationHrs, overShoot, durationDays, sortOrder, repeating, durationUnit,
                             query, size, retireComments, hmisBaseUrl, hmisApiKey);
                 }
                 default:
@@ -5668,7 +5673,7 @@ public class AnthropicApiService implements Serializable {
     private String callTimedItemsApi(String method, String id, String feeId, String name, String code,
             String departmentType, String inwardChargeType, String departmentId, String institutionId,
             String categoryId, String inactive, String fee, String ffee, String durationHours, String overShootHours,
-            String durationDaysForMoCharge, String sortOrder, String repeating,
+            String durationDaysForMoCharge, String sortOrder, String repeating, String durationUnit,
             String query, String size, String retireComments,
             String hmisBaseUrl, String hmisApiKey) {
         if (hmisBaseUrl == null || hmisBaseUrl.trim().isEmpty()) {
@@ -5763,13 +5768,15 @@ public class AnthropicApiService implements Serializable {
                 case "POST_FEE": {
                     if (id.isEmpty()) return "Error: id is required for POST_FEE.";
                     if (name.isEmpty()) return "Error: name is required for POST_FEE.";
-                    if (durationHours.isEmpty()) return "Error: durationHours is required for POST_FEE.";
-                    double dh = Double.parseDouble(durationHours);
-                    if (dh <= 0) return "Error: durationHours must be > 0.";
+                    boolean oneTime = "ONE_TIME".equalsIgnoreCase(durationUnit.trim());
+                    if (durationHours.isEmpty() && !oneTime) return "Error: durationHours is required for POST_FEE.";
+                    double dh = durationHours.isEmpty() ? 0.0 : Double.parseDouble(durationHours);
+                    if (dh <= 0 && !oneTime) return "Error: durationHours must be > 0.";
                     javax.json.JsonObjectBuilder b = Json.createObjectBuilder()
                             .add("name", name)
                             .add("durationHours", dh)
                             .add("fee", fee.isEmpty() ? 0.0 : Double.parseDouble(fee));
+                    if (!durationUnit.isEmpty()) b.add("durationUnit", durationUnit.trim().toUpperCase(java.util.Locale.ROOT));
                     if (!ffee.isEmpty()) b.add("ffee", Double.parseDouble(ffee));
                     if (!overShootHours.isEmpty()) b.add("overShootHours", Double.parseDouble(overShootHours));
                     if (!durationDaysForMoCharge.isEmpty()) b.add("durationDaysForMoCharge", Long.parseLong(durationDaysForMoCharge));
@@ -5793,6 +5800,7 @@ public class AnthropicApiService implements Serializable {
                     if (!durationDaysForMoCharge.isEmpty()) b.add("durationDaysForMoCharge", Long.parseLong(durationDaysForMoCharge));
                     if (!sortOrder.isEmpty()) b.add("sortOrder", Integer.parseInt(sortOrder));
                     if (!repeating.isEmpty()) b.add("repeating", Boolean.parseBoolean(repeating));
+                    if (!durationUnit.isEmpty()) b.add("durationUnit", durationUnit.trim().toUpperCase(java.util.Locale.ROOT));
                     HttpRequest req = HttpRequest.newBuilder().uri(URI.create(baseUrl + "/" + id + "/fees/" + feeId))
                             .timeout(Duration.ofSeconds(15)).header("Finance", hmisApiKey)
                             .header("Content-Type", "application/json")
@@ -6016,7 +6024,8 @@ public class AnthropicApiService implements Serializable {
           .append("Use PUT to update name, code, departmentType, inwardChargeType, departmentId, institutionId, categoryId, or inactive flag. ")
           .append("Use DELETE to soft-retire an item. Use ACTIVATE / DEACTIVATE to toggle availability without retiring. ")
           .append("For tiered fee management: LIST_FEES lists all fees ordered by sortOrder. ")
-          .append("POST_FEE creates a fee tier — required: name, durationHours (> 0). fee, ffee, overShootHours, sortOrder, repeating are optional. ")
+          .append("POST_FEE creates a fee tier — required: name, durationHours (> 0, not needed when durationUnit is ONE_TIME). fee, ffee, overShootHours, sortOrder, repeating, durationUnit are optional. ")
+          .append("durationUnit (ONE_TIME | MINUTE | HOUR | DAY, default HOUR) sets what durationHours/overShootHours count in. ")
           .append("PUT_FEE updates an existing fee tier (requires feeId). DELETE_FEE soft-retires a fee tier. ")
           .append("Always confirm with the user before POST, PUT, or DELETE — changes affect live inward timed billing.\n\n");
         sb.append("### manage_inpatient_templates\n");
@@ -6678,7 +6687,7 @@ public class AnthropicApiService implements Serializable {
                     {"PATCH",  "/timed-items/{id}/activate", "Set inactive=false"},
                     {"PATCH",  "/timed-items/{id}/deactivate", "Set inactive=true"},
                     {"GET",    "/timed-items/{id}/fees",     "List fee tiers for an item (ordered by sortOrder)"},
-                    {"POST",   "/timed-items/{id}/fees",     "Add fee tier. Body: name, durationHours (required); fee, ffee, overShootHours, sortOrder, repeating optional"},
+                    {"POST",   "/timed-items/{id}/fees",     "Add fee tier. Body: name, durationHours (required unless durationUnit=ONE_TIME); fee, ffee, overShootHours, sortOrder, repeating, durationUnit optional"},
                     {"PUT",    "/timed-items/{id}/fees/{feeId}", "Update fee tier"},
                     {"DELETE", "/timed-items/{id}/fees/{feeId}", "Soft-retire fee tier"}
                 });

--- a/src/main/java/com/divudi/service/inward/TimedItemApiService.java
+++ b/src/main/java/com/divudi/service/inward/TimedItemApiService.java
@@ -322,6 +322,9 @@ public class TimedItemApiService implements Serializable {
         fee.setDurationDaysForMoCharge(request.getDurationDaysForMoCharge());
         fee.setSortOrder(request.getSortOrder());
         fee.setRepeating(request.isRepeating());
+        // Omitted by older clients; the entity reads a null unit as HOUR, which
+        // is what every fee created before duration units existed meant.
+        fee.setDurationUnit(request.getDurationUnit());
         fee.setCreater(user);
         fee.setCreatedAt(Calendar.getInstance().getTime());
         fee.setRetired(false);
@@ -372,6 +375,9 @@ public class TimedItemApiService implements Serializable {
         }
         if (request.getRepeating() != null) {
             fee.setRepeating(request.getRepeating());
+        }
+        if (request.getDurationUnit() != null) {
+            fee.setDurationUnit(request.getDurationUnit());
         }
 
         fee.setEditer(user);
@@ -531,6 +537,7 @@ public class TimedItemApiService implements Serializable {
         dto.setFfee(fee.getFfee());
         dto.setDurationHours(fee.getDurationHours());
         dto.setOverShootHours(fee.getOverShootHours());
+        dto.setDurationUnit(fee.getDurationUnit());
         dto.setDurationDaysForMoCharge(fee.getDurationDaysForMoCharge());
         dto.setSortOrder(fee.getSortOrder());
         dto.setRepeating(fee.isRepeating());

--- a/src/main/java/com/divudi/service/inward/TimedItemApiService.java
+++ b/src/main/java/com/divudi/service/inward/TimedItemApiService.java
@@ -19,6 +19,7 @@ import com.divudi.core.entity.Department;
 import com.divudi.core.entity.Institution;
 import com.divudi.core.entity.Item;
 import com.divudi.core.entity.WebUser;
+import com.divudi.core.data.inward.TimedItemDurationUnit;
 import com.divudi.core.entity.inward.TimedItem;
 import com.divudi.core.entity.inward.TimedItemCategory;
 import com.divudi.core.entity.inward.TimedItemFee;
@@ -322,9 +323,12 @@ public class TimedItemApiService implements Serializable {
         fee.setDurationDaysForMoCharge(request.getDurationDaysForMoCharge());
         fee.setSortOrder(request.getSortOrder());
         fee.setRepeating(request.isRepeating());
-        // Omitted by older clients; the entity reads a null unit as HOUR, which
-        // is what every fee created before duration units existed meant.
-        fee.setDurationUnit(request.getDurationUnit());
+        // Omitted by older clients. Store the explicit HOUR default rather than
+        // leaving the column null — that is what the fee page writes for a
+        // UI-created fee, and it keeps new rows unambiguous. Reads still default
+        // a null unit to HOUR for rows created before duration units existed.
+        fee.setDurationUnit(request.getDurationUnit() != null
+                ? request.getDurationUnit() : TimedItemDurationUnit.HOUR);
         fee.setCreater(user);
         fee.setCreatedAt(Calendar.getInstance().getTime());
         fee.setRetired(false);

--- a/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
+++ b/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
@@ -476,6 +476,7 @@ public class CapabilityStatementResource {
                         "Manage timed item master data (room rent, oxygen, ICU time, etc.) and their tiered fee slots (TimedItemFee). "
                         + "TimedItem entities are consumed by the inward timed service page (/inward/inward_timed_service_consume.xhtml). "
                         + "Fees are ordered by sortOrder and support durationHours/overShootHours/repeating for tiered block billing. "
+                        + "durationUnit (ONE_TIME | MINUTE | HOUR | DAY, default HOUR) sets what durationHours/overShootHours are counted in. "
                         + "Sub-resource: /timed-items/{id}/fees for per-item fee management. "
                         + "Sub-resource: /timed-items/categories for TimedItemCategory CRUD (GET list, GET /{id}, POST, PUT /{id}, DELETE /{id}). "
                         + "PATCH /activate and /deactivate control availability without retiring.",

--- a/src/main/java/com/divudi/ws/inward/InwardRoomFacilityChargeApi.java
+++ b/src/main/java/com/divudi/ws/inward/InwardRoomFacilityChargeApi.java
@@ -244,8 +244,12 @@ public class InwardRoomFacilityChargeApi {
             charge.setCreatedAt(new Date());
             charge.setCreater(user);
 
-            // Build TimedItemFee (all parsing done above; now safe to persist)
+            // Build TimedItemFee (all parsing done above; now safe to persist).
+            // Start at the same explicit default RoomFacilityChargeController writes
+            // for a UI-created charge, so an omitted unit stores HOUR rather than
+            // leaving the column null and relying on the read-time default.
             TimedItemFee timedItemFee = new TimedItemFee();
+            timedItemFee.setDurationUnit(TimedItemDurationUnit.HOUR);
             Double durationHours = asDouble(body.get("timedItemFeeDurationHours"));
             if (durationHours != null) timedItemFee.setDurationHours(durationHours);
             Double overShootHours = asDouble(body.get("timedItemFeeOverShootHours"));
@@ -362,6 +366,7 @@ public class InwardRoomFacilityChargeApi {
                 boolean needCreate = timedItemFee == null;
                 if (needCreate) {
                     timedItemFee = new TimedItemFee();
+                    timedItemFee.setDurationUnit(TimedItemDurationUnit.HOUR);
                 }
                 if (newDurationHours != null) timedItemFee.setDurationHours(newDurationHours);
                 if (newOverShootHours != null) timedItemFee.setOverShootHours(newOverShootHours);

--- a/src/main/java/com/divudi/ws/inward/InwardRoomFacilityChargeApi.java
+++ b/src/main/java/com/divudi/ws/inward/InwardRoomFacilityChargeApi.java
@@ -6,6 +6,7 @@
 package com.divudi.ws.inward;
 
 import com.divudi.bean.common.ApiKeyController;
+import com.divudi.core.data.inward.TimedItemDurationUnit;
 import com.divudi.core.entity.ApiKey;
 import com.divudi.core.entity.Department;
 import com.divudi.core.entity.WebUser;
@@ -177,7 +178,8 @@ public class InwardRoomFacilityChargeApi {
      * Body: { "name" (required), "departmentId" (required), "roomId", "roomCategoryId",
      *         "roomCharge", "maintananceCharge", "linenCharge", "nursingCharge",
      *         "moCharge", "moChargeForAfterDuration", "adminstrationCharge", "medicalCareCharge",
-     *         "timedItemFeeDurationHours", "timedItemFeeOverShootHours", "timedItemFeeDurationDaysForMoCharge" }
+     *         "timedItemFeeDurationHours", "timedItemFeeOverShootHours", "timedItemFeeDurationDaysForMoCharge",
+     *         "timedItemFeeDurationUnit" (ONE_TIME | MINUTE | HOUR | DAY, defaults to HOUR) }
      */
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
@@ -250,6 +252,8 @@ public class InwardRoomFacilityChargeApi {
             if (overShootHours != null) timedItemFee.setOverShootHours(overShootHours);
             Long durationDaysForMoCharge = asLong(body.get("timedItemFeeDurationDaysForMoCharge"));
             if (durationDaysForMoCharge != null) timedItemFee.setDurationDaysForMoCharge(durationDaysForMoCharge);
+            TimedItemDurationUnit durationUnit = asDurationUnit(body.get("timedItemFeeDurationUnit"));
+            if (durationUnit != null) timedItemFee.setDurationUnit(durationUnit);
             timedItemFeeFacade.create(timedItemFee);
 
             charge.setTimedItemFee(timedItemFee);
@@ -343,10 +347,12 @@ public class InwardRoomFacilityChargeApi {
             // Parse all timed values before any DB writes to avoid orphaned rows.
             if (body.containsKey("timedItemFeeDurationHours")
                     || body.containsKey("timedItemFeeOverShootHours")
-                    || body.containsKey("timedItemFeeDurationDaysForMoCharge")) {
+                    || body.containsKey("timedItemFeeDurationDaysForMoCharge")
+                    || body.containsKey("timedItemFeeDurationUnit")) {
                 Double newDurationHours = body.containsKey("timedItemFeeDurationHours") ? asDouble(body.get("timedItemFeeDurationHours")) : null;
                 Double newOverShootHours = body.containsKey("timedItemFeeOverShootHours") ? asDouble(body.get("timedItemFeeOverShootHours")) : null;
                 Long newDurationDays = body.containsKey("timedItemFeeDurationDaysForMoCharge") ? asLong(body.get("timedItemFeeDurationDaysForMoCharge")) : null;
+                TimedItemDurationUnit newDurationUnit = body.containsKey("timedItemFeeDurationUnit") ? asDurationUnit(body.get("timedItemFeeDurationUnit")) : null;
                 // All parsing done; now safe to write
                 TimedItemFee timedItemFee = charge.getTimedItemFee();
                 boolean needCreate = timedItemFee == null;
@@ -356,6 +362,7 @@ public class InwardRoomFacilityChargeApi {
                 if (newDurationHours != null) timedItemFee.setDurationHours(newDurationHours);
                 if (newOverShootHours != null) timedItemFee.setOverShootHours(newOverShootHours);
                 if (newDurationDays != null) timedItemFee.setDurationDaysForMoCharge(newDurationDays);
+                if (newDurationUnit != null) timedItemFee.setDurationUnit(newDurationUnit);
                 if (needCreate) {
                     timedItemFeeFacade.create(timedItemFee);
                     charge.setTimedItemFee(timedItemFee);
@@ -649,6 +656,7 @@ public class InwardRoomFacilityChargeApi {
             tif.put("durationHours", r.getTimedItemFee().getDurationHours());
             tif.put("overShootHours", r.getTimedItemFee().getOverShootHours());
             tif.put("durationDaysForMoCharge", r.getTimedItemFee().getDurationDaysForMoCharge());
+            tif.put("durationUnit", r.getTimedItemFee().getDurationUnit().name());
             row.put("timedItemFee", tif);
         } else {
             row.put("timedItemFee", null);
@@ -712,6 +720,18 @@ public class InwardRoomFacilityChargeApi {
             return Long.parseLong(s);
         } catch (NumberFormatException e) {
             throw new IllegalArgumentException("Invalid numeric id: '" + o + "'");
+        }
+    }
+
+    private TimedItemDurationUnit asDurationUnit(Object o) {
+        if (o == null) return null;
+        String s = o.toString().trim();
+        if (s.isEmpty()) return null;
+        try {
+            return TimedItemDurationUnit.valueOf(s.toUpperCase(java.util.Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid timedItemFeeDurationUnit: '" + o
+                    + "'. Expected one of ONE_TIME, MINUTE, HOUR, DAY.");
         }
     }
 

--- a/src/main/java/com/divudi/ws/inward/InwardRoomFacilityChargeApi.java
+++ b/src/main/java/com/divudi/ws/inward/InwardRoomFacilityChargeApi.java
@@ -254,6 +254,10 @@ public class InwardRoomFacilityChargeApi {
             if (durationDaysForMoCharge != null) timedItemFee.setDurationDaysForMoCharge(durationDaysForMoCharge);
             TimedItemDurationUnit durationUnit = asDurationUnit(body.get("timedItemFeeDurationUnit"));
             if (durationUnit != null) timedItemFee.setDurationUnit(durationUnit);
+            String durationError = validateBlockDuration(timedItemFee);
+            if (durationError != null) {
+                return errorResponse(durationError, 400);
+            }
             timedItemFeeFacade.create(timedItemFee);
 
             charge.setTimedItemFee(timedItemFee);
@@ -363,6 +367,10 @@ public class InwardRoomFacilityChargeApi {
                 if (newOverShootHours != null) timedItemFee.setOverShootHours(newOverShootHours);
                 if (newDurationDays != null) timedItemFee.setDurationDaysForMoCharge(newDurationDays);
                 if (newDurationUnit != null) timedItemFee.setDurationUnit(newDurationUnit);
+                String durationError = validateBlockDuration(timedItemFee);
+                if (durationError != null) {
+                    return errorResponse(durationError, 400);
+                }
                 if (needCreate) {
                     timedItemFeeFacade.create(timedItemFee);
                     charge.setTimedItemFee(timedItemFee);
@@ -721,6 +729,27 @@ public class InwardRoomFacilityChargeApi {
         } catch (NumberFormatException e) {
             throw new IllegalArgumentException("Invalid numeric id: '" + o + "'");
         }
+    }
+
+    /**
+     * A time-based block with no duration bills nothing, for every stay, forever —
+     * {@code InwardBeanController.calCount()} returns 0 when the block length is 0.
+     * The sibling timed-item fee endpoint already rejects that combination
+     * (TimedItemFeeCreateRequestDTO.isValid); this keeps the two consistent rather
+     * than letting a room be created that silently never charges.
+     *
+     * @return an error message, or null when the fee is billable
+     */
+    private String validateBlockDuration(TimedItemFee fee) {
+        if (fee.isOneTime()) {
+            return null;
+        }
+        if (fee.getDurationHours() <= 0) {
+            return "timedItemFeeDurationHours must be greater than 0 for a "
+                    + fee.getDurationUnit().name() + " block"
+                    + " (use timedItemFeeDurationUnit=ONE_TIME for a flat charge).";
+        }
+        return null;
     }
 
     private TimedItemDurationUnit asDurationUnit(Object o) {

--- a/src/main/webapp/inward/inward_room_facility.xhtml
+++ b/src/main/webapp/inward/inward_room_facility.xhtml
@@ -124,11 +124,20 @@
                                                     var="c" itemLabel="#{c.name}" itemValue="#{c}" class="w-100 ml-2" >
                                     </p:autoComplete>
 
-                                    <h:outputLabel value="Fee Calculation Block Duration in Hours"/>
+                                    <h:outputLabel value="Fee Calculation Block Unit"/>
+                                    <p:outputLabel value=": " style="width: 30px; text-align: center; " ></p:outputLabel>
+                                    <p:selectOneMenu value="#{roomFacilityChargeController.current.timedItemFee.durationUnit}"
+                                                     class="w-100 mt-2 mb-2"
+                                                     title="The unit the block duration below is counted in">
+                                        <f:selectItems value="#{roomFacilityChargeController.durationUnits}" var="du"
+                                                       itemLabel="#{du.label}" itemValue="#{du}"/>
+                                    </p:selectOneMenu>
+
+                                    <h:outputLabel value="Fee Calculation Block Duration"/>
                                     <p:outputLabel value=": " style="width: 30px; text-align: center; " ></p:outputLabel>
                                     <p:inputText autocomplete="off" value="#{roomFacilityChargeController.current.timedItemFee.durationHours}" class="w-100 mt-2 mb-2"/>
 
-                                    <h:outputLabel value="Over Shoot Hour for the last Block"/>
+                                    <h:outputLabel value="Over Shoot for the last Block"/>
                                     <p:outputLabel value=": " style="width: 30px; text-align: center; " ></p:outputLabel>
                                     <p:inputText autocomplete="off" value="#{roomFacilityChargeController.current.timedItemFee.overShootHours}" class="w-100 ml-2"/>
 

--- a/src/main/webapp/inward/inward_room_vacant.xhtml
+++ b/src/main/webapp/inward/inward_room_vacant.xhtml
@@ -64,7 +64,7 @@
                         </p:column>
 
                         <p:column headerText="Room Charges for 24 Hrs" width="10em" styleClass="text-end">
-                            <h:outputText value="#{pr.timedItemFee != null and pr.timedItemFee.durationHours > 0 ? pr.roomCharge * (24 / pr.timedItemFee.durationHours) : 0}">
+                            <h:outputText value="#{roomOccupancyController.getDailyEquivalentRoomCharge(pr)}">
                                 <f:convertNumber pattern="#,##0.00"/>
                             </h:outputText>
                         </p:column>

--- a/src/main/webapp/inward/inward_timed_item_fee.xhtml
+++ b/src/main/webapp/inward/inward_timed_item_fee.xhtml
@@ -144,11 +144,11 @@
 
                                 </h:panelGrid>
 
-                                <p:commandButton 
-                                    id="btnAddTo" 
-                                    value="Add" 
+                                <p:commandButton
+                                    id="btnAddTo"
+                                    value="Add"
                                     icon="fa fa-plus"
-                                    update="gpDetail dtbFee"
+                                    update="gpDetail dtbFee :growl"
                                     style="width: 150px;"
                                     action="#{timedItemFeeController.saveCharge}" 
                                     class="ui-button-success mt-2 mb-3">

--- a/src/main/webapp/inward/inward_timed_item_fee.xhtml
+++ b/src/main/webapp/inward/inward_timed_item_fee.xhtml
@@ -173,13 +173,17 @@
                                                            var="du"
                                                            itemLabel="#{du.label}"
                                                            itemValue="#{du}"/>
+                                            <!-- Without this, switching a row away from One Time Fee leaves the two
+                                                 inputs below disabled. A disabled input submits nothing, so the row's
+                                                 Update would keep the old duration and silently price the fee at zero. -->
+                                            <p:ajax event="change" process="@this" update="rowDuration rowOverShoot"/>
                                         </p:selectOneMenu>
                                     </p:column>
                                     <p:column headerText="Duration">
-                                        <p:inputText value="#{bi.durationHours}" autocomplete="off" disabled="#{bi.oneTime}" />
+                                        <p:inputText id="rowDuration" value="#{bi.durationHours}" autocomplete="off" disabled="#{bi.oneTime}" />
                                     </p:column>
                                     <p:column headerText="Over Shoot">
-                                        <p:inputText value="#{bi.overShootHours}" autocomplete="off" disabled="#{bi.oneTime}" />
+                                        <p:inputText id="rowOverShoot" value="#{bi.overShootHours}" autocomplete="off" disabled="#{bi.oneTime}" />
                                     </p:column>
                                     <p:column headerText="Slot Order" style="width: 90px">
                                         <p:inputText value="#{bi.sortOrder}" autocomplete="off" style="width: 60px;"/>

--- a/src/main/webapp/inward/inward_timed_item_fee.xhtml
+++ b/src/main/webapp/inward/inward_timed_item_fee.xhtml
@@ -82,19 +82,40 @@
                                         value="#{timedItemFeeController.currentFee.ffee}" 
                                         style="width: 500px;"/>
 
-                                    <h:outputLabel value="Duration Hour"/>
+                                    <h:outputLabel value="Charged By"/>
                                     <p:outputLabel value=": " style="width: 30px; text-align: center; " ></p:outputLabel>
-                                    <p:inputText 
-                                        autocomplete="off" 
+                                    <p:selectOneMenu
+                                        id="cmbDurationUnit"
+                                        style="width: 500px;"
                                         class="mt-2 mb-2"
-                                        value="#{timedItemFeeController.currentFee.durationHours}" 
-                                        style="width: 500px;"/>
+                                        value="#{timedItemFeeController.currentFee.durationUnit}"
+                                        title="How the elapsed time of this service is turned into a charge">
+                                        <f:selectItems value="#{timedItemFeeController.durationUnits}"
+                                                       var="du"
+                                                       itemLabel="#{du.label}"
+                                                       itemValue="#{du}"/>
+                                        <p:ajax event="change" process="@this" update="txtDuration txtOverShoot"/>
+                                    </p:selectOneMenu>
 
-                                    <h:outputLabel value="Over Shoot Hour"/>
+                                    <h:outputLabel value="Duration"/>
                                     <p:outputLabel value=": " style="width: 30px; text-align: center; " ></p:outputLabel>
                                     <p:inputText
+                                        id="txtDuration"
+                                        autocomplete="off"
+                                        class="mt-2 mb-2"
+                                        value="#{timedItemFeeController.currentFee.durationHours}"
+                                        disabled="#{timedItemFeeController.currentFee.oneTime}"
+                                        title="Length of one charged block, counted in the unit selected above"
+                                        style="width: 500px;"/>
+
+                                    <h:outputLabel value="Over Shoot"/>
+                                    <p:outputLabel value=": " style="width: 30px; text-align: center; " ></p:outputLabel>
+                                    <p:inputText
+                                        id="txtOverShoot"
                                         autocomplete="off"
                                         value="#{timedItemFeeController.currentFee.overShootHours}"
+                                        disabled="#{timedItemFeeController.currentFee.oneTime}"
+                                        title="Grace period, in the same unit, before a part-used block is charged as a full block"
                                         style="width: 500px;"/>
 
                                     <h:outputLabel value="Slot Order"/>
@@ -146,11 +167,19 @@
                                     <p:column headerText="Foreigner Fee">
                                         <p:inputText value="#{bi.ffee}" autocomplete="off" />
                                     </p:column>
-                                    <p:column headerText="Duration Hour">
-                                        <p:inputText value="#{bi.durationHours}" autocomplete="off" />
+                                    <p:column headerText="Charged By">
+                                        <p:selectOneMenu value="#{bi.durationUnit}" style="width: 100%;">
+                                            <f:selectItems value="#{timedItemFeeController.durationUnits}"
+                                                           var="du"
+                                                           itemLabel="#{du.label}"
+                                                           itemValue="#{du}"/>
+                                        </p:selectOneMenu>
+                                    </p:column>
+                                    <p:column headerText="Duration">
+                                        <p:inputText value="#{bi.durationHours}" autocomplete="off" disabled="#{bi.oneTime}" />
                                     </p:column>
                                     <p:column headerText="Over Shoot">
-                                        <p:inputText value="#{bi.overShootHours}" autocomplete="off" />
+                                        <p:inputText value="#{bi.overShootHours}" autocomplete="off" disabled="#{bi.oneTime}" />
                                     </p:column>
                                     <p:column headerText="Slot Order" style="width: 90px">
                                         <p:inputText value="#{bi.sortOrder}" autocomplete="off" style="width: 60px;"/>

--- a/src/test/java/com/divudi/bean/inward/TimedItemDurationUnitCalculationTest.java
+++ b/src/test/java/com/divudi/bean/inward/TimedItemDurationUnitCalculationTest.java
@@ -128,11 +128,32 @@ class TimedItemDurationUnitCalculationTest {
     }
 
     @Test
+    void oneTimeFeeIgnoresALeftoverDurationValue() {
+        // Switching a configured fee back to One Time on the fee page leaves the
+        // previous duration sitting on the row, so a one-time fee with a non-zero
+        // duration is a state the UI can produce. It must still charge once.
+        TimedItemFee f = fee(2, 1, TimedItemDurationUnit.ONE_TIME);
+        assertEquals(0.0, f.getDurationMinutes(), 0.0001);
+        assertEquals(0.0, f.getOverShootMinutes(), 0.0001);
+        assertEquals(1.0, count(f, 500), 0.0001);
+    }
+
+    @Test
     void oneTimeFeeIsChargedEvenWithNoElapsedTime() {
         // calCount returns 0 for a zero-length span on time-based fees; a one-time
         // fee is not time-based, so it must still be charged.
         assertEquals(1.0, count(fee(0, 0, TimedItemDurationUnit.ONE_TIME), 0), 0.0001);
         assertEquals(0.0, count(fee(1, 0, TimedItemDurationUnit.HOUR), 0), 0.0001);
+    }
+
+    @Test
+    void aMissingFeeCountsAsNothingToBillRatherThanThrowing() {
+        // RoomFacilityCharge.timedItemFee is a nullable mapping, so the room paths
+        // can hand these methods a null fee. That has to behave like an
+        // unconfigured fee (count 0), not break the page rendering the bill.
+        Date[] s = span(150);
+        assertEquals(0.0, inwardBean.calCount(null, s[0], s[1]), 0.0001);
+        assertEquals(0.0, inwardBean.calCountWithoutOverShoot(null, s[0], s[1]), 0.0001);
     }
 
     @Test

--- a/src/test/java/com/divudi/bean/inward/TimedItemDurationUnitCalculationTest.java
+++ b/src/test/java/com/divudi/bean/inward/TimedItemDurationUnitCalculationTest.java
@@ -157,6 +157,17 @@ class TimedItemDurationUnitCalculationTest {
     }
 
     @Test
+    void aTimeBasedFeeWithNoDurationBillsNothingRatherThanOvercharging() {
+        // Persisted data can still carry a time-based fee with duration 0. Dividing
+        // by it yields Infinity, which casts to a huge block count — the failure mode
+        // to guard against here is an overcharge, not a crash.
+        Date[] s = span(150);
+        assertEquals(0.0, inwardBean.calCount(fee(0, 0, TimedItemDurationUnit.HOUR), s[0], s[1]), 0.0001);
+        assertEquals(0.0, inwardBean.calCountWithoutOverShoot(fee(0, 0, TimedItemDurationUnit.HOUR), s[0], s[1]), 0.0001);
+        assertEquals(0.0, inwardBean.calCountWithoutOverShoot(fee(0, 0, null), s[0], s[1]), 0.0001);
+    }
+
+    @Test
     void calCountWithoutOverShootAlsoHonoursUnits() {
         Date[] halfHour = span(30);
         assertEquals(30.0,

--- a/src/test/java/com/divudi/bean/inward/TimedItemDurationUnitCalculationTest.java
+++ b/src/test/java/com/divudi/bean/inward/TimedItemDurationUnitCalculationTest.java
@@ -1,0 +1,148 @@
+package com.divudi.bean.inward;
+
+import com.divudi.core.data.inward.TimedItemDurationUnit;
+import com.divudi.core.entity.inward.TimedItemFee;
+import java.util.Date;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers issue #23206 — a timed service fee can be charged one time, per
+ * minute, per hour or per day, and every existing (unit-less) fee keeps its
+ * hour-based behaviour.
+ */
+class TimedItemDurationUnitCalculationTest {
+
+    private static final long MINUTE_MS = 60L * 1000L;
+
+    private final InwardBeanController inwardBean = new InwardBeanController();
+
+    private TimedItemFee fee(double duration, double overShoot, TimedItemDurationUnit unit) {
+        TimedItemFee f = new TimedItemFee();
+        f.setDurationHours(duration);
+        f.setOverShootHours(overShoot);
+        f.setDurationUnit(unit);
+        return f;
+    }
+
+    private Date[] span(long minutes) {
+        Date from = new Date(0L);
+        Date to = new Date(minutes * MINUTE_MS);
+        return new Date[]{from, to};
+    }
+
+    private double count(TimedItemFee f, long elapsedMinutes) {
+        Date[] s = span(elapsedMinutes);
+        return inwardBean.calCount(f, s[0], s[1]);
+    }
+
+    // ---------- unit conversion on the entity ----------
+
+    @Test
+    void unsetUnitReadsAsHour() {
+        TimedItemFee f = fee(2, 0, null);
+        assertEquals(TimedItemDurationUnit.HOUR, f.getDurationUnit());
+        assertEquals(120.0, f.getDurationMinutes(), 0.0001);
+        assertFalse(f.isOneTime());
+    }
+
+    @Test
+    void eachUnitConvertsToMinutes() {
+        assertEquals(30.0, fee(30, 0, TimedItemDurationUnit.MINUTE).getDurationMinutes(), 0.0001);
+        assertEquals(120.0, fee(2, 0, TimedItemDurationUnit.HOUR).getDurationMinutes(), 0.0001);
+        assertEquals(1440.0, fee(1, 0, TimedItemDurationUnit.DAY).getDurationMinutes(), 0.0001);
+        assertEquals(0.0, fee(5, 0, TimedItemDurationUnit.ONE_TIME).getDurationMinutes(), 0.0001);
+    }
+
+    @Test
+    void overShootUsesTheSameUnitAsTheBlock() {
+        assertEquals(15.0, fee(60, 15, TimedItemDurationUnit.MINUTE).getOverShootMinutes(), 0.0001);
+        assertEquals(720.0, fee(1, 0.5, TimedItemDurationUnit.DAY).getOverShootMinutes(), 0.0001);
+    }
+
+    @Test
+    void durationInHoursHonoursTheUnit() {
+        assertEquals(24.0, fee(1, 0, TimedItemDurationUnit.DAY).getDurationInHours(), 0.0001);
+        assertEquals(0.5, fee(30, 0, TimedItemDurationUnit.MINUTE).getDurationInHours(), 0.0001);
+    }
+
+    // ---------- existing hour-based behaviour is unchanged ----------
+
+    @Test
+    void legacyHourFeeCountsWholeHourBlocks() {
+        // 1-hour block, no overshoot, 150 minutes used -> 2 whole blocks.
+        assertEquals(2.0, count(fee(1, 0, null), 150), 0.0001);
+    }
+
+    @Test
+    void legacyHourFeeChargesOneBlockForAShortStay() {
+        // Under a full block still charges one block (count == 0 branch).
+        assertEquals(1.0, count(fee(1, 0, null), 20), 0.0001);
+    }
+
+    @Test
+    void hourUnitMatchesTheLegacyNullUnit() {
+        assertEquals(count(fee(1, 0, null), 150),
+                count(fee(1, 0, TimedItemDurationUnit.HOUR), 150), 0.0001);
+    }
+
+    // ---------- new units ----------
+
+    @Test
+    void perMinuteFeeChargesEveryMinuteUsed() {
+        // The issue's worked example: Rs. 10 per minute for 30 minutes = Rs. 300.
+        TimedItemFee f = fee(1, 0, TimedItemDurationUnit.MINUTE);
+        f.setFee(10.0);
+        double blocks = count(f, 30);
+        assertEquals(30.0, blocks, 0.0001);
+        assertEquals(300.0, blocks * f.getFee(), 0.0001);
+    }
+
+    @Test
+    void perMinuteFeeWithAMultiMinuteBlock() {
+        // 15-minute blocks, 50 minutes used -> 3 whole blocks (no overshoot configured).
+        assertEquals(3.0, count(fee(15, 0, TimedItemDurationUnit.MINUTE), 50), 0.0001);
+    }
+
+    @Test
+    void perDayFeeCountsWholeDayBlocks() {
+        // 1-day block, 36 hours used -> 1 whole day, remainder not charged without overshoot.
+        assertEquals(1.0, count(fee(1, 0, TimedItemDurationUnit.DAY), 36 * 60), 0.0001);
+    }
+
+    @Test
+    void perDayOverShootIsCountedInDays() {
+        // 1-day block with a half-day grace; 36 hours leaves a 12-hour remainder,
+        // which reaches the grace window and so charges a second day.
+        assertEquals(2.0, count(fee(1, 0.5, TimedItemDurationUnit.DAY), 36 * 60), 0.0001);
+    }
+
+    @Test
+    void oneTimeFeeChargesExactlyOnceHoweverLongItRan() {
+        TimedItemFee f = fee(0, 0, TimedItemDurationUnit.ONE_TIME);
+        assertTrue(f.isOneTime());
+        assertEquals(1.0, count(f, 5), 0.0001);
+        assertEquals(1.0, count(f, 60 * 24 * 7), 0.0001);
+    }
+
+    @Test
+    void oneTimeFeeIsChargedEvenWithNoElapsedTime() {
+        // calCount returns 0 for a zero-length span on time-based fees; a one-time
+        // fee is not time-based, so it must still be charged.
+        assertEquals(1.0, count(fee(0, 0, TimedItemDurationUnit.ONE_TIME), 0), 0.0001);
+        assertEquals(0.0, count(fee(1, 0, TimedItemDurationUnit.HOUR), 0), 0.0001);
+    }
+
+    @Test
+    void calCountWithoutOverShootAlsoHonoursUnits() {
+        Date[] halfHour = span(30);
+        assertEquals(30.0,
+                inwardBean.calCountWithoutOverShoot(fee(1, 0, TimedItemDurationUnit.MINUTE), halfHour[0], halfHour[1]),
+                0.0001);
+        assertEquals(1.0,
+                inwardBean.calCountWithoutOverShoot(fee(0, 0, TimedItemDurationUnit.ONE_TIME), halfHour[0], halfHour[1]),
+                0.0001);
+    }
+}


### PR DESCRIPTION
Closes #23206

## Problem

A timed service fee could only be defined in hours. `TimedItemFee.durationHours`
was the length of one charged block and every calculation multiplied it by 60,
so:

- a per-minute service had to be faked as a fractional hour (`0.0166…`),
- a per-day service worked only because someone typed `24`,
- a flat one-off charge could not be expressed at all.

## Fix

`TimedItemFee` gains a `durationUnit` — `ONE_TIME | MINUTE | HOUR | DAY` — that
says what `durationHours` and `overShootHours` are counted in. The conversion
lives on the entity (`getDurationMinutes()`, `getOverShootMinutes()`,
`getDurationInHours()`), so the existing calculation funnel picks it up without
any call site changing its logic:

`InwardBeanController.calCount` / `calCountWithoutOverShoot` are what the room
management page, the interim bill, the final bill, the timed service consume
page and the surgery bill all go through. `ONE_TIME` short-circuits both to a
count of 1, so the fee is charged exactly once however long the service ran.

Configuration UI: **Charged By** dropdown next to the (renamed) **Duration**
field on `/inward/inward_timed_item_fee.xhtml`, plus the same selector on
`/inward/inward_room_facility.xhtml` for room charge blocks.

## Decisions made without approval

The issue gave the requirement but not the design. Each of these was decided
from the code rather than asked:

| Decision | Why |
|---|---|
| The unit goes on `TimedItemFee`, not `TimedItem` | `RoomFacilityCharge` holds a `TimedItemFee` directly with **no owning `TimedItem`**, so a service-level field could never reach room charges. The issue also names the *fee* page as the place to configure this. |
| `durationHours` keeps its name | Database compatibility. It now means "duration value"; the UI labels it "Duration" and pairs it with "Charged By". |
| `getDurationUnit()` returns `HOUR` when the column is null, instead of null | Every fee saved before this field existed was hour-based. Defaulting on read also stops the config dropdowns from rendering a legacy fee as whichever option is listed first — which would have silently converted rows to `ONE_TIME` on the next save. The entity hierarchy uses field access, so nothing is written back until a unit is actually chosen. |
| Saving a time-based fee with duration `0` is now rejected on the fee page | It could only ever price at zero, and `ONE_TIME` is the proper way to express a flat charge. |
| REST/AI surfaces extended too | Fee DTOs, the timed-item fee endpoints, the room facility charge endpoint and the capability statement — so the unit is not settable only through the UI. |
| A one-time room charge shows as a single billed slot in the room duration breakdown, and as its raw amount in the vacant-room "24 Hrs" column | Both are display mirrors of `calCount`, which returns 1 for a one-time fee. |

## ⚠️ Schema change required before deploy

`TimedItemFee` is part of the single-table `Fee` hierarchy, so this needs a new
**`DURATIONUNIT` column on the `FEE` table**. It has **not** been generated or
applied here — run `/generate-ddl` and apply it through the admin
**Add Missing Columns** page.

## Verification

- **14 new unit tests** (`TimedItemDurationUnitCalculationTest`), covering:
  - the issue's worked example — Rs. 10/minute × 30 minutes = **Rs. 300**
  - multi-minute blocks (15-min blocks, 50 minutes → 3 blocks)
  - per-day blocks, and an overshoot expressed in days (½ day grace on a 36-hour
    stay → 2 days)
  - one-time charging at 5 minutes, at a week, and at zero elapsed time
  - **regression guard**: a fee with no unit counts whole hour blocks exactly as
    before, and `HOUR` produces an identical result to the legacy null
- Full suite: **221 tests, 0 failures**.
- Browser verification was **not** possible in this unattended run: the
  `DURATIONUNIT` column does not exist in the local database yet, and applying
  DDL is deliberately left to a human. Confirmed the column is absent
  (`INFORMATION_SCHEMA` check on `FEE`) rather than assumed. Once the column is
  added, the paths worth clicking through are: configure a per-minute service →
  consume it on `/inward/inward_timed_service_consume.xhtml` → check the interim
  and final bill totals; and a room facility charge switched to `DAY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Timed fees support one-time, minute, hour, and day-based billing.
  - Room and service fee forms allow selecting duration units.
  - APIs include duration units in requests and responses.
  - One-time fees can omit duration and overshoot values.

- **Bug Fixes**
  - Corrected calculations for varied duration units and one-time charges.
  - Added validation requiring positive durations for time-based fees.
  - Room charges now calculate daily equivalents consistently.
  - Charges use the entered service start time when available.
  - Updated fields refresh correctly when changing billing units.

- **Documentation**
  - Updated API, capability, and testing guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->