### PR TITLE
fix(inward): show Outside Charge item name on Interim Bill

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -3220,19 +3220,37 @@ public class BhtSummeryController implements Serializable {
         getIntrimPrintController().getCurrentBill().setAdjustedTotal(grantTotal);
 
         for (ChargeItemTotal cit : chargeItemTotals) {
+            // Outside Charge items folded into this category's total are
+            // listed as their own rows below (issue #22989) — the charge
+            // type is derivable from each item, so they don't need to be
+            // hidden inside the category row. Subtract their combined value
+            // back out here so the category row shows only its non-Outside
+            // Charge (service) portion, avoiding double counting; the
+            // overall bill total is unaffected since it is set separately
+            // above from grantTotal.
+            double additionalTotal = 0.0;
+            for (ChargeItemTotal.AdditionalChargeItem item : cit.getAdditionalChargeItems()) {
+                additionalTotal += item.getAmount();
+            }
+            double categoryOnlyValue = cit.getTotal() - additionalTotal;
+
             BillItem billItem = new BillItem();
             billItem.setInwardChargeType(cit.getInwardChargeType());
             billItem.setBill(getIntrimPrintController().getCurrentBill());
-            billItem.setGrossValue(cit.getTotal());
-            billItem.setAdjustedValue(cit.getTotal());
+            billItem.setGrossValue(categoryOnlyValue);
+            billItem.setAdjustedValue(categoryOnlyValue);
             billItem.setReferanceBillItem(getBillBean().fetchBillItem(patientEncounter, BillType.InwardIntrimBill, cit.getInwardChargeType()));
-            // Surface which Outside Charge item(s) this category's total
-            // includes, since this synthetic row has no single Item of its
-            // own to display (issue #22989).
-            if (!cit.getAdditionalChargeItemNames().isEmpty()) {
-                billItem.setDescreption(String.join(", ", cit.getAdditionalChargeItemNames()));
-            }
             getIntrimPrintController().getCurrentBill().getBillItems().add(billItem);
+
+            for (ChargeItemTotal.AdditionalChargeItem item : cit.getAdditionalChargeItems()) {
+                BillItem outsideChargeItemBillItem = new BillItem();
+                outsideChargeItemBillItem.setInwardChargeType(cit.getInwardChargeType());
+                outsideChargeItemBillItem.setBill(getIntrimPrintController().getCurrentBill());
+                outsideChargeItemBillItem.setDescreption(item.getName());
+                outsideChargeItemBillItem.setGrossValue(item.getAmount());
+                outsideChargeItemBillItem.setAdjustedValue(item.getAmount());
+                getIntrimPrintController().getCurrentBill().getBillItems().add(outsideChargeItemBillItem);
+            }
         }
 
         return "inward_bill_intrim_print";
@@ -4850,17 +4868,18 @@ public class BhtSummeryController implements Serializable {
     private void setChargeValueFromAdditional() {
         // OPTIMIZED: Fetch all totals in ONE bulk query
         Map<InwardChargeType, Double> bulkTotals = getInwardBean().caltValueFromAdditionalChargeBulk(getPatientEncounter(), childPatientEncouters);
-        // Item names behind those totals, so the Interim Bill can show which
-        // Outside Charge item(s) a category's total includes (issue #22989).
-        Map<InwardChargeType, List<String>> bulkItemNames = getInwardBean().caltAdditionalChargeItemNamesBulk(getPatientEncounter(), childPatientEncouters);
+        // The individual Outside Charge items (name + amount) behind those
+        // totals, so callers can list the items themselves in place of the
+        // category total instead of just the charge-type label (issue #22989).
+        Map<InwardChargeType, List<ChargeItemTotal.AdditionalChargeItem>> bulkItems = getInwardBean().caltAdditionalChargeItemDetailsBulk(getPatientEncounter(), childPatientEncouters);
 
         for (ChargeItemTotal cit : chargeItemTotals) {
             double adj = bulkTotals.getOrDefault(cit.getInwardChargeType(), 0.0);
             double tot = cit.getTotal();
             cit.setTotal(tot + adj);
-            List<String> names = bulkItemNames.get(cit.getInwardChargeType());
-            if (names != null) {
-                cit.setAdditionalChargeItemNames(names);
+            List<ChargeItemTotal.AdditionalChargeItem> items = bulkItems.get(cit.getInwardChargeType());
+            if (items != null) {
+                cit.setAdditionalChargeItems(items);
             }
         }
     }

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -3226,6 +3226,12 @@ public class BhtSummeryController implements Serializable {
             billItem.setGrossValue(cit.getTotal());
             billItem.setAdjustedValue(cit.getTotal());
             billItem.setReferanceBillItem(getBillBean().fetchBillItem(patientEncounter, BillType.InwardIntrimBill, cit.getInwardChargeType()));
+            // Surface which Outside Charge item(s) this category's total
+            // includes, since this synthetic row has no single Item of its
+            // own to display (issue #22989).
+            if (!cit.getAdditionalChargeItemNames().isEmpty()) {
+                billItem.setDescreption(String.join(", ", cit.getAdditionalChargeItemNames()));
+            }
             getIntrimPrintController().getCurrentBill().getBillItems().add(billItem);
         }
 
@@ -4844,11 +4850,18 @@ public class BhtSummeryController implements Serializable {
     private void setChargeValueFromAdditional() {
         // OPTIMIZED: Fetch all totals in ONE bulk query
         Map<InwardChargeType, Double> bulkTotals = getInwardBean().caltValueFromAdditionalChargeBulk(getPatientEncounter(), childPatientEncouters);
+        // Item names behind those totals, so the Interim Bill can show which
+        // Outside Charge item(s) a category's total includes (issue #22989).
+        Map<InwardChargeType, List<String>> bulkItemNames = getInwardBean().caltAdditionalChargeItemNamesBulk(getPatientEncounter(), childPatientEncouters);
 
         for (ChargeItemTotal cit : chargeItemTotals) {
             double adj = bulkTotals.getOrDefault(cit.getInwardChargeType(), 0.0);
             double tot = cit.getTotal();
             cit.setTotal(tot + adj);
+            List<String> names = bulkItemNames.get(cit.getInwardChargeType());
+            if (names != null) {
+                cit.setAdditionalChargeItemNames(names);
+            }
         }
     }
 

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -3232,7 +3232,11 @@ public class BhtSummeryController implements Serializable {
             for (ChargeItemTotal.AdditionalChargeItem item : cit.getAdditionalChargeItems()) {
                 additionalTotal += item.getAmount();
             }
-            double categoryOnlyValue = cit.getTotal() - additionalTotal;
+            // additionalTotal and cit.getTotal() come from two separate bulk
+            // queries (setChargeValueFromAdditional()), so a charge committed
+            // between them could in theory make additionalTotal exceed the
+            // total. Clamp rather than let the category row go negative.
+            double categoryOnlyValue = Math.max(0.0, cit.getTotal() - additionalTotal);
 
             BillItem billItem = new BillItem();
             billItem.setInwardChargeType(cit.getInwardChargeType());

--- a/src/main/java/com/divudi/bean/inward/InwardBeanController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardBeanController.java
@@ -13,6 +13,7 @@ import com.divudi.core.data.BillTypeAtomic;
 import com.divudi.core.data.DepartmentType;
 import com.divudi.core.data.FeeType;
 import com.divudi.core.data.PaymentMethod;
+import com.divudi.core.data.dataStructure.ChargeItemTotal;
 import com.divudi.core.data.dataStructure.DepartmentBillItems;
 import com.divudi.core.data.inward.InwardChargeType;
 
@@ -67,6 +68,7 @@ import java.util.Calendar;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.EnumMap;
 import java.util.Map;
@@ -1867,14 +1869,17 @@ public class InwardBeanController implements Serializable {
     }
 
     /**
-     * Names of the specific Outside Charge items contributing to each
-     * charge type's total, so the Interim Bill can show which item(s) a
-     * category's total includes instead of only the category label
-     * (issue #22989). Companion to {@link #caltValueFromAdditionalChargeBulk}
-     * — same filter, but item names instead of a summed value.
+     * The specific Outside Charge items (name + amount, summed per item
+     * name) contributing to each charge type's total, so the Interim Bill
+     * can list the actual items instead of only the category label
+     * (issue #22989) — the InwardChargeType a charge belongs to is already
+     * derivable from the item, so callers can show the item directly rather
+     * than the shared category row. Companion to
+     * {@link #caltValueFromAdditionalChargeBulk} — same filter, broken out
+     * per item instead of summed into one value.
      */
-    public Map<InwardChargeType, List<String>> caltAdditionalChargeItemNamesBulk(PatientEncounter patientEncounter, List<PatientEncounter> cpts) {
-        String sql = "SELECT DISTINCT i.inwardChargeType, i.item.name"
+    public Map<InwardChargeType, List<ChargeItemTotal.AdditionalChargeItem>> caltAdditionalChargeItemDetailsBulk(PatientEncounter patientEncounter, List<PatientEncounter> cpts) {
+        String sql = "SELECT i.inwardChargeType, i.item.name, i.netValue"
                 + " FROM BillItem i "
                 + " WHERE i.retired=false "
                 + " AND i.bill.billType=:btp "
@@ -1892,19 +1897,32 @@ public class InwardBeanController implements Serializable {
 
         List<Object[]> results = getBillItemFacade().findObjectsArrayByJpql(sql, m, TemporalType.DATE);
 
-        Map<InwardChargeType, List<String>> namesMap = new EnumMap<>(InwardChargeType.class);
+        // Group by charge type, then merge same-named items within a type
+        // (e.g. the same Outside Charge item added twice) into one summed row.
+        Map<InwardChargeType, Map<String, Double>> amountsByTypeAndName = new EnumMap<>(InwardChargeType.class);
         if (results != null) {
             for (Object[] row : results) {
                 InwardChargeType chargeType = (InwardChargeType) row[0];
                 String itemName = (String) row[1];
+                double amount = row[2] != null ? ((Number) row[2]).doubleValue() : 0.0;
                 if (chargeType == null || itemName == null || itemName.isEmpty()) {
                     continue;
                 }
-                namesMap.computeIfAbsent(chargeType, k -> new ArrayList<>()).add(itemName);
+                amountsByTypeAndName.computeIfAbsent(chargeType, k -> new LinkedHashMap<>())
+                        .merge(itemName, amount, Double::sum);
             }
         }
 
-        return namesMap;
+        Map<InwardChargeType, List<ChargeItemTotal.AdditionalChargeItem>> itemsMap = new EnumMap<>(InwardChargeType.class);
+        for (Map.Entry<InwardChargeType, Map<String, Double>> byType : amountsByTypeAndName.entrySet()) {
+            List<ChargeItemTotal.AdditionalChargeItem> items = new ArrayList<>();
+            for (Map.Entry<String, Double> byName : byType.getValue().entrySet()) {
+                items.add(new ChargeItemTotal.AdditionalChargeItem(byName.getKey(), byName.getValue()));
+            }
+            itemsMap.put(byType.getKey(), items);
+        }
+
+        return itemsMap;
     }
 
     public List<PatientEncounter> fetchChildPatientEncounter(PatientEncounter patientEncounter) {

--- a/src/main/java/com/divudi/bean/inward/InwardBeanController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardBeanController.java
@@ -1866,6 +1866,47 @@ public class InwardBeanController implements Serializable {
         return totalsMap;
     }
 
+    /**
+     * Names of the specific Outside Charge items contributing to each
+     * charge type's total, so the Interim Bill can show which item(s) a
+     * category's total includes instead of only the category label
+     * (issue #22989). Companion to {@link #caltValueFromAdditionalChargeBulk}
+     * — same filter, but item names instead of a summed value.
+     */
+    public Map<InwardChargeType, List<String>> caltAdditionalChargeItemNamesBulk(PatientEncounter patientEncounter, List<PatientEncounter> cpts) {
+        String sql = "SELECT DISTINCT i.inwardChargeType, i.item.name"
+                + " FROM BillItem i "
+                + " WHERE i.retired=false "
+                + " AND i.bill.billType=:btp "
+                + " AND i.bill.patientEncounter IN :pe "
+                + " AND i.item IS NOT NULL";
+
+        HashMap m = new HashMap();
+        m.put("btp", BillType.InwardOutSideBill);
+        List<PatientEncounter> pts = new ArrayList<>();
+        pts.add(patientEncounter);
+        if (cpts != null && !cpts.isEmpty()) {
+            pts.addAll(cpts);
+        }
+        m.put("pe", pts);
+
+        List<Object[]> results = getBillItemFacade().findObjectsArrayByJpql(sql, m, TemporalType.DATE);
+
+        Map<InwardChargeType, List<String>> namesMap = new EnumMap<>(InwardChargeType.class);
+        if (results != null) {
+            for (Object[] row : results) {
+                InwardChargeType chargeType = (InwardChargeType) row[0];
+                String itemName = (String) row[1];
+                if (chargeType == null || itemName == null || itemName.isEmpty()) {
+                    continue;
+                }
+                namesMap.computeIfAbsent(chargeType, k -> new ArrayList<>()).add(itemName);
+            }
+        }
+
+        return namesMap;
+    }
+
     public List<PatientEncounter> fetchChildPatientEncounter(PatientEncounter patientEncounter) {
         List<PatientEncounter> cpt = new ArrayList<>();
 

--- a/src/main/java/com/divudi/core/data/dataStructure/ChargeItemTotal.java
+++ b/src/main/java/com/divudi/core/data/dataStructure/ChargeItemTotal.java
@@ -29,22 +29,48 @@ public class ChargeItemTotal {
     private List<PatientRoom> patientRooms;
     List<BillFee> billFees;
     /**
-     * Names of the specific Outside Charge items whose value was folded into
-     * this charge type's total (issue #22989). Populated only for charge
-     * types that received an Outside Charge contribution; empty otherwise.
-     * Display-only — does not affect total/discount/validation calculations.
+     * The specific Outside Charge items (name + amount) whose value was
+     * folded into this charge type's total (issue #22989). Populated only
+     * for charge types that received an Outside Charge contribution; empty
+     * otherwise. Display-only — the amounts here are already included in
+     * {@link #total}; they are broken out separately so a caller can list
+     * the items in place of the shared category total instead of double
+     * counting. Does not itself affect total/discount/validation.
      */
-    private List<String> additionalChargeItemNames;
+    private List<AdditionalChargeItem> additionalChargeItems;
 
-    public List<String> getAdditionalChargeItemNames() {
-        if (additionalChargeItemNames == null) {
-            additionalChargeItemNames = new ArrayList<>();
+    public List<AdditionalChargeItem> getAdditionalChargeItems() {
+        if (additionalChargeItems == null) {
+            additionalChargeItems = new ArrayList<>();
         }
-        return additionalChargeItemNames;
+        return additionalChargeItems;
     }
 
-    public void setAdditionalChargeItemNames(List<String> additionalChargeItemNames) {
-        this.additionalChargeItemNames = additionalChargeItemNames;
+    public void setAdditionalChargeItems(List<AdditionalChargeItem> additionalChargeItems) {
+        this.additionalChargeItems = additionalChargeItems;
+    }
+
+    /**
+     * One Outside Charge item's name and the amount it contributed to its
+     * charge type's total. See {@link #additionalChargeItems}.
+     */
+    public static class AdditionalChargeItem {
+
+        private final String name;
+        private final double amount;
+
+        public AdditionalChargeItem(String name, double amount) {
+            this.name = name;
+            this.amount = amount;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public double getAmount() {
+            return amount;
+        }
     }
 
     public List<BillFee> getBillFees() {

--- a/src/main/java/com/divudi/core/data/dataStructure/ChargeItemTotal.java
+++ b/src/main/java/com/divudi/core/data/dataStructure/ChargeItemTotal.java
@@ -28,6 +28,24 @@ public class ChargeItemTotal {
     private String comments;
     private List<PatientRoom> patientRooms;
     List<BillFee> billFees;
+    /**
+     * Names of the specific Outside Charge items whose value was folded into
+     * this charge type's total (issue #22989). Populated only for charge
+     * types that received an Outside Charge contribution; empty otherwise.
+     * Display-only — does not affect total/discount/validation calculations.
+     */
+    private List<String> additionalChargeItemNames;
+
+    public List<String> getAdditionalChargeItemNames() {
+        if (additionalChargeItemNames == null) {
+            additionalChargeItemNames = new ArrayList<>();
+        }
+        return additionalChargeItemNames;
+    }
+
+    public void setAdditionalChargeItemNames(List<String> additionalChargeItemNames) {
+        this.additionalChargeItemNames = additionalChargeItemNames;
+    }
 
     public List<BillFee> getBillFees() {
         return billFees;

--- a/src/main/webapp/inward/inward_bill_intrim_print.xhtml
+++ b/src/main/webapp/inward/inward_bill_intrim_print.xhtml
@@ -90,7 +90,7 @@
                     <p:dataTable id="dList" value="#{intrimPrintController.currentBill.billItems}" 
                                  var="c" scrollable="true" scrollHeight="500">
                         <p:column headerText="Inward Charge Type" >
-                            <h:outputLabel  value="#{c.inwardChargeType.name}"  />
+                            <h:outputLabel  value="#{not empty c.descreption ? c.descreption : c.inwardChargeType.name}"  />
                         </p:column>
                         <p:column headerText="Total">
                             <h:outputLabel value="#{c.grossValue}" >

--- a/src/main/webapp/resources/inward/bill/intrimBill.xhtml
+++ b/src/main/webapp/resources/inward/bill/intrimBill.xhtml
@@ -204,7 +204,12 @@
 
                             <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Group Bed Charges in Bills', false)}">
                                 <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
-                                    <h:panelGroup rendered="#{bip.adjustedValue != 0 and bip.inwardChargeType ne 'LinenCharges' and bip.inwardChargeType ne 'MOCharges' and bip.inwardChargeType ne 'NursingCharges' and bip.inwardChargeType ne 'MaintainCharges' and bip.inwardChargeType ne 'MedicalCareICU' and bip.inwardChargeType ne 'AdministrationCharge'}">
+                                    <!-- A named Outside Charge item row (bip.descreption set) is always
+                                         shown on its own line regardless of charge type, even when that
+                                         type is one of the bed-charge categories folded into the grouped
+                                         row below — otherwise the item would silently disappear (issue
+                                         #22989) while its value still counts toward the grouped total. -->
+                                    <h:panelGroup rendered="#{bip.adjustedValue != 0 and (not empty bip.descreption or (bip.inwardChargeType ne 'LinenCharges' and bip.inwardChargeType ne 'MOCharges' and bip.inwardChargeType ne 'NursingCharges' and bip.inwardChargeType ne 'MaintainCharges' and bip.inwardChargeType ne 'MedicalCareICU' and bip.inwardChargeType ne 'AdministrationCharge'))}">
                                         <tr>
                                             <td style="text-align: left;" >
                                                 <h:outputLabel value="#{not empty bip.descreption ? bip.descreption : bip.inwardChargeType.name}" />

--- a/src/main/webapp/resources/inward/bill/intrimBill.xhtml
+++ b/src/main/webapp/resources/inward/bill/intrimBill.xhtml
@@ -191,7 +191,10 @@
                                         <tr>
                                             <td style="text-align: left;" >
                                                 <h:outputLabel  value="#{bip.inwardChargeType.name}" />
-                                            </td>                                   
+                                                <h:panelGroup rendered="#{not empty bip.descreption}" layout="block">
+                                                    <h:outputLabel value="(#{bip.descreption})" style="font-size: 0.85em; font-style: italic;" />
+                                                </h:panelGroup>
+                                            </td>
                                             <td style="text-align: right;" >
                                                 <h:outputLabel value="#{bip.adjustedValue}">
                                                     <f:convertNumber pattern="#,##0.00" />
@@ -208,7 +211,10 @@
                                         <tr>
                                             <td style="text-align: left;" >
                                                 <h:outputLabel  value="#{bip.inwardChargeType.name}" />
-                                            </td>                                   
+                                                <h:panelGroup rendered="#{not empty bip.descreption}" layout="block">
+                                                    <h:outputLabel value="(#{bip.descreption})" style="font-size: 0.85em; font-style: italic;" />
+                                                </h:panelGroup>
+                                            </td>
                                             <td style="text-align: right;" >
                                                 <h:outputLabel value="#{bip.adjustedValue}">
                                                     <f:convertNumber pattern="#,##0.00" />

--- a/src/main/webapp/resources/inward/bill/intrimBill.xhtml
+++ b/src/main/webapp/resources/inward/bill/intrimBill.xhtml
@@ -190,10 +190,7 @@
                                     <h:panelGroup rendered="#{bip.adjustedValue !=0}">
                                         <tr>
                                             <td style="text-align: left;" >
-                                                <h:outputLabel  value="#{bip.inwardChargeType.name}" />
-                                                <h:panelGroup rendered="#{not empty bip.descreption}" layout="block">
-                                                    <h:outputLabel value="(#{bip.descreption})" style="font-size: 0.85em; font-style: italic;" />
-                                                </h:panelGroup>
+                                                <h:outputLabel value="#{not empty bip.descreption ? bip.descreption : bip.inwardChargeType.name}" />
                                             </td>
                                             <td style="text-align: right;" >
                                                 <h:outputLabel value="#{bip.adjustedValue}">
@@ -210,10 +207,7 @@
                                     <h:panelGroup rendered="#{bip.adjustedValue != 0 and bip.inwardChargeType ne 'LinenCharges' and bip.inwardChargeType ne 'MOCharges' and bip.inwardChargeType ne 'NursingCharges' and bip.inwardChargeType ne 'MaintainCharges' and bip.inwardChargeType ne 'MedicalCareICU' and bip.inwardChargeType ne 'AdministrationCharge'}">
                                         <tr>
                                             <td style="text-align: left;" >
-                                                <h:outputLabel  value="#{bip.inwardChargeType.name}" />
-                                                <h:panelGroup rendered="#{not empty bip.descreption}" layout="block">
-                                                    <h:outputLabel value="(#{bip.descreption})" style="font-size: 0.85em; font-style: italic;" />
-                                                </h:panelGroup>
+                                                <h:outputLabel value="#{not empty bip.descreption ? bip.descreption : bip.inwardChargeType.name}" />
                                             </td>
                                             <td style="text-align: right;" >
                                                 <h:outputLabel value="#{bip.adjustedValue}">


### PR DESCRIPTION
## Summary
Fixes the remaining part of #22989 — the Interim Bill (print + reprint) now lists each Outside Charge item by its own name as its own line, instead of folding it into the shared charge-type category row. (The ID-column-width fix from this same branch already merged separately via PR #23242.)

The other two documents named in the issue — the Outside Charge bill's own print templates, and the Service Bill print/reprint composites — were already fixed in PR #23093 (merged).

## Root cause
The Interim Bill (both print and reprint, sharing `resources/inward/bill/intrimBill.xhtml`) aggregates line items by `InwardChargeType` category — one synthetic `BillItem` per category, built in `BhtSummeryController#toPrintItrim()`. When an Outside Charge item's value was folded into a category's total (`setChargeValueFromAdditional()`), only the category label showed (e.g. "Instrument Charges"), never the specific item name (e.g. "Harmonic Machine").

## Approach (revised per follow-up instruction)
An initial version of this fix (first commit on this branch) annotated the category row with the item name in parentheses. Per direct follow-up instruction, this was replaced with a cleaner design: **list each Outside Charge item as its own row, using the item's own name instead of the category label** — the `InwardChargeType` a charge belongs to is already derivable from the item itself (`Item.inwardChargeType`, the same field `BillItem.inwardChargeType` is populated from when the charge is added), so there's no need to fold it into a shared category bucket for display.

- `ChargeItemTotal` carries a list of `AdditionalChargeItem` (name + amount) per category — the specific Outside Charge items contributing to that category's total.
- `InwardBeanController#caltAdditionalChargeItemDetailsBulk()` (bulk query, same filter as the existing `caltValueFromAdditionalChargeBulk`) fetches those items' names and amounts, summed per item name.
- `toPrintItrim()` now emits: (a) the category row showing only its non-Outside-Charge (service) portion — `cit.getTotal()` minus the sum of its Outside Charge items, so the category row and the item rows don't double-count — and (b) one row per Outside Charge item, labeled with the item's name.
- `intrimBill.xhtml` and the editable pre-print staging table (`inward_bill_intrim_print.xhtml`) both show the item name in place of the category label for these rows.

This keeps every existing total/discount/validation calculation untouched — the overall bill total is set separately from `grantTotal` and is unaffected by how the rows are split.

## Testing
Verified end-to-end locally with Playwright + DB check against existing test data (BHT/56755, an Outside Charge "Harmonic Machine" item, the only charge in the "Instrument Charges" category):
1. Rebuilt and redeployed locally (`mvn package` + `asadmin deploy --force`).
2. Navigated Inward > Interim Bill > searched BHT/56755 > Print Interim.
3. Confirmed the print preview now lists **"Harmonic Machine  100.00"** as its own line, in place of "Instrument Charges" (which is correctly omitted now that its service-only portion is 0, rather than showing "Instrument Charges  0.00").
4. Confirmed Total (211,687.45) and Due (210,187.45) unchanged by this row-splitting change.
5. Checked server log — no exceptions.

Screenshot: https://github.com/hmislk/hmis.wiki/raw/master/images/issue_22989_interim_bill_item_listed.png

The reprint path (`inward_reprint_bill_intrim.xhtml`) reads the same persisted `BillItem` rows via the same composite, so it's covered by the same change without a separate code path.

Closes #22989

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interim bills now show individual Outside Charge items with their names and amounts.
  * Outside Charge totals are calculated separately from category totals for clearer billing details.

* **Improvements**
  * Charge labels and line items now use customized descriptions when available, with automatic fallback to the standard charge name.
  * Category totals remain accurate and do not display negative values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->