### PR TITLE
Fix: remove duplicate Service Name column showing raw entity in Timed Service Detail

### DIFF
--- a/src/main/webapp/inward/inward_bill_intrim_finalized.xhtml
+++ b/src/main/webapp/inward/inward_bill_intrim_finalized.xhtml
@@ -314,13 +314,6 @@
                                     </f:facet>
                                     <h:outputLabel value="#{pt.item.name}"/>
                                 </p:column>
-                                <p:column headerText="Service Name">
-
-                                    <f:facet name="header">
-                                        <h:outputLabel value="Service Name"/>
-                                    </f:facet>
-                                    <h:outputLabel value="#{pt}"/>
-                                </p:column>
                                 <p:column headerText="Start Time">
                                     <f:facet name="header">
                                         <h:outputLabel value="Start Time"/>


### PR DESCRIPTION
## Summary
- Removes the leftover debugging column in the Timed Service Detail tab on the Inward Payment Bill (finalized) page (`inward_bill_intrim_finalized.xhtml`) that duplicated the "Service Name" header but bound to the loop variable itself (`#{pt}`) instead of `#{pt.item.name}`, printing raw text like `com.divudi.core.entity.PatientItem[ id=7 ]` in the UI and in the tab's Excel export.
- The correct `Service Name` column (bound to `#{pt.item.name}`) is left unchanged, along with all other columns (Start Time, Stopped Time, Total, Discount, Net Total, Added User, Inward Charge Type).
- Only `inward_bill_intrim_finalized.xhtml` was affected — the sibling pages (`inward_bill_intrim.xhtml`, `inward_bill_intrim_estimate.xhtml`, `inward_bill_intrim_finalized_error_correction.xhtml`) already render the table correctly without the extra column.

## Test plan
- [x] Confirmed the removed block was the exact duplicate column described in the issue (verified line numbers and content against `origin/development` before editing).
- [x] JSF/XHTML-only change with no compilation or persistence changes, per project convention for this class of fix.
- [ ] Manual verification in a running environment: open Inward → Inward Payment Bill for a BHT with timed services, confirm the Timed Service Detail tab shows a single Service Name column, and that Export Excel no longer contains `com.divudi.core.entity...` text.

Closes #23235


---
_Generated by [Claude Code](https://claude.ai/code/session_01KbNMCjQo86mU3Cr4S76eup)_