### PR TITLE
docs(skills): require wiki page updates, and scope test-data limit to remote DBs (#23245)

### DIFF
--- a/.claude/skills/dev-issue-unattended/SKILL.md
+++ b/.claude/skills/dev-issue-unattended/SKILL.md
@@ -87,10 +87,20 @@ documented here, and warrants stopping and asking rather than guessing.
   evidence-backed part of the approved fix. Applying that DDL to any
   database — even local — stays a human's call via the admin UI's "Add
   Missing..." page, same as it always is; this skill never runs it.
-- Never create test data with a direct database write (`INSERT`/`UPDATE`).
-  Same rule as `playwright-e2e`
-  [§15](../../../developer_docs/testing/playwright-e2e-workflow.md#15-always-generate-test-data--never-fall-back-to-code-only-verification):
-  generate it through the app, or stop — see step 4.
+- Never write to a **remote** database — production, staging, or anything
+  reached over an SSH tunnel. Read-only there, always, no exceptions.
+  A **local** database (localhost, no tunnel) is a disposable test
+  environment: no development environment is ever set up on a hosting
+  server, so "the database is local" is a reliable proxy for "this is safe
+  to modify freely". Create, mutate, and abandon local test data as needed —
+  do **not** revert it afterwards or treat local rows as precious.
+  Preferring to generate data *through the app* still applies as guidance
+  (`playwright-e2e`
+  [§15](../../../developer_docs/testing/playwright-e2e-workflow.md#15-always-generate-test-data--never-fall-back-to-code-only-verification)),
+  because a fixture that bypasses the app's own validation can pass a test
+  while proving nothing — but locally that is a judgement call, not a hard
+  limit, and direct SQL is fine when it is simply the faster route. See
+  step 4.
 - Never put institution names, patient/doctor names, or credentials in any
   GitHub issue, PR, or comment (same rule as `dev-issue`, non-negotiable here
   too since there's no human proofreading before it posts).
@@ -268,20 +278,23 @@ SELECT ... FROM <entity-table> WHERE <feature-relevant condition>
 ORDER BY <recency> LIMIT 5;
 ```
 
-- Prefer an existing record over creating one — it's already representative
-  and needs no cleanup.
+- Prefer an existing record over creating one — it's already representative.
 - If nothing suitable exists, **generate it through the app** (per
   `playwright-e2e`
   [§15](../../../developer_docs/testing/playwright-e2e-workflow.md#15-always-generate-test-data--never-fall-back-to-code-only-verification):
   create a purchase before a return, a shift-start before a shift-end, etc.)
-  instead of asking which record to use.
-- If the app itself can't produce what's needed either (e.g. the only path
-  to the required state is blocked by unrelated broken data, or requires a
-  second user session you don't have credentials for): this is a hard-limit
-  stop, same as an unreproducible bug in step 2a — post what was tried and
-  why it didn't work, and end the run. Do not paper over it with a direct
-  database write; a fixture that skips the app's own validation/business
-  logic can pass a test while proving nothing real.
+  instead of asking which record to use. Going through the app is preferred
+  because it exercises the same validation and business logic the fix has to
+  survive.
+- If the app can't get you there (the path is blocked by unrelated broken
+  data, or needs a second user session you don't have credentials for),
+  **write the local database directly** — `INSERT`/`UPDATE` is fine on a
+  local DB. Say so in the PR, and be aware of what a hand-built fixture
+  skips: if it bypasses the very validation the fix depends on, the test
+  proves less, so prefer the app route when the difference matters.
+- **Never** do any of this against a remote/tunnelled database (see Hard
+  limits). Locally, don't revert or clean up test data afterwards — a local
+  DB is disposable and the next run can reset it.
 - Environment is local Payara unless the issue explicitly requires otherwise
   — never assume a remote/production environment unattended (hard limit).
 
@@ -324,13 +337,27 @@ findings, end the run.
 Same as `dev-issue` step 9 — append new Playwright/dev gotchas to
 `developer_docs/testing/playwright-e2e-workflow.md` if any surfaced.
 
-## 10. Publish evidence (wiki, issue, PR)
+## 10. Publish evidence and update the wiki
 
-Same as `dev-issue` step 10 (screenshots to `../hmis.wiki/images/`, wiki
-commit/push, issue comment with embedded raw wiki-image URLs, clean up
-`tmp/`) — with extra weight on redaction since no human reviews the
-screenshots before they're published: when in doubt about a screenshot,
-crop tighter or drop it rather than publish it uncertain.
+Same as `dev-issue` step 10 — including its **required** wiki-page update
+(find the page, embed the screenshots, replace outdated images, correct any
+text the change makes wrong, or create/skip the page with the reason stated),
+and linking the updated page(s) in the issue comment. Publishing an image
+without wiring it into a page leaves it orphaned; that is not a completed
+step 10.
+
+Two additions for unattended runs:
+
+- **Extra weight on redaction**, since no human reviews the screenshots
+  before they're published: when in doubt about a screenshot, crop tighter or
+  drop it rather than publish it uncertain. This applies to the wiki page too
+  — a page edit is as public as an issue comment.
+- **Wiki prose is a judgment call, so record it.** Rewriting a page's text
+  unattended is exactly the kind of decision step 3 exists to document: note
+  what you changed and why in the "Decisions made without approval" section
+  of the PR (step 13). Correcting text that a fix has made wrong is expected;
+  rewriting a page's structure or scope beyond the change at hand is not —
+  leave that and say so.
 
 ## 11. Pre-push check
 
@@ -348,10 +375,13 @@ limit above before writing it, same as an issue or PR body.
 
 ## 13. Create the PR
 
-Same as `dev-issue` step 13, plus a **"Decisions made without approval"**
-section up front listing every step-3 judgment call in one place, so the
-user can scan exactly what to double-check first. Redact this body per the
-hard limit above too — same as every other publication point.
+Same as `dev-issue` step 13 — including its required **Documentation**
+section linking the wiki page(s) updated in step 10 (or stating that none was
+needed, and why) — plus a **"Decisions made without approval"** section up
+front listing every step-3 judgment call in one place, so the user can scan
+exactly what to double-check first. Any wiki prose you rewrote belongs in
+that list. Redact this body per the hard limit above too — same as every
+other publication point.
 
 ## 14. Review loop (until mergeable) — waiting without the user present
 

--- a/.claude/skills/dev-issue-unattended/SKILL.md
+++ b/.claude/skills/dev-issue-unattended/SKILL.md
@@ -92,7 +92,10 @@ documented here, and warrants stopping and asking rather than guessing.
   A **local** database (localhost, no tunnel) is a disposable test
   environment: no development environment is ever set up on a hosting
   server, so "the database is local" is a reliable proxy for "this is safe
-  to modify freely". Create, mutate, and abandon local test data as needed —
+  to modify freely". Confirm it genuinely is local before the first write —
+  the JNDI name in `persistence.xml` plus a `localhost` host with no active
+  tunnel on the DB port. If a datasource points anywhere else, treat it as
+  remote and stop. Create, mutate, and abandon local test data as needed —
   do **not** revert it afterwards or treat local rows as precious.
   Preferring to generate data *through the app* still applies as guidance
   (`playwright-e2e`
@@ -352,12 +355,22 @@ Two additions for unattended runs:
   before they're published: when in doubt about a screenshot, crop tighter or
   drop it rather than publish it uncertain. This applies to the wiki page too
   — a page edit is as public as an issue comment.
-- **Wiki prose is a judgment call, so record it.** Rewriting a page's text
-  unattended is exactly the kind of decision step 3 exists to document: note
-  what you changed and why in the "Decisions made without approval" section
-  of the PR (step 13). Correcting text that a fix has made wrong is expected;
-  rewriting a page's structure or scope beyond the change at hand is not —
-  leave that and say so.
+- **Wiki prose: only publish what you can verify.** A wrong page edit is
+  public the moment it's pushed, and noting it in the PR afterwards doesn't
+  unpublish it. So the test is not "am I confident?" but **"can I point at the
+  code, or at evidence from this run, that shows the current text is wrong?"**
+  - **Publish** — inserting verified screenshots, and correcting text that
+    demonstrably contradicts the code or the behaviour you just verified.
+    Cite the evidence in the PR (e.g. *"page documented room discharge via
+    `roomDischargeDateTime`; `hasActiveRoom()` deliberately stopped using
+    that field in #21935"*).
+  - **Leave it and flag it** — anything you'd be *inferring*: prose that
+    merely reads as unclear or outdated, claims about behaviour outside what
+    this run touched, or restructuring a page's scope. Note it in the PR as a
+    documentation issue for a human, rather than rewriting it unattended.
+
+  Record every prose change either way in the "Decisions made without
+  approval" section of the PR (step 13).
 
 ## 11. Pre-push check
 

--- a/.claude/skills/dev-issue/SKILL.md
+++ b/.claude/skills/dev-issue/SKILL.md
@@ -191,10 +191,14 @@ Follow playwright-e2e
       (e.g. `Inpatient-Nursing-Discharge.md`), so the page usually exists
       even for a narrow bug fix.
 
-   b. **Embed the screenshots** with a relative path and a caption that says
-      what the reader is looking at:
+   b. **Embed the screenshots** with a relative path, plus a visible caption
+      beneath. Markdown alt text is not a rendered caption — it serves screen
+      readers, while an italic line under the image is what a sighted reader
+      skimming the page actually sees:
       ```markdown
       ![Nursing discharge blocked by pending pharmacy items](images/23222-fixed-discharge-blocked.png)
+
+      *Nursing discharge blocked: the pending pharmacy items are listed and Confirm stays disabled.*
       ```
 
    c. **Replace outdated images.** If the page already has a screenshot of a

--- a/.claude/skills/dev-issue/SKILL.md
+++ b/.claude/skills/dev-issue/SKILL.md
@@ -160,7 +160,7 @@ quirk, a new accessibility gap, a new verification pattern), append it to
 `developer_docs/testing/playwright-e2e-workflow.md` — same pattern as the
 §0a/§5a additions from issue #21499. Don't force this if nothing new came up.
 
-## 10. Publish evidence (wiki, issue, PR)
+## 10. Publish evidence and update the wiki
 
 Follow playwright-e2e
 [§8 Publishing screenshot evidence](../../../developer_docs/testing/playwright-e2e-workflow.md#8-publishing-screenshot-evidence)
@@ -172,22 +172,72 @@ Follow playwright-e2e
    evidence, redact patient identifiers, credentials, tokens, cookies, and
    other sensitive fields from the request/response bodies before they leave
    `tmp/`.
-2. Copy the durable, non-sensitive screenshots into `../hmis.wiki/images/`,
-   then commit and push the wiki from `../hmis.wiki`. Redacted API
-   request/response snippets aren't images — post them as fenced code blocks
-   directly in the issue comment/PR instead of adding them to the wiki.
-3. Add a comment (or update the description) on issue `$0`, embedding the
-   wiki images via their raw URLs
-   (`https://raw.githubusercontent.com/wiki/hmislk/hmis/images/<name>.png`)
-   or the redacted API snippets as code blocks. For bug issues where step 2a
-   ran, label and pair the step 2a "before" evidence with the step 7 "after"
-   evidence so the fix is visible as a comparison. For bug issues where step
-   2a was skipped (root cause already confirmed by reading code), there is
-   no "before" evidence — publish only the step 7 confirmation, with no
-   comparison implied.
-4. Remove the temporary screenshots/evidence from the project `tmp/` folder.
+2. Copy the durable, non-sensitive screenshots into `../hmis.wiki/images/`.
+   Redacted API request/response snippets aren't images — post them as fenced
+   code blocks in the issue/PR instead of adding them to the wiki.
 
-These wiki image URLs are reused in the PR description in step 13.
+3. **Update the wiki page(s) for the feature you changed.** This is a
+   required part of the work, not an optional extra — publishing an image
+   without wiring it into a page leaves it orphaned, which is why the wiki
+   currently has ~600 images but only ~55 pages that reference any.
+
+   a. **Find the page.** Search the sibling wiki repo for the feature by
+      name, page title, and menu path:
+      ```bash
+      cd ../hmis.wiki && ls *.md | grep -iE "<feature|module keyword>"
+      grep -ril "<feature name>" *.md | head
+      ```
+      Wiki pages are named after the user-facing screen
+      (e.g. `Inpatient-Nursing-Discharge.md`), so the page usually exists
+      even for a narrow bug fix.
+
+   b. **Embed the screenshots** with a relative path and a caption that says
+      what the reader is looking at:
+      ```markdown
+      ![Nursing discharge blocked by pending pharmacy items](images/23222-fixed-discharge-blocked.png)
+      ```
+
+   c. **Replace outdated images.** If the page already has a screenshot of a
+      screen your change altered — or one that simply looks nothing like the
+      current UI — replace it rather than appending a second, contradictory
+      one. Keeping the wiki current as the UI improves is part of the job.
+
+   d. **Correct any text the change makes wrong.** A page can document
+      intended behaviour that never actually worked. `Inpatient-Nursing-Discharge.md`
+      described the pending-pharmacy block as working while the check had
+      been silently dead since it shipped (issue #23222). If the fix changes
+      what a user sees or can do, reconcile the prose with reality — and if
+      the page described the behaviour correctly all along, say so in the PR
+      so the reviewer knows the page was checked, not skipped.
+
+   e. **If no page exists**, judge which case applies rather than defaulting:
+      - The change is user-visible (a screen, a workflow, a report, a
+        setting) → **create the page**, following the structure and tone of a
+        neighbouring page in the same module.
+      - The change is invisible to end users (an internal query fix with no
+        behavioural difference, a refactor, a build change) → **no page**;
+        the screenshot is evidence for the issue/PR only. Say which you chose
+        and why in the PR.
+
+4. Commit and push the wiki from `../hmis.wiki` — both the images and the
+   page edits, in one commit.
+
+5. Add a comment (or update the description) on issue `$0` that includes:
+   - the evidence — wiki images by raw URL
+     (`https://raw.githubusercontent.com/wiki/hmislk/hmis/images/<name>.png`)
+     or redacted API snippets as code blocks. For bug issues where step 2a
+     ran, label and pair the "before" and "after" evidence. Where step 2a was
+     skipped (root cause confirmed by reading code), publish only the step 7
+     confirmation, with no comparison implied.
+   - **a link to the wiki page(s) you updated**
+     (`https://github.com/hmislk/hmis/wiki/<Page-Name>`). The person who
+     raised the issue needs to see how the finished feature works, not just
+     that a fix landed.
+
+6. Remove the temporary screenshots/evidence from the project `tmp/` folder.
+
+The wiki image URLs **and the wiki page links** are both reused in the PR
+description in step 13.
 
 ## 11. Pre-push check
 
@@ -215,6 +265,14 @@ and summarize the Playwright + DB verification performed in steps 7-8
 (concrete enough that a reviewer trusts it was actually tested), and embed
 the same wiki-hosted screenshots from step 10 so reviewers can see the
 verified behavior without redeploying locally.
+
+It must also **link the wiki page(s) updated in step 10**
+(`https://github.com/hmislk/hmis/wiki/<Page-Name>`), under a short
+**Documentation** heading. Reviewers check the change against the documented
+behaviour, so a PR that alters what users see without showing the
+corresponding page edit can't be reviewed properly. If step 10 concluded no
+page was needed (internal-only change), say that explicitly instead — an
+absent Documentation section reads as forgotten, not as deliberate.
 
 ## 14. Review loop (until mergeable)
 

--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -306,10 +306,43 @@ show the fixed control without private information.
    project `tmp/` folder.
 2. For user-facing documentation, copy final screenshots into the sibling wiki
    repo under `../hmis.wiki/images/`.
-3. Reference wiki images in markdown as `images/example_name.png`.
-4. Commit and push the wiki immediately from `../hmis.wiki`.
+3. **Embed each image in the wiki page for the feature** — this is the step
+   that is most often skipped, and skipping it is why the wiki currently holds
+   ~600 images but only ~55 pages reference any. An image nobody links to
+   documents nothing.
+
+   Find the page by feature name, screen title, or menu path — pages are named
+   after the user-facing screen (e.g. `Inpatient-Nursing-Discharge.md`):
+
+   ```bash
+   cd ../hmis.wiki
+   ls *.md | grep -iE "<feature|module keyword>"
+   grep -ril "<feature name>" *.md | head
+   ```
+
+   Reference the image with a relative path and a caption saying what the
+   reader is looking at:
+
+   ```markdown
+   ![Nursing discharge blocked by pending pharmacy items](images/23222-fixed-discharge-blocked.png)
+   ```
+
+   **Replace outdated screenshots rather than accumulating them.** If the page
+   already shows a screen your change altered — or one that no longer matches
+   the current UI at all — swap it out. Two contradictory screenshots of the
+   same screen are worse than one stale one.
+
+   If no page covers the feature: create one when the change is user-visible
+   (screen, workflow, report, setting), following a neighbouring page in the
+   same module. Skip it when the change is invisible to end users (internal
+   query fix, refactor, build change) — there the screenshot is evidence for
+   the issue/PR only.
+4. Commit and push the wiki immediately from `../hmis.wiki` — images and page
+   edits together.
 5. To embed the same image in a GitHub issue or PR comment, use the raw wiki
-   URL:
+   URL (and link the page itself as
+   `https://github.com/hmislk/hmis/wiki/<Page-Name>`, so the reader can see the
+   feature documented in context rather than a floating screenshot):
 
 ```text
 https://raw.githubusercontent.com/wiki/hmislk/hmis/images/example_name.png
@@ -451,8 +484,20 @@ return against it. For issues, create a purchase → issue → return. The
 For qty fields with `async="true"` blur handlers, use slow `browser_type` + Tab key to commit — do not rely on jQuery-blur (see §3).
 
 Never close a QA session with "code looks correct" as the only evidence.
-If you cannot generate data through the app, stop and discuss alternatives
-with the developer before falling back.
+
+If the app genuinely can't get you to the required state (the path is blocked
+by unrelated broken data, or needs a second user session you lack credentials
+for), **write the local database directly** — `INSERT`/`UPDATE` against a
+local DB is fine, and a local DB is disposable: don't revert test data or
+treat local rows as precious. Going through the app stays the preference
+because it exercises the same validation and business logic the fix has to
+survive, so a hand-built fixture that bypasses that validation proves less —
+weigh that when it matters, and note in the PR how the data was made.
+
+**This applies to local databases only.** A remote or SSH-tunnelled database
+(production, staging) is read-only, always. No development environment is ever
+set up on a hosting server, so "localhost, no tunnel" is a reliable proxy for
+"safe to modify freely".
 
 ## 16. List pages that filter by `toDepartment = session department`
 

--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -320,11 +320,14 @@ show the fixed control without private information.
    grep -ril "<feature name>" *.md | head
    ```
 
-   Reference the image with a relative path and a caption saying what the
-   reader is looking at:
+   Reference the image with a relative path. Markdown alt text is *not* a
+   rendered caption, so add a visible italic line beneath it — readers
+   skimming a long page rely on that, and screen readers use the alt text:
 
    ```markdown
    ![Nursing discharge blocked by pending pharmacy items](images/23222-fixed-discharge-blocked.png)
+
+   *Nursing discharge blocked: the pending pharmacy items are listed and Confirm stays disabled.*
    ```
 
    **Replace outdated screenshots rather than accumulating them.** If the page


### PR DESCRIPTION
Closes #23245

Two gaps found while running #23222 end to end with `dev-issue-unattended`. Both were in the skills, not in that run's execution — I followed the steps as written and still produced no user documentation.

## Gap 1 — the wiki was treated as an image host, not documentation

`dev-issue` step 10 said to copy screenshots into `../hmis.wiki/images/`, commit, and embed the raw URLs in the issue and PR. **It never said to update a wiki page.** `playwright-e2e` §8 said to "reference wiki images as `images/name.png`" without saying *in which page*, so the step was unactionable and got skipped.

The cost is measurable in the wiki as it stands today:

| | |
|---|---|
| Wiki pages | 1,102 |
| Pages referencing any image | **55** |
| Images on disk | **609** |

Images get published for issue/PR embedding and then orphaned — including the one published for #23222.

Pages also drift out of true with nothing prompting anyone to reconcile them. `Inpatient-Nursing-Discharge.md` documented the pending-pharmacy block as working behaviour while that check had been **silently dead since it shipped**, and documented room discharge via `roomDischargeDateTime` — a mechanism the code deliberately abandoned in #21935 because it stayed null after multi-room changes.

### What changed

- Step 10 is now **"Publish evidence and update the wiki"**, with the page update as a required sub-step: find the page (with concrete search commands), embed screenshots with captions, **replace outdated images** rather than accumulating contradictory ones, correct text the change makes wrong, and make an explicit create-vs-skip decision when no page exists.
- The **issue comment** must link the updated page — the reporter needs to see how the finished feature works, not just that a fix landed.
- The **PR description** gains a required **Documentation** section linking the page. An absent section must say no page was needed, so it reads as deliberate rather than forgotten.
- `playwright-e2e` §8 now says which page to put the image in, and covers replacing stale screenshots.
- For unattended runs: rewriting wiki prose is a judgment call, so it goes in the PR's "Decisions made without approval" list, and page edits carry the same redaction weight as an issue comment.

## Gap 2 — the test-data limit was scoped to the wrong boundary

The hard limit read *"never create test data with a direct database write"*, and step 4 made "the app can't produce this state" a **full stop**.

The real constraint is never writing to a **remote** database. No development environment is ever set up on a hosting server, so *"localhost, no tunnel"* is a reliable proxy for *"safe to modify freely"*. As written, the rule caused real waste in #23222 — local rows were treated as precious and a test discharge was reverted through the UI for no benefit — and the step-4 stop could have blocked that run entirely.

### What changed

- **Remote/tunnelled DBs → read-only, always.** Unchanged, non-negotiable.
- **Local DBs → writable and disposable.** Explicitly *not* to be reverted or treated as precious.
- Generating data through the app stays the **preference** — it exercises the validation the fix has to survive, so a fixture that bypasses it proves less — but as guidance, not a hard limit, with direct local SQL allowed when it is simply faster.

## Documentation

Worked example, committed separately in the wiki repo:

- **[Inpatient Nursing Discharge](https://github.com/hmislk/hmis/wiki/Inpatient-Nursing-Discharge)** — first screenshot added to the page, and **both** prerequisites corrected: room discharge no longer described via the abandoned `roomDischargeDateTime` field, and all four pending-pharmacy blocking cases now listed (the one users actually hit — medicines issued but not yet received by the Ward — was missing entirely).

This PR itself changes only skill/workflow docs, so there is no further user-facing page to update.

## Verification

- No application code touched; nothing to build or deploy.
- Wiki page edit pushed and confirmed rendering live with the image resolving.
- `persistence.xml` committed with CI placeholders, restored to local JNDI unstaged afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development and testing guidance for documenting feature changes in the relevant wiki pages.
  * Added requirements to embed or replace screenshots and link updated documentation in issue and pull request evidence.
  * Clarified test-data handling: disposable local databases may be updated directly when needed, while remote and tunneled databases remain read-only.
  * Added documentation requirements for recording locally generated test data and wiki edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->