### PR TITLE
fix(inward): make Department optional in Inward Discount Matrix – Pharmacy

### DIFF
--- a/src/main/java/com/divudi/bean/common/PriceMatrixController.java
+++ b/src/main/java/com/divudi/bean/common/PriceMatrixController.java
@@ -1735,6 +1735,18 @@ public class PriceMatrixController implements Serializable {
      * a.inwardChargeType IS NULL to keep service/pharmacy rows isolated from
      * room-charge-type rows.
      */
+    /**
+     * NOTE (2026-08, issue #23220): this JPQL calculation path filters
+     * `department` as an exact match only — unlike paymentMethod/admissionType
+     * in this same query, it does NOT wildcard-match rows where the matrix
+     * entry's department is null. This is a known gap, tracked separately in
+     * issue #23237 (https://github.com/hmislk/hmis/issues/23237). It is
+     * intentionally NOT fixed here: the equivalent native-SQL calculation path
+     * (PriceMatrixNativeSqlService.fetchDiscountPct), which is what inpatient
+     * pharmacy issuing actually uses in production, received the fix instead.
+     * This JPQL path is considered legacy/soon-to-be-superseded and should not
+     * be extended further — see #23237 before making changes here.
+     */
     private Double fetchInwardDiscountMatrixPercentCore(PaymentMethod bhtType, PaymentScheme scheme,
             AdmissionType admissionType, Department department, Category category, Item item,
             InwardChargeType chargeType, boolean chargeTypeSpecific, Institution creditCompany) {

--- a/src/main/java/com/divudi/bean/inward/InwardDiscountMatrixController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardDiscountMatrixController.java
@@ -119,11 +119,6 @@ public class InwardDiscountMatrixController implements Serializable {
             return;
         }
 
-        if (department == null) {
-            JsfUtil.addErrorMessage("Please select a Department");
-            return;
-        }
-
         if (category == null) {
             JsfUtil.addErrorMessage("Please select a category");
             return;
@@ -190,13 +185,16 @@ public class InwardDiscountMatrixController implements Serializable {
         filterItems = null;
         HashMap<String, Object> hm = new HashMap<>();
         String sql = "select a from InwardDiscountMatrix a"
+                + " left join a.paymentScheme ps"
+                + " left join a.department dept"
+                + " left join a.category cat"
                 + " where a.retired = false"
                 + " and a.inwardChargeType is null"
                 + " and (type(a.category) = :svc"
                 + "   or type(a.category) = :sub"
                 + "   or type(a.category) = :inv"
                 + "   or a.category is null)"
-                + " order by a.paymentScheme.name, a.department.name, a.category.name";
+                + " order by ps.name, dept.name, cat.name";
         hm.put("svc", ServiceCategory.class);
         hm.put("sub", ServiceSubCategory.class);
         hm.put("inv", InvestigationCategory.class);
@@ -207,11 +205,14 @@ public class InwardDiscountMatrixController implements Serializable {
         filterItems = null;
         HashMap<String, Object> hm = new HashMap<>();
         String sql = "select a from InwardDiscountMatrix a"
+                + " left join a.paymentScheme ps"
+                + " left join a.department dept"
+                + " left join a.category cat"
                 + " where a.retired = false"
                 + " and a.inwardChargeType is null"
                 + " and (type(a.category) = :pharm"
                 + "   or a.category is null)"
-                + " order by a.paymentScheme.name, a.department.name, a.category.name";
+                + " order by ps.name, dept.name, cat.name";
         hm.put("pharm", PharmaceuticalItemCategory.class);
         items = ejbFacade.findByJpql(sql, hm);
     }

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
@@ -72,6 +72,7 @@ import com.divudi.core.facade.PharmaceuticalBillItemFacade;
 import com.divudi.core.facade.StockFacade;
 import com.divudi.core.facade.StockHistoryFacade;
 import com.divudi.service.pharmacy.DirectIssueBatchService;
+import com.divudi.service.pharmacy.PriceMatrixNativeSqlService;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -235,6 +236,8 @@ public class PharmacySaleBhtController implements Serializable {
     BillService billService;
     @EJB
     private PharmacyService pharmacyService;
+    @EJB
+    private PriceMatrixNativeSqlService priceMatrixNativeSqlService;
 
     @Inject
     ConfigOptionApplicationController configOptionApplicationController;
@@ -2294,6 +2297,7 @@ public class PharmacySaleBhtController implements Serializable {
         double total = 0;
         double netTotal = 0;
         double marginTotal = 0;
+        double discountTotal = 0;
         PatientEncounter encounter = bill != null ? bill.getPatientEncounter() : null;
         for (BillItem bi : billItems) {
 
@@ -2313,18 +2317,52 @@ public class PharmacySaleBhtController implements Serializable {
 
             bi.setMarginValue(margin);
 
-            bi.setNetValue(bi.getGrossValue() + bi.getMarginValue());
+            // Inward discount-matrix application (issue #23220 — previously
+            // this flow applied margin only and never looked up a discount).
+            // BillItem (the entity) has no discountPercent/discountValue
+            // fields — those exist only on BillItemData, the DTO used by
+            // InpatientDirectIssueNativeSqlController. This flow stores the
+            // discount as a currency amount in the existing `discount`
+            // field, matching the sign convention already used by
+            // PharmacyPreSettleController.calTotal()/settle() and
+            // BhtIssueReturnController/IssueReturnController elsewhere in
+            // this codebase: netValue = grossValue [+ marginValue] - discount.
+            double discountValue = 0.0;
+            try {
+                Item item = bi.getItem();
+                if (item != null && matrixDepartment != null && priceMatrixNativeSqlService.isDiscountAllowed(item.getId())) {
+                    Long schemeId = encounter != null && encounter.getPaymentScheme() != null ? encounter.getPaymentScheme().getId() : null;
+                    Long admTypeId = encounter != null && encounter.getAdmissionType() != null ? encounter.getAdmissionType().getId() : null;
+                    String pmName = paymentMethod != null ? paymentMethod.name() : null;
+                    double discountPct = priceMatrixNativeSqlService.getInwardDiscountPct(item.getId(), pmName, schemeId, admTypeId, matrixDepartment.getId());
+                    // Gross value in this flow is stored positive (see the
+                    // margin calculation above, which ADDS to netValue), so
+                    // the discount amount is likewise computed and applied
+                    // as a positive currency value subtracted from netValue.
+                    discountValue = (discountPct / 100.0) * Math.abs(bi.getGrossValue());
+                }
+            } catch (Exception e) {
+                LOGGER.log(Level.WARNING, "[updateMargin] inward discount lookup failed for billItem id={0}", bi.getId());
+            }
+            bi.setDiscount(discountValue);
+
+            bi.setNetValue(bi.getGrossValue() + bi.getMarginValue() - bi.getDiscount());
             bi.setAdjustedValue(bi.getNetValue());
             getBillItemFacade().edit(bi);
 
             total += bi.getGrossValue();
             netTotal += bi.getNetValue();
             marginTotal += bi.getMarginValue();
+            discountTotal += bi.getDiscount();
         }
 
         bill.setTotal(total);
         bill.setNetTotal(netTotal);
         bill.setMargin(marginTotal);
+        // Roll up the discount total onto the bill, matching the existing
+        // pattern used elsewhere in this file (see calTotal(), ~line 2491,
+        // and PharmacyPreSettleController.calTotal()).
+        bill.setDiscount(discountTotal);
         getBillFacade().edit(bill);
 
     }

--- a/src/main/java/com/divudi/service/pharmacy/PriceMatrixNativeSqlService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PriceMatrixNativeSqlService.java
@@ -217,7 +217,7 @@ public class PriceMatrixNativeSqlService {
             sql.append(" AND paymentScheme_ID IS NULL");
         }
         if (deptId != null) {
-            sql.append(" AND department_ID=?");
+            sql.append(" AND (department_ID=? OR department_ID IS NULL)");
         } else {
             sql.append(" AND department_ID IS NULL");
         }

--- a/src/main/java/com/divudi/ws/inward/InwardDiscountMatrixApi.java
+++ b/src/main/java/com/divudi/ws/inward/InwardDiscountMatrixApi.java
@@ -135,7 +135,9 @@ public class InwardDiscountMatrixApi {
             }
 
             StringBuilder jpql = new StringBuilder(
-                    "select a from InwardDiscountMatrix a where a.retired = false");
+                    "select a from InwardDiscountMatrix a"
+                    + " left join a.paymentScheme ps left join a.department dept left join a.category cat"
+                    + " where a.retired = false");
             Map<String, Object> params = new HashMap<>();
 
             if ("service".equals(scope)) {
@@ -178,7 +180,7 @@ public class InwardDiscountMatrixApi {
                 params.put("ccid", creditCompanyId);
             }
 
-            jpql.append(" order by a.paymentScheme.name, a.department.name, a.category.name");
+            jpql.append(" order by ps.name, dept.name, cat.name");
 
             List<PriceMatrix> rows = priceMatrixFacade.findByJpql(jpql.toString(), params, limit);
             List<Map<String, Object>> payload = new ArrayList<>();


### PR DESCRIPTION
## What this does

Closes #23220. Makes **Department** optional when configuring the **Inward Discount Matrix – Pharmacy**, and — the part the issue actually needed — makes a department-less row genuinely **apply to any department** at calculation time, which it did not before even where the schema already allowed a null department.

## Investigation summary

- **Only one place** enforced Department as mandatory: `InwardDiscountMatrixController.saveForPharmacy()`. The entity (`PriceMatrix.department`) was already nullable, and the REST API (`InwardDiscountMatrixApi.create()`/`update()`) already treated `departmentId` as fully optional both ways.
- **Real gap**: the discount-calculation core filtered `department` as an exact match only when a real department was supplied — unlike `paymentMethod`/`admissionType` in the same query, which already wildcard-match. A department-less matrix row could never actually match a real bill.
- **Latent bug found and fixed**: `loadPharmacy()`/`loadServiceInvestigation()` and the API's `list()` used an un-aliased path expression in `ORDER BY` (`order by a.department.name`), which JPA/EclipseLink resolves as an implicit **inner join** — silently dropping department-null rows from both the management table and the API listing, exactly the rows this issue is about to make common.
- **Scope expansion, discussed and approved**: inpatients get pharmacy items two ways — Direct Issue (already used the native-SQL calculation path) and **Issue for Requests** (ward-dispensing). Investigation found Issue for Requests applied **zero** inward discount at all (margin only). Wired in real discount-matrix application to that flow too, in this PR.

## Changes

- `InwardDiscountMatrixController.saveForPharmacy()` — removed the mandatory-department guard.
- `PriceMatrixNativeSqlService.fetchDiscountPct()` — department now wildcard-matches (`department_ID=? OR department_ID IS NULL`) the same way paymentMethod/admissionType already do. This is the native-SQL path Direct Issue actually uses in production. A department-specific row still outranks a wildcard row via the existing `ORDER BY` tie-break.
- `InwardDiscountMatrixController.loadPharmacy()` / `loadServiceInvestigation()` and `InwardDiscountMatrixApi.list()` — rewritten with explicit `LEFT JOIN`s so department-null (and scheme/category-null) rows aren't silently excluded.
- `PharmacySaleBhtController.updateMargin()` — wired in discount-matrix application to "Issue for Requests", reusing the same native-SQL lookup as Direct Issue, respecting this flow's own sign convention (`BillItem.discount` currency field, not the `discountPercent`/`discountValue` DTO fields Direct Issue uses).
- `PriceMatrixController.fetchInwardDiscountMatrixPercentCore()` — added a comment marking this parallel JPQL calculation path as having the same gap, intentionally **not** fixed here (deferred to #23237) since the native-SQL path is what actually matters for live billing.

## Out of scope / follow-up

- #23237 tracks the deferred JPQL-path fix (`PriceMatrixController`), for whoever still needs it once/if that path is confirmed to have live callers.

## Testing performed

Local Payara + Playwright + DB verification, department **Inward**, BHT/56755 ("Demo Test Patient"):

1. **Management UI**: created a Pharmacy discount matrix row (Staff scheme, Tablet category, 15%, no Department) — save succeeded and the row is visible in the list (proves both the validation removal and the `loadPharmacy()` left-join fix).

   ![Discount matrix row saved with no Department](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23220-discount-matrix-no-department.png)

2. **Direct Issue**: issued "Metrogyl 200mg tablet" against BHT/56755 (real department = Inward). The department-less rule correctly applied — 15% discount computed and persisted.

   ![Direct Issue applying the department-wildcard discount](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23220-direct-issue-wildcard-discount.png)

   DB: `BILL.DISCOUNT=3.612`, `NETTOTAL=29.8592` (Gross 24.08, Margin 9.39).

3. **Issue for Requests**: same rule, same item, same BHT, via the ward-request → dispense flow (`ward_pharmacy_bht_issue.xhtml`). This flow previously applied **zero** discount always — after the fix, discount is applied end-to-end.

   DB: `BILL.DISCOUNT=3.612`, `NETTOTAL=30.8224`, `MARGIN=10.3544`.

4. **API**: `GET /api/inward-discount-matrix?scope=pharmacy` correctly lists the department-null row (confirms the `list()` left-join fix).

Full investigation notes and checklist: `tmp/23220-inward-discount-matrix-department-optional-master-plan.md` on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)