### PR TITLE
23209 stock report by item align quantity purchase value and retail sale value columns

### DIFF
--- a/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_item_DTO.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_item_DTO.xhtml
@@ -140,10 +140,21 @@
                                  content. -->
                             <style>
                                 [id="frm:tbl"] td, [id="frm:tbl"] th { white-space: nowrap; }
+                                /* All three scrollable tables (header / body / footer) must auto-size
+                                   to content AND use border-box so a width set from outerWidth()
+                                   renders as the same box on all three. Leaving the footer out (or
+                                   leaving it content-box) is what let the totals row drift out of
+                                   alignment for long item names - issue #23209. */
                                 [id="frm:tbl"] .ui-datatable-scrollable-header table,
-                                [id="frm:tbl"] .ui-datatable-scrollable-body table {
+                                [id="frm:tbl"] .ui-datatable-scrollable-body table,
+                                [id="frm:tbl"] .ui-datatable-scrollable-footer table {
                                     table-layout: auto !important;
                                     width: auto !important;
+                                }
+                                [id="frm:tbl"] .ui-datatable-scrollable-header th,
+                                [id="frm:tbl"] .ui-datatable-scrollable-body td,
+                                [id="frm:tbl"] .ui-datatable-scrollable-footer td {
+                                    box-sizing: border-box;
                                 }
                             </style>
                             <script>
@@ -158,9 +169,17 @@
                                     if (!$headerCells.length || !$bodyRows.length) {
                                         return;
                                     }
+
+                                    // Clear any previously pinned widths so every cell reports its
+                                    // natural content width again.
                                     $headerCells.css('width', '');
                                     $bodyRows.find('> td').css('width', '');
                                     $footerCells.css('width', '');
+
+                                    // PASS 1 - measure only. Pinning a column before the later columns
+                                    // are measured redistributes space in a table-layout:auto table and
+                                    // corrupts their outerWidth(), so all reads must happen first.
+                                    var widths = [];
                                     $headerCells.each(function(colIndex) {
                                         var maxWidth = $(this).outerWidth() || 0;
                                         $bodyRows.each(function() {
@@ -173,16 +192,38 @@
                                         if (footerWidth > maxWidth) {
                                             maxWidth = footerWidth;
                                         }
-                                        $(this).css('width', maxWidth + 'px');
+                                        widths[colIndex] = maxWidth;
+                                    });
+
+                                    // PASS 2 - apply. With box-sizing:border-box (set in CSS above) the
+                                    // border-box width from outerWidth() maps 1:1 onto css('width').
+                                    $headerCells.each(function(colIndex) {
+                                        var w = widths[colIndex] + 'px';
+                                        $(this).css('width', w);
                                         $bodyRows.each(function() {
-                                            $(this).find('> td').eq(colIndex).css('width', maxWidth + 'px');
+                                            $(this).find('> td').eq(colIndex).css('width', w);
                                         });
-                                        $footerCells.eq(colIndex).css('width', maxWidth + 'px');
+                                        $footerCells.eq(colIndex).css('width', w);
                                     });
                                 }
-                                $(document).ready(function() {
+                                // Run once the DOM is ready, then again after the browser has
+                                // finished layout/paint and PrimeFaces has run its own scrollable
+                                // column sync - on a full-page load (the non-AJAX "Process" submit)
+                                // there is no oncomplete hook, and a bare ready() call measures the
+                                // table before PF has laid out the three scrollable sub-tables.
+                                function alignStockByItemColumnsDeferred() {
                                     alignStockByItemColumns();
-                                });
+                                    if (window.requestAnimationFrame) {
+                                        requestAnimationFrame(function() {
+                                            requestAnimationFrame(alignStockByItemColumns);
+                                        });
+                                    } else {
+                                        setTimeout(alignStockByItemColumns, 50);
+                                    }
+                                    setTimeout(alignStockByItemColumns, 250);
+                                }
+                                $(document).ready(alignStockByItemColumnsDeferred);
+                                $(window).on('load', alignStockByItemColumnsDeferred);
                             </script>
 
                             <p:dataTable

--- a/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_item_DTO.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_item_DTO.xhtml
@@ -225,11 +225,14 @@
                                 </p:column>
                                 <p:columnGroup type="footer">
                                     <p:row>
-                                        <p:column colspan="4" footerText="Total">
+                                        <p:column/>
+                                        <p:column/>
+                                        <p:column footerText="Total">
                                             <f:facet name="footer">
                                                 <h:outputLabel value="Total" />
                                             </f:facet>
                                         </p:column>
+                                        <p:column/>
                                         <p:column style="text-align: right;" footerText="#{reportsStock.stockPurchaseValue}">
                                             <f:facet name="footer" >
                                                 <h:outputLabel value="#{reportsStock.stockPurchaseValue}" >

--- a/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_item_DTO.xhtml
+++ b/src/main/webapp/pharmacy/pharmacy_report_department_stock_by_item_DTO.xhtml
@@ -109,10 +109,10 @@
                                     </p:commandButton>
                                     <p:commandButton styleClass="ui-button-info mx-1" icon="fas fa-print" value="Print"
                                                      actionListener="#{reportsStock.prepareForPrint()}"
-                                                     oncomplete="$('#frm\\:print').click()"
+                                                     oncomplete="alignStockByItemColumns(); $('#frm\\:print').click()"
                                                      update=":frm:tbl"/>
                                     <p:commandButton id="print" value="Actual print" style="display: none">
-                                        <p:ajax event="click" listener="#{reportsStock.prepareForView()}" update=":frm:tbl"/>
+                                        <p:ajax event="click" listener="#{reportsStock.prepareForView()}" update=":frm:tbl" oncomplete="alignStockByItemColumns()"/>
                                         <p:printer target=":frm:tbl" />
                                     </p:commandButton>
                                 </h:panelGroup>
@@ -126,7 +126,18 @@
                                  wrapping long item names onto multiple lines. table-layout must be
                                  overridden from PrimeFaces' default "fixed" (which silently clips
                                  nowrap content to the container width) to "auto" so the table can
-                                 actually grow past the scrollable viewport. Issue #23052. -->
+                                 actually grow past the scrollable viewport. Issue #23052.
+
+                                 Because scrollable="true" renders the header/body/footer as three
+                                 independent <table> elements, letting each auto-size to its own content
+                                 means a long item name only widens the BODY table's Item column - the
+                                 header/footer tables have short content in that column and stay narrow,
+                                 so every column after Item drifts out of alignment (issue #23209).
+                                 alignStockByItemColumns() re-measures the widest cell per column across
+                                 all three tables and pins that width on all three, so they always match
+                                 regardless of item-name length. It reruns after every AJAX update
+                                 (paginate/sort/filter/print) since those redraw the body with different
+                                 content. -->
                             <style>
                                 [id="frm:tbl"] td, [id="frm:tbl"] th { white-space: nowrap; }
                                 [id="frm:tbl"] .ui-datatable-scrollable-header table,
@@ -135,10 +146,48 @@
                                     width: auto !important;
                                 }
                             </style>
+                            <script>
+                                function alignStockByItemColumns() {
+                                    var $wrapper = $('#frm\\:tbl');
+                                    var $headerTable = $wrapper.find('.ui-datatable-scrollable-header table').first();
+                                    var $bodyTable = $wrapper.find('.ui-datatable-scrollable-body table').first();
+                                    var $footerTable = $wrapper.find('.ui-datatable-scrollable-footer table').first();
+                                    var $headerCells = $headerTable.find('> thead > tr > th');
+                                    var $bodyRows = $bodyTable.find('> tbody > tr');
+                                    var $footerCells = $footerTable.find('> tfoot > tr > td');
+                                    if (!$headerCells.length || !$bodyRows.length) {
+                                        return;
+                                    }
+                                    $headerCells.css('width', '');
+                                    $bodyRows.find('> td').css('width', '');
+                                    $footerCells.css('width', '');
+                                    $headerCells.each(function(colIndex) {
+                                        var maxWidth = $(this).outerWidth() || 0;
+                                        $bodyRows.each(function() {
+                                            var cellWidth = $(this).find('> td').eq(colIndex).outerWidth() || 0;
+                                            if (cellWidth > maxWidth) {
+                                                maxWidth = cellWidth;
+                                            }
+                                        });
+                                        var footerWidth = $footerCells.eq(colIndex).outerWidth() || 0;
+                                        if (footerWidth > maxWidth) {
+                                            maxWidth = footerWidth;
+                                        }
+                                        $(this).css('width', maxWidth + 'px');
+                                        $bodyRows.each(function() {
+                                            $(this).find('> td').eq(colIndex).css('width', maxWidth + 'px');
+                                        });
+                                        $footerCells.eq(colIndex).css('width', maxWidth + 'px');
+                                    });
+                                }
+                                $(document).ready(function() {
+                                    alignStockByItemColumns();
+                                });
+                            </script>
 
                             <p:dataTable
-                                id="tbl" 
-                                rowIndexVar="ii" 
+                                id="tbl"
+                                rowIndexVar="ii"
                                 value="#{reportsStock.stockReportByItemDTOS}" var="i"
                                 rendered="#{reportsStock.stockReportByItemDTOS.size() ne 0 }"
                                 rows="#{reportsStock.paginator?'20':reportsStock.stockReportByItemDTOS.size()}"
@@ -147,6 +196,9 @@
                                 rowsPerPageTemplate="20, 50, 100"
                                 scrollable="true"
                                 scrollWidth="100%">
+                                <p:ajax event="page" oncomplete="alignStockByItemColumns()" />
+                                <p:ajax event="sort" oncomplete="alignStockByItemColumns()" />
+                                <p:ajax event="filter" oncomplete="alignStockByItemColumns()" />
                                 <f:facet name="header">
                                     <h:panelGroup layout="block">
                                         <h:outputLabel value="Stock Report by Item"/>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stock report table alignment when printing and scrolling.
  * Column widths now remain consistent across headers, item rows, and totals.
  * Print layouts are adjusted reliably before the report opens.
  * Improved alignment after sorting, filtering, paging, and other table updates.
  * Updated the totals row to align correctly with corresponding table columns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->