### PR TITLE
fix(inward): block Nursing Discharge when pharmacy items are pending ward receipt (#23222)

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -2013,20 +2013,28 @@ window.setTimeout = function (fn, delay) { return delay >= 2500 ? 0 : window.__o
 The real growl then stays rendered for the screenshot (nothing about the message is faked — only the dismissal is
 deferred). Reload the page afterwards to drop the patch. Verified while testing issue #23206.
 
-## Icon-only PrimeFaces buttons: a raw DOM `.click()` does nothing
+## Some PrimeFaces buttons need a jQuery-triggered click
 
-On Inward pages (`inpatient_search.xhtml`, `admission_profile.xhtml`) the row-action buttons are
-`ui-button-icon-only` and carry **no `onclick` attribute** — PrimeFaces binds the submit handler through
-jQuery instead. A plain `element.click()` (and Playwright's own click, when the ref resolves to the inner
-icon) fires the DOM event without triggering the jQuery-bound handler, so the form never submits and the
-page silently stays put — no error, no server log entry. Trigger the jQuery handler explicitly:
+Most `p:commandButton`s submit fine with a normal Playwright click — including
+`ajax="false"` text-valued buttons such as `form:btnNursingDischarge` on
+`admission_profile.xhtml`, which navigate correctly on a plain
+`page.locator('#form\:btnNursingDischarge').click()`.
+
+The exception is **icon-only row controls** inside a `p:dataTable` (e.g. the
+`ui-button-icon-only` action buttons on `inpatient_search.xhtml`, which render with
+no `value` and no `onclick`). There, PrimeFaces binds the handler through jQuery and a
+raw `element.click()` from inside `browser_evaluate` can fire the DOM event without
+invoking it — the form never submits and the page silently stays put, with no error and
+no server-log entry. Fall back to triggering the jQuery handler for those:
 
 ```js
-window.jQuery(document.getElementById('form:btnNursingDischarge')).trigger('click');
+window.jQuery(document.getElementById('form:tblBills:0:j_idt638')).trigger('click');
 ```
 
-Inspect `$._data(el, 'events')` first if unsure — the absence of a `click` key alongside `mousedown`/`mouseup`
-is the tell. Verified while testing issue #23222.
+Inspect `$._data(el, 'events')` if unsure — the absence of a `click` key alongside
+`mousedown`/`mouseup` is the tell. Either way, **assert the outcome** (URL change, or the
+expected element on the destination page) rather than assuming the click worked.
+Verified while testing issue #23222.
 
 ## A local "Unknown column" 500 is schema drift — use the app's own migration page
 
@@ -2037,22 +2045,43 @@ navigate to `/faces/mf.xhtml` and click **Load Latest DDL from Wiki and Update B
 than hand-writing `ALTER TABLE`. Re-check the column with `SHOW COLUMNS` before resuming the test.
 Verified while testing issue #23222.
 
-## Prove a server-side guard, not just a disabled button
+## An unchanged database does NOT prove a server-side guard ran
 
-When a fix disables a button via `disabled="#{bean.someCheck()}"`, the disabled attribute alone is weak
-evidence — it proves the UI hint, not the guard that actually protects production. Strip it and submit
-anyway, then assert in the DB that nothing changed:
+When a fix disables a button via `disabled="#{bean.someCheck()}"`, it is tempting to strip the
+attribute, submit, observe the DB unchanged, and call the server-side guard proven. **That
+inference is invalid** — and on JSF it is usually wrong.
+
+JSF **skips the action of a component it rendered as `disabled`**: the decode phase ignores the
+activation, so the action method is never invoked. The postback returns 200, the page re-renders,
+and the database is unchanged — identical to what a working guard looks like from the outside.
+Confirmed on `inward_nursing_discharge.xhtml`, whose Confirm button carries
+`disabled="#{nursingDischargeController.hasPendingPharmacyItems()}"`: re-POSTing the form produced
+`msgs:[]` (no growl message at all), proving `confirmNursingDischarge()` never ran.
+
+So before asserting DB state, **assert the action executed** — the expected message is the cheapest
+signal. Re-POST the form and inspect the response body directly:
 
 ```js
-const b = document.getElementById('formX:btnConfirm');
-b.disabled = false; b.classList.remove('ui-state-disabled');
-window.confirm = () => true;              // bypass the JS confirm guard too
-window.jQuery(b).trigger('click');
+const fd = new FormData(document.getElementById('formNursingDischarge'));
+fd.set('formNursingDischarge:btnConfirmNursingDischarge', '');   // use the button's real (often empty) value
+const html = await (await fetch(location.href, {
+  method: 'POST', body: new URLSearchParams(fd),
+  headers: {'Content-Type': 'application/x-www-form-urlencoded'}
+})).text();
+// msgs:[...] populated => the action ran; msgs:[] => it did not
 ```
 
-Always pair this with the **negative test** — a record with nothing pending must still succeed — otherwise
-you have not distinguished "correctly blocks" from "blocks everything". Undo any state the negative test
-creates through the app's own Cancel action, never with an `UPDATE`. Verified while testing issue #23222.
+An `ajax="false"` button reloads the page, so a growl is usually gone before any screenshot or
+follow-up `browser_evaluate` — read it out of the raw response as above rather than from the DOM.
+
+To exercise a guard that is unreachable while the button renders disabled, recreate the **race it
+exists for**: load the page while the record is clean (button enabled), make the blocking condition
+true, then submit the stale page.
+
+Always pair this with the **negative test** — a record with nothing pending must still succeed —
+otherwise you have not distinguished "correctly blocks" from "blocks everything". Undo any state the
+negative test creates through the app's own Cancel action, never with an `UPDATE`.
+Verified while testing issue #23222.
 
 ## Quick checklist
 
@@ -2071,6 +2100,6 @@ creates through the app's own Cancel action, never with an `UPDATE`. Verified wh
       clicks and closed dialogs via `.ui-dialog-titlebar-close`, not `Escape`.
 - [ ] Re-logged in and re-selected department after any redeploy before continuing.
 - [ ] If test data is unavailable, **generated it through the app** (create purchase → return → etc.) rather than falling back to code-only checks.
-- [ ] For icon-only PrimeFaces buttons, triggered the jQuery handler (`$(el).trigger('click')`) rather than a raw DOM `.click()`.
+- [ ] Asserted the outcome of every click (URL/destination element); for icon-only datatable row buttons that silently no-op, fell back to `$(el).trigger('click')`.
 - [ ] Resolved any local "Unknown column" 500 via the app's own `/faces/mf.xhtml` migration page, not hand-written DDL.
-- [ ] For a guard fix: bypassed the disabled button and confirmed the **server-side** rejection in the DB, and ran the negative test (clean record still succeeds), reverting it through the app.
+- [ ] For a guard fix: asserted the **action actually executed** (expected message in the response) before treating unchanged DB state as proof — a JSF-disabled button skips its action entirely — and ran the negative test (clean record still succeeds), reverting it through the app.

--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -2013,6 +2013,47 @@ window.setTimeout = function (fn, delay) { return delay >= 2500 ? 0 : window.__o
 The real growl then stays rendered for the screenshot (nothing about the message is faked — only the dismissal is
 deferred). Reload the page afterwards to drop the patch. Verified while testing issue #23206.
 
+## Icon-only PrimeFaces buttons: a raw DOM `.click()` does nothing
+
+On Inward pages (`inpatient_search.xhtml`, `admission_profile.xhtml`) the row-action buttons are
+`ui-button-icon-only` and carry **no `onclick` attribute** — PrimeFaces binds the submit handler through
+jQuery instead. A plain `element.click()` (and Playwright's own click, when the ref resolves to the inner
+icon) fires the DOM event without triggering the jQuery-bound handler, so the form never submits and the
+page silently stays put — no error, no server log entry. Trigger the jQuery handler explicitly:
+
+```js
+window.jQuery(document.getElementById('form:btnNursingDischarge')).trigger('click');
+```
+
+Inspect `$._data(el, 'events')` first if unsure — the absence of a `click` key alongside `mousedown`/`mouseup`
+is the tell. Verified while testing issue #23222.
+
+## A local "Unknown column" 500 is schema drift — use the app's own migration page
+
+A restored/older local DB can lag the entity model (e.g. `Unknown column 'DURATIONUNIT' in 'field list'`
+loading a `TimedItemFee`), producing a 500 on pages that are otherwise unrelated to what you're testing.
+The login screen flags this as **"Database Migration Pending"**. Fix it through the app's own UI —
+navigate to `/faces/mf.xhtml` and click **Load Latest DDL from Wiki and Update Both Databases** — rather
+than hand-writing `ALTER TABLE`. Re-check the column with `SHOW COLUMNS` before resuming the test.
+Verified while testing issue #23222.
+
+## Prove a server-side guard, not just a disabled button
+
+When a fix disables a button via `disabled="#{bean.someCheck()}"`, the disabled attribute alone is weak
+evidence — it proves the UI hint, not the guard that actually protects production. Strip it and submit
+anyway, then assert in the DB that nothing changed:
+
+```js
+const b = document.getElementById('formX:btnConfirm');
+b.disabled = false; b.classList.remove('ui-state-disabled');
+window.confirm = () => true;              // bypass the JS confirm guard too
+window.jQuery(b).trigger('click');
+```
+
+Always pair this with the **negative test** — a record with nothing pending must still succeed — otherwise
+you have not distinguished "correctly blocks" from "blocks everything". Undo any state the negative test
+creates through the app's own Cancel action, never with an `UPDATE`. Verified while testing issue #23222.
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.
@@ -2030,3 +2071,6 @@ deferred). Reload the page afterwards to drop the patch. Verified while testing 
       clicks and closed dialogs via `.ui-dialog-titlebar-close`, not `Escape`.
 - [ ] Re-logged in and re-selected department after any redeploy before continuing.
 - [ ] If test data is unavailable, **generated it through the app** (create purchase → return → etc.) rather than falling back to code-only checks.
+- [ ] For icon-only PrimeFaces buttons, triggered the jQuery handler (`$(el).trigger('click')`) rather than a raw DOM `.click()`.
+- [ ] Resolved any local "Unknown column" 500 via the app's own `/faces/mf.xhtml` migration page, not hand-written DDL.
+- [ ] For a guard fix: bypassed the disabled button and confirmed the **server-side** rejection in the DB, and ran the negative test (clean record still succeeds), reverting it through the app.

--- a/src/main/java/com/divudi/bean/inward/NursingDischargeController.java
+++ b/src/main/java/com/divudi/bean/inward/NursingDischargeController.java
@@ -72,6 +72,18 @@ public class NursingDischargeController implements Serializable {
     // Pending pharmacy validation
     // -------------------------------------------------------------------------
 
+    /**
+     * Rebuilds the list of pharmacy transactions that block nursing discharge.
+     * <p>
+     * Every query below uses explicit {@code LEFT JOIN}s for {@code creater} and
+     * {@code toDepartment} rather than implicit path navigation
+     * ({@code b.toDepartment.name}). Implicit navigation through a nullable
+     * relationship generates an INNER JOIN, which silently drops every row whose
+     * FK is NULL - and {@code PharmacySaleBhtController.savePreBillFinally()}
+     * explicitly sets {@code toDepartment = null} on inward issue bills. That made
+     * the whole pending check return an empty list, so nursing discharge went
+     * through with medicines still awaiting ward receipt (issue #23222).
+     */
     public void loadPendingPharmacyItems() {
         pendingPharmacyItems = new ArrayList<>();
         if (currentEncounter == null) {
@@ -85,8 +97,12 @@ public class NursingDischargeController implements Serializable {
 
     @SuppressWarnings("unchecked")
     private List<PendingPharmacyItemDTO> fetchPendingRequests() {
-        String jpql = "SELECT new com.divudi.core.data.dto.PendingPharmacyItemDTO(b.id, b.deptId, b.billDate, b.billTypeAtomic, b.creater.webUserPerson.name, b.toDepartment.name)"
+        String jpql = "SELECT new com.divudi.core.data.dto.PendingPharmacyItemDTO(b.id, b.deptId, b.billDate, b.billTypeAtomic,"
+                + " COALESCE(createrPerson.name, ''), COALESCE(toDept.name, ''))"
                 + " FROM Bill b"
+                + " LEFT JOIN b.creater creater"
+                + " LEFT JOIN creater.webUserPerson createrPerson"
+                + " LEFT JOIN b.toDepartment toDept"
                 + " WHERE b.patientEncounter = :pe"
                 + " AND b.billTypeAtomic = :bta"
                 + " AND b.cancelled = false"
@@ -100,8 +116,12 @@ public class NursingDischargeController implements Serializable {
 
     @SuppressWarnings("unchecked")
     private List<PendingPharmacyItemDTO> fetchUnacceptedIssues() {
-        String jpql = "SELECT new com.divudi.core.data.dto.PendingPharmacyItemDTO(b.id, b.deptId, b.billDate, b.billTypeAtomic, b.creater.webUserPerson.name, b.toDepartment.name)"
+        String jpql = "SELECT new com.divudi.core.data.dto.PendingPharmacyItemDTO(b.id, b.deptId, b.billDate, b.billTypeAtomic,"
+                + " COALESCE(createrPerson.name, ''), COALESCE(toDept.name, ''))"
                 + " FROM Bill b"
+                + " LEFT JOIN b.creater creater"
+                + " LEFT JOIN creater.webUserPerson createrPerson"
+                + " LEFT JOIN b.toDepartment toDept"
                 + " WHERE b.patientEncounter = :pe"
                 + " AND b.billTypeAtomic IN :btas"
                 + " AND b.cancelled = false"
@@ -121,8 +141,12 @@ public class NursingDischargeController implements Serializable {
 
     @SuppressWarnings("unchecked")
     private List<PendingPharmacyItemDTO> fetchUnacceptedWardReturns() {
-        String jpql = "SELECT new com.divudi.core.data.dto.PendingPharmacyItemDTO(b.id, b.deptId, b.billDate, b.billTypeAtomic, b.creater.webUserPerson.name, b.toDepartment.name)"
+        String jpql = "SELECT new com.divudi.core.data.dto.PendingPharmacyItemDTO(b.id, b.deptId, b.billDate, b.billTypeAtomic,"
+                + " COALESCE(createrPerson.name, ''), COALESCE(toDept.name, ''))"
                 + " FROM Bill b"
+                + " LEFT JOIN b.creater creater"
+                + " LEFT JOIN creater.webUserPerson createrPerson"
+                + " LEFT JOIN b.toDepartment toDept"
                 + " WHERE b.patientEncounter = :pe"
                 + " AND b.billTypeAtomic = :bta"
                 + " AND b.cancelled = false"
@@ -136,8 +160,12 @@ public class NursingDischargeController implements Serializable {
 
     @SuppressWarnings("unchecked")
     private List<PendingPharmacyItemDTO> fetchUnprocessedDirectIssueReturns() {
-        String jpql = "SELECT new com.divudi.core.data.dto.PendingPharmacyItemDTO(b.id, b.deptId, b.billDate, b.billTypeAtomic, b.creater.webUserPerson.name, b.toDepartment.name)"
+        String jpql = "SELECT new com.divudi.core.data.dto.PendingPharmacyItemDTO(b.id, b.deptId, b.billDate, b.billTypeAtomic,"
+                + " COALESCE(createrPerson.name, ''), COALESCE(toDept.name, ''))"
                 + " FROM Bill b"
+                + " LEFT JOIN b.creater creater"
+                + " LEFT JOIN creater.webUserPerson createrPerson"
+                + " LEFT JOIN b.toDepartment toDept"
                 + " WHERE b.patientEncounter = :pe"
                 + " AND b.billTypeAtomic = :bta"
                 + " AND b.cancelled = false"


### PR DESCRIPTION
Closes #23222

## Summary

Nursing Discharge could be confirmed while medicines issued by the Pharmacy were still awaiting receipt by the Ward.

The interesting part: **the blocking logic already existed** in `NursingDischargeController` (panel, disabled button, and a server-side guard). It never fired because all four pending-item queries silently matched zero rows.

## Decisions made without approval

| Decision | Why |
|---|---|
| **Fixed all four queries, not just the issue-side one** named in the report | `fetchPendingRequests`, `fetchUnacceptedIssues`, `fetchUnacceptedWardReturns` and `fetchUnprocessedDirectIssueReturns` share the identical defect. Fixing only the reported one would have left the ward-return and direct-issue-return checks silently dead. |
| **`LEFT JOIN` + `COALESCE(name, '')`** rather than making the DTO fields nullable | Matches the existing precedent in `SearchController` (transfer-request list query), so the table renders blank rather than the string `null`. No DTO constructor change — per the repo rule against modifying existing constructors. |
| **Did not change any message wording** | The issue proposes specific warning text. The existing panel already says *"Nursing discharge is blocked until all items below are resolved"* and the guard says *"Cannot confirm nursing discharge: N pending pharmacy item(s) must be resolved first."* The reported defect was that neither ever appeared, not that they read wrong. Flagging in case different wording is wanted. |
| **Did not add `BillType` to the filter** | The sibling receive query pins `BillType.PharmacyBhtPre`; this one filters on `billTypeAtomic` only. Left as-is deliberately to keep the change to the join fix and avoid altering matching behaviour. |

## Root cause

Each query projected `b.creater.webUserPerson.name` and `b.toDepartment.name` **directly inside the `SELECT NEW` clause**. In JPQL, path navigation through a nullable relationship generates an **INNER JOIN**, so any bill whose FK is `NULL` is silently dropped — no exception, no log entry, just an empty list.

`PharmacySaleBhtController.savePreBillFinally()` explicitly sets `toDepartment = null` on inward issue bills:

```java
getPreBill().setToDepartment(null);
getPreBill().setToInstitution(null);
```

So the INNER JOIN excluded **100%** of them. Measured on the local database:

```
BILLTYPEATOMIC                       total   todept_null
DIRECT_ISSUE_INWARD_MEDICINE         40548   40548
DIRECT_ISSUE_INWARD_MEDICINE_RETURN   2120    2120
```

With the pending list always empty, `hasPendingPharmacyItems()` returned `false` (button enabled) **and** the server-side guard in `confirmNursingDischarge()` passed — matching the report exactly: an issue pending receipt at 05:36 PM, nursing discharge confirmed at 05:46 PM.

This is the same trap already documented in-code in `SearchController.fetchIssuedBillDtos`:

> `LEFT JOIN`s are required: implicit path navigation (`b.referenceBill.id`) generates an inner join that silently excludes bills where `referenceBill_ID` is NULL

## Fix

Explicit `LEFT JOIN` per hop plus `COALESCE` for the nullable name columns, in all four queries.

## Verification

Old vs new join semantics, run against the same real rows:

```
OLD (implicit INNER JOIN)   0 rows
NEW (explicit LEFT JOIN)    2 rows
```

End-to-end against a local deployment:

- **Blocked case** — BHT with 2 unprocessed direct-issue returns now shows the warning panel with both rows and a disabled Confirm button.
- **Server-side guard** — reached via the stale-page race it exists for (page loaded while clean, condition becomes true, stale page submitted): `confirmNursingDischarge()` calls `loadPendingPharmacyItems()` fresh before deciding, so it blocks correctly there.

  <sub>Corrected after CodeRabbit review: my original claim here was "stripped the `disabled` attribute, submitted, DB unchanged, therefore the guard held." That inference was invalid — JSF **skips the action of a component it rendered as `disabled`**, so that postback never invoked the method at all (verified: the response came back with `msgs:[]`, no message). The fix is unaffected; the evidence I cited for it was wrong. Details in the review threads and in commit 7e9ed971be.</sub>
- **Negative case (no over-blocking)** — a BHT with nothing pending still discharges successfully (`NURSINGDISCHARGED = 1`, timestamp + user stamped). Reverted afterwards through the page's own Cancel action.

![Nursing discharge blocked by pending pharmacy items](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23222-fixed-discharge-blocked.png)

*(Staff names redacted in the screenshot.)*

## Notes for the reviewer

- No schema change, no privilege change, no migration.
- Also added three learnings to `developer_docs/testing/playwright-e2e-workflow.md` (icon-only PrimeFaces buttons need a jQuery-triggered click; local "Unknown column" 500s should be fixed via the app's own `/faces/mf.xhtml` page; and always prove a server-side guard plus the negative case rather than trusting a disabled button).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nursing discharge pharmacy records so entries with missing creator or department details remain visible.
  * Added safe handling for unavailable creator and department names, displaying blank values instead of errors.

* **Documentation**
  * Clarified Playwright guidance for icon-only controls and verifying click outcomes.
  * Updated server-side validation testing guidance to verify action execution and response messages.
  * Retained schema-drift troubleshooting guidance and refreshed the testing checklist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
