### PR TITLE
feat(inward): make the timed services metadata API complete and reversible (#23236)

### DIFF
--- a/developer_docs/api/using-apis/API_TIMED_ITEMS.md
+++ b/developer_docs/api/using-apis/API_TIMED_ITEMS.md
@@ -1,0 +1,280 @@
+# Timed Items API
+
+Master data for **timed services** — inward charges billed by how long something ran
+(oxygen, ICU time, cardiac monitoring, nebulisation) — and the tiered fee slots that price
+them.
+
+This API manages *configuration*. Recording or billing actual usage against a patient is a
+different surface entirely and is not covered here.
+
+- Base path: `/api/timed-items`
+- Auth: `Finance: <api-key>` header on every request
+- Entities: `TimedItem` (a service), `TimedItemFee` (one fee slot), `TimedItemCategory`
+
+Consumed by the inward timed service page
+(`/inward/inward_timed_service_consume.xhtml`) and configured in the UI at
+`/inward/inward_timed_item.xhtml` / `inward_timed_item_fee.xhtml`.
+
+## Response envelope
+
+```json
+{ "status": "success", "code": 200, "data": { } }
+{ "status": "error",   "code": 400, "message": "..." }
+```
+
+---
+
+## How fee slots work
+
+A timed item carries an ordered list of fee slots. `sortOrder` is the **slot position**:
+slot 1 prices the first block of the stay, slot 2 the second, and so on. The last slot with
+`repeating = true` continues to price every block beyond the list.
+
+`durationHours` is the length of one block and `durationUnit` says what that length is
+counted in:
+
+| durationUnit | Meaning |
+|---|---|
+| `ONE_TIME` | Charge the fee once for the whole service, regardless of duration |
+| `MINUTE` | `durationHours` counts minutes |
+| `HOUR` | `durationHours` counts hours — **the default** when the field is omitted |
+| `DAY` | `durationHours` counts days |
+
+`durationHours` keeps its historical name for database compatibility; with a unit attached
+it is really "duration value".
+
+### Slot rules
+
+These are enforced identically here and on the fee page — an identical payload is accepted
+or rejected the same way on both surfaces.
+
+| Rule | Behaviour |
+|---|---|
+| `sortOrder` omitted or `0` | Auto-assigned to the next free slot (highest in use + 1) |
+| `sortOrder` less than 1 | `400 — Slot Order must be 1 or greater.` |
+| `sortOrder` already used by another live fee on the same item | `400 — Slot Order must be unique per service.` |
+| `durationHours <= 0` on any unit except `ONE_TIME` | `400 — Duration must be greater than 0 for a <unit> fee.` |
+
+Duplicate or zero slot orders are rejected because the billing code orders fees by
+`sortOrder` and then picks a tier **by position**. A collision makes that ordering
+ambiguous, so the stay could be priced at the wrong tier with nothing visibly wrong.
+
+---
+
+## Timed items
+
+### Search
+
+```
+GET /api/timed-items/search
+```
+
+| Param | Notes |
+|---|---|
+| `query` | Matched against name and code, case-insensitively, as a substring |
+| `departmentType` | `DepartmentType` enum, e.g. `Inward`, `Theatre` |
+| `inwardChargeType` | `InwardChargeType` enum, e.g. `OxygenCharges`, `Nebulisation` |
+| `categoryId` | `TimedItemCategory` id |
+| `departmentId` | Department id |
+| `institutionId` | Institution id |
+| `inactive` | `true` / `false` |
+| `includeRetired` | `true` to include retired items. Default `false` |
+| `limit` | Page size, 1–100. Default 30 |
+| `offset` | Rows to skip. Default 0 |
+
+```json
+{
+  "status": "success",
+  "code": 200,
+  "data": {
+    "items": [
+      {
+        "id": 13838979,
+        "name": "Oxygen Therapy",
+        "code": "OXYTEST",
+        "departmentType": "Inward",
+        "inwardChargeType": "OxygenCharges",
+        "categoryId": 1667,
+        "categoryName": "Respiratory Care",
+        "total": 500.0,
+        "inactive": false,
+        "retired": false
+      }
+    ],
+    "total": 137,
+    "limit": 30,
+    "offset": 0
+  }
+}
+```
+
+`total` is the number of rows matching the filters, ignoring `limit`/`offset` — use it to
+decide whether another page remains.
+
+### Get one
+
+```
+GET /api/timed-items/{id}
+GET /api/timed-items/{id}?includeRetired=true
+```
+
+Returns the item with its fee list. A retired item is `404` unless `includeRetired=true`,
+which also includes retired fees in the response.
+
+### Create
+
+```
+POST /api/timed-items
+```
+
+```json
+{
+  "name": "Oxygen Therapy",
+  "departmentType": "Inward",
+  "inwardChargeType": "OxygenCharges",
+  "code": "OXY",
+  "departmentId": 486,
+  "institutionId": 2,
+  "categoryId": 1667,
+  "inactive": false
+}
+```
+
+`name`, `departmentType` and `inwardChargeType` are required. `code` is generated from the
+name if omitted.
+
+### Update, retire, restore
+
+```
+PUT    /api/timed-items/{id}                    all fields optional
+DELETE /api/timed-items/{id}?retireComments=... soft-retire
+PATCH  /api/timed-items/{id}/restore            un-retire
+PATCH  /api/timed-items/{id}/activate           inactive = false
+PATCH  /api/timed-items/{id}/deactivate         inactive = true
+```
+
+`DELETE` never removes a row — it sets `retired = true`. `restore` clears that along with
+the retirer, timestamp and comments. Fees that were already retired before the item was
+retired stay retired: restoring a service does not resurrect slot configuration that may
+have been removed deliberately.
+
+Restoring something that is not retired returns `409`.
+
+**Retire vs deactivate:** deactivate hides a service from selection but leaves it
+configured and reportable; retire removes it from the catalogue. Prefer deactivate for
+"we're not offering this at the moment".
+
+---
+
+## Fee slots
+
+### List
+
+```
+GET /api/timed-items/{id}/fees
+GET /api/timed-items/{id}/fees?includeRetired=true
+```
+
+Ordered by `sortOrder`, then id.
+
+### Add one
+
+```
+POST /api/timed-items/{id}/fees
+```
+
+```json
+{
+  "name": "First hour",
+  "fee": 500,
+  "ffee": 750,
+  "durationHours": 1,
+  "durationUnit": "HOUR",
+  "overShootHours": 0,
+  "sortOrder": 1,
+  "repeating": false
+}
+```
+
+`name` is required. `durationHours` must be greater than 0 unless `durationUnit` is
+`ONE_TIME`. `ffee` (foreigner fee) defaults to `fee`. `durationUnit` defaults to `HOUR`.
+
+### Replace the whole list
+
+```
+PUT /api/timed-items/{id}/fees
+```
+
+```json
+{
+  "fees": [
+    { "name": "First hour",  "fee": 500, "durationHours": 1, "durationUnit": "HOUR", "sortOrder": 1 },
+    { "id": 13523704, "name": "Second hour", "fee": 400, "durationHours": 1, "sortOrder": 2 },
+    { "name": "Thereafter", "fee": 300, "durationHours": 1, "sortOrder": 3, "repeating": true }
+  ]
+}
+```
+
+Prefer this over a run of `POST`s when configuring a tiered service:
+
+- The whole set is validated before anything is written, so a bad slot in the middle cannot
+  leave the service half-configured.
+- Slot-order uniqueness is checked across the complete list rather than one row at a time.
+- The parent item's total is recalculated once instead of once per call.
+
+A row **with** an `id` updates that existing slot; a row **without** one adds a slot. Any
+live slot whose id is absent from the array is retired. Send `{"fees": []}` to clear every
+slot.
+
+### Update one, retire, restore
+
+```
+PUT    /api/timed-items/{id}/fees/{feeId}          all fields optional
+DELETE /api/timed-items/{id}/fees/{feeId}          soft-retire
+PATCH  /api/timed-items/{id}/fees/{feeId}/restore  un-retire
+```
+
+`PUT` validates the fee **as it will be stored**, not just the fields that arrived: a
+payload that only switches the unit can still leave a zero-length block, and one that only
+moves the slot order can still collide with a sibling.
+
+Restoring a fee needs a live parent — restore the item first. If the slot it used to occupy
+was taken while it was retired, the restore is rejected with the uniqueness error; move the
+occupying slot first.
+
+---
+
+## Categories
+
+`TimedItemCategory` groups services in the UI.
+
+```
+GET    /api/timed-items/categories?query=&limit=
+GET    /api/timed-items/categories/{id}
+POST   /api/timed-items/categories            body: { "name": "...", "code": "..." }
+PUT    /api/timed-items/categories/{id}
+DELETE /api/timed-items/categories/{id}?retireComments=...
+```
+
+`POST` with a name already in use returns `409` with
+`{"status": "already_exists", "id": ..., "name": "..."}`.
+
+---
+
+## Status codes
+
+| Code | When |
+|---|---|
+| 400 | Validation failure — slot order, duration, bad enum value, malformed JSON or query param |
+| 401 | Missing, unknown or expired `Finance` key |
+| 404 | Item or fee does not exist, or is retired and `includeRetired` was not set |
+| 409 | Restoring something that is not retired; duplicate category name |
+
+---
+
+## Related
+
+- [API_INWARD_ROOM.md](API_INWARD_ROOM.md) — room facility charges use a `TimedItemFee` for
+  their billing block and accept the same `durationUnit` as
+  `timedItemFeeDurationUnit`
+- AI chat tool: `manage_timed_items` (see `AnthropicApiService`)

--- a/src/main/java/com/divudi/bean/inward/InwardBeanController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardBeanController.java
@@ -3301,7 +3301,11 @@ public class InwardBeanController implements Serializable {
         }
         HashMap hm = new HashMap();
         hm.put("id", ti.getId());
-        String sql = "SELECT tif FROM TimedItemFee tif WHERE tif.retired=false AND tif.item.id=:id ORDER BY tif.sortOrder ASC";
+        // The id tiebreak matters: getFeeForBlock() indexes into this list positionally,
+        // so any two fees sharing a sortOrder would otherwise order arbitrarily and the
+        // same stay could be billed at a different tier on different runs. New fees can
+        // no longer collide (TimedItemFeeRules), but rows saved before that still can.
+        String sql = "SELECT tif FROM TimedItemFee tif WHERE tif.retired=false AND tif.item.id=:id ORDER BY tif.sortOrder ASC, tif.id ASC";
         List<TimedItemFee> fees = getTimedItemFeeFacade().findByJpql(sql, hm);
         return fees != null ? fees : new ArrayList<>();
     }

--- a/src/main/java/com/divudi/bean/inward/TimedItemFeeController.java
+++ b/src/main/java/com/divudi/bean/inward/TimedItemFeeController.java
@@ -18,6 +18,8 @@ import com.divudi.core.facade.DepartmentFacade;
 import com.divudi.core.facade.TimedItemFacade;
 import com.divudi.core.facade.TimedItemFeeFacade;
 import com.divudi.core.util.JsfUtil;
