### PR TITLE
feat(skills): merge-gate posts a PR status comment per run

### DIFF
--- a/.claude/skills/merge-gate/SKILL.md
+++ b/.claude/skills/merge-gate/SKILL.md
@@ -4,10 +4,12 @@ description: >
   Gate one or more open PRs before merge: CI check, then a code-level
   regression/business-rule review, then (only if that's clean) end-to-end
   Playwright verification of the PR's own workflow(s) plus two fixed
-  baseline checks. Use when asked to "gate PR(s) for merge", "run
-  merge-gate on #N", "check these PRs are safe to merge", or before merging
-  any PR that touches shared/core code (API, billing, pharmacy) where a
-  regression could silently break unrelated functions.
+  baseline checks. Posts one top-level status comment per PR per run
+  (PASSED or BLOCKED-*) so the outcome is visible on GitHub, not just in
+  chat. Use when asked to "gate PR(s) for merge", "run merge-gate on #N",
+  "check these PRs are safe to merge", or before merging any PR that
+  touches shared/core code (API, billing, pharmacy) where a regression
+  could silently break unrelated functions.
 argument-hint: "<pr-number> [pr-number...]"
 ---
 
@@ -45,9 +47,10 @@ after the last PR.
 gh pr checks <PR>
 ```
 
-- Failing → record `BLOCKED-CI`, stop this PR, move to the next.
+- Failing → record `BLOCKED-CI`, post the PR status comment (see
+  § PR status comment), stop this PR, move to the next.
 - Pending → `ScheduleWakeup` ~270s (same cadence as `dev-issue` §14), recheck
-  once. Still not green → `BLOCKED-CI`, stop this PR.
+  once. Still not green → `BLOCKED-CI`, post the comment, stop this PR.
 - Passing → continue.
 
 ### 1. Fetch and checkout
@@ -76,7 +79,7 @@ Classify the findings it returns:
 
 | Category | Effect |
 |---|---|
-| correctness, regression, business-rule violation | **Blocking.** Comments are already posted by `--comment`; summarize in chat; record `BLOCKED-REVIEW`; stop this PR — do not run Phase 2/3. |
+| correctness, regression, business-rule violation | **Blocking.** Inline comments are already posted by `--comment`; summarize in chat; post the PR status comment (see § PR status comment); record `BLOCKED-REVIEW`; stop this PR — do not run Phase 2/3. |
 | style, simplification, efficiency, reuse-only | **Non-blocking.** Note in chat, continue to Phase 2 regardless. |
 
 No findings at all → continue to Phase 2.
@@ -106,7 +109,8 @@ $env:JAVA_HOME="C:\Program Files\Eclipse Adoptium\jdk-11.0.23.9-hotspot"
 
 Check the server log for deployment errors before proceeding. **If `mvn
 clean package` fails, `asadmin redeploy` fails, or the server log shows
-deployment errors, stop this PR here**: capture the failure output, record
+deployment errors, stop this PR here**: capture the failure output, post
+the PR status comment (see § PR status comment) with that output, record
 `BLOCKED-BUILD`, and move to the next PR — don't attempt Phase 3 against a
 stale or undeployed build.
 
@@ -140,9 +144,86 @@ patient identifiers, credentials, tokens, and other sensitive fields from
 that evidence before it leaves `tmp/` (referenced in chat, posted to a PR
 comment, etc.) — same rule as `dev-issue` §2a/§10. Do not attempt a fix
 inline — report it and discuss next steps (per CLAUDE.md "discuss
-uncertainties"); fixing is separate `dev-issue` work.
+uncertainties"); fixing is separate `dev-issue` work. Post the PR status
+comment (see § PR status comment) describing what failed, with the
+evidence redacted.
 
-All three pass → record `PASSED`.
+All three pass → record `PASSED` and post the PR status comment (see
+§ PR status comment).
+
+## PR status comment
+
+Post exactly **one top-level PR comment per PR per run**, at whatever
+terminal state that PR's pipeline reaches (whether it stops early or runs
+all the way to `PASSED`). This is an intentional, carved-out exception to
+the general "never post top-level PR comments, only reply to reviewer
+threads" rule — merge-gate is reporting its own factual outcome, not review
+opinion needing threading, so a fresh top-level comment each run is
+correct, not noise. Post via:
+
+```bash
+gh pr comment <PR> --body "..."
+```
+
+If merge-gate is re-run on the same PR later (e.g. after the author
+pushed fixes), post a **new** comment rather than editing/deleting the
+previous one — the history of gate runs staying visible is the point.
+
+Use an outcome-specific template so a PR author or a merger who wasn't in
+this session gets enough context without opening the chat transcript:
+
+**`PASSED`:**
+```
+## 🚦 Merge Gate: PASSED
+
+**Tested:**
+- PR workflow: <short description of what was exercised>
+- Baseline A (pharmacy sale → COGS variance): ✅ no unexplained variance
+- Baseline B (OPD sale → Cashier Details): ✅ sale appears correctly
+
+Ready for final human review and merge.
+```
+
+**`BLOCKED-CI`:**
+```
+## 🚦 Merge Gate: BLOCKED — CI failing
+
+Check `<check name>` failed: <run URL>. Merge-gate stopped before the
+code review pass.
+```
+
+**`BLOCKED-REVIEW`:** keep this one short — the inline `--comment` findings
+from Phase 1 already carry the detail.
+```
+## 🚦 Merge Gate: BLOCKED — code review found regressions
+
+See the inline comments above for specifics. Merge-gate stopped here;
+Phase 2/3 (build, E2E, baselines) did not run.
+```
+
+**`BLOCKED-BUILD`:**
+```
+## 🚦 Merge Gate: BLOCKED — build/deploy failed
+
+<relevant tail of the compile or asadmin failure output>
+
+Merge-gate could not verify this PR end-to-end because the build/deploy
+step itself failed.
+```
+
+**`BLOCKED-E2E`:**
+```
+## 🚦 Merge Gate: BLOCKED — end-to-end verification found a bug
+
+**Failed:** <PR workflow name, or "Baseline A: COGS variance", or
+"Baseline B: Cashier Details">
+
+<redacted description of what went wrong — no patient identifiers,
+credentials, or tokens>
+
+This was not auto-fixed — it needs discussion (per CLAUDE.md "discuss
+uncertainties") as separate `dev-issue` work.
+```
 
 ## Final report
 
@@ -153,9 +234,13 @@ After all PRs are processed, print a table:
 
 Outcome is one of `PASSED`, `BLOCKED-CI`, `BLOCKED-REVIEW`, `BLOCKED-BUILD`,
 `BLOCKED-E2E`. For every `PASSED` row, say it's ready for the user's final
-review and merge. For blocked rows, link the PR comment (Phase 1), the
-build/deploy failure output (2a), or the evidence captured (Phase 3). Never
-merge, approve, or request changes on the user's behalf.
+review and merge. For blocked rows, link the PR status comment (which
+itself links the Phase 1 inline comments, the build/deploy failure output,
+or the Phase 3 evidence, depending on where it stopped). Every PR should
+already have its status comment posted per § PR status comment by the time
+this table prints — the table is a summary for this chat, the comment is
+the durable record on GitHub. Never merge, approve, or request changes on
+the user's behalf.
 
 ## Hygiene
 
@@ -169,5 +254,6 @@ merge, approve, or request changes on the user's behalf.
 ## Required permissions
 
 Same as `playwright-e2e` (full `mcp__playwright__*` set, Maven +
-`asadmin`, `mysql` read access) plus `gh` for PR checkout/checks/diff and
-the `Agent` tool for the Phase 2 `Explore` dispatch.
+`asadmin`, `mysql` read access) plus `gh` for PR checkout/checks/diff/comment
+(`gh pr comment`, per § PR status comment) and the `Agent` tool for the
+Phase 2 `Explore` dispatch.

--- a/.claude/skills/merge-gate/SKILL.md
+++ b/.claude/skills/merge-gate/SKILL.md
@@ -75,16 +75,14 @@ Invoke the `code-review` skill against this PR at **high** effort with
 `--comment`, so findings post directly to the PR (reuses the existing
 review engine instead of duplicating its logic).
 
-Classify the findings it returns:
+**Before classifying anything, run the fallback below** to confirm every
+finding the sub-agent claims to have posted actually landed — do this
+*before* the classification step decides to record `BLOCKED-REVIEW` and
+stop, not after. Running it after the stop decision defeats the point:
+by the time you've stopped this PR and moved to the next one, an
+unverified silent drop stays silently dropped.
 
-| Category | Effect |
-|---|---|
-| correctness, regression, business-rule violation | **Blocking.** Inline comments are already posted by `--comment`; summarize in chat; post the PR status comment (see § PR status comment); record `BLOCKED-REVIEW`; stop this PR — do not run Phase 2/3. |
-| style, simplification, efficiency, reuse-only | **Non-blocking.** Note in chat, continue to Phase 2 regardless. |
-
-No findings at all → continue to Phase 2.
-
-#### Fallback — verify every blocking finding actually landed as a comment
+#### Fallback — verify every finding actually landed as a comment
 
 `code-review --comment` posts via GitHub's PR-review-comment API, which can
 only anchor a comment on a line that appears in **this PR's own diff**. A
@@ -97,7 +95,8 @@ PR, because one lived in a file outside the diff and the anchor silently
 failed).
 
 Before trusting the sub-agent's "posted successfully" claim, verify for
-every finding classified as blocking. Get the actual poster identity first
+every finding it returned (classification happens after this, once you
+know what's actually posted). Get the actual poster identity first
 (don't hardcode a username or just exclude `coderabbitai[bot]` — an
 unrelated human/bot comment at the same path:line would then be
 misread as confirmation), and **always paginate** — the default page size
@@ -111,8 +110,9 @@ gh api --paginate repos/hmislk/hmis/pulls/<PR>/comments \
   --jq --arg me "$me" '.[] | select(.user.login == $me) | "\(.path):\(.line)"'
 ```
 
-Cross-check this list against the findings returned. For any blocking
-finding missing from it:
+Cross-check this list against the findings returned. For any finding
+missing from it (blocking or not — verify all of them, since
+classification hasn't happened yet):
 
 1. Check whether its file is part of the PR's diff at all:
    `gh pr diff <PR> --name-only`.
@@ -136,9 +136,21 @@ finding missing from it:
 Post any recovered findings with `gh api repos/hmislk/hmis/pulls/<PR>/comments
 -f commit_id=<head-sha> -f path=<path> -F line=<n> -f side=RIGHT -f
 body=<text>` (head SHA from `gh pr view <PR> --json commits -q
-'.commits[-1].oid'`). Re-run the verification query once more before moving
-on — don't proceed to Phase 2 on an unconfirmed assumption that everything
-posted.
+'.commits[-1].oid'`). Re-run the verification query once more before
+classifying anything — don't classify or stop on an unconfirmed assumption
+that everything posted.
+
+#### Classify
+
+Now that every finding is confirmed actually posted (or folded into the
+status comment per case 4 above), classify what the sub-agent returned:
+
+| Category | Effect |
+|---|---|
+| correctness, regression, business-rule violation | **Blocking.** Inline comments are already confirmed posted; summarize in chat; post the PR status comment (see § PR status comment); record `BLOCKED-REVIEW`; stop this PR — do not run Phase 2/3. |
+| style, simplification, efficiency, reuse-only | **Non-blocking.** Note in chat, continue to Phase 2 regardless. |
+
+No findings at all → continue to Phase 2.
 
 ### Phase 2 — Identify affected workflows
 

--- a/.claude/skills/merge-gate/SKILL.md
+++ b/.claude/skills/merge-gate/SKILL.md
@@ -104,10 +104,14 @@ silently truncates past ~30 comments, which would make a real PR with
 substantial CodeRabbit + human discussion look falsely under-verified (or
 mask a genuinely missing finding sitting past the cutoff):
 
+`gh api --jq` only accepts one filter-string argument — piping `--arg` and
+its value straight after it fails with `accepts 1 arg(s), received 4`.
+Pipe to a standalone `jq` instead:
+
 ```bash
 me=$(gh api user --jq '.login')
-gh api --paginate repos/hmislk/hmis/pulls/<PR>/comments \
-  --jq --arg me "$me" '.[] | select(.user.login == $me) | "\(.path):\(.line)"'
+gh api --paginate repos/hmislk/hmis/pulls/<PR>/comments | \
+  jq --arg me "$me" '.[] | select(.user.login == $me) | "\(.path):\(.line)"'
 ```
 
 Cross-check this list against the findings returned. For any finding

--- a/.claude/skills/merge-gate/SKILL.md
+++ b/.claude/skills/merge-gate/SKILL.md
@@ -84,6 +84,55 @@ Classify the findings it returns:
 
 No findings at all → continue to Phase 2.
 
+#### Fallback — verify every blocking finding actually landed as a comment
+
+`code-review --comment` posts via GitHub's PR-review-comment API, which can
+only anchor a comment on a line that appears in **this PR's own diff**. A
+finding whose defect lives in a file the PR doesn't touch (e.g. a downstream
+method the new code merely *calls*) has nowhere to anchor — and can be
+silently dropped instead of posted, with no error surfaced back. Confirmed
+happening in practice (PR #23082, 2026-08-22: two blocking findings were
+returned by the sub-agent as "posted" but never actually appeared on the
+PR, because one lived in a file outside the diff and the anchor silently
+failed).
+
+Before trusting the sub-agent's "posted successfully" claim, verify for
+every finding classified as blocking:
+
+```bash
+gh api repos/hmislk/hmis/pulls/<PR>/comments \
+  --jq '.[] | select(.user.login != "coderabbitai[bot]") | "\(.path):\(.line)"'
+```
+
+Cross-check this list against the findings returned. For any blocking
+finding missing from it:
+
+1. Check whether its file is part of the PR's diff at all:
+   `gh pr diff <PR> --name-only`.
+2. **File is in the diff, but the exact line isn't inside a commentable
+   hunk** (GitHub only allows anchoring within a hunk's context window —
+   posting will fail with `"could not be resolved"`): get the real hunk
+   boundaries with `gh api repos/hmislk/hmis/pulls/<PR>/files --jq
+   '.[] | select(.filename=="<path>") | .patch'` and anchor on the nearest
+   line that's actually inside it instead.
+3. **File isn't in the diff at all**: anchor the comment on the *calling*
+   line in a file that IS in the diff (typically the new code that invokes
+   the problematic downstream method) and cite the true file:line of the
+   actual defect explicitly in the comment body text, since the anchor
+   line is just the closest available hook, not the defect's real
+   location.
+4. **No related diff line exists at all**: don't force a mis-anchored
+   comment. Fold the finding into the top-level PR status comment instead
+   (see § PR status comment) — that comment isn't line-anchored, so it can
+   reference any file/line freely.
+
+Post any recovered findings with `gh api repos/hmislk/hmis/pulls/<PR>/comments
+-f commit_id=<head-sha> -f path=<path> -F line=<n> -f side=RIGHT -f
+body=<text>` (head SHA from `gh pr view <PR> --json commits -q
+'.commits[-1].oid'`). Re-run the verification query once more before moving
+on — don't proceed to Phase 2 on an unconfirmed assumption that everything
+posted.
+
 ### Phase 2 — Identify affected workflows
 
 ```bash

--- a/.claude/skills/merge-gate/SKILL.md
+++ b/.claude/skills/merge-gate/SKILL.md
@@ -97,11 +97,18 @@ PR, because one lived in a file outside the diff and the anchor silently
 failed).
 
 Before trusting the sub-agent's "posted successfully" claim, verify for
-every finding classified as blocking:
+every finding classified as blocking. Get the actual poster identity first
+(don't hardcode a username or just exclude `coderabbitai[bot]` — an
+unrelated human/bot comment at the same path:line would then be
+misread as confirmation), and **always paginate** — the default page size
+silently truncates past ~30 comments, which would make a real PR with
+substantial CodeRabbit + human discussion look falsely under-verified (or
+mask a genuinely missing finding sitting past the cutoff):
 
 ```bash
-gh api repos/hmislk/hmis/pulls/<PR>/comments \
-  --jq '.[] | select(.user.login != "coderabbitai[bot]") | "\(.path):\(.line)"'
+me=$(gh api user --jq '.login')
+gh api --paginate repos/hmislk/hmis/pulls/<PR>/comments \
+  --jq --arg me "$me" '.[] | select(.user.login == $me) | "\(.path):\(.line)"'
 ```
 
 Cross-check this list against the findings returned. For any blocking
@@ -158,10 +165,11 @@ $env:JAVA_HOME="C:\Program Files\Eclipse Adoptium\jdk-11.0.23.9-hotspot"
 
 Check the server log for deployment errors before proceeding. **If `mvn
 clean package` fails, `asadmin redeploy` fails, or the server log shows
-deployment errors, stop this PR here**: capture the failure output, post
-the PR status comment (see § PR status comment) with that output, record
-`BLOCKED-BUILD`, and move to the next PR — don't attempt Phase 3 against a
-stale or undeployed build.
+deployment errors, stop this PR here**: capture the failure output, redact
+it of credentials/connection strings/hostnames (same rule as § Phase 3's
+evidence redaction), post the PR status comment (see § PR status comment)
+with the redacted excerpt, record `BLOCKED-BUILD`, and move to the next
+PR — don't attempt Phase 3 against a stale or undeployed build.
 
 ### Phase 3 — End-to-end verification
 
@@ -222,7 +230,7 @@ Use an outcome-specific template so a PR author or a merger who wasn't in
 this session gets enough context without opening the chat transcript:
 
 **`PASSED`:**
-```
+```markdown
 ## 🚦 Merge Gate: PASSED
 
 **Tested:**
@@ -233,35 +241,48 @@ this session gets enough context without opening the chat transcript:
 Ready for final human review and merge.
 ```
 
-**`BLOCKED-CI`:**
-```
-## 🚦 Merge Gate: BLOCKED — CI failing
+**`BLOCKED-CI`:** covers both an explicit check failure and a check that
+never went green after the recheck — use wording that fits either.
+```markdown
+## 🚦 Merge Gate: BLOCKED — CI not passing
 
-Check `<check name>` failed: <run URL>. Merge-gate stopped before the
+CI did not reach a passing state: <failed check name and run URL, or
+"still pending after the ~270s recheck">. Merge-gate stopped before the
 code review pass.
 ```
 
 **`BLOCKED-REVIEW`:** keep this one short — the inline `--comment` findings
-from Phase 1 already carry the detail.
-```
-## 🚦 Merge Gate: BLOCKED — code review found regressions
+from Phase 1 already carry the detail. Covers correctness, regression, AND
+business-rule-violation findings, not just regressions — say "blocking
+findings," not "regressions."
+```markdown
+## 🚦 Merge Gate: BLOCKED — blocking code-review findings
 
 See the inline comments above for specifics. Merge-gate stopped here;
 Phase 2/3 (build, E2E, baselines) did not run.
 ```
 
-**`BLOCKED-BUILD`:**
-```
+**`BLOCKED-BUILD`:** redact the failure output the same way as the E2E
+evidence rule below — Maven/Payara/asadmin output can contain JDBC
+connection strings, JNDI names, hostnames, or other values CLAUDE.md's
+credentials rule forbids ever leaving the machine. Redact before this
+excerpt goes anywhere near `gh pr comment`, and cap its length.
+```markdown
 ## 🚦 Merge Gate: BLOCKED — build/deploy failed
 
-<relevant tail of the compile or asadmin failure output>
+<relevant tail of the compile or asadmin failure output, redacted of
+credentials, connection strings, hostnames, and other sensitive values>
 
 Merge-gate could not verify this PR end-to-end because the build/deploy
 step itself failed.
 ```
 
-**`BLOCKED-E2E`:**
-```
+**`BLOCKED-E2E`:** the description below is inline, redacted prose — **not**
+a link or attachment. Raw evidence (screenshots, DB output) stays local in
+`tmp/` and is never uploaded anywhere; there's no attachment mechanism in
+this workflow. Don't imply otherwise in the Final report either (see
+§ Final report).
+```markdown
 ## 🚦 Merge Gate: BLOCKED — end-to-end verification found a bug
 
 **Failed:** <PR workflow name, or "Baseline A: COGS variance", or
@@ -282,14 +303,17 @@ After all PRs are processed, print a table:
 |---|---|---|---|
 
 Outcome is one of `PASSED`, `BLOCKED-CI`, `BLOCKED-REVIEW`, `BLOCKED-BUILD`,
-`BLOCKED-E2E`. For every `PASSED` row, say it's ready for the user's final
-review and merge. For blocked rows, link the PR status comment (which
-itself links the Phase 1 inline comments, the build/deploy failure output,
-or the Phase 3 evidence, depending on where it stopped). Every PR should
-already have its status comment posted per § PR status comment by the time
-this table prints — the table is a summary for this chat, the comment is
-the durable record on GitHub. Never merge, approve, or request changes on
-the user's behalf.
+`BLOCKED-E2E`. Every row's `Notes/links` cell — PASSED included — should
+include the URL of that PR's status comment (see § PR status comment); this
+is the durable GitHub record, the table itself is just a summary for this
+chat. For every `PASSED` row, additionally say it's ready for the user's
+final review and merge. For blocked rows, the status comment itself points
+to whatever's relevant: the Phase 1 inline comments, the (redacted)
+build/deploy failure excerpt, or a redacted description of the Phase 3
+failure — evidence never leaves `tmp/` as a link or attachment, only as
+inline redacted prose (see § PR status comment). Every PR should already
+have its status comment posted by the time this table prints. Never merge,
+approve, or request changes on the user's behalf.
 
 ## Hygiene
 

--- a/developer_docs/git/2026-08-22-merge-gate-skill-design.md
+++ b/developer_docs/git/2026-08-22-merge-gate-skill-design.md
@@ -190,6 +190,27 @@ outcome, not review opinion. If merge-gate is re-run on the same PR later,
 it posts a new comment rather than editing the old one, so the run history
 stays visible. Full templates: see the skill file's § PR status comment.
 
+## Addendum (2026-08-23) — missing-comment fallback
+
+Posting the PR status comments (previous addendum) surfaced a second bug:
+PR #23082's two blocking findings from the original run had never actually
+been posted, despite the sub-agent reporting them as posted. Root cause:
+GitHub's PR-review-comment API can only anchor a comment on a line inside
+the PR's own diff; one finding's defect lived in a file (`ChannelService.java`)
+that PR #23082 doesn't touch — it's only *called* by the new code — so the
+anchor had nowhere to attach and silently failed with no error surfaced
+back to the caller.
+
+Added a verification step to Phase 1: after `code-review --comment` runs,
+cross-check the findings it returned against what's actually present via
+`gh api .../pulls/<PR>/comments`, rather than trusting the "posted
+successfully" claim at face value. For anything missing, a documented
+fallback: anchor on the nearest related line that IS in the diff (usually
+the calling line) and cite the real file:line in the comment body text; if
+no related diff line exists at all, fold the finding into the top-level PR
+status comment instead, since that one isn't line-anchored. Full steps:
+see the skill file's § Fallback (under Phase 1).
+
 ## Hygiene
 
 - `persistence.xml` discarded and restored to local JNDI around each PR's

--- a/developer_docs/git/2026-08-22-merge-gate-skill-design.md
+++ b/developer_docs/git/2026-08-22-merge-gate-skill-design.md
@@ -211,6 +211,22 @@ no related diff line exists at all, fold the finding into the top-level PR
 status comment instead, since that one isn't line-anchored. Full steps:
 see the skill file's § Fallback (under Phase 1).
 
+CodeRabbit's own review of that addition caught a real ordering bug: the
+Fallback section was written *after* the classification table's "record
+`BLOCKED-REVIEW`; stop this PR" instruction, so a linear read could stop
+the PR before ever running the verification meant to catch a silent drop
+— defeating the point. Reordered so the Fallback runs immediately after
+invoking `code-review --comment` and *before* classification; classifying
+now happens once every returned finding is confirmed actually posted (or
+folded into the status comment). Also incorporated CodeRabbit's other 6
+findings on the same review pass: markdown-tagged all 5 status-comment
+template fences, made BLOCKED-CI/BLOCKED-REVIEW wording cover their full
+trigger range, redacted the BLOCKED-BUILD failure excerpt the same way as
+E2E evidence, corrected BLOCKED-E2E to not overclaim a link/attachment
+exists (it's inline redacted prose — building real attachment support was
+discussed and deliberately deferred), and required the status-comment URL
+in every Final report row, not just blocked ones.
+
 ## Hygiene
 
 - `persistence.xml` discarded and restored to local JNDI around each PR's

--- a/developer_docs/git/2026-08-22-merge-gate-skill-design.md
+++ b/developer_docs/git/2026-08-22-merge-gate-skill-design.md
@@ -172,6 +172,24 @@ PRs: "ready for your final review to merge." The skill never merges or
 approves — that's always the user's call, matching every other skill's
 convention (`dev-issue` §15, `review-pr`).
 
+## Addendum (2026-08-23) — PR status comments
+
+The first real run (PRs #23214, #23082, #23073, #22929, #22841) exposed a
+gap: only Phase 1's `code-review --comment` left any trace on GitHub.
+`PASSED` PRs and `BLOCKED-CI`/`BLOCKED-BUILD`/`BLOCKED-E2E` outcomes were
+invisible outside the chat session that ran them — a PR author or a
+different merger had no way to see the gate ran at all.
+
+Decision: post exactly one top-level PR comment per PR per run, at the
+terminal state (whichever outcome that is), with an outcome-specific
+template. This is a deliberate, discussed exception to the project's
+general "no top-level PR comments, reply in threads only" rule (see the
+`feedback_pr_review_comments` memory) — that rule governs responding to
+*existing* reviewer feedback; this is the gate reporting its own factual
+outcome, not review opinion. If merge-gate is re-run on the same PR later,
+it posts a new comment rather than editing the old one, so the run history
+stays visible. Full templates: see the skill file's § PR status comment.
+
 ## Hygiene
 
 - `persistence.xml` discarded and restored to local JNDI around each PR's


### PR DESCRIPTION
## Summary
Real usage of `/merge-gate` on PRs #23214, #23082, #23073, #22929, #22841 exposed a gap: only Phase 1's `code-review --comment` left any trace on GitHub. `PASSED` PRs and `BLOCKED-CI`/`BLOCKED-BUILD`/`BLOCKED-E2E` outcomes were invisible outside the chat session that ran the gate — a PR author or a different merger had no way to see the gate ran at all, let alone what it found.

## Changes
- New **§ PR status comment**: `/merge-gate` posts exactly one top-level `gh pr comment` per PR per run, at whatever terminal state that PR's pipeline reaches.
- Outcome-specific comment templates for `PASSED`, `BLOCKED-CI`, `BLOCKED-REVIEW`, `BLOCKED-BUILD`, `BLOCKED-E2E`.
- Documented as a deliberate, discussed exception to the project's "reply-only, no top-level PR comments" rule — merge-gate is reporting its own factual outcome, not review opinion needing threading.
- Re-running the gate on the same PR posts a *new* comment rather than editing the old one, so the run history stays visible.
- Updated `developer_docs/git/2026-08-22-merge-gate-skill-design.md` with an addendum explaining the decision.

## Discussed & decided with user (2026-08-22)
1. Carve out the top-level-comment exception — yes.
2. Granularity — one summary comment at the terminal state (not per-stage, to avoid spamming a multi-PR batch).
3. A "known local environment quirks" doc (audit JNDI name, patient-required config, OPD referral requirement, COGS report timing) was discussed but deferred as a separate follow-up.

Not code — JSF/skill/docs-only change, no compilation needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Merge-gate checks now post clear top-level status comments for passed or blocked validations.
  * Status comments summarize CI, review, build/deployment, and end-to-end outcomes.
  * Each rerun posts a new status comment while preserving prior results.
  * Review findings are verified, with missing findings automatically recovered or included in the overall status.
  * Build and end-to-end failures include appropriately redacted evidence, and final reports link to the relevant status comment.

* **Documentation**
  * Documented status-comment behavior, fallback handling, evidence redaction, and required permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->