### PR TITLE
fix(inward): filter Discount Scheme dropdown by selected Payment Method

### DIFF
--- a/src/main/java/com/divudi/bean/membership/PaymentSchemeController.java
+++ b/src/main/java/com/divudi/bean/membership/PaymentSchemeController.java
@@ -565,6 +565,19 @@ public class PaymentSchemeController implements Serializable {
     }
 
     public List<PaymentScheme> getPaymentSchemesForInward() {
+        return getPaymentSchemesForInward(null);
+    }
+
+    /**
+     * Discount schemes valid for inpatient bills, restricted to those
+     * applicable to the given Payment Method via {@link AllowedPaymentMethod}
+     * (issue #23223). A scheme with no configured allowed-payment-method
+     * rows is treated as unrestricted (shown for every payment method) —
+     * same default-permissive convention {@code DiscountSchemeValidationService}
+     * uses for {@link com.divudi.core.entity.membership.RestrictedPaymentMethod}.
+     * Pass {@code null} to skip the payment-method filter entirely.
+     */
+    public List<PaymentScheme> getPaymentSchemesForInward(PaymentMethod paymentMethod) {
         StringBuilder jpql = new StringBuilder("SELECT i FROM PaymentScheme i WHERE i.retired = false AND i.validForInpatientBills = true");
         Map<String, Object> parameters = new HashMap<>();
         if (sessionController.getDepartment() != null) {
@@ -575,6 +588,11 @@ public class PaymentSchemeController implements Serializable {
                 jpql.append(" AND i.department = :dep");
                 parameters.put("dep", sessionController.getDepartment());
             }
+        }
+        if (paymentMethod != null) {
+            jpql.append(" AND (i NOT IN (SELECT apm.paymentScheme FROM AllowedPaymentMethod apm WHERE apm.retired = false AND apm.paymentScheme IS NOT NULL)")
+                    .append(" OR i IN (SELECT apm2.paymentScheme FROM AllowedPaymentMethod apm2 WHERE apm2.retired = false AND apm2.paymentMethod = :pm))");
+            parameters.put("pm", paymentMethod);
         }
         jpql.append(" ORDER BY i.orderNo, i.name");
         return getFacade().findByJpql(jpql.toString(), parameters);

--- a/src/main/webapp/inward/inward_admission.xhtml
+++ b/src/main/webapp/inward/inward_admission.xhtml
@@ -462,7 +462,7 @@
                                             <p:outputLabel value="Discount Scheme" styleClass="d-block"/>
                                             <p:selectOneMenu class="w-100" styleClass="form-control w-100" value="#{admissionController.paymentScheme}">
                                                 <f:selectItem itemLabel="No Discount Scheme" itemValue="#{null}"/>
-                                                <f:selectItems value="#{paymentSchemeController.paymentSchemesForInward}"
+                                                <f:selectItems value="#{paymentSchemeController.getPaymentSchemesForInward(admissionController.current.paymentMethod)}"
                                                                var="ps" itemLabel="#{ps.name}" itemValue="#{ps}"/>
                                             </p:selectOneMenu>
                                         </div>

--- a/src/main/webapp/inward/inward_edit_admission_payment.xhtml
+++ b/src/main/webapp/inward/inward_edit_admission_payment.xhtml
@@ -64,13 +64,13 @@
                                     <h:outputLabel value="Select Payment Method" />
                                     <p:selectOneMenu class="w-100" id="cmbPs" value="#{bhtEditController.current.paymentMethod}">
                                         <f:selectItems value="#{enumController.paymentMethodForAdmission}" />
-                                        <p:ajax event="change" listener="#{bhtEditController.listnerForPaymentMethodChange()}" update="cmbClaimable" />
+                                        <p:ajax event="change" listener="#{bhtEditController.listnerForPaymentMethodChange()}" update="cmbClaimable cmbDiscountScheme" />
                                     </p:selectOneMenu>
 
                                     <h:outputLabel value="Discount Scheme" />
-                                    <p:selectOneMenu class="w-100" value="#{bhtEditController.paymentScheme}">
+                                    <p:selectOneMenu class="w-100" id="cmbDiscountScheme" value="#{bhtEditController.paymentScheme}">
                                         <f:selectItem itemLabel="No Discount Scheme" itemValue="#{null}" />
-                                        <f:selectItems value="#{paymentSchemeController.paymentSchemesForInward}"
+                                        <f:selectItems value="#{paymentSchemeController.getPaymentSchemesForInward(bhtEditController.current.paymentMethod)}"
                                                        var="ps" itemLabel="#{ps.name}" itemValue="#{ps}" />
                                     </p:selectOneMenu>
 


### PR DESCRIPTION
## Problem

During patient admission (and when editing an existing admission's payment details), the **Discount Scheme** dropdown showed membership/discount schemes that are not applicable to the selected **Payment Method**. E.g. a scheme configured with Applicable Payment Method = Cash still appeared — and could be saved — when the admission's Payment Method was Credit.

Closes #23223

## Root cause

`PaymentSchemeController.getPaymentSchemesForInward()` (`src/main/java/com/divudi/bean/membership/PaymentSchemeController.java`) filtered by `retired`, `validForInpatientBills`, and optionally `department`, but never by `PaymentMethod`. Both consuming pages bound the dropdown to this same unfiltered method:
- `inward/inward_admission.xhtml` (create admission)
- `inward/inward_edit_admission_payment.xhtml` (edit admission payment details)

## Fix

- Added an overload `getPaymentSchemesForInward(PaymentMethod)` that additionally restricts results using `AllowedPaymentMethod` (the table backing the admin "Discount Scheme Allowed Payment Methods" page, which matches the issue's "Applicable Payment Method" language): a scheme with **no** configured `AllowedPaymentMethod` rows is treated as unrestricted (shown for every payment method) — the same default-permissive convention `DiscountSchemeValidationService` already uses for the `RestrictedPaymentMethod` blacklist, so existing schemes that never configured this field don't silently vanish from every dropdown. The original no-arg getter is preserved (delegates with `null`, i.e. unfiltered) so no other EL caller's behavior changes.
- Both XHTML pages now call `paymentSchemeController.getPaymentSchemesForInward(<controller>.current.paymentMethod)` instead of the bare property.
- `inward_edit_admission_payment.xhtml`'s Discount Scheme `p:selectOneMenu` had no `id` and wasn't included in the Payment Method `p:ajax`'s `update` list, so switching Payment Method there never refreshed the scheme list even before this fix. Gave it `id="cmbDiscountScheme"` and added it to the `update` attribute. `inward_admission.xhtml` already wraps both fields in the same `pg1` panel group that its Payment Method `p:ajax` re-renders, so no markup change was needed there.

## Decisions made without approval

This was run via `dev-issue-unattended` (issue owner unreachable) — flagging every judgment call here for review:

1. **AllowedPaymentMethod (whitelist) vs RestrictedPaymentMethod (blacklist)** — chose `AllowedPaymentMethod` since it's what the admin UI and the issue's own example ("Applicable Payment Method: Cash") describe; treated "no rows configured" as unrestricted rather than "hidden everywhere", to avoid a regression for schemes that never used this field.
2. **New overload instead of changing the existing getter's signature/behavior** — added `getPaymentSchemesForInward(PaymentMethod)` rather than modifying `getPaymentSchemesForInward()` in place, so any other caller of the bare EL property is unaffected.
3. **Scope: inward only** — `getPaymentSchemesForOPD()`, `getPaymentSchemesForPharmacy()`, and `getPaymentSchemesForChannel()` (all backed by the shared `createPaymentSchemes(...)` helper) have the identical unfiltered-by-payment-method gap, used across ~25 OPD/pharmacy/channel pages. Left those out of this fix since the issue is specific to inward admission — flagging as a follow-up candidate rather than expanding scope here.
4. **No server-side save-time validation added** — `DiscountSchemeValidationService.validateDiscountScheme(...)` is wired into OPD and pharmacy bill-settle paths but not into `AdmissionController`/`BhtEditController`'s save methods, so (even after this fix) a stale client-side selection could theoretically still be POSTed. The issue only asks for dropdown filtering, so this was left out of scope and noted here for a possible separate issue rather than silently expanded.

## Verification

Tested end-to-end with Playwright against local Payara/MySQL (`coop` DB):
1. Created a real `PaymentScheme` ("E2E Test Cash Only 23223", `validForInpatientBills=true`) through the admin UI and restricted it to `Cash` via the "Discount Scheme Allowed Payment Methods" admin page.
2. On `inward_edit_admission_payment.xhtml` for an existing Credit admission (BHT/56757): confirmed the dropdown showed only "No Discount Scheme" (test scheme correctly excluded). Switched Payment Method to Cash via the AJAX dropdown — test scheme correctly appeared. Selected it, saved, and confirmed `PAYMENTSCHEME_ID` persisted correctly in the DB.
3. Switched Payment Method back to Credit and saved again — confirmed the now-invalid scheme selection was correctly cleared (`PAYMENTSCHEME_ID` → `NULL`), not left as a stale reference.
4. Repeated the dropdown-filtering check (steps 2's read-only portion) on `inward_admission.xhtml` (create-admission page) with the same session state — same correct exclude/include behavior via the existing `pg1` AJAX refresh.
5. Reverted the test admission to its original state (Credit, no scheme) and retired the test `PaymentScheme` through the admin UI afterward — no test data left behind.
6. Confirmed offline compile, full `mvn package`, and local redeploy succeeded with no new errors in `server.log` related to `PaymentScheme`/`AllowedPaymentMethod`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)