### PR TITLE
hotfix: pending-receive notice + disbursement/inward count fixes

### DIFF
--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -4277,6 +4277,26 @@ public class SearchController implements Serializable {
         fetchTransferIssuedListDtos(Boolean.FALSE);
     }
 
+    public long getPendingTransferReceiveCountForLoggedDepartment() {
+        if (getSessionController().getDepartment() == null) {
+            return 0;
+        }
+        List<BillTypeAtomic> btas = new ArrayList<>();
+        btas.add(BillTypeAtomic.PHARMACY_ISSUE);
+        Map<String, Object> params = new HashMap<>();
+        params.put("toDep", getSessionController().getDepartment());
+        params.put("bTp", btas);
+        params.put("fromDate", CommonFunctions.getStartOfDay(CommonFunctions.addDaysToDate(new Date(), -3L)));
+        String jpql = "SELECT COUNT(b) FROM Bill b "
+                + "WHERE b.retired = false "
+                + "AND b.toDepartment = :toDep "
+                + "AND b.billTypeAtomic IN :bTp "
+                + "AND b.cancelled = false "
+                + "AND b.fullyIssued = false "
+                + "AND b.createdAt >= :fromDate ";
+        return getBillFacade().findLongByJpql(jpql, params, TemporalType.TIMESTAMP);
+    }
+
     private void fetchTransferIssuedListDtos(Boolean fullyIssuedFilter) {
         List<BillTypeAtomic> btas = new ArrayList<>();
         btas.add(BillTypeAtomic.PHARMACY_ISSUE);

--- a/src/main/java/com/divudi/bean/inward/InwardBeanController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardBeanController.java
@@ -2175,27 +2175,27 @@ public class InwardBeanController implements Serializable {
             System.out.println("Department: " + dep.getName() + " has " + items.size() + " items");
 
             if (!items.isEmpty()) {
-                // BULK QUERY 1: Get all billed counts for all items in one query
-                Map<Long, Long> billedCounts = getBulkBillItemCounts(items, pts, forwardRefBill, BilledBill.class);
+                // BULK QUERY 1: Get all billed quantities for all items in one query
+                Map<Long, Double> billedCounts = getBulkBillItemCounts(items, pts, forwardRefBill, BilledBill.class);
 
-                // BULK QUERY 2: Get all cancelled counts
-                Map<Long, Long> cancelledCounts = getBulkBillItemCounts(items, pts, forwardRefBill, CancelledBill.class);
+                // BULK QUERY 2: Get all cancelled quantities
+                Map<Long, Double> cancelledCounts = getBulkBillItemCounts(items, pts, forwardRefBill, CancelledBill.class);
 
-                // BULK QUERY 3: Get all refund counts
-                Map<Long, Long> refundCounts = getBulkBillItemCounts(items, pts, forwardRefBill, RefundBill.class);
+                // BULK QUERY 3: Get all refund quantities
+                Map<Long, Double> refundCounts = getBulkBillItemCounts(items, pts, forwardRefBill, RefundBill.class);
 
-                // BULK QUERY 4: Get all checked counts
-                Map<Long, Long> checkedCounts = getBulkCheckedBillItemCounts(items, patientEncounter);
+                // BULK QUERY 4: Get all checked quantities
+                Map<Long, Double> checkedCounts = getBulkCheckedBillItemCounts(items, patientEncounter);
 
                 // BULK QUERY 5: Get Gross/Discount/Margin/Net/VAT value breakdown
                 Map<Long, double[]> valueBreakdown = getBulkBillItemValueBreakdown(items, pts);
 
                 // Apply the counts to items (no more database queries!)
                 for (Item itm : items) {
-                    long billed = billedCounts.getOrDefault(itm.getId(), 0L);
-                    long cancelled = cancelledCounts.getOrDefault(itm.getId(), 0L);
-                    long refund = refundCounts.getOrDefault(itm.getId(), 0L);
-                    long checked = checkedCounts.getOrDefault(itm.getId(), 0L);
+                    double billed = billedCounts.getOrDefault(itm.getId(), 0.0);
+                    double cancelled = cancelledCounts.getOrDefault(itm.getId(), 0.0);
+                    double refund = refundCounts.getOrDefault(itm.getId(), 0.0);
+                    double checked = checkedCounts.getOrDefault(itm.getId(), 0.0);
                     double[] values = valueBreakdown.getOrDefault(itm.getId(), new double[5]);
 
                     itm.setTransCheckedCount(checked);
@@ -2222,16 +2222,17 @@ public class InwardBeanController implements Serializable {
     }
 
     /**
-     * Bulk query to get bill item counts for multiple items at once
-     * Returns a map of itemId -> count
+     * Bulk query to get bill item quantities for multiple items at once.
+     * Returns a map of itemId -> total quantity (sum of BillItem.qty, not
+     * a row count - a single BillItem can carry qty > 1).
      */
-    private Map<Long, Long> getBulkBillItemCounts(List<Item> items, List<PatientEncounter> pts, Bill forwardBill, Class billClass) {
+    private Map<Long, Double> getBulkBillItemCounts(List<Item> items, List<PatientEncounter> pts, Bill forwardBill, Class billClass) {
         if (items == null || items.isEmpty()) {
             return new HashMap<>();
         }
 
         HashMap hm = new HashMap();
-        String sql = "SELECT b.item.id, count(b) FROM BillItem b "
+        String sql = "SELECT b.item.id, SUM(ABS(b.qty)) FROM BillItem b "
                 + " WHERE b.retired=false "
                 + " and b.bill.billType=:btp "
                 + " and b.bill.patientEncounter IN :pe "
@@ -2252,11 +2253,11 @@ public class InwardBeanController implements Serializable {
 
         List<Object[]> results = getBillItemFacade().findObjectsArrayByJpql(sql, hm, TemporalType.TIME);
 
-        Map<Long, Long> countMap = new HashMap<>();
+        Map<Long, Double> countMap = new HashMap<>();
         if (results != null) {
             for (Object[] row : results) {
                 Long itemId = (Long) row[0];
-                Long count = (Long) row[1];
+                Double count = row[1] != null ? ((Number) row[1]).doubleValue() : 0.0;
                 countMap.put(itemId, count);
             }
         }
@@ -2305,15 +2306,18 @@ public class InwardBeanController implements Serializable {
     }
 
     /**
-     * Bulk query to get checked bill item counts for multiple items at once
+     * Bulk query to get checked bill item quantities for multiple items at
+     * once. Returns a map of itemId -> total checked quantity (sum of
+     * BillItem.qty), matching the quantity basis of getBulkBillItemCounts so
+     * Pending Check Count (billed - checked) stays in the same unit.
      */
-    private Map<Long, Long> getBulkCheckedBillItemCounts(List<Item> items, PatientEncounter patientEncounter) {
+    private Map<Long, Double> getBulkCheckedBillItemCounts(List<Item> items, PatientEncounter patientEncounter) {
         if (items == null || items.isEmpty()) {
             return new HashMap<>();
         }
 
         HashMap hm = new HashMap();
-        String sql = "SELECT b.item.id, count(b) FROM BillItem b "
+        String sql = "SELECT b.item.id, SUM(ABS(b.qty)) FROM BillItem b "
                 + " WHERE b.retired=false "
                 + " and b.bill.billType=:btp "
                 + " and b.bill.patientEncounter=:pe "
@@ -2330,11 +2334,11 @@ public class InwardBeanController implements Serializable {
 
         List<Object[]> results = getBillItemFacade().findObjectsArrayByJpql(sql, hm, TemporalType.TIMESTAMP);
 
-        Map<Long, Long> countMap = new HashMap<>();
+        Map<Long, Double> countMap = new HashMap<>();
         if (results != null) {
             for (Object[] row : results) {
                 Long itemId = (Long) row[0];
-                Long count = (Long) row[1];
+                Double count = row[1] != null ? ((Number) row[1]).doubleValue() : 0.0;
                 countMap.put(itemId, count);
             }
         }

--- a/src/main/java/com/divudi/bean/inward/InwardBeanController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardBeanController.java
@@ -2190,6 +2190,9 @@ public class InwardBeanController implements Serializable {
                 // BULK QUERY 5: Get Gross/Discount/Margin/Net/VAT value breakdown
                 Map<Long, double[]> valueBreakdown = getBulkBillItemValueBreakdown(items, pts);
 
+                // BULK QUERY 6: Get pending-check bill counts (distinct bills, not quantity)
+                Map<Long, Long> pendingCheckBillCounts = getBulkPendingCheckBillCounts(items, pts, forwardRefBill);
+
                 // Apply the counts to items (no more database queries!)
                 for (Item itm : items) {
                     double billed = billedCounts.getOrDefault(itm.getId(), 0.0);
@@ -2197,6 +2200,7 @@ public class InwardBeanController implements Serializable {
                     double refund = refundCounts.getOrDefault(itm.getId(), 0.0);
                     double checked = checkedCounts.getOrDefault(itm.getId(), 0.0);
                     double[] values = valueBreakdown.getOrDefault(itm.getId(), new double[5]);
+                    long pendingCheckBillCount = pendingCheckBillCounts.getOrDefault(itm.getId(), 0L);
 
                     itm.setTransCheckedCount(checked);
                     itm.setTransBillItemCount(billed - (cancelled + refund));
@@ -2205,6 +2209,7 @@ public class InwardBeanController implements Serializable {
                     itm.setTransMarginValue(values[2]);
                     itm.setTransNetValue(values[3]);
                     itm.setTransVat(values[4]);
+                    itm.setTransPendingCheckBillCount(pendingCheckBillCount);
                 }
             }
 
@@ -2339,6 +2344,54 @@ public class InwardBeanController implements Serializable {
             for (Object[] row : results) {
                 Long itemId = (Long) row[0];
                 Double count = row[1] != null ? ((Number) row[1]).doubleValue() : 0.0;
+                countMap.put(itemId, count);
+            }
+        }
+
+        return countMap;
+    }
+
+    /**
+     * Bulk query to get the pending-check bill count for multiple items at
+     * once. Unlike getBulkBillItemCounts/getBulkCheckedBillItemCounts (which
+     * are quantity-based), this counts distinct Bills - not summed qty -
+     * since "Pending Check Count" on the Service Details tab means "how many
+     * bills for this item still need checking", not a quantity.
+     */
+    private Map<Long, Long> getBulkPendingCheckBillCounts(List<Item> items, List<PatientEncounter> pts, Bill forwardBill) {
+        if (items == null || items.isEmpty()) {
+            return new HashMap<>();
+        }
+
+        HashMap hm = new HashMap();
+        String sql = "SELECT b.item.id, COUNT(DISTINCT b.bill) FROM BillItem b "
+                + " WHERE b.retired=false "
+                + " and b.bill.billType=:btp "
+                + " and b.bill.patientEncounter IN :pe "
+                + " and b.item IN :items "
+                + " and type(b.bill)=:cls "
+                + " and b.bill.checkedBy is null "
+                + " and b.bill.cancelled=false";
+
+        if (forwardBill != null) {
+            sql += " and b.bill.forwardReferenceBill=:fB";
+            hm.put("fB", forwardBill);
+        }
+
+        sql += " GROUP BY b.item.id";
+
+        hm.put("btp", BillType.InwardBill);
+        hm.put("pe", pts);
+        hm.put("items", items);
+        hm.put("cls", BilledBill.class);
+
+        List<Object[]> results = getBillItemFacade().findObjectsArrayByJpql(sql, hm, TemporalType.TIME);
+
+        Map<Long, Long> countMap = new HashMap<>();
+        if (results != null) {
+            for (Object[] row : results) {
+                Long itemId = (Long) row[0];
+                Long count = (Long) row[1];
                 countMap.put(itemId, count);
             }
         }

--- a/src/main/java/com/divudi/core/entity/Item.java
+++ b/src/main/java/com/divudi/core/entity/Item.java
@@ -214,6 +214,8 @@ public class Item implements Serializable, Comparable<Item>, RetirableEntity {
     @Transient
     double transCheckedCount;
     @Transient
+    private long transPendingCheckBillCount;
+    @Transient
     private double transGrossValue;
     @Transient
     private double transDiscount;
@@ -397,6 +399,14 @@ public class Item implements Serializable, Comparable<Item>, RetirableEntity {
 
     public void setTransCheckedCount(double transCheckedCount) {
         this.transCheckedCount = transCheckedCount;
+    }
+
+    public long getTransPendingCheckBillCount() {
+        return transPendingCheckBillCount;
+    }
+
+    public void setTransPendingCheckBillCount(long transPendingCheckBillCount) {
+        this.transPendingCheckBillCount = transPendingCheckBillCount;
     }
 
     public double getTransGrossValue() {

--- a/src/main/webapp/inward/inward_bill_intrim.xhtml
+++ b/src/main/webapp/inward/inward_bill_intrim.xhtml
@@ -676,8 +676,8 @@
                                                     </f:facet>
                                                 </p:column>
 
-                                                <p:column >
-                                                    <f:facet name="header">
+                                                <p:column styleClass="text-end">
+                                                    <f:facet name="header" >
                                                         <h:outputLabel value="Count"/>
                                                     </f:facet>
                                                 </p:column>
@@ -760,7 +760,7 @@
                                                 <h:outputLabel value="#{ser.transCheckedCount}" rendered="#{ser.transBillItemCount ne 0}"/>
                                             </p:column>
                                             <p:column styleClass="text-end">
-                                                <h:outputLabel value="#{ser.transBillItemCount - ser.transCheckedCount}" rendered="#{ser.transBillItemCount ne 0}">
+                                                <h:outputLabel value="#{ser.transPendingCheckBillCount}" rendered="#{ser.transBillItemCount ne 0}">
                                                     <f:convertNumber pattern="#,##0"/>
                                                 </h:outputLabel>
                                             </p:column>

--- a/src/main/webapp/pharmacy/disbursement_index.xhtml
+++ b/src/main/webapp/pharmacy/disbursement_index.xhtml
@@ -46,7 +46,7 @@
                                     actionListener="#{searchController.makeListNull()}"
                                     styleClass="ui-button-stage-approve w-100"
                                     icon="fas fa-check-double"
-                                    rendered="#{webUserController.hasPrivilege('PharmacyDisbursementFinalizeRequest')}" />
+                                    rendered="#{webUserController.hasPrivilege('PharmacyDisbursementRequestApproval')}" />
                                 <p:commandButton
                                     value="Approved Requests"
                                     ajax="false"
@@ -55,7 +55,7 @@
                                     actionListener="#{searchController.makeListNull()}"
                                     class="ui-button-secondary w-100"
                                     icon="fas fa-check-double"
-                                    rendered="#{webUserController.hasPrivilege('PharmacyDisbursementFinalizeRequest')}" />
+                                    rendered="#{webUserController.hasPrivilege('PharmacyDisbursementRequestApproval')}" />
                             </div>
                         </p:tab>
                         <p:tab title="Issues" >

--- a/src/main/webapp/resources/ezcomp/menu.xhtml
+++ b/src/main/webapp/resources/ezcomp/menu.xhtml
@@ -24,6 +24,28 @@
                 align-items: center;
                 gap: 6px;
             }
+            .pending-receive-menu-banner {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                gap: 0.75rem;
+                padding: 0.75rem 1.25rem;
+                border: 1px solid #ffe08a;
+                border-left: 5px solid #f0ad4e;
+                background: linear-gradient(90deg, #fff8e6 0%, #fffdf7 100%);
+                box-shadow: 0 1px 4px rgba(0,0,0,0.06);
+            }
+            .pending-receive-menu-banner .pi,
+            .pending-receive-menu-banner .fa {
+                color: #f0ad4e;
+                font-size: 24px;
+            }
+            .pending-receive-menu-banner-text {
+                font-weight: 700;
+                font-size: 20px;
+                color: #8a6416;
+                text-align: center;
+            }
         </style>
 
         <h:form id="notificationPushForm">
@@ -64,6 +86,24 @@
                     <div class="d-flex justify-content-center shadow-4 p-2" style="background-color: #{configOptionApplicationController.getColorValueByKey('Message background color')}; font-weight: 700; font-size: 18px;">
                         <h:outputText value="#{configOptionApplicationController.getLongTextValueByKey('Message to system users')}" style="font-weight: 700; font-size: 25px;"></h:outputText>
                     </div>
+                </div>
+            </h:panelGroup>
+            
+            <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Display Pending Disbursement Recieve Notice',false) and searchController.pendingTransferReceiveCountForLoggedDepartment > 0}">
+                <div class="pending-receive-menu-banner">
+                    <i class="pi pi-exclamation-triangle"/>
+                    <h:outputFormat styleClass="pending-receive-menu-banner-text" value="You have {0} transfer issue(s) pending to receive for {1}.">
+                        <f:param value="#{searchController.pendingTransferReceiveCountForLoggedDepartment}"/>
+                        <f:param value="#{sessionController.department.name}"/>
+                    </h:outputFormat>
+                    <p:commandButton
+                        value="Receive Now"
+                        ajax="false"
+                        title="Go to the Receive Issued Items list"
+                        action="/pharmacy/pharmacy_transfer_issued_list?faces-redirect=true"
+                        actionListener="#{searchController.makeListNull()}"
+                        styleClass="ui-button-warning"
+                        icon="fas fa-truck-loading"/>
                 </div>
             </h:panelGroup>
 


### PR DESCRIPTION
## Summary

- **Pharmacy Disbursement**: "Approve"/"Approved Requests" menu buttons were gated by `PharmacyDisbursementFinalizeRequest` instead of the privilege the underlying approval action actually checks, `PharmacyDisbursementRequestApproval`. (Issue #23230)
- **Pharmacy Disbursement**: new opt-in warning banner in the main menu (`Display Pending Disbursement Recieve Notice` config key) showing pending transfer-receive items for the logged-in department, with a "Receive Now" shortcut. (Issue #23231)
- **Inward Interim Bill**: Service Details tab `Count`/`Checked Count` columns summed BillItem rows instead of billed quantity, undercounting any line billed with qty > 1. `Pending Check Count` now shows the actual count of bills still awaiting check instead of a quantity-based subtraction. (Issue #23232)

## Test plan

- [ ] Verify Approve Requests / Approved Requests buttons render for a user holding only `PharmacyDisbursementRequestApproval`
- [ ] Enable `Display Pending Disbursement Recieve Notice` config, confirm the banner shows/hides correctly and "Receive Now" navigates to `pharmacy_transfer_issued_list`
- [ ] On Inward Interim Bill → Service Details tab, verify Count/Checked Count reflect billed quantity (not row count) and Pending Check Count matches the number of unchecked bills for an item

🤖 Generated with [Claude Code](https://claude.com/claude-code)