+import com.divudi.service.inward.TimedItemFeeRuleException;
+import com.divudi.service.inward.TimedItemFeeRules;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Date;
@@ -50,6 +52,12 @@ public class TimedItemFeeController implements Serializable {
     private TimedItemFeeFacade itemFeeFacade;
     @EJB
     private DepartmentFacade departmentFacade;
+    /**
+     * Slot-order and duration rules, shared with the REST API so an identical fee is
+     * accepted or rejected identically on both surfaces (issue #23236 §3).
+     */
+    @EJB
+    private TimedItemFeeRules timedItemFeeRules;
     private List<TimedItemFee> fees;
     private TimedItem currentIx;
     private TimedItemFee currentFee;
@@ -79,26 +87,15 @@ public class TimedItemFeeController implements Serializable {
             JsfUtil.addErrorMessage("Please select a charge");
             return;
         }
-        if (!currentFee.isOneTime() && currentFee.getDurationHours() <= 0) {
-            JsfUtil.addErrorMessage("Duration must be greater than 0 for a "
-                    + currentFee.getDurationUnit().getLabel() + " fee.");
+        currentFee.setItem(currentIx);
+        boolean isNew = currentFee.getId() == null || currentFee.getId() == 0;
+        try {
+            currentFee.setSortOrder(timedItemFeeRules.applyToFee(currentFee, getCharges()));
+        } catch (TimedItemFeeRuleException e) {
+            JsfUtil.addErrorMessage(e.getMessage());
             return;
         }
-        currentFee.setItem(currentIx);
-        if (currentFee.getId() == null || currentFee.getId() == 0) {
-            if (currentFee.getSortOrder() == 0) {
-                currentFee.setSortOrder(getCharges().size() + 1);
-            }
-            if (currentFee.getSortOrder() < 1) {
-                JsfUtil.addErrorMessage("Slot Order must be 1 or greater.");
-                return;
-            }
-            boolean duplicateSortOrder = getCharges().stream()
-                    .anyMatch(f -> f.getSortOrder() == currentFee.getSortOrder());
-            if (duplicateSortOrder) {
-                JsfUtil.addErrorMessage("Slot Order must be unique per service.");
-                return;
-            }
+        if (isNew) {
             currentFee.setCreatedAt(new Date());
             currentFee.setCreater(getSessionController().getLoggedUser());
             getTimedItemFeeFacade().create(currentFee);
@@ -160,13 +157,17 @@ public class TimedItemFeeController implements Serializable {
             JsfUtil.addErrorMessage("Please Enter Fee Name.");
             return;
         }
-        // Same guard as saveCharge(). It matters more here: the row's Duration input
-        // is disabled while the row is a One Time Fee, and a disabled input submits
-        // nothing — so switching a row to a time-based unit could otherwise save a
-        // duration of 0, which prices every block at zero.
-        if (!tif.isOneTime() && tif.getDurationHours() <= 0) {
-            JsfUtil.addErrorMessage("Duration must be greater than 0 for a "
-                    + tif.getDurationUnit().getLabel() + " fee.");
+        // Same rules as saveCharge(), from the same place. The duration guard matters
+        // more here: the row's Duration input is disabled while the row is a One Time
+        // Fee, and a disabled input submits nothing — so switching a row to a
+        // time-based unit could otherwise save a duration of 0, which prices every
+        // block at zero. The slot-order guard closes the matching hole: editing a row's
+        // Slot Order to one already in use makes the billing tier order ambiguous.
+        try {
+            timedItemFeeRules.validateDuration(tif.getDurationUnit(), tif.getDurationHours());
+            timedItemFeeRules.validateSlotOrder(tif.getSortOrder(), getCharges(), tif.getId());
+        } catch (TimedItemFeeRuleException e) {
+            JsfUtil.addErrorMessage(e.getMessage());
             return;
         }
         tif.setEditedAt(new Date());

--- a/src/main/java/com/divudi/core/data/dto/timeditem/TimedItemFeeBulkRequestDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/timeditem/TimedItemFeeBulkRequestDTO.java
@@ -1,0 +1,43 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.core.data.dto.timeditem;
+
+import java.util.List;
+
+/**
+ * The complete slot list for a timed item, replacing whatever is configured now
+ * ({@code PUT /timed-items/{id}/fees}).
+ *
+ * <p>Configuring an N-slot tiered service one POST at a time takes N round trips, each
+ * re-saving the parent's total, and lets the slot-order uniqueness rule see only one row
+ * at a time. Submitting the whole set makes the configuration atomic and lets the rule be
+ * checked across the complete list (issue #23236 §4).
+ *
+ * @author Buddhika
+ */
+public class TimedItemFeeBulkRequestDTO {
+
+    private List<TimedItemFeeUpsertDTO> fees;
+
+    public TimedItemFeeBulkRequestDTO() {
+    }
+
+    /**
+     * An empty list is valid — it retires every slot. A missing list is not: that is
+     * far more likely to be a malformed body than a deliberate "remove everything".
+     */
+    public boolean isValid() {
+        return fees != null;
+    }
+
+    public List<TimedItemFeeUpsertDTO> getFees() {
+        return fees;
+    }
+
+    public void setFees(List<TimedItemFeeUpsertDTO> fees) {
+        this.fees = fees;
+    }
+}

--- a/src/main/java/com/divudi/core/data/dto/timeditem/TimedItemFeeUpsertDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/timeditem/TimedItemFeeUpsertDTO.java
@@ -1,0 +1,115 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.core.data.dto.timeditem;
+
+import com.divudi.core.data.inward.TimedItemDurationUnit;
+
+/**
+ * One slot in a bulk fee write ({@code PUT /timed-items/{id}/fees}).
+ *
+ * <p>{@code id} is what distinguishes an update from a create: present means "this is
+ * the existing fee with that id", absent means "add a new slot". Any live fee whose id
+ * is missing from the submitted list is retired by the bulk write.
+ *
+ * @author Buddhika
+ */
+public class TimedItemFeeUpsertDTO {
+
+    /** Existing fee to update. Null/absent creates a new fee. */
+    private Long id;
+    private String name;
+    private double fee;
+    private double ffee;
+    private double durationHours;
+    private double overShootHours;
+    private long durationDaysForMoCharge;
+    private int sortOrder;
+    private boolean repeating;
+    private TimedItemDurationUnit durationUnit;
+
+    public TimedItemFeeUpsertDTO() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public double getFee() {
+        return fee;
+    }
+
+    public void setFee(double fee) {
+        this.fee = fee;
+    }
+
+    public double getFfee() {
+        return ffee;
+    }
+
+    public void setFfee(double ffee) {
+        this.ffee = ffee;
+    }
+
+    public double getDurationHours() {
+        return durationHours;
+    }
+
+    public void setDurationHours(double durationHours) {
+        this.durationHours = durationHours;
+    }
+
+    public double getOverShootHours() {
+        return overShootHours;
+    }
+
+    public void setOverShootHours(double overShootHours) {
+        this.overShootHours = overShootHours;
+    }
+
+    public long getDurationDaysForMoCharge() {
+        return durationDaysForMoCharge;
+    }
+
+    public void setDurationDaysForMoCharge(long durationDaysForMoCharge) {
+        this.durationDaysForMoCharge = durationDaysForMoCharge;
+    }
+
+    public int getSortOrder() {
+        return sortOrder;
+    }
+
+    public void setSortOrder(int sortOrder) {
+        this.sortOrder = sortOrder;
+    }
+
+    public boolean isRepeating() {
+        return repeating;
+    }
+
+    public void setRepeating(boolean repeating) {
+        this.repeating = repeating;
+    }
+
+    public TimedItemDurationUnit getDurationUnit() {
+        return durationUnit;
+    }
+
+    public void setDurationUnit(TimedItemDurationUnit durationUnit) {
+        this.durationUnit = durationUnit;
+    }
+}

--- a/src/main/java/com/divudi/core/data/dto/timeditem/TimedItemSearchPageDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/timeditem/TimedItemSearchPageDTO.java
@@ -1,0 +1,68 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.core.data.dto.timeditem;
+
+import java.util.List;
+
+/**
+ * One page of timed item search results.
+ *
+ * <p>Carries {@code total} alongside the rows so a caller can tell whether it is
+ * seeing the whole catalogue or only the first slice — without it, a client paging
+ * through the list has no way to know when to stop (issue #23236 §4).
+ *
+ * @author Buddhika
+ */
+public class TimedItemSearchPageDTO {
+
+    private List<TimedItemSearchResultDTO> items;
+    /** Rows matching the filters, ignoring limit/offset. */
+    private long total;
+    private int limit;
+    private int offset;
+
+    public TimedItemSearchPageDTO() {
+    }
+
+    public TimedItemSearchPageDTO(List<TimedItemSearchResultDTO> items, long total, int limit, int offset) {
+        this.items = items;
+        this.total = total;
+        this.limit = limit;
+        this.offset = offset;
+    }
+
+    public List<TimedItemSearchResultDTO> getItems() {
+        return items;
+    }
+
+    public void setItems(List<TimedItemSearchResultDTO> items) {
+        this.items = items;
+    }
+
+    public long getTotal() {
+        return total;
+    }
+
+    public void setTotal(long total) {
+        this.total = total;
+    }
+
+    public int getLimit() {
+        return limit;
+    }
+
+    public void setLimit(int limit) {
+        this.limit = limit;
+    }
+
+    public int getOffset() {
+        return offset;
+    }
+
+    public void setOffset(int offset) {
+        this.offset = offset;
+    }
+}

--- a/src/main/java/com/divudi/core/data/dto/timeditem/TimedItemSearchResultDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/timeditem/TimedItemSearchResultDTO.java
@@ -21,6 +21,14 @@ public class TimedItemSearchResultDTO {
     private Double total;
     private Double totalForForeigner;
     private boolean inactive;
+    /**
+     * Always false unless the caller asked for retired rows with includeRetired=true —
+     * the search excludes them otherwise. Exposed so an agent that retired the wrong
+     * service can list what it retired and pick the id to restore (issue #23236 §2).
+     */
+    private boolean retired;
+    private Long categoryId;
+    private String categoryName;
 
     public TimedItemSearchResultDTO() {
     }
@@ -95,5 +103,29 @@ public class TimedItemSearchResultDTO {
 
     public void setInactive(boolean inactive) {
         this.inactive = inactive;
+    }
+
+    public boolean isRetired() {
+        return retired;
+    }
+
+    public void setRetired(boolean retired) {
+        this.retired = retired;
+    }
+
+    public Long getCategoryId() {
+        return categoryId;
+    }
+
+    public void setCategoryId(Long categoryId) {
+        this.categoryId = categoryId;
+    }
+
+    public String getCategoryName() {
+        return categoryName;
+    }
+
+    public void setCategoryName(String categoryName) {
+        this.categoryName = categoryName;
     }
 }

--- a/src/main/java/com/divudi/core/facade/AbstractFacade.java
+++ b/src/main/java/com/divudi/core/facade/AbstractFacade.java
@@ -592,6 +592,36 @@ public abstract class AbstractFacade<T> {
                 .getResultList();
     }
 
+    /**
+     * Paginated query with named parameters.
+     *
+     * <p>Prefer this over {@code findByJpql(jpql, params, fromRecord, toRecord)} for paging:
+     * that method takes an inclusive end index and skips {@code setMaxResults} entirely when
+     * it works out to 0, so asking for the single first row (offset 0, one result) silently
+     * returns the whole result set. Here {@code maxResults} is a plain count and is always
+     * applied.
+     */
+    public List<T> findByJpqlWithRange(String jpql, Map<String, Object> parameters,
+            int startPosition, int maxResults) {
+        TypedQuery<T> qry = getEntityManager().createQuery(jpql, entityClass);
+        if (parameters != null) {
+            for (Map.Entry<String, Object> entry : parameters.entrySet()) {
+                if (entry.getValue() instanceof Date) {
+                    qry.setParameter(entry.getKey(), (Date) entry.getValue(), TemporalType.TIMESTAMP);
+                } else {
+                    qry.setParameter(entry.getKey(), entry.getValue());
+                }
+            }
+        }
+        qry.setFirstResult(Math.max(startPosition, 0));
+        qry.setMaxResults(Math.max(maxResults, 1));
+        try {
+            return qry.getResultList();
+        } catch (Exception e) {
+            return new ArrayList<>();
+        }
+    }
+
     public List<?> findLightsByJpql(String jpql) {
         Query qry = getEntityManager().createQuery(jpql);
         return qry.getResultList();

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -859,6 +859,11 @@ public class AnthropicApiService implements Serializable {
                                 .add("timedItemFeeDurationDaysForMoCharge", Json.createObjectBuilder()
                                         .add("type", "string")
                                         .add("description", "Duration days for MO charge calculation. Optional."))
+                                .add("timedItemFeeDurationUnit", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "ONE_TIME, MINUTE, HOUR or DAY — the unit the two values above are "
+                                                + "counted in. Optional; defaults to HOUR. Use DAY to charge the room per day "
+                                                + "and ONE_TIME to charge it once regardless of the length of stay."))
                                 .add("query", Json.createObjectBuilder()
                                         .add("type", "string")
                                         .add("description", "Search text for LIST methods. Optional."))
@@ -1790,8 +1795,11 @@ public class AnthropicApiService implements Serializable {
                         + "TimedItems are consumed by the inward timed service page to bill patients for duration-based charges. "
                         + "Fees are ordered by sortOrder; each fee defines a durationHours block with an optional overShootHours grace window. "
                         + "durationUnit says what durationHours/overShootHours are counted in (ONE_TIME, MINUTE, HOUR, DAY) and defaults to HOUR. "
-                        + "Methods for items: LIST, GET, POST, PUT, DELETE, ACTIVATE, DEACTIVATE. "
-                        + "Methods for fees: LIST_FEES, POST_FEE, PUT_FEE, DELETE_FEE. "
+                        + "Methods for items: LIST, GET, POST, PUT, DELETE, RESTORE, ACTIVATE, DEACTIVATE. "
+                        + "Methods for fees: LIST_FEES, POST_FEE, PUT_FEE, DELETE_FEE, RESTORE_FEE, PUT_FEES. "
+                        + "DELETE and DELETE_FEE only soft-retire, and RESTORE / RESTORE_FEE undo them, so a "
+                        + "mistaken retire is recoverable — pass includeRetired=true to LIST or GET to see what "
+                        + "was retired and get the id to restore. "
                         + "Always confirm with the user before creating, updating, or retiring records.")
                 .add("input_schema", Json.createObjectBuilder()
                         .add("type", "object")
@@ -1799,16 +1807,17 @@ public class AnthropicApiService implements Serializable {
                                 .add("method", Json.createObjectBuilder()
                                         .add("type", "string")
                                         .add("enum", Json.createArrayBuilder()
-                                                .add("LIST").add("GET").add("POST").add("PUT").add("DELETE")
+                                                .add("LIST").add("GET").add("POST").add("PUT").add("DELETE").add("RESTORE")
                                                 .add("ACTIVATE").add("DEACTIVATE")
-                                                .add("LIST_FEES").add("POST_FEE").add("PUT_FEE").add("DELETE_FEE"))
+                                                .add("LIST_FEES").add("POST_FEE").add("PUT_FEE").add("DELETE_FEE")
+                                                .add("RESTORE_FEE").add("PUT_FEES"))
                                         .add("description", "Operation to perform."))
                                 .add("id", Json.createObjectBuilder()
                                         .add("type", "string")
-                                        .add("description", "Timed item id. Required for GET, PUT, DELETE, ACTIVATE, DEACTIVATE, LIST_FEES, POST_FEE, PUT_FEE, DELETE_FEE."))
+                                        .add("description", "Timed item id. Required for GET, PUT, DELETE, RESTORE, ACTIVATE, DEACTIVATE, LIST_FEES, POST_FEE, PUT_FEE, DELETE_FEE, RESTORE_FEE, PUT_FEES."))
                                 .add("feeId", Json.createObjectBuilder()
                                         .add("type", "string")
-                                        .add("description", "Fee id. Required for PUT_FEE and DELETE_FEE."))
+                                        .add("description", "Fee id. Required for PUT_FEE, DELETE_FEE and RESTORE_FEE."))
                                 .add("name", Json.createObjectBuilder()
                                         .add("type", "string")
                                         .add("description", "Name of the timed item or fee. Required for POST and POST_FEE."))
@@ -1857,12 +1866,30 @@ public class AnthropicApiService implements Serializable {
                                 .add("repeating", Json.createObjectBuilder()
                                         .add("type", "string")
                                         .add("description", "true or false — whether this fee repeats for multiple blocks. Optional."))
+                                .add("fees", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "PUT_FEES only — the complete slot list as a JSON array string, e.g. "
+                                                + "[{\"name\":\"First hour\",\"fee\":500,\"durationHours\":1,\"durationUnit\":\"HOUR\",\"sortOrder\":1},"
+                                                + "{\"id\":123,\"name\":\"Thereafter\",\"fee\":300,\"durationHours\":1,\"sortOrder\":2,\"repeating\":true}]. "
+                                                + "Include an id to update an existing slot, omit it to add one. Any existing slot "
+                                                + "missing from the array is retired. Send [] to clear every slot. Prefer this over "
+                                                + "repeated POST_FEE calls when configuring a tiered service — it is validated and "
+                                                + "applied as one atomic set."))
                                 .add("query", Json.createObjectBuilder()
                                         .add("type", "string")
-                                        .add("description", "Search text for LIST. Optional."))
+                                        .add("description", "Search text for LIST. Matched against name and code, case-insensitively. Optional."))
                                 .add("size", Json.createObjectBuilder()
                                         .add("type", "string")
-                                        .add("description", "Max results (1–100). Optional."))
+                                        .add("description", "Max results per page for LIST (1–100). Optional; defaults to 30."))
+                                .add("offset", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "LIST only — rows to skip, for paging through a catalogue larger than one page. "
+                                                + "The response carries a total count so you can tell whether more remain. Optional; defaults to 0."))
+                                .add("includeRetired", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "true or false — include retired records in LIST, GET and LIST_FEES. "
+                                                + "Optional; defaults to false. Use it to find a record that was retired by mistake "
+                                                + "so it can be restored with RESTORE / RESTORE_FEE."))
                                 .add("retireComments", Json.createObjectBuilder()
                                         .add("type", "string")
                                         .add("description", "Reason for retirement. Optional for DELETE/DELETE_FEE.")))
@@ -2359,6 +2386,7 @@ public class AnthropicApiService implements Serializable {
                     String durationHours  = toolInput.containsKey("timedItemFeeDurationHours")      ? toolInput.getString("timedItemFeeDurationHours", "")      : "";
                     String overShoot      = toolInput.containsKey("timedItemFeeOverShootHours")     ? toolInput.getString("timedItemFeeOverShootHours", "")     : "";
                     String durationDays   = toolInput.containsKey("timedItemFeeDurationDaysForMoCharge") ? toolInput.getString("timedItemFeeDurationDaysForMoCharge", "") : "";
+                    String durationUnit   = toolInput.containsKey("timedItemFeeDurationUnit")       ? toolInput.getString("timedItemFeeDurationUnit", "")       : "";
                     String query          = toolInput.containsKey("query")                          ? toolInput.getString("query", "")                          : "";
                     String size           = toolInput.containsKey("size")                           ? toolInput.getString("size", "")                           : "";
                     String retireComments = toolInput.containsKey("retireComments")                 ? toolInput.getString("retireComments", "")                 : "";
@@ -2367,7 +2395,7 @@ public class AnthropicApiService implements Serializable {
                     return callInwardRoomsApi(method, id, name, code, desc, roomCategoryId, roomId,
                             departmentId, filled, svgChildView, roomCharge, maintCharge, linenCharge, nursingCharge,
                             moCharge, moAfterCharge, adminCharge, medCareCharge,
-                            durationHours, overShoot, durationDays,
+                            durationHours, overShoot, durationDays, durationUnit,
                             query, size, retireComments, timedItemId, linkId, hmisBaseUrl, hmisApiKey);
                 }
                 case "manage_bed_board_svg": {
@@ -2492,13 +2520,16 @@ public class AnthropicApiService implements Serializable {
                     String sortOrder    = toolInput.containsKey("sortOrder")         ? toolInput.getString("sortOrder", "")         : "";
                     String repeating    = toolInput.containsKey("repeating")         ? toolInput.getString("repeating", "")         : "";
                     String durationUnit = toolInput.containsKey("durationUnit")      ? toolInput.getString("durationUnit", "")      : "";
+                    String feesJson     = toolInput.containsKey("fees")              ? toolInput.getString("fees", "")              : "";
                     String query        = toolInput.containsKey("query")             ? toolInput.getString("query", "")             : "";
                     String size         = toolInput.containsKey("size")              ? toolInput.getString("size", "")              : "";
+                    String offset       = toolInput.containsKey("offset")            ? toolInput.getString("offset", "")            : "";
+                    String includeRetired = toolInput.containsKey("includeRetired")  ? toolInput.getString("includeRetired", "")    : "";
                     String retireComments = toolInput.containsKey("retireComments")  ? toolInput.getString("retireComments", "")    : "";
                     return callTimedItemsApi(method, id, feeId, name, code, deptType, chargeType,
                             departmentId, institutionId, categoryId, inactive,
                             fee, ffee, durationHrs, overShoot, durationDays, sortOrder, repeating, durationUnit,
-                            query, size, retireComments, hmisBaseUrl, hmisApiKey);
+                            feesJson, query, size, offset, includeRetired, retireComments, hmisBaseUrl, hmisApiKey);
                 }
                 default:
                     return "Unknown tool: " + toolName;
@@ -3892,6 +3923,7 @@ public class AnthropicApiService implements Serializable {
             String roomCharge, String maintananceCharge, String linenCharge, String nursingCharge,
             String moCharge, String moChargeForAfterDuration, String adminstrationCharge, String medicalCareCharge,
             String timedItemFeeDurationHours, String timedItemFeeOverShootHours, String timedItemFeeDurationDaysForMoCharge,
+            String timedItemFeeDurationUnit,
             String query, String size, String retireComments, String timedItemId, String linkId,
             String hmisBaseUrl, String hmisApiKey) {
 
@@ -4051,6 +4083,7 @@ public class AnthropicApiService implements Serializable {
                     if (timedItemFeeDurationHours != null && !timedItemFeeDurationHours.isEmpty()) bodyMap.put("timedItemFeeDurationHours", Double.parseDouble(timedItemFeeDurationHours));
                     if (timedItemFeeOverShootHours != null && !timedItemFeeOverShootHours.isEmpty()) bodyMap.put("timedItemFeeOverShootHours", Double.parseDouble(timedItemFeeOverShootHours));
                     if (timedItemFeeDurationDaysForMoCharge != null && !timedItemFeeDurationDaysForMoCharge.isEmpty()) bodyMap.put("timedItemFeeDurationDaysForMoCharge", Long.parseLong(timedItemFeeDurationDaysForMoCharge));
+                    if (timedItemFeeDurationUnit != null && !timedItemFeeDurationUnit.isEmpty()) bodyMap.put("timedItemFeeDurationUnit", timedItemFeeDurationUnit.trim().toUpperCase(java.util.Locale.ROOT));
                     String bodyJson = new com.google.gson.Gson().toJson(bodyMap);
                     request = HttpRequest.newBuilder().uri(URI.create(baseUrl + "/api/inward/room-facility-charges"))
                             .timeout(Duration.ofSeconds(15)).header("Finance", hmisApiKey)
@@ -4076,6 +4109,7 @@ public class AnthropicApiService implements Serializable {
                     if (timedItemFeeDurationHours != null && !timedItemFeeDurationHours.isEmpty()) bodyMap.put("timedItemFeeDurationHours", Double.parseDouble(timedItemFeeDurationHours));
                     if (timedItemFeeOverShootHours != null && !timedItemFeeOverShootHours.isEmpty()) bodyMap.put("timedItemFeeOverShootHours", Double.parseDouble(timedItemFeeOverShootHours));
                     if (timedItemFeeDurationDaysForMoCharge != null && !timedItemFeeDurationDaysForMoCharge.isEmpty()) bodyMap.put("timedItemFeeDurationDaysForMoCharge", Long.parseLong(timedItemFeeDurationDaysForMoCharge));
+                    if (timedItemFeeDurationUnit != null && !timedItemFeeDurationUnit.isEmpty()) bodyMap.put("timedItemFeeDurationUnit", timedItemFeeDurationUnit.trim().toUpperCase(java.util.Locale.ROOT));
                     String bodyJson = new com.google.gson.Gson().toJson(bodyMap);
                     request = HttpRequest.newBuilder().uri(URI.create(baseUrl + "/api/inward/room-facility-charges/" + id))
                             .timeout(Duration.ofSeconds(15)).header("Finance", hmisApiKey)
@@ -5674,7 +5708,8 @@ public class AnthropicApiService implements Serializable {
             String departmentType, String inwardChargeType, String departmentId, String institutionId,
             String categoryId, String inactive, String fee, String ffee, String durationHours, String overShootHours,
             String durationDaysForMoCharge, String sortOrder, String repeating, String durationUnit,
-            String query, String size, String retireComments,
+            String feesJson, String query, String size, String offset, String includeRetired,
+            String retireComments,
             String hmisBaseUrl, String hmisApiKey) {
         if (hmisBaseUrl == null || hmisBaseUrl.trim().isEmpty()) {
             return "Error: HMIS base URL is not configured.";
@@ -5689,16 +5724,24 @@ public class AnthropicApiService implements Serializable {
             switch (method.toUpperCase()) {
                 case "LIST": {
                     StringBuilder url = new StringBuilder(baseUrl).append("/search?limit=").append(size.isEmpty() ? "30" : size);
+                    if (!offset.isEmpty()) url.append("&offset=").append(URLEncoder.encode(offset, StandardCharsets.UTF_8));
                     if (!query.isEmpty()) url.append("&query=").append(URLEncoder.encode(query, StandardCharsets.UTF_8));
                     if (!departmentType.isEmpty()) url.append("&departmentType=").append(URLEncoder.encode(departmentType, StandardCharsets.UTF_8));
+                    if (!inwardChargeType.isEmpty()) url.append("&inwardChargeType=").append(URLEncoder.encode(inwardChargeType, StandardCharsets.UTF_8));
+                    if (!categoryId.isEmpty()) url.append("&categoryId=").append(URLEncoder.encode(categoryId, StandardCharsets.UTF_8));
+                    if (!departmentId.isEmpty()) url.append("&departmentId=").append(URLEncoder.encode(departmentId, StandardCharsets.UTF_8));
+                    if (!institutionId.isEmpty()) url.append("&institutionId=").append(URLEncoder.encode(institutionId, StandardCharsets.UTF_8));
                     if (!inactive.isEmpty()) url.append("&inactive=").append(URLEncoder.encode(inactive, StandardCharsets.UTF_8));
+                    if (!includeRetired.isEmpty()) url.append("&includeRetired=").append(URLEncoder.encode(includeRetired, StandardCharsets.UTF_8));
                     HttpRequest req = HttpRequest.newBuilder().uri(URI.create(url.toString()))
                             .timeout(Duration.ofSeconds(15)).header("Finance", hmisApiKey).GET().build();
                     return client.send(req, HttpResponse.BodyHandlers.ofString()).body();
                 }
                 case "GET": {
                     if (id.isEmpty()) return "Error: id is required for GET.";
-                    HttpRequest req = HttpRequest.newBuilder().uri(URI.create(baseUrl + "/" + id))
+                    StringBuilder url = new StringBuilder(baseUrl).append("/").append(id);
+                    if (!includeRetired.isEmpty()) url.append("?includeRetired=").append(URLEncoder.encode(includeRetired, StandardCharsets.UTF_8));
+                    HttpRequest req = HttpRequest.newBuilder().uri(URI.create(url.toString()))
                             .timeout(Duration.ofSeconds(15)).header("Finance", hmisApiKey).GET().build();
                     return client.send(req, HttpResponse.BodyHandlers.ofString()).body();
                 }
@@ -5745,6 +5788,13 @@ public class AnthropicApiService implements Serializable {
                             .timeout(Duration.ofSeconds(15)).header("Finance", hmisApiKey).DELETE().build();
                     return client.send(req, HttpResponse.BodyHandlers.ofString()).body();
                 }
+                case "RESTORE": {
+                    if (id.isEmpty()) return "Error: id is required for RESTORE.";
+                    HttpRequest req = HttpRequest.newBuilder().uri(URI.create(baseUrl + "/" + id + "/restore"))
+                            .timeout(Duration.ofSeconds(15)).header("Finance", hmisApiKey)
+                            .method("PATCH", HttpRequest.BodyPublishers.noBody()).build();
+                    return client.send(req, HttpResponse.BodyHandlers.ofString()).body();
+                }
                 case "ACTIVATE": {
                     if (id.isEmpty()) return "Error: id is required for ACTIVATE.";
                     HttpRequest req = HttpRequest.newBuilder().uri(URI.create(baseUrl + "/" + id + "/activate"))
@@ -5761,7 +5811,9 @@ public class AnthropicApiService implements Serializable {
                 }
                 case "LIST_FEES": {
                     if (id.isEmpty()) return "Error: id is required for LIST_FEES.";
-                    HttpRequest req = HttpRequest.newBuilder().uri(URI.create(baseUrl + "/" + id + "/fees"))
+                    StringBuilder url = new StringBuilder(baseUrl).append("/").append(id).append("/fees");
+                    if (!includeRetired.isEmpty()) url.append("?includeRetired=").append(URLEncoder.encode(includeRetired, StandardCharsets.UTF_8));
+                    HttpRequest req = HttpRequest.newBuilder().uri(URI.create(url.toString()))
                             .timeout(Duration.ofSeconds(15)).header("Finance", hmisApiKey).GET().build();
                     return client.send(req, HttpResponse.BodyHandlers.ofString()).body();
                 }
@@ -5814,8 +5866,38 @@ public class AnthropicApiService implements Serializable {
                             .timeout(Duration.ofSeconds(15)).header("Finance", hmisApiKey).DELETE().build();
                     return client.send(req, HttpResponse.BodyHandlers.ofString()).body();
                 }
+                case "RESTORE_FEE": {
+                    if (id.isEmpty()) return "Error: id is required for RESTORE_FEE.";
+                    if (feeId.isEmpty()) return "Error: feeId is required for RESTORE_FEE.";
+                    HttpRequest req = HttpRequest.newBuilder().uri(URI.create(baseUrl + "/" + id + "/fees/" + feeId + "/restore"))
+                            .timeout(Duration.ofSeconds(15)).header("Finance", hmisApiKey)
+                            .method("PATCH", HttpRequest.BodyPublishers.noBody()).build();
+                    return client.send(req, HttpResponse.BodyHandlers.ofString()).body();
+                }
+                case "PUT_FEES": {
+                    if (id.isEmpty()) return "Error: id is required for PUT_FEES.";
+                    if (feesJson == null || feesJson.trim().isEmpty()) {
+                        return "Error: fees is required for PUT_FEES. Pass the complete slot list as a JSON array, or [] to clear every slot.";
+                    }
+                    // Parsed rather than concatenated so a malformed array is reported here
+                    // instead of reaching the API as an unparseable body.
+                    com.google.gson.JsonArray arr;
+                    try {
+                        arr = com.google.gson.JsonParser.parseString(feesJson.trim()).getAsJsonArray();
+                    } catch (Exception ex) {
+                        return "Error: fees must be a JSON array. " + ex.getMessage();
+                    }
+                    com.google.gson.JsonObject wrapper = new com.google.gson.JsonObject();
+                    wrapper.add("fees", arr);
+                    HttpRequest req = HttpRequest.newBuilder().uri(URI.create(baseUrl + "/" + id + "/fees"))
+                            .timeout(Duration.ofSeconds(15)).header("Finance", hmisApiKey)
+                            .header("Content-Type", "application/json")
+                            .PUT(HttpRequest.BodyPublishers.ofString(wrapper.toString())).build();
+                    return client.send(req, HttpResponse.BodyHandlers.ofString()).body();
+                }
                 default:
-                    return "Unknown method: " + method + ". Valid: LIST, GET, POST, PUT, DELETE, ACTIVATE, DEACTIVATE, LIST_FEES, POST_FEE, PUT_FEE, DELETE_FEE";
+                    return "Unknown method: " + method + ". Valid: LIST, GET, POST, PUT, DELETE, RESTORE, "
+                            + "ACTIVATE, DEACTIVATE, LIST_FEES, POST_FEE, PUT_FEE, DELETE_FEE, RESTORE_FEE, PUT_FEES";
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
@@ -5966,6 +6048,9 @@ public class AnthropicApiService implements Serializable {
           .append("LIST_TIMED_ITEMS / ADD_TIMED_ITEM / REMOVE_TIMED_ITEM manage the TimedItem services attached to a ")
           .append("room facility charge so they auto-bill by duration of stay alongside its fixed fees ")
           .append("(id = room facility charge id; timedItemId required for ADD_TIMED_ITEM; linkId required for REMOVE_TIMED_ITEM). ")
+          .append("A charge's billing block is set with timedItemFeeDurationHours, timedItemFeeOverShootHours and ")
+          .append("timedItemFeeDurationUnit (ONE_TIME | MINUTE | HOUR | DAY, default HOUR) — the unit says what the other two ")
+          .append("are counted in, so pass DAY to charge a room per day rather than per hour. ")
           .append("Always confirm with the user before POST, PUT, or DELETE — these changes affect live inward room billing.\n\n");
         sb.append("### manage_bed_board_svg\n");
         sb.append("Read and set the graphical bed-board SVG drawings used by the Inpatient Bed Board page. ")
@@ -6018,15 +6103,21 @@ public class AnthropicApiService implements Serializable {
         sb.append("### manage_timed_items\n");
         sb.append("Manage timed item master data (room rent, oxygen, ICU time, etc.) and their tiered fee slots. ")
           .append("TimedItems (DTYPE=TimedItem) are consumed by the inward timed service page to bill patients for duration-based charges. ")
-          .append("Use LIST to search items (filter by departmentType e.g. Inward or Theatre). ")
+          .append("Use LIST to search items — filters: query (name/code, case-insensitive), departmentType (e.g. Inward or Theatre), ")
+          .append("inwardChargeType, categoryId, departmentId, institutionId, inactive. Paged with size + offset; the response carries ")
+          .append("a total count so you can tell whether more rows remain. ")
           .append("Use GET to fetch a single item with its fees. ")
           .append("Use POST to create a new timed item — required: name, departmentType, inwardChargeType. ")
           .append("Use PUT to update name, code, departmentType, inwardChargeType, departmentId, institutionId, categoryId, or inactive flag. ")
-          .append("Use DELETE to soft-retire an item. Use ACTIVATE / DEACTIVATE to toggle availability without retiring. ")
+          .append("Use DELETE to soft-retire an item and RESTORE to undo that. Use ACTIVATE / DEACTIVATE to toggle availability without retiring. ")
+          .append("Retired records are hidden by default — pass includeRetired=true to LIST, GET or LIST_FEES to find something retired by mistake and get its id. ")
           .append("For tiered fee management: LIST_FEES lists all fees ordered by sortOrder. ")
           .append("POST_FEE creates a fee tier — required: name, durationHours (> 0, not needed when durationUnit is ONE_TIME). fee, ffee, overShootHours, sortOrder, repeating, durationUnit are optional. ")
           .append("durationUnit (ONE_TIME | MINUTE | HOUR | DAY, default HOUR) sets what durationHours/overShootHours count in. ")
-          .append("PUT_FEE updates an existing fee tier (requires feeId). DELETE_FEE soft-retires a fee tier. ")
+          .append("sortOrder is the billing slot: it must be 1 or greater and unique within the service, and is auto-assigned to the next free slot if omitted. ")
+          .append("PUT_FEE updates an existing fee tier (requires feeId). DELETE_FEE soft-retires a fee tier and RESTORE_FEE undoes that. ")
+          .append("PUT_FEES replaces the entire slot list in one atomic, fully-validated call — prefer it over a run of POST_FEE calls when ")
+          .append("configuring a tiered service; slots you leave out of the array are retired. ")
           .append("Always confirm with the user before POST, PUT, or DELETE — changes affect live inward timed billing.\n\n");
         sb.append("### manage_inpatient_templates\n");
         sb.append("Create, read, update, and retire document templates (HTML with placeholder tokens). ")
@@ -6676,20 +6767,24 @@ public class AnthropicApiService implements Serializable {
         appendModule(sb, "Timed Items", "/timed-items",
                 "Manage timed item master data and their tiered fee slots for duration-based inward billing. "
                 + "Items have departmentType (Inward, Theatre) and inwardChargeType. "
-                + "Each item can have multiple TimedItemFee tiers ordered by sortOrder.",
-                githubUrl(branch, "developer_docs/api/building-apis/rest-api-development-guide.md"),
+                + "Each item can have multiple TimedItemFee tiers ordered by sortOrder, which must be >= 1 and "
+                + "unique per item. Retire is soft and reversible via the restore endpoints.",
+                githubUrl(branch, "developer_docs/api/using-apis/API_TIMED_ITEMS.md"),
                 new String[][]{
-                    {"GET",    "/timed-items/search?query=&departmentType=&limit=", "Search timed items"},
-                    {"GET",    "/timed-items/{id}",          "Fetch one timed item with fees"},
+                    {"GET",    "/timed-items/search?query=&departmentType=&inwardChargeType=&categoryId=&departmentId=&institutionId=&inactive=&includeRetired=&limit=&offset=", "Search timed items. Returns {items, total, limit, offset}"},
+                    {"GET",    "/timed-items/{id}?includeRetired=", "Fetch one timed item with fees"},
                     {"POST",   "/timed-items",               "Create timed item. Body: name, departmentType, inwardChargeType (all required); code, departmentId, institutionId, categoryId, inactive optional"},
                     {"PUT",    "/timed-items/{id}",          "Update timed item (all fields optional, including categoryId)"},
                     {"DELETE", "/timed-items/{id}",          "Soft-retire timed item"},
+                    {"PATCH",  "/timed-items/{id}/restore",  "Un-retire timed item"},
                     {"PATCH",  "/timed-items/{id}/activate", "Set inactive=false"},
                     {"PATCH",  "/timed-items/{id}/deactivate", "Set inactive=true"},
-                    {"GET",    "/timed-items/{id}/fees",     "List fee tiers for an item (ordered by sortOrder)"},
+                    {"GET",    "/timed-items/{id}/fees?includeRetired=", "List fee tiers for an item (ordered by sortOrder)"},
                     {"POST",   "/timed-items/{id}/fees",     "Add fee tier. Body: name, durationHours (required unless durationUnit=ONE_TIME); fee, ffee, overShootHours, sortOrder, repeating, durationUnit optional"},
+                    {"PUT",    "/timed-items/{id}/fees",     "Replace the whole slot list atomically. Body: {fees:[...]}; slots omitted from the array are retired"},
                     {"PUT",    "/timed-items/{id}/fees/{feeId}", "Update fee tier"},
-                    {"DELETE", "/timed-items/{id}/fees/{feeId}", "Soft-retire fee tier"}
+                    {"DELETE", "/timed-items/{id}/fees/{feeId}", "Soft-retire fee tier"},
+                    {"PATCH",  "/timed-items/{id}/fees/{feeId}/restore", "Un-retire fee tier"}
                 });
 
         // ── Login History / Config ────────────────────────────────────────────

--- a/src/main/java/com/divudi/service/inward/TimedItemApiService.java
+++ b/src/main/java/com/divudi/service/inward/TimedItemApiService.java
@@ -571,6 +571,16 @@ public class TimedItemApiService implements Serializable {
             existingById.put(f.getId(), f);
         }
 
+        // Retired fees are tracked only to tell "this id is not yours" apart from "this id
+        // is yours but retired" — a bulk write operates on the live slot list, so naming a
+        // retired fee is a mistake worth reporting accurately rather than as a wrong owner.
+        Set<Long> retiredIds = new HashSet<>();
+        for (TimedItemFee f : fetchFees(item, true)) {
+            if (f.isRetired()) {
+                retiredIds.add(f.getId());
+            }
+        }
+
         // Validate the entire submitted set before writing anything, so a bad slot in the
         // middle of the list does not leave the service half-reconfigured.
         Set<Integer> seenSlots = new HashSet<>();
@@ -584,6 +594,10 @@ public class TimedItemApiService implements Serializable {
                 throw new TimedItemFeeRuleException("Fee must be a non-negative value");
             }
             if (row.getId() != null && !existingById.containsKey(row.getId())) {
+                if (retiredIds.contains(row.getId())) {
+                    throw new TimedItemFeeRuleException("Fee with ID " + row.getId()
+                            + " is retired. Restore it first, or omit the id to add a new slot.");
+                }
                 throw new TimedItemFeeRuleException("Fee with ID " + row.getId()
                         + " does not belong to TimedItem with ID " + item.getId());
             }

--- a/src/main/java/com/divudi/service/inward/TimedItemApiService.java
+++ b/src/main/java/com/divudi/service/inward/TimedItemApiService.java
@@ -10,7 +10,10 @@ import com.divudi.core.data.dto.timeditem.TimedItemCreateRequestDTO;
 import com.divudi.core.data.dto.timeditem.TimedItemFeeCreateRequestDTO;
 import com.divudi.core.data.dto.timeditem.TimedItemFeeDTO;
 import com.divudi.core.data.dto.timeditem.TimedItemFeeUpdateRequestDTO;
+import com.divudi.core.data.dto.timeditem.TimedItemFeeBulkRequestDTO;
+import com.divudi.core.data.dto.timeditem.TimedItemFeeUpsertDTO;
 import com.divudi.core.data.dto.timeditem.TimedItemResponseDTO;
+import com.divudi.core.data.dto.timeditem.TimedItemSearchPageDTO;
 import com.divudi.core.data.dto.timeditem.TimedItemSearchResultDTO;
 import com.divudi.core.data.dto.timeditem.TimedItemUpdateRequestDTO;
 import com.divudi.core.data.inward.InwardChargeType;
@@ -32,13 +35,15 @@ import com.divudi.core.util.CommonFunctions;
 
 import javax.ejb.EJB;
 import javax.ejb.Stateless;
-import javax.persistence.TemporalType;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Business logic for Timed Item API.
@@ -64,25 +69,44 @@ public class TimedItemApiService implements Serializable {
     @EJB
     private CategoryFacade categoryFacade;
 
+    @EJB
+    private TimedItemFeeRules timedItemFeeRules;
+
     // =========================================================================
     // Search
     // =========================================================================
 
-    public List<TimedItemSearchResultDTO> searchTimedItems(String query, String departmentType,
-            Boolean inactive, int limit) throws Exception {
+    /**
+     * Search timed items, returning one page plus the total number of matches.
+     *
+     * <p>Every filter here is a field this same API sets on create, so a caller can find
+     * a record again by whatever it used to configure it. {@code includeRetired} exists
+     * because the retire/restore round trip is otherwise blind — a retired item is
+     * invisible to every other read path (issue #23236 §2, §4).
+     */
+    public TimedItemSearchPageDTO searchTimedItems(String query, String departmentType,
+            Boolean inactive, Long categoryId, String inwardChargeType, Long departmentId,
+            Long institutionId, boolean includeRetired, int limit, int offset) throws Exception {
 
         Map<String, Object> params = new HashMap<>();
 
-        StringBuilder jpql = new StringBuilder();
-        jpql.append("SELECT i FROM TimedItem i WHERE i.retired = false ");
+        StringBuilder where = new StringBuilder();
+        where.append(" WHERE 1 = 1 ");
+
+        if (!includeRetired) {
+            where.append("AND i.retired = false ");
+        }
 
         if (query != null && !query.trim().isEmpty()) {
-            jpql.append("AND (i.name LIKE :query OR i.code LIKE :query) ");
-            params.put("query", "%" + query.trim() + "%");
+            // Upper-cased on both sides so matching is defined here rather than by the
+            // deployment's collation — the same thing listCategories and the UI
+            // autocomplete already do.
+            where.append("AND (upper(i.name) LIKE :query OR upper(i.code) LIKE :query) ");
+            params.put("query", "%" + query.trim().toUpperCase() + "%");
         }
 
         if (departmentType != null && !departmentType.trim().isEmpty()) {
-            jpql.append("AND i.departmentType = :departmentType ");
+            where.append("AND i.departmentType = :departmentType ");
             try {
                 params.put("departmentType", DepartmentType.valueOf(departmentType.trim()));
             } catch (IllegalArgumentException e) {
@@ -90,21 +114,49 @@ public class TimedItemApiService implements Serializable {
             }
         }
 
+        if (inwardChargeType != null && !inwardChargeType.trim().isEmpty()) {
+            where.append("AND i.inwardChargeType = :inwardChargeType ");
+            try {
+                params.put("inwardChargeType", InwardChargeType.valueOf(inwardChargeType.trim()));
+            } catch (IllegalArgumentException e) {
+                throw new Exception("Invalid inwardChargeType: " + inwardChargeType);
+            }
+        }
+
         if (inactive != null) {
-            jpql.append("AND i.inactive = :inactive ");
+            where.append("AND i.inactive = :inactive ");
             params.put("inactive", inactive);
         }
 
-        jpql.append("ORDER BY i.name");
+        if (categoryId != null) {
+            where.append("AND i.category.id = :categoryId ");
+            params.put("categoryId", categoryId);
+        }
 
-        List<TimedItem> results = timedItemFacade.findByJpql(
-                jpql.toString(), params, TemporalType.TIMESTAMP, limit);
+        if (departmentId != null) {
+            where.append("AND i.department.id = :departmentId ");
+            params.put("departmentId", departmentId);
+        }
+
+        if (institutionId != null) {
+            where.append("AND i.institution.id = :institutionId ");
+            params.put("institutionId", institutionId);
+        }
+
+        // COUNT returns a Long — findLongByJpql, never findDoubleByJpql (which would
+        // swallow the ClassCastException and report 0 every time).
+        long total = timedItemFacade.findLongByJpql(
+                "SELECT COUNT(i) FROM TimedItem i" + where, params);
+
+        List<TimedItem> results = timedItemFacade.findByJpqlWithRange(
+                "SELECT i FROM TimedItem i" + where + "ORDER BY i.name, i.id",
+                params, offset, limit);
 
         List<TimedItemSearchResultDTO> dtos = new ArrayList<>();
         for (TimedItem item : results) {
             dtos.add(buildSearchResultDTO(item));
         }
-        return dtos;
+        return new TimedItemSearchPageDTO(dtos, total, limit, offset);
     }
 
     // =========================================================================
@@ -112,8 +164,17 @@ public class TimedItemApiService implements Serializable {
     // =========================================================================
 
     public TimedItemResponseDTO findTimedItemById(Long id) throws Exception {
-        TimedItem item = loadAndValidate(id);
-        List<TimedItemFee> fees = fetchFees(item);
+        return findTimedItemById(id, false);
+    }
+
+    /**
+     * @param includeRetired read a retired item (and its retired fees) instead of
+     *                       rejecting it, so an agent can review what it retired before
+     *                       deciding whether to restore it
+     */
+    public TimedItemResponseDTO findTimedItemById(Long id, boolean includeRetired) throws Exception {
+        TimedItem item = includeRetired ? loadAllowingRetired(id) : loadAndValidate(id);
+        List<TimedItemFee> fees = fetchFees(item, includeRetired);
         return buildResponseDTO(item, fees, "TimedItem found successfully");
     }
 
@@ -271,6 +332,30 @@ public class TimedItemApiService implements Serializable {
         return buildResponseDTO(item, new ArrayList<>(), "TimedItem retired successfully");
     }
 
+    /**
+     * Undo a retire. Without this, an agent that retires the wrong service cannot put it
+     * back through the API at all — recovery needs the UI or direct database access
+     * (issue #23236 §2).
+     */
+    public TimedItemResponseDTO restoreTimedItem(Long id, WebUser user) throws Exception {
+        TimedItem item = loadAllowingRetired(id);
+        if (!item.isRetired()) {
+            throw new Exception("TimedItem with ID " + id + " is not retired");
+        }
+        item.setRetired(false);
+        item.setRetiredAt(null);
+        item.setRetirer(null);
+        item.setRetireComments(null);
+        item.setEditer(user);
+        item.setEditedAt(Calendar.getInstance().getTime());
+        timedItemFacade.edit(item);
+
+        // Fees retired alongside the item stay retired: restoring the service should not
+        // silently resurrect slot configuration the user may have removed on purpose.
+        List<TimedItemFee> fees = fetchFees(item);
+        return buildResponseDTO(item, fees, "TimedItem restored successfully");
+    }
+
     public TimedItemResponseDTO activateTimedItem(Long id, WebUser user) throws Exception {
         TimedItem item = loadAndValidate(id);
         item.setInactive(false);
@@ -294,8 +379,12 @@ public class TimedItemApiService implements Serializable {
     // =========================================================================
 
     public List<TimedItemFeeDTO> listFees(Long timedItemId) throws Exception {
-        TimedItem item = loadAndValidate(timedItemId);
-        List<TimedItemFee> fees = fetchFees(item);
+        return listFees(timedItemId, false);
+    }
+
+    public List<TimedItemFeeDTO> listFees(Long timedItemId, boolean includeRetired) throws Exception {
+        TimedItem item = includeRetired ? loadAllowingRetired(timedItemId) : loadAndValidate(timedItemId);
+        List<TimedItemFee> fees = fetchFees(item, includeRetired);
         List<TimedItemFeeDTO> dtos = new ArrayList<>();
         for (TimedItemFee fee : fees) {
             dtos.add(buildFeeDTO(fee));
@@ -304,7 +393,7 @@ public class TimedItemApiService implements Serializable {
     }
 
     public TimedItemResponseDTO addFee(Long timedItemId, TimedItemFeeCreateRequestDTO request, WebUser user) throws Exception {
-        if (request == null || !request.isValid()) {
+        if (request == null || request.getName() == null || request.getName().trim().isEmpty()) {
             throw new Exception("Valid fee request required (name is required)");
         }
         if (request.getFee() < 0) {
@@ -329,6 +418,11 @@ public class TimedItemApiService implements Serializable {
         // a null unit to HOUR for rows created before duration units existed.
         fee.setDurationUnit(request.getDurationUnit() != null
                 ? request.getDurationUnit() : TimedItemDurationUnit.HOUR);
+
+        // Same rules the fee page applies, from the same place, so an identical payload
+        // is accepted or rejected identically on both surfaces (issue #23236 §3).
+        fee.setSortOrder(timedItemFeeRules.applyToFee(fee, fetchFees(item)));
+
         fee.setCreater(user);
         fee.setCreatedAt(Calendar.getInstance().getTime());
         fee.setRetired(false);
@@ -384,6 +478,12 @@ public class TimedItemApiService implements Serializable {
             fee.setDurationUnit(request.getDurationUnit());
         }
 
+        // Validate the fee as it will be stored, not just the fields that arrived: a
+        // payload that only switches the unit can still leave a zero-length block, and a
+        // payload that only moves the slot order can still collide with a sibling.
+        timedItemFeeRules.validateDuration(fee.getDurationUnit(), fee.getDurationHours());
+        timedItemFeeRules.validateSlotOrder(fee.getSortOrder(), fetchFees(item), fee.getId());
+
         fee.setEditer(user);
         fee.setEditedAt(Calendar.getInstance().getTime());
         timedItemFeeFacade.edit(fee);
@@ -409,9 +509,166 @@ public class TimedItemApiService implements Serializable {
         return buildResponseDTO(item, fees, "Fee removed successfully");
     }
 
+    /**
+     * Undo a fee retire. The parent must be live — restore the item first — because a
+     * live fee hanging off a retired service is a state neither surface can show.
+     */
+    public TimedItemResponseDTO restoreFee(Long timedItemId, Long feeId, WebUser user) throws Exception {
+        TimedItem item = loadAndValidate(timedItemId);
+
+        if (feeId == null) {
+            throw new Exception("Fee ID is required");
+        }
+        TimedItemFee fee = timedItemFeeFacade.find(feeId);
+        if (fee == null) {
+            throw new Exception("TimedItemFee not found with ID: " + feeId);
+        }
+        if (fee.getItem() == null || !fee.getItem().getId().equals(item.getId())) {
+            throw new Exception("Fee with ID " + feeId + " does not belong to TimedItem with ID " + item.getId());
+        }
+        if (!fee.isRetired()) {
+            throw new Exception("TimedItemFee with ID " + feeId + " is not retired");
+        }
+
+        // The slot this fee used to occupy may have been taken while it was retired.
+        timedItemFeeRules.validateSlotOrder(fee.getSortOrder(), fetchFees(item), fee.getId());
+
+        fee.setRetired(false);
+        fee.setRetiredAt(null);
+        fee.setRetirer(null);
+        fee.setRetireComments(null);
+        fee.setEditer(user);
+        fee.setEditedAt(Calendar.getInstance().getTime());
+        timedItemFeeFacade.edit(fee);
+
+        recalculateTotal(item);
+
+        List<TimedItemFee> fees = fetchFees(item);
+        return buildResponseDTO(item, fees, "Fee restored successfully");
+    }
+
+    /**
+     * Replace a timed item's whole slot list in one call.
+     *
+     * <p>Validating the complete set together is the point: slot-order uniqueness can only
+     * really be checked against every slot at once, and the parent's total is recalculated
+     * once instead of once per round trip (issue #23236 §4).
+     *
+     * <p>Live fees whose id is absent from the payload are retired.
+     */
+    public TimedItemResponseDTO replaceFees(Long timedItemId, TimedItemFeeBulkRequestDTO request,
+            WebUser user) throws Exception {
+        if (request == null || !request.isValid()) {
+            throw new TimedItemFeeRuleException(
+                    "A fees array is required; send [] to clear all slots");
+        }
+
+        TimedItem item = loadAndValidate(timedItemId);
+        List<TimedItemFee> existing = fetchFees(item);
+
+        Map<Long, TimedItemFee> existingById = new HashMap<>();
+        for (TimedItemFee f : existing) {
+            existingById.put(f.getId(), f);
+        }
+
+        // Validate the entire submitted set before writing anything, so a bad slot in the
+        // middle of the list does not leave the service half-reconfigured.
+        Set<Integer> seenSlots = new HashSet<>();
+        List<Integer> resolvedSlots = new ArrayList<>();
+        int nextAutoSlot = 0;
+        for (TimedItemFeeUpsertDTO row : request.getFees()) {
+            if (row == null || row.getName() == null || row.getName().trim().isEmpty()) {
+                throw new TimedItemFeeRuleException("Every fee in the list requires a name");
+            }
+            if (row.getFee() < 0) {
+                throw new TimedItemFeeRuleException("Fee must be a non-negative value");
+            }
+            if (row.getId() != null && !existingById.containsKey(row.getId())) {
+                throw new TimedItemFeeRuleException("Fee with ID " + row.getId()
+                        + " does not belong to TimedItem with ID " + item.getId());
+            }
+            timedItemFeeRules.validateDuration(row.getDurationUnit(), row.getDurationHours());
+
+            int slot = row.getSortOrder();
+            if (slot == 0) {
+                // Auto-assign above every slot in the submitted set, not just the stored
+                // ones — the set being written is what the uniqueness rule applies to.
+                if (nextAutoSlot == 0) {
+                    nextAutoSlot = highestSubmittedSlot(request.getFees());
+                }
+                slot = ++nextAutoSlot;
+            }
+            if (slot < 1) {
+                throw new TimedItemFeeRuleException("Slot Order must be 1 or greater.");
+            }
+            if (!seenSlots.add(slot)) {
+                throw new TimedItemFeeRuleException("Slot Order must be unique per service.");
+            }
+            resolvedSlots.add(slot);
+        }
+
+        Date now = Calendar.getInstance().getTime();
+        Set<Long> submittedIds = new HashSet<>();
+
+        for (int i = 0; i < request.getFees().size(); i++) {
+            TimedItemFeeUpsertDTO row = request.getFees().get(i);
+            boolean isNew = row.getId() == null;
+            TimedItemFee fee = isNew ? new TimedItemFee() : existingById.get(row.getId());
+
+            fee.setItem(item);
+            fee.setName(row.getName().trim());
+            fee.setFee(row.getFee());
+            fee.setFfee(row.getFfee() > 0 ? row.getFfee() : row.getFee());
+            fee.setDurationHours(row.getDurationHours());
+            fee.setOverShootHours(row.getOverShootHours());
+            fee.setDurationDaysForMoCharge(row.getDurationDaysForMoCharge());
+            fee.setSortOrder(resolvedSlots.get(i));
+            fee.setRepeating(row.isRepeating());
+            fee.setDurationUnit(row.getDurationUnit() != null
+                    ? row.getDurationUnit() : TimedItemDurationUnit.HOUR);
+
+            if (isNew) {
+                fee.setRetired(false);
+                fee.setCreater(user);
+                fee.setCreatedAt(now);
+                timedItemFeeFacade.create(fee);
+            } else {
+                fee.setEditer(user);
+                fee.setEditedAt(now);
+                timedItemFeeFacade.edit(fee);
+                submittedIds.add(fee.getId());
+            }
+        }
+
+        for (TimedItemFee f : existing) {
+            if (!submittedIds.contains(f.getId())) {
+                f.setRetired(true);
+                f.setRetirer(user);
+                f.setRetiredAt(now);
+                f.setRetireComments("Removed by bulk fee update");
+                timedItemFeeFacade.edit(f);
+            }
+        }
+
+        recalculateTotal(item);
+
+        List<TimedItemFee> fees = fetchFees(item);
+        return buildResponseDTO(item, fees, "Fees replaced successfully");
+    }
+
     // =========================================================================
     // Private helpers
     // =========================================================================
+
+    private int highestSubmittedSlot(List<TimedItemFeeUpsertDTO> rows) {
+        int max = 0;
+        for (TimedItemFeeUpsertDTO r : rows) {
+            if (r != null && r.getSortOrder() > max) {
+                max = r.getSortOrder();
+            }
+        }
+        return max;
+    }
 
     private TimedItemCategory resolveCategory(Long categoryId) throws Exception {
         Category category = categoryFacade.find(categoryId);
@@ -422,15 +679,21 @@ public class TimedItemApiService implements Serializable {
     }
 
     private TimedItem loadAndValidate(Long id) throws Exception {
+        TimedItem item = loadAllowingRetired(id);
+        if (item.isRetired()) {
+            throw new Exception("TimedItem with ID " + id + " is retired");
+        }
+        return item;
+    }
+
+    /** Load without rejecting a retired row — for reads that opted in, and for restore. */
+    private TimedItem loadAllowingRetired(Long id) throws Exception {
         if (id == null) {
             throw new Exception("TimedItem ID is required");
         }
         TimedItem item = timedItemFacade.find(id);
         if (item == null) {
             throw new Exception("TimedItem not found with ID: " + id);
-        }
-        if (item.isRetired()) {
-            throw new Exception("TimedItem with ID " + id + " is retired");
         }
         return item;
     }
@@ -453,7 +716,13 @@ public class TimedItemApiService implements Serializable {
     }
 
     private List<TimedItemFee> fetchFees(TimedItem item) {
-        String jpql = "SELECT f FROM TimedItemFee f WHERE f.item = :item AND f.retired = false ORDER BY f.sortOrder, f.id";
+        return fetchFees(item, false);
+    }
+
+    private List<TimedItemFee> fetchFees(TimedItem item, boolean includeRetired) {
+        String jpql = "SELECT f FROM TimedItemFee f WHERE f.item = :item "
+                + (includeRetired ? "" : "AND f.retired = false ")
+                + "ORDER BY f.sortOrder, f.id";
         Map<String, Object> params = new HashMap<>();
         params.put("item", item);
         return timedItemFeeFacade.findByJpql(jpql, params);
@@ -484,11 +753,16 @@ public class TimedItemApiService implements Serializable {
         dto.setTotal(item.getTotal());
         dto.setTotalForForeigner(item.getTotalForForeigner());
         dto.setInactive(item.isInactive());
+        dto.setRetired(item.isRetired());
         if (item.getDepartmentType() != null) {
             dto.setDepartmentType(item.getDepartmentType().name());
         }
         if (item.getInwardChargeType() != null) {
             dto.setInwardChargeType(item.getInwardChargeType().name());
+        }
+        if (item.getCategory() != null) {
+            dto.setCategoryId(item.getCategory().getId());
+            dto.setCategoryName(item.getCategory().getName());
         }
         return dto;
     }

--- a/src/main/java/com/divudi/service/inward/TimedItemFeeRuleException.java
+++ b/src/main/java/com/divudi/service/inward/TimedItemFeeRuleException.java
@@ -1,0 +1,23 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.service.inward;
+
+/**
+ * Raised when a timed item fee breaks one of the rules in {@link TimedItemFeeRules}.
+ *
+ * <p>The message is written for the person configuring the fee, not for a log: the
+ * fee page shows it verbatim through {@code JsfUtil.addErrorMessage}, and the REST
+ * API returns it as the body of a 400. That is the point — one rule, one wording,
+ * whichever surface the payload arrived on.
+ *
+ * @author Buddhika
+ */
+public class TimedItemFeeRuleException extends Exception {
+
+    public TimedItemFeeRuleException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/divudi/service/inward/TimedItemFeeRules.java
+++ b/src/main/java/com/divudi/service/inward/TimedItemFeeRules.java
@@ -1,0 +1,109 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.service.inward;
+
+import com.divudi.core.data.inward.TimedItemDurationUnit;
+import com.divudi.core.entity.inward.TimedItemFee;
+
+import javax.ejb.Stateless;
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * The single definition of the rules a {@link TimedItemFee} must satisfy, shared by
+ * the fee page ({@code TimedItemFeeController}) and the REST API
+ * ({@code TimedItemApiService}) so an identical payload is accepted or rejected
+ * identically whichever surface it arrives on (issue #23236 §3).
+ *
+ * <p>These are not cosmetic checks. {@code InwardBeanController.getAllTimedItemFees}
+ * orders fees by {@code sortOrder} and {@code getFeeForBlock} then picks
+ * {@code fees.get(blockNumber - 1)}, so a duplicate or zero slot order makes the
+ * ordering non-deterministic and a tiered service can silently charge the wrong tier.
+ * A zero-length block is just as bad in the other direction: it bills nothing for
+ * every stay.
+ *
+ * @author Buddhika
+ */
+@Stateless
+public class TimedItemFeeRules implements Serializable {
+
+    /**
+     * The slot order to give a fee that was saved without one.
+     *
+     * <p>Deliberately {@code max + 1} rather than {@code size + 1}: with slots 1 and 3
+     * already taken, {@code size + 1} yields 3 and collides with an existing row, so
+     * the auto-assignment itself would be rejected by
+     * {@link #validateSlotOrder(int, List, Long)}. The next free slot above the
+     * highest one in use always fits.
+     */
+    public int nextSlotOrder(List<TimedItemFee> existingFees) {
+        int max = 0;
+        if (existingFees != null) {
+            for (TimedItemFee f : existingFees) {
+                if (f.getSortOrder() > max) {
+                    max = f.getSortOrder();
+                }
+            }
+        }
+        return max + 1;
+    }
+
+    /**
+     * Slot order must be a real position (1 or greater) and must not collide with
+     * another fee on the same service.
+     *
+     * @param editingFeeId id of the fee being edited, so a row does not clash with
+     *                     itself; null when the fee is new
+     */
+    public void validateSlotOrder(int sortOrder, List<TimedItemFee> existingFees, Long editingFeeId)
+            throws TimedItemFeeRuleException {
+        if (sortOrder < 1) {
+            throw new TimedItemFeeRuleException("Slot Order must be 1 or greater.");
+        }
+        if (existingFees == null) {
+            return;
+        }
+        for (TimedItemFee f : existingFees) {
+            if (f.isRetired()) {
+                continue;
+            }
+            if (editingFeeId != null && f.getId() != null && editingFeeId.equals(f.getId())) {
+                continue;
+            }
+            if (f.getSortOrder() == sortOrder) {
+                throw new TimedItemFeeRuleException("Slot Order must be unique per service.");
+            }
+        }
+    }
+
+    /**
+     * A time-based fee needs a block longer than zero — a zero-length block bills
+     * nothing for every stay. A ONE_TIME fee is not time-based, so it is exempt.
+     */
+    public void validateDuration(TimedItemDurationUnit unit, double durationHours)
+            throws TimedItemFeeRuleException {
+        TimedItemDurationUnit effective = unit == null ? TimedItemDurationUnit.HOUR : unit;
+        if (effective == TimedItemDurationUnit.ONE_TIME) {
+            return;
+        }
+        if (durationHours <= 0) {
+            throw new TimedItemFeeRuleException(
+                    "Duration must be greater than 0 for a " + effective.getLabel() + " fee.");
+        }
+    }
+
+    /**
+     * Both rules for one fee, resolving an unset slot order first. Returns the slot
+     * order that should be stored.
+     */
+    public int applyToFee(TimedItemFee fee, List<TimedItemFee> existingFees)
+            throws TimedItemFeeRuleException {
+        validateDuration(fee.getDurationUnit(), fee.getDurationHours());
+        int sortOrder = fee.getSortOrder() == 0 ? nextSlotOrder(existingFees) : fee.getSortOrder();
+        validateSlotOrder(sortOrder, existingFees, fee.getId());
+        return sortOrder;
+    }
+}

--- a/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
+++ b/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
@@ -222,7 +222,8 @@ public class CapabilityStatementResource {
                         + "Charge fields: roomCharge, maintananceCharge, linenCharge, nursingCharge, "
                         + "moCharge, moChargeForAfterDuration, adminstrationCharge, medicalCareCharge. "
                         + "TimedItemFee fields: timedItemFeeDurationHours, timedItemFeeOverShootHours, "
-                        + "timedItemFeeDurationDaysForMoCharge.",
+                        + "timedItemFeeDurationDaysForMoCharge, timedItemFeeDurationUnit "
+                        + "(ONE_TIME | MINUTE | HOUR | DAY, default HOUR — what the hour fields are counted in).",
                         "API Key",
                         "GET", "POST", "PUT", "DELETE"))
                 .add(resource("Inward Room Facility Timed Items", "/api/inward/room-facility-charges/{id}/timed-items",
@@ -477,9 +478,17 @@ public class CapabilityStatementResource {
                         + "TimedItem entities are consumed by the inward timed service page (/inward/inward_timed_service_consume.xhtml). "
                         + "Fees are ordered by sortOrder and support durationHours/overShootHours/repeating for tiered block billing. "
                         + "durationUnit (ONE_TIME | MINUTE | HOUR | DAY, default HOUR) sets what durationHours/overShootHours are counted in. "
-                        + "Sub-resource: /timed-items/{id}/fees for per-item fee management. "
+                        + "sortOrder must be 1 or greater and unique per item — it is the billing slot position — and is auto-assigned "
+                        + "to the next free slot when omitted; the same rules apply on the fee page and on this API. "
+                        + "GET /search filters on query (name/code, case-insensitive), departmentType, inwardChargeType, categoryId, "
+                        + "departmentId, institutionId, inactive and includeRetired, and pages with limit + offset, returning "
+                        + "{items, total, limit, offset}. "
+                        + "Sub-resource: /timed-items/{id}/fees for per-item fee management; PUT on that path replaces the whole slot "
+                        + "list atomically (slots absent from the body are retired). "
                         + "Sub-resource: /timed-items/categories for TimedItemCategory CRUD (GET list, GET /{id}, POST, PUT /{id}, DELETE /{id}). "
-                        + "PATCH /activate and /deactivate control availability without retiring.",
+                        + "PATCH /activate and /deactivate control availability without retiring. "
+                        + "DELETE only soft-retires; PATCH /{id}/restore and PATCH /{id}/fees/{feeId}/restore undo it, and "
+                        + "includeRetired=true on the read paths lists what was retired.",
                         "API Key",
                         "GET", "POST", "PUT", "PATCH", "DELETE"))
                 .add(resource("Collecting Centre Fees", "/api/pricing/collecting_centre_fees",

--- a/src/main/java/com/divudi/ws/inward/TimedItemApi.java
+++ b/src/main/java/com/divudi/ws/inward/TimedItemApi.java
@@ -7,11 +7,12 @@ package com.divudi.ws.inward;
 
 import com.divudi.bean.common.ApiKeyController;
 import com.divudi.core.data.dto.timeditem.TimedItemCreateRequestDTO;
+import com.divudi.core.data.dto.timeditem.TimedItemFeeBulkRequestDTO;
 import com.divudi.core.data.dto.timeditem.TimedItemFeeCreateRequestDTO;
 import com.divudi.core.data.dto.timeditem.TimedItemFeeDTO;
 import com.divudi.core.data.dto.timeditem.TimedItemFeeUpdateRequestDTO;
 import com.divudi.core.data.dto.timeditem.TimedItemResponseDTO;
-import com.divudi.core.data.dto.timeditem.TimedItemSearchResultDTO;
+import com.divudi.core.data.dto.timeditem.TimedItemSearchPageDTO;
 import com.divudi.core.data.dto.timeditem.TimedItemUpdateRequestDTO;
 import com.divudi.core.entity.ApiKey;
 import com.divudi.core.entity.Category;
@@ -19,6 +20,7 @@ import com.divudi.core.entity.WebUser;
 import com.divudi.core.entity.inward.TimedItemCategory;
 import com.divudi.core.facade.CategoryFacade;
 import com.divudi.service.inward.TimedItemApiService;
+import com.divudi.service.inward.TimedItemFeeRuleException;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
@@ -93,8 +95,10 @@ public class TimedItemApi {
 
             String query = uriInfo.getQueryParameters().getFirst("query");
             String departmentType = uriInfo.getQueryParameters().getFirst("departmentType");
+            String inwardChargeType = uriInfo.getQueryParameters().getFirst("inwardChargeType");
             String inactiveStr = uriInfo.getQueryParameters().getFirst("inactive");
             String limitStr = uriInfo.getQueryParameters().getFirst("limit");
+            String offsetStr = uriInfo.getQueryParameters().getFirst("offset");
 
             Boolean inactive = null;
             if (inactiveStr != null && !inactiveStr.trim().isEmpty()) {
@@ -103,6 +107,22 @@ public class TimedItemApi {
                     return errorResponse("Invalid inactive value. Use true or false.", 400);
                 }
                 inactive = Boolean.parseBoolean(raw);
+            }
+
+            Boolean includeRetired = parseBooleanParam("includeRetired");
+            if (includeRetired == null) {
+                return errorResponse("Invalid includeRetired value. Use true or false.", 400);
+            }
+
+            Long categoryId;
+            Long departmentId;
+            Long institutionId;
+            try {
+                categoryId = parseLongParam("categoryId");
+                departmentId = parseLongParam("departmentId");
+                institutionId = parseLongParam("institutionId");
+            } catch (NumberFormatException e) {
+                return errorResponse(e.getMessage(), 400);
             }
 
             int limit = 30;
@@ -115,12 +135,26 @@ public class TimedItemApi {
                 }
             }
 
-            List<TimedItemSearchResultDTO> results = timedItemApiService.searchTimedItems(
-                    query, departmentType, inactive, limit);
+            int offset = 0;
+            if (offsetStr != null && !offsetStr.trim().isEmpty()) {
+                try {
+                    offset = Math.max(Integer.parseInt(offsetStr.trim()), 0);
+                } catch (NumberFormatException e) {
+                    return errorResponse("Invalid offset format", 400);
+                }
+            }
+
+            TimedItemSearchPageDTO results = timedItemApiService.searchTimedItems(
+                    query, departmentType, inactive, categoryId, inwardChargeType,
+                    departmentId, institutionId, includeRetired, limit, offset);
             return successResponse(results);
 
         } catch (Exception e) {
-            return errorResponse("An error occurred: " + e.getMessage(), 500);
+            String msg = e.getMessage();
+            if (msg != null && msg.contains("Invalid")) {
+                return errorResponse(msg, 400);
+            }
+            return errorResponse("An error occurred: " + msg, 500);
         }
     }
 
@@ -138,18 +172,16 @@ public class TimedItemApi {
                 return errorResponse("Not a valid key", 401);
             }
 
-            TimedItemResponseDTO result = timedItemApiService.findTimedItemById(id);
+            Boolean includeRetired = parseBooleanParam("includeRetired");
+            if (includeRetired == null) {
+                return errorResponse("Invalid includeRetired value. Use true or false.", 400);
+            }
+
+            TimedItemResponseDTO result = timedItemApiService.findTimedItemById(id, includeRetired);
             return successResponse(result);
 
         } catch (Exception e) {
-            String msg = e.getMessage();
-            if (msg != null && msg.contains("not found")) {
-                return errorResponse(msg, 404);
-            }
-            if (msg != null && msg.contains("Invalid")) {
-                return errorResponse(msg, 400);
-            }
-            return errorResponse("An error occurred: " + (msg != null ? msg : "Unknown error"), 500);
+            return mapError(e);
         }
     }
 
@@ -216,14 +248,7 @@ public class TimedItemApi {
             return successResponse(response);
 
         } catch (Exception e) {
-            String msg = e.getMessage();
-            if (msg != null && msg.contains("not found")) {
-                return errorResponse(msg, 404);
-            }
-            if (msg != null && msg.contains("Invalid")) {
-                return errorResponse(msg, 400);
-            }
-            return errorResponse("An error occurred: " + (msg != null ? msg : "Unknown error"), 500);
+            return mapError(e);
         }
     }
 
@@ -246,14 +271,29 @@ public class TimedItemApi {
             return successResponse(response);
 
         } catch (Exception e) {
-            String msg = e.getMessage();
-            if (msg != null && msg.contains("not found")) {
-                return errorResponse(msg, 404);
+            return mapError(e);
+        }
+    }
+
+    /**
+     * Un-retire a timed item, undoing DELETE /api/timed-items/{id}.
+     * PATCH /api/timed-items/{id}/restore
+     */
+    @PATCH
+    @Path("/{id}/restore")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response restoreTimedItem(@PathParam("id") Long id) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
             }
-            if (msg != null && msg.contains("Invalid")) {
-                return errorResponse(msg, 400);
-            }
-            return errorResponse("An error occurred: " + (msg != null ? msg : "Unknown error"), 500);
+
+            TimedItemResponseDTO response = timedItemApiService.restoreTimedItem(id, user);
+            return successResponse(response);
+
+        } catch (Exception e) {
+            return mapError(e);
         }
     }
 
@@ -275,14 +315,7 @@ public class TimedItemApi {
             return successResponse(response);
 
         } catch (Exception e) {
-            String msg = e.getMessage();
-            if (msg != null && msg.contains("not found")) {
-                return errorResponse(msg, 404);
-            }
-            if (msg != null && msg.contains("Invalid")) {
-                return errorResponse(msg, 400);
-            }
-            return errorResponse("An error occurred: " + (msg != null ? msg : "Unknown error"), 500);
+            return mapError(e);
         }
     }
 
@@ -304,14 +337,7 @@ public class TimedItemApi {
             return successResponse(response);
 
         } catch (Exception e) {
-            String msg = e.getMessage();
-            if (msg != null && msg.contains("not found")) {
-                return errorResponse(msg, 404);
-            }
-            if (msg != null && msg.contains("Invalid")) {
-                return errorResponse(msg, 400);
-            }
-            return errorResponse("An error occurred: " + (msg != null ? msg : "Unknown error"), 500);
+            return mapError(e);
         }
     }
 
@@ -333,18 +359,16 @@ public class TimedItemApi {
                 return errorResponse("Not a valid key", 401);
             }
 
-            List<TimedItemFeeDTO> fees = timedItemApiService.listFees(id);
+            Boolean includeRetired = parseBooleanParam("includeRetired");
+            if (includeRetired == null) {
+                return errorResponse("Invalid includeRetired value. Use true or false.", 400);
+            }
+
+            List<TimedItemFeeDTO> fees = timedItemApiService.listFees(id, includeRetired);
             return successResponse(fees);
 
         } catch (Exception e) {
-            String msg = e.getMessage();
-            if (msg != null && msg.contains("not found")) {
-                return errorResponse(msg, 404);
-            }
-            if (msg != null && msg.contains("Invalid")) {
-                return errorResponse(msg, 400);
-            }
-            return errorResponse("An error occurred: " + (msg != null ? msg : "Unknown error"), 500);
+            return mapError(e);
         }
     }
 
@@ -378,14 +402,7 @@ public class TimedItemApi {
             return successResponse(201, response);
 
         } catch (Exception e) {
-            String msg = e.getMessage();
-            if (msg != null && msg.contains("not found")) {
-                return errorResponse(msg, 404);
-            }
-            if (msg != null && msg.contains("Invalid")) {
-                return errorResponse(msg, 400);
-            }
-            return errorResponse("An error occurred: " + (msg != null ? msg : "Unknown error"), 500);
+            return mapError(e);
         }
     }
 
@@ -419,14 +436,7 @@ public class TimedItemApi {
             return successResponse(response);
 
         } catch (Exception e) {
-            String msg = e.getMessage();
-            if (msg != null && msg.contains("not found")) {
-                return errorResponse(msg, 404);
-            }
-            if (msg != null && msg.contains("Invalid")) {
-                return errorResponse(msg, 400);
-            }
-            return errorResponse("An error occurred: " + (msg != null ? msg : "Unknown error"), 500);
+            return mapError(e);
         }
     }
 
@@ -448,14 +458,66 @@ public class TimedItemApi {
             return successResponse(response);
 
         } catch (Exception e) {
-            String msg = e.getMessage();
-            if (msg != null && msg.contains("not found")) {
-                return errorResponse(msg, 404);
+            return mapError(e);
+        }
+    }
+
+    /**
+     * Un-retire a fee, undoing DELETE /api/timed-items/{id}/fees/{feeId}.
+     * PATCH /api/timed-items/{id}/fees/{feeId}/restore
+     */
+    @PATCH
+    @Path("/{id}/fees/{feeId}/restore")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response restoreFee(@PathParam("id") Long id, @PathParam("feeId") Long feeId) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
             }
-            if (msg != null && msg.contains("Invalid")) {
-                return errorResponse(msg, 400);
+
+            TimedItemResponseDTO response = timedItemApiService.restoreFee(id, feeId, user);
+            return successResponse(response);
+
+        } catch (Exception e) {
+            return mapError(e);
+        }
+    }
+
+    /**
+     * Replace the whole fee slot list in one atomic call.
+     * PUT /api/timed-items/{id}/fees
+     * Body: { "fees": [ { "id": 123, "name": "First hour", "fee": 500, "durationHours": 1,
+     *                     "durationUnit": "HOUR", "sortOrder": 1 }, ... ] }
+     * Fees present in the item but absent from the list are retired.
+     */
+    @PUT
+    @Path("/{id}/fees")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response replaceFees(@PathParam("id") Long id, String requestBody) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
             }
-            return errorResponse("An error occurred: " + (msg != null ? msg : "Unknown error"), 500);
+
+            TimedItemFeeBulkRequestDTO request;
+            try {
+                request = gson.fromJson(requestBody, TimedItemFeeBulkRequestDTO.class);
+            } catch (JsonSyntaxException e) {
+                return errorResponse("Invalid JSON format: " + e.getMessage(), 400);
+            }
+
+            if (request == null) {
+                return errorResponse("Request body is required", 400);
+            }
+
+            TimedItemResponseDTO response = timedItemApiService.replaceFees(id, request, user);
+            return successResponse(response);
+
+        } catch (Exception e) {
+            return mapError(e);
         }
     }
 
@@ -683,6 +745,72 @@ public class TimedItemApi {
     // =========================================================================
     // Private helpers
     // =========================================================================
+
+    /**
+     * Maps a service-layer exception onto an HTTP status.
+     *
+     * <p>"is retired" / "is not retired" are 404 and 409 rather than the 500 they used to
+     * fall through to — a retired record is a real, findable state now that
+     * includeRetired and restore exist, not an internal failure (issue #23236 §2).
+     */
+    private Response mapError(Exception e) {
+        String msg = e.getMessage();
+        // A broken rule is always the caller's payload, never a server fault — checked by
+        // type so the status does not depend on how the message happens to be worded.
+        if (e instanceof TimedItemFeeRuleException) {
+            return errorResponse(msg, 400);
+        }
+        if (msg == null) {
+            return errorResponse("An error occurred: Unknown error", 500);
+        }
+        if (msg.contains("not found")) {
+            return errorResponse(msg, 404);
+        }
+        if (msg.contains("is retired")) {
+            return errorResponse(msg + " — use ?includeRetired=true to read it, "
+                    + "or PATCH the restore endpoint to bring it back.", 404);
+        }
+        if (msg.contains("is not retired") || msg.contains("is already retired")) {
+            return errorResponse(msg, 409);
+        }
+        if (msg.contains("Invalid") || msg.contains("required") || msg.contains("does not belong")
+                || msg.contains("must be") || msg.contains("Slot Order") || msg.contains("Duration must")) {
+            return errorResponse(msg, 400);
+        }
+        return errorResponse("An error occurred: " + msg, 500);
+    }
+
+    /**
+     * @return the flag, or null when the caller sent something that is neither true nor
+     *         false — silently treating a typo as false would hide retired rows the
+     *         caller explicitly asked for
+     */
+    private Boolean parseBooleanParam(String name) {
+        String raw = uriInfo.getQueryParameters().getFirst(name);
+        if (raw == null || raw.trim().isEmpty()) {
+            return Boolean.FALSE;
+        }
+        String v = raw.trim().toLowerCase();
+        if ("true".equals(v)) {
+            return Boolean.TRUE;
+        }
+        if ("false".equals(v)) {
+            return Boolean.FALSE;
+        }
+        return null;
+    }
+
+    private Long parseLongParam(String name) {
+        String raw = uriInfo.getQueryParameters().getFirst(name);
+        if (raw == null || raw.trim().isEmpty()) {
+            return null;
+        }
+        try {
+            return Long.parseLong(raw.trim());
+        } catch (NumberFormatException e) {
+            throw new NumberFormatException("Invalid " + name + " format");
+        }
+    }
 
     private WebUser validateApiKey(String key) {
         if (key == null || key.trim().isEmpty()) {


### PR DESCRIPTION
Closes #23236

`#23206` (PR #23219) added a duration unit to `TimedItemFee` so timed services can be charged per minute, per day or once. That work landed on the REST endpoints and on the `manage_timed_items` tool, but left the surrounding **metadata API** — the surface an agent uses to add, edit and retire timed service master data — incomplete in four ways. This PR closes all four.

**No schema change.** `DURATIONUNIT` and `SORTORDER` already exist on the `fee` table, so `generate-ddl` was not needed.

---

## §1 — The room charging unit was unreachable from the agent tool

`InwardRoomFacilityChargeApi` always accepted `timedItemFeeDurationUnit`; `manage_inward_rooms` simply never sent it — absent from the schema, the input extraction and both request bodies. An agent asked to configure a room as per-day got the `HOUR` default with no error, while the sibling `manage_timed_items` tool exposed the same field on the same entity.

Threaded through all three places, mirroring how `manage_timed_items` already handles `durationUnit`.

## §2 — Retire was one-way and retired records were invisible

`DELETE` set `retired = true` and nothing ever set it back, while every read path filtered retired rows out — and `loadAndValidate` *threw* on a retired item, producing a 500. A service retired by mistake could be neither restored nor listed without database access.

- `PATCH /timed-items/{id}/restore` and `PATCH /timed-items/{id}/fees/{feeId}/restore`
- `includeRetired` on `/search`, `/{id}` and `/{id}/fees`
- the missing `retired` field on `TimedItemSearchResultDTO`
- a retired record now answers **404 with the way to reach it**, and restoring something live returns 409

Restoring a fee requires a live parent and re-checks slot uniqueness, since the slot may have been taken while it was retired.

## §3 — Fee validation diverged from the UI

The fee page auto-assigned a slot order, required it to be `>= 1` and required it to be unique per service. `addFee` stored whatever arrived, including `0`.

This is not cosmetic: `getAllTimedItemFees` orders by `sortOrder` and `getFeeForBlock` then indexes `fees.get(blockNumber - 1)`, so a duplicate or zero made an agent-configured tiered service charge a different tier than intended, with nothing visibly wrong.

New `TimedItemFeeRules` EJB holds the single definition, called by **both** `TimedItemApiService` and `TimedItemFeeController`, **on create and on update** (the row-edit path was previously unchecked on both surfaces). Messages are the page's existing wording, so the UI is unchanged and the API now returns the same text.

Two things beyond what the issue lists:

- The page also rejected a non-`ONE_TIME` fee with `durationHours <= 0`; the API only reported the generic "name is required". Now shared too.
- Auto-assign moves from `size() + 1` to `max(sortOrder) + 1`. The old formula collides across a gap — with slots 1 and 3 present it yields 3, which the uniqueness rule then rejects.

`getAllTimedItemFees` also gained an `, tif.id` tiebreak so rows that *already* carry duplicates order deterministically on the billing path.

## §4 — Search was too thin to find the record to edit

Added `categoryId`, `inwardChargeType`, `departmentId`, `institutionId` and `includeRetired` — every one a field this same API sets on create — plus `offset` paging with a total count. `query` is now upper-cased on both sides, so matching is defined in code rather than by the deployment's collation.

`data` becomes `{items, total, limit, offset}`. **This is a breaking response-shape change**; the only in-tree consumer is the `manage_timed_items` LIST branch, updated in the same PR.

`PUT /timed-items/{id}/fees` writes a whole slot list atomically — the whole set is validated before anything is written, uniqueness is checked across the complete list rather than row by row, and the parent total is recalculated once instead of once per round trip. Slots absent from the payload are retired.

## Incidental fix — `AbstractFacade` pagination

The existing `findByJpql(jpql, params, fromRecord, toRecord)` takes an *inclusive* end index and skips `setMaxResults` entirely when it computes to 0, so asking for the single first row silently returned the **entire result set**. Caught during verification (`limit=1&offset=0` returned 4 of 4 rows). Added a `findByJpqlWithRange(jpql, params, startPosition, maxResults)` overload that takes a plain count; the existing method is untouched.

---

## Verification

Built with Maven, redeployed to local Payara, exercised against the `coop` database using the four timed service test records from #23206. Every write confirmed in MySQL.

**§1** — created a throwaway room charge in the Inward department with `timedItemFeeDurationUnit=DAY`; `fee.DURATIONUNIT = 'DAY'` in the DB. `PUT_CHARGE` to `ONE_TIME` also persisted; `FORTNIGHT` rejected with 400. Charge retired afterwards, all 99 pre-existing room blocks untouched.

**§2** — full retire → invisible → `includeRetired=true` → 404-with-guidance → restore → visible round trip on a test service, plus restoring the fee that #23206 left retired. Re-restore returns 409.

**§3** — API rejects duplicate slot (`Slot Order must be unique per service.`), `sortOrder=-5` (`Slot Order must be 1 or greater.`) and a zero-length `MINUTE` block (`Duration must be greater than 0 for a Per Minute fee.`); a zero-duration `ONE_TIME` fee is correctly accepted. With slots 1 and 9 in use, an omitted slot order was assigned **10**.

**§4** — verified each new filter returns the right rows; paging checked at `offset` 0/1/3 with `limit=1` against `total=4`. Bulk write kept the id-carrying row, created two, retired the two omitted (audit comment `Removed by bulk fee update`), recalculated the total once. All four rejection paths return 400 **and leave the existing configuration intact** — re-read confirmed.

**Regression** — all 17 `TimedItemDurationUnitCalculationTest` cases from #23206 pass; the per-minute and one-time test services price unchanged.

### Fee page (Playwright)

The §3 rules now run through shared code, so the page was re-checked end to end: a blank slot order auto-assigned to 4 and saved; a normal fee saved; a duplicate slot order rejected; editing an existing row's slot order to a duplicate rejected (new behaviour — DB confirmed the row kept its original slot).

![Duplicate slot order rejected on the fee page](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23236-fee-page-duplicate-slot-order-rejected.png)

![Zero duration rejected for a Per Day fee](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23236-fee-page-zero-duration-rejected.png)

## Docs

`CapabilityStatementResource` updated for both the Timed Items and Inward Room Facility Charges entries. New `developer_docs/api/using-apis/API_TIMED_ITEMS.md` (none existed); the `appendModule` call now references it instead of the generic REST guide. `manage_timed_items` gained `RESTORE`, `RESTORE_FEE`, `PUT_FEES` and the new filters, with its system-prompt block updated to match.

## Reviewer notes

- The `/search` response shape change is deliberate and was chosen over adding a second endpoint — the API is new and its only in-tree caller is updated here. Worth a second opinion if anything out-of-tree consumes it.
- Enforcing slot-order rules on the **update** path is new behaviour on both surfaces. Existing rows that already carry a duplicate or zero slot order will be rejected on save until corrected — which is the intent, but it is a behaviour change for anyone editing such a row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added paginated timed-item search with filters for charge type, category, department, institution, and retired records.
  - Added timed-item and fee restoration options.
  - Added atomic bulk fee replacement with validation and automatic retirement of omitted fees.
  - Added configurable fee duration units, including one-time, minute, hour, and day.
  - Improved timed-item and fee details with category and retirement status.

- **Bug Fixes**
  - Fee ordering is now deterministic when multiple fees share the same order.

- **Documentation**
  - Added comprehensive Timed Items API documentation and updated capability descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->