### PR TITLE
feat(pharmacy): split rate/value and discount privileges on BHT issue bills

### DIFF
--- a/src/main/java/com/divudi/bean/common/PageMetadataRegistry.java
+++ b/src/main/java/com/divudi/bean/common/PageMetadataRegistry.java
@@ -96,6 +96,29 @@ public class PageMetadataRegistry implements Serializable {
                 "Controls visibility of the Settings button in print preview"
         ));
         registerPage(opdDoctorPaymentBillReprint);
+
+        PageMetadata bhtIssueReprintMetadata = new PageMetadata(
+                "ward/ward_pharmacy_reprint_bht_issue_bill_reprint",
+                "Inward Pharmacy BHT Issue Bill Reprint",
+                "Reprint an inward pharmacy BHT issue bill in various paper formats, with rate/value and discount amounts gated by privilege",
+                "PharmacyBillSearch"
+        );
+        bhtIssueReprintMetadata.addPrivilege(new PrivilegeInfo(
+                "Admin",
+                "Administrative access to configuration interface",
+                "Controls visibility of the Config button"
+        ));
+        bhtIssueReprintMetadata.addPrivilege(new PrivilegeInfo(
+                "NursingIPBillingViewRates",
+                "View drug rates, net values, and totals on the reprinted bill and its print formats",
+                "Rate radio selector; showRate attribute passed to all 5 print composites (issueBill, saleBill_prabodha, saleBill_five_five, A4_paper_with_headings, saleBill_Header_Inward); Gross Value/Net Value columns and Total/NetTotal footer in the on-page summary table"
+        ));
+        bhtIssueReprintMetadata.addPrivilege(new PrivilegeInfo(
+                "IPBillingViewDiscount",
+                "View discount amounts and margin/matrix-value (service charge equivalent) on the reprinted bill and its print formats",
+                "showDiscount attribute passed to all 5 print composites; Matrix Value column in the on-page summary table"
+        ));
+        registerPage(bhtIssueReprintMetadata);
     }
 
     /**

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
@@ -169,6 +169,13 @@ public class PharmacySaleBhtController implements Serializable {
             OptionScope.APPLICATION
         ));
 
+        metadata.addConfigOption(new ConfigOptionInfo(
+            "Nursing IP Billing - Show Rate and Value",
+            "Controls whether rate/value columns are shown on the inward pharmacy BHT issue page (combined with the NursingIPBillingViewRates privilege)",
+            "Item table, row-expansion panel, autocomplete columns: rate/value visibility",
+            OptionScope.APPLICATION
+        ));
+
         // Register privileges used on this page
         metadata.addPrivilege(new PrivilegeInfo(
             "Admin",
@@ -183,9 +190,15 @@ public class PharmacySaleBhtController implements Serializable {
         ));
 
         metadata.addPrivilege(new PrivilegeInfo(
-            "ShowDrugCharges",
-            "View drug prices and financial charges in the billing interface",
-            "Item autocomplete and bill table: Rate and value columns visibility"
+            "NursingIPBillingViewRates",
+            "View drug rates, values, and net totals in the inward pharmacy BHT issue billing interface",
+            "Item table rate/value columns, row-expansion Sale Rate/Cost Rate, header summary Net Total"
+        ));
+
+        metadata.addPrivilege(new PrivilegeInfo(
+            "IPBillingViewDiscount",
+            "View discount amounts and margin/matrix-value (service charge equivalent) on inward pharmacy BHT issue bills",
+            "Header summary Discount field, row-expansion Matrix Value field"
         ));
 
         // Register the page metadata

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -694,6 +694,7 @@ public enum Privileges {
     PharmacyTransfer("Pharmacy Transfer"),
     PharmacyTransferViewRates("Pharmacy Transfer View Rates"),
     NursingIPBillingViewRates("Nursing IP Billing View Rates"),
+    IPBillingViewDiscount("IP Billing View Discount"),
     IPRequestViewRates("IP Request View Rates"),
     StockRequestViewRates("Stock Request View Rates"),
     ConsumptionViewRates("Consumption View Rates"),
@@ -1380,6 +1381,7 @@ public enum Privileges {
             case PharmacyTransfer:
             case PharmacyTransferViewRates:
             case NursingIPBillingViewRates:
+            case IPBillingViewDiscount:
             case IPRequestViewRates:
             case StockRequestViewRates:
             case ConsumptionViewRates:

--- a/src/main/webapp/resources/pharmacy/inward/A4_paper_with_headings.xhtml
+++ b/src/main/webapp/resources/pharmacy/inward/A4_paper_with_headings.xhtml
@@ -13,6 +13,7 @@
         <cc:attribute name="bill" type="com.divudi.core.entity.Bill" />
         <cc:attribute name="duplicate" type="java.lang.Boolean"/>
         <cc:attribute name="showRate" default="true"/>
+        <cc:attribute name="showDiscount" default="true"/>
     </cc:interface>
 
     <!-- IMPLEMENTATION -->
@@ -301,7 +302,7 @@
 
 
 
-                    <h:panelGroup rendered="#{cc.attrs.bill.discount ne 0.0 and cc.attrs.showRate}">
+                    <h:panelGroup rendered="#{cc.attrs.bill.discount ne 0.0 and cc.attrs.showDiscount}">
                         <tr>
                             <td  class="totalsBlock" style="text-align: left;">
                                 <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0}" value="Discount " style="font-weight: bolder!important;"/>

--- a/src/main/webapp/resources/pharmacy/inward/issueBill.xhtml
+++ b/src/main/webapp/resources/pharmacy/inward/issueBill.xhtml
@@ -13,6 +13,7 @@
         <cc:attribute name="cancelled" />
         <cc:attribute name="title" default="Issue Bill" />
         <cc:attribute name="showRate" default="true" />
+        <cc:attribute name="showDiscount" default="true" />
     </cc:interface>
 
     <!-- IMPLEMENTATION -->
@@ -372,7 +373,7 @@
                             </td>
                         </tr>
                     </ui:fragment>
-                    <ui:fragment rendered="#{cc.attrs.showRate}">
+                    <ui:fragment rendered="#{cc.attrs.showDiscount}">
                         <tr>
                             <td  class="totalsBlock" style="text-align: left;">
                                 <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0}" value="Discount " style="font-weight: bolder!important;"/>
@@ -383,6 +384,8 @@
                                 </h:outputLabel>
                             </td>
                         </tr>
+                    </ui:fragment>
+                    <ui:fragment rendered="#{cc.attrs.showRate}">
                         <tr>
                             <td  class="totalsBlock" style="text-align: left;">
                                 <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0}"    value="Net Total" />
@@ -393,7 +396,8 @@
                                 </h:outputLabel>
                             </td>
                         </tr>
-
+                    </ui:fragment>
+                    <ui:fragment rendered="#{cc.attrs.showDiscount}">
                         <tr>
 
                             <td  class="totalsBlock" style="text-align: left;">

--- a/src/main/webapp/resources/pharmacy/saleBill_Header_Inward.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBill_Header_Inward.xhtml
@@ -12,6 +12,7 @@
         <cc:attribute name="bill" />
         <cc:attribute name="duplicate" />
         <cc:attribute name="showRate" default="true" />
+        <cc:attribute name="showDiscount" default="true" />
     </cc:interface>
 
     <!-- IMPLEMENTATION -->
@@ -222,33 +223,33 @@
 
                 <table style="width: 100%;">
 
-                    <ui:fragment rendered="#{cc.attrs.showRate}">
+                    <ui:fragment rendered="#{cc.attrs.showRate or cc.attrs.showDiscount}">
                         <tr>
                             <td class="totalsBlock1" style="text-align: left; width: 60%;">
-                                <h:outputLabel rendered="#{cc.attrs.bill.discount ne 0.0}" value="Total" />
+                                <h:outputLabel rendered="#{cc.attrs.bill.discount ne 0.0 and cc.attrs.showRate}" value="Total" />
                             </td>
                             <td  class="totalsBlock1" style="text-align: right!important; width: 40%;">
-                                <h:outputLabel rendered="#{cc.attrs.bill.discount ne 0.0}" value="#{cc.attrs.bill.total}" >
+                                <h:outputLabel rendered="#{cc.attrs.bill.discount ne 0.0 and cc.attrs.showRate}" value="#{cc.attrs.bill.total}" >
                                     <f:convertNumber pattern="#,##0.00" />
                                 </h:outputLabel>
                             </td>
                         </tr>
                         <tr>
                             <td  class="totalsBlock1" style="text-align: left;">
-                                <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0}" value="Discount " style="font-weight: bolder!important;"/>
+                                <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0 and cc.attrs.showDiscount}" value="Discount " style="font-weight: bolder!important;"/>
                             </td>
                             <td  class="totalsBlock1" style="text-align: right!important; ;">
-                                <h:outputLabel rendered="#{cc.attrs.bill.discount ne 0.0}"   value="#{-cc.attrs.bill.discount}" style="font-weight: bolder!important;" >
+                                <h:outputLabel rendered="#{cc.attrs.bill.discount ne 0.0 and cc.attrs.showDiscount}"   value="#{-cc.attrs.bill.discount}" style="font-weight: bolder!important;" >
                                     <f:convertNumber pattern="#,##0.00" />
                                 </h:outputLabel>
                             </td>
                         </tr>
                         <tr>
                             <td  class="totalsBlock1" style="text-align: left;">
-                                <h:outputLabel    value="Net Total" />
+                                <h:outputLabel  rendered="#{cc.attrs.showRate}"  value="Net Total" />
                             </td>
                             <td  class="totalsBlock1" style="text-align: right!important;font-weight: bold; ;">
-                                <h:outputLabel    value="#{cc.attrs.bill.netTotal}">
+                                <h:outputLabel  rendered="#{cc.attrs.showRate}"  value="#{cc.attrs.bill.netTotal}">
                                     <f:convertNumber pattern="#,##0.00" />
                                 </h:outputLabel>
                             </td>
@@ -257,11 +258,11 @@
                         <tr>
 
                             <td  class="totalsBlock1" style="text-align: left;">
-                                <h:outputLabel  rendered="#{cc.attrs.bill.discountPercentPharmacy ne 0.0 and cc.attrs.bill.discount ne 0.0}" value="Discount Percent" style="font-weight: bolder!important;"/>
+                                <h:outputLabel  rendered="#{cc.attrs.bill.discountPercentPharmacy ne 0.0 and cc.attrs.bill.discount ne 0.0 and cc.attrs.showDiscount}" value="Discount Percent" style="font-weight: bolder!important;"/>
                             </td>
 
                             <td  class="totalsBlock1" style="text-align: right!important;font-weight: bold; ; ">
-                                <h:outputLabel  rendered="#{cc.attrs.bill.discountPercentPharmacy ne 0.0 and cc.attrs.bill.discount ne 0.0}"    value="#{cc.attrs.bill.discountPercentPharmacy} %">
+                                <h:outputLabel  rendered="#{cc.attrs.bill.discountPercentPharmacy ne 0.0 and cc.attrs.bill.discount ne 0.0 and cc.attrs.showDiscount}"    value="#{cc.attrs.bill.discountPercentPharmacy} %">
                                     <f:convertNumber pattern="#,##0.0" />
                                 </h:outputLabel>
 

--- a/src/main/webapp/resources/pharmacy/saleBill_five_five.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBill_five_five.xhtml
@@ -12,6 +12,7 @@
         <cc:attribute name="bill" />
         <cc:attribute name="duplicate" />
         <cc:attribute name="showRate" default="true" />
+        <cc:attribute name="showDiscount" default="true" />
     </cc:interface>
 
     <!-- IMPLEMENTATION -->
@@ -401,7 +402,7 @@
                         </tr>
                     </h:panelGroup>
 
-                    <h:panelGroup rendered="#{cc.attrs.bill.discount ne 0.0 and cc.attrs.showRate}">
+                    <h:panelGroup rendered="#{cc.attrs.bill.discount ne 0.0 and cc.attrs.showDiscount}">
                         <tr>
                             <td  class="totalsBlock" style="text-align: left;">
                                 <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0}" value="Discount " style="font-weight: bolder!important;"/>

--- a/src/main/webapp/resources/pharmacy/saleBill_prabodha.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBill_prabodha.xhtml
@@ -11,6 +11,7 @@
         <cc:attribute name="bill" />
         <cc:attribute name="duplicate" />
         <cc:attribute name="showRate" default="true" />
+        <cc:attribute name="showDiscount" default="true" />
     </cc:interface>
 
     <!-- IMPLEMENTATION -->
@@ -314,6 +315,8 @@
                             </h:outputLabel>
                         </td>
                     </tr>
+                    </ui:fragment>
+                    <ui:fragment rendered="#{cc.attrs.showDiscount}">
                     <tr>
                         <td  class="totalsBlock" style="text-align: left;">
                             <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0}" value="Discount " style="font-weight: bolder!important;"/>
@@ -324,6 +327,8 @@
                             </h:outputLabel>
                         </td>
                     </tr>
+                    </ui:fragment>
+                    <ui:fragment rendered="#{cc.attrs.showRate}">
                     <tr>
                         <td  class="totalsBlock" style="text-align: left;">
                             <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0}"    value="Net Total" />
@@ -331,10 +336,11 @@
                         <td  class="totalsBlock" style="text-align: right!important;font-weight: bold; ; padding-right: 30px; ">
                             <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0}"    value="#{cc.attrs.bill.netTotal}">
                                 <f:convertNumber pattern="#,##0.00" />
-                            </h:outputLabel>                          
-                        </td>                        
+                            </h:outputLabel>
+                        </td>
                     </tr>
-
+                    </ui:fragment>
+                    <ui:fragment rendered="#{cc.attrs.showDiscount}">
                     <tr>
 
                         <td  class="totalsBlock" style="text-align: left;">
@@ -631,6 +637,7 @@
 
                 <table style="width: 100%;">
 
+                    <ui:fragment rendered="#{cc.attrs.showRate}">
                     <tr>
                         <td class="totalsBlock" style="text-align: left; width: 60%;">
                             <h:outputLabel value="Total" />
@@ -641,6 +648,8 @@
                             </h:outputLabel>
                         </td>
                     </tr>
+                    </ui:fragment>
+                    <ui:fragment rendered="#{cc.attrs.showDiscount}">
                     <tr>
                         <td  class="totalsBlock" style="text-align: left;">
                             <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0}" value="Discount " style="font-weight: bolder!important;"/>
@@ -651,6 +660,8 @@
                             </h:outputLabel>
                         </td>
                     </tr>
+                    </ui:fragment>
+                    <ui:fragment rendered="#{cc.attrs.showRate}">
                     <tr>
                         <td  class="totalsBlock" style="text-align: left;">
                             <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0}"    value="Net Total" />
@@ -658,10 +669,11 @@
                         <td  class="totalsBlock" style="text-align: right!important;font-weight: bold; ; padding-right: 30px; ">
                             <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0}"    value="#{cc.attrs.bill.netTotal}">
                                 <f:convertNumber pattern="#,##0.00" />
-                            </h:outputLabel>                          
-                        </td>                        
+                            </h:outputLabel>
+                        </td>
                     </tr>
-
+                    </ui:fragment>
+                    <ui:fragment rendered="#{cc.attrs.showDiscount}">
                     <tr>
 
                         <td  class="totalsBlock" style="text-align: left;">
@@ -676,6 +688,7 @@
 
                         </td>
                     </tr>
+                    </ui:fragment>
 
                     <tr>
                         <td  class="totalsBlock" style="text-align: left;">

--- a/src/main/webapp/ward/ward_pharmacy_bht_issue.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_bht_issue.xhtml
@@ -65,6 +65,17 @@
                                 action="#{pharmacySaleBhtController.settlePharmacyBhtIssueAccept}"
                                 ajax="false" >
                             </p:commandButton>
+
+                            <p:commandButton
+                                id="btnConfig"
+                                rendered="#{webUserController.hasPrivilege('Admin')}"
+                                value="Config"
+                                icon="fa fa-cog"
+                                title="Page Configuration Management"
+                                action="#{pageAdminController.navigateToPageAdmin('inward/pharmacy_bill_issue_bht')}"
+                                ajax="false"
+                                class="ui-button-secondary">
+                            </p:commandButton>
                         </div>
                     </div>
 
@@ -245,12 +256,12 @@
                                                rendered="#{pharmacySaleBhtController.bhtRequestBill.priority ne null
                                                            and pharmacySaleBhtController.bhtRequestBill.priority.name() ne 'NORMAL'}"
                                                style="background-color:#{pharmacySaleBhtController.bhtRequestBill.priority.priorityColor}; color:#212529;"></p:tag>
-                                        <p:outputLabel value="Discount" ></p:outputLabel>
-                                        <p:outputLabel value=":" ></p:outputLabel>
-                                        <p:outputLabel value="#{pharmacySaleBhtController.bhtRequestBill.discount}" ><f:convertNumber pattern="#,##0.00" /></p:outputLabel>
-                                        <p:outputLabel value="Net Total" ></p:outputLabel>
-                                        <p:outputLabel value=":" ></p:outputLabel>
-                                        <p:outputLabel value="#{pharmacySaleBhtController.billItemTotal}" ><f:convertNumber pattern="#,##0.00" /></p:outputLabel>
+                                        <p:outputLabel value="Discount" rendered="#{webUserController.hasPrivilege('IPBillingViewDiscount')}" ></p:outputLabel>
+                                        <p:outputLabel value=":" rendered="#{webUserController.hasPrivilege('IPBillingViewDiscount')}" ></p:outputLabel>
+                                        <p:outputLabel value="#{pharmacySaleBhtController.bhtRequestBill.discount}" rendered="#{webUserController.hasPrivilege('IPBillingViewDiscount')}" ><f:convertNumber pattern="#,##0.00" /></p:outputLabel>
+                                        <p:outputLabel value="Net Total" rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}" ></p:outputLabel>
+                                        <p:outputLabel value=":" rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}" ></p:outputLabel>
+                                        <p:outputLabel value="#{pharmacySaleBhtController.billItemTotal}" rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}" ><f:convertNumber pattern="#,##0.00" /></p:outputLabel>
                                         <p:outputLabel value="Comment" ></p:outputLabel>
                                         <p:outputLabel value=":" ></p:outputLabel>
                                         <p:outputLabel value="#{pharmacySaleBhtController.bhtRequestBill.comments}" ></p:outputLabel>
@@ -462,18 +473,18 @@
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
                                 </div>
-                                <div class="col-md-3">
-                                    <strong>Matrix Value: </strong>
-                                    <h:outputLabel value="#{bItm.marginValue}">
-                                        <f:convertNumber pattern="#,##0.00" />
-                                    </h:outputLabel>
-                                </div>
                                 <h:panelGroup layout="block" styleClass="col-md-3" rendered="#{webUserController.hasPrivilege('Developers')}">
                                     <strong>Available Stock: </strong>
                                     <h:outputText value="#{bItm.pharmaceuticalBillItem.stock.stock}">
                                         <f:convertNumber integerOnly="true" />
                                     </h:outputText>
                                 </h:panelGroup>
+                            </h:panelGroup>
+                            <h:panelGroup layout="block" styleClass="col-md-3" rendered="#{webUserController.hasPrivilege('IPBillingViewDiscount')}">
+                                <strong>Matrix Value: </strong>
+                                <h:outputLabel value="#{bItm.marginValue}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
                             </h:panelGroup>
                         </p:rowExpansion>
 

--- a/src/main/webapp/ward/ward_pharmacy_reprint_bht_issue_bill_reprint.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_reprint_bht_issue_bill_reprint.xhtml
@@ -179,31 +179,31 @@
 
                                         <h:panelGroup   id="gpBillPreviewSingle" rendered="#{sessionController.loggedPreference.pharmacyBillPaperType eq 'PosPaper'}">
                                             <h:panelGroup rendered="#{sessionController.loggedPreference.pharmacyBillPrabodha eq false}" >
-                                                <ph:issueBill bill="#{pharmacyBillSearch.bill}" duplicate="true" showRate="#{webUserController.hasPrivilege('NursingIPBillingViewRates') and pharmacyBillSearch.printBhtIssueBillWithRate}" showDiscount="#{webUserController.hasPrivilege('IPBillingViewDiscount') and pharmacyBillSearch.printBhtIssueBillWithRate}" />
+                                                <ph:issueBill bill="#{pharmacyBillSearch.bill}" duplicate="true" showRate="#{webUserController.hasPrivilege('NursingIPBillingViewRates') and pharmacyBillSearch.printBhtIssueBillWithRate}" showDiscount="#{webUserController.hasPrivilege('IPBillingViewDiscount')}" />
                                             </h:panelGroup>
                                         </h:panelGroup>
 
                                         <h:panelGroup id="gpBillPreviewDouble" rendered="#{sessionController.loggedPreference.pharmacyBillPaperType eq 'PosPaper'}">
                                             <h:panelGroup     rendered="#{sessionController.loggedPreference.pharmacyBillPrabodha eq true}">
-                                                <phi:saleBill_prabodha bill="#{pharmacyBillSearch.bill}" showRate="#{webUserController.hasPrivilege('NursingIPBillingViewRates') and pharmacyBillSearch.printBhtIssueBillWithRate}" showDiscount="#{webUserController.hasPrivilege('IPBillingViewDiscount') and pharmacyBillSearch.printBhtIssueBillWithRate}"></phi:saleBill_prabodha>
+                                                <phi:saleBill_prabodha bill="#{pharmacyBillSearch.bill}" showRate="#{webUserController.hasPrivilege('NursingIPBillingViewRates') and pharmacyBillSearch.printBhtIssueBillWithRate}" showDiscount="#{webUserController.hasPrivilege('IPBillingViewDiscount')}"></phi:saleBill_prabodha>
                                             </h:panelGroup>
                                         </h:panelGroup>
 
                                         <h:panelGroup id="gpBillPreviewFiveFive" rendered="#{sessionController.loggedPreference.pharmacyBillPaperType eq 'FiveFivePaper'}">
                                             <h:panelGroup rendered="true" >
-                                                <phi:saleBill_five_five bill="#{pharmacyBillSearch.bill}" showRate="#{webUserController.hasPrivilege('NursingIPBillingViewRates') and pharmacyBillSearch.printBhtIssueBillWithRate}" showDiscount="#{webUserController.hasPrivilege('IPBillingViewDiscount') and pharmacyBillSearch.printBhtIssueBillWithRate}"></phi:saleBill_five_five>
+                                                <phi:saleBill_five_five bill="#{pharmacyBillSearch.bill}" showRate="#{webUserController.hasPrivilege('NursingIPBillingViewRates') and pharmacyBillSearch.printBhtIssueBillWithRate}" showDiscount="#{webUserController.hasPrivilege('IPBillingViewDiscount')}"></phi:saleBill_five_five>
                                             </h:panelGroup>
                                         </h:panelGroup>
 
                                         <h:panelGroup id="gpBillPreviewA4" rendered="#{sessionController.loggedPreference.pharmacyBillPaperType eq 'A4Paper'}">
                                             <h:panelGroup rendered="true" >
-                                                <ph:A4_paper_with_headings bill="#{pharmacyBillSearch.bill}" showRate="#{webUserController.hasPrivilege('NursingIPBillingViewRates') and pharmacyBillSearch.printBhtIssueBillWithRate}" showDiscount="#{webUserController.hasPrivilege('IPBillingViewDiscount') and pharmacyBillSearch.printBhtIssueBillWithRate}"></ph:A4_paper_with_headings>
+                                                <ph:A4_paper_with_headings bill="#{pharmacyBillSearch.bill}" showRate="#{webUserController.hasPrivilege('NursingIPBillingViewRates') and pharmacyBillSearch.printBhtIssueBillWithRate}" showDiscount="#{webUserController.hasPrivilege('IPBillingViewDiscount')}"></ph:A4_paper_with_headings>
                                             </h:panelGroup>
                                         </h:panelGroup>
 
                                         <h:panelGroup id="gpBillPreviewPosHeader" rendered="#{sessionController.loggedPreference.pharmacyBillPaperType eq 'PosHeaderPaper'}">
                                             <h:panelGroup rendered="true" >
-                                                <phi:saleBill_Header_Inward bill="#{pharmacyBillSearch.bill}" duplicate="true" showRate="#{webUserController.hasPrivilege('NursingIPBillingViewRates') and pharmacyBillSearch.printBhtIssueBillWithRate}" showDiscount="#{webUserController.hasPrivilege('IPBillingViewDiscount') and pharmacyBillSearch.printBhtIssueBillWithRate}" />
+                                                <phi:saleBill_Header_Inward bill="#{pharmacyBillSearch.bill}" duplicate="true" showRate="#{webUserController.hasPrivilege('NursingIPBillingViewRates') and pharmacyBillSearch.printBhtIssueBillWithRate}" showDiscount="#{webUserController.hasPrivilege('IPBillingViewDiscount')}" />
                                             </h:panelGroup>
                                         </h:panelGroup>
 

--- a/src/main/webapp/ward/ward_pharmacy_reprint_bht_issue_bill_reprint.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_reprint_bht_issue_bill_reprint.xhtml
@@ -42,9 +42,19 @@
                                         action="#{bhtIssueReturnController.navigateToReturnPharmacyDirectIssueToInpatients(pharmacyBillSearch.bill)}"   
                                         icon="fa fa-undo"
                                         disabled="#{pharmacyBillSearch.bill.cancelled eq true or pharmacyBillSearch.bill.patientEncounter.discharged eq true}"  >                                
-                                        <f:setPropertyActionListener 
-                                            value="#{pharmacyBillSearch.bill}" 
+                                        <f:setPropertyActionListener
+                                            value="#{pharmacyBillSearch.bill}"
                                             target="#{bhtIssueReturnController.bill}"  />
+                            </p:commandButton>
+                            <p:commandButton
+                                class="ui-button-secondary mx-1"
+                                style="float: right;"
+                                icon="fa fa-cog"
+                                ajax="false"
+                                rendered="#{webUserController.hasPrivilege('Admin')}"
+                                title="Page Configuration Management"
+                                action="#{pageAdminController.navigateToPageAdmin('ward/ward_pharmacy_reprint_bht_issue_bill_reprint')}"
+                                value="Config">
                             </p:commandButton>
                         </f:facet>
 
@@ -56,12 +66,11 @@
                                         <h:outputLabel value="#{pharmacyBillSearch.bill.department.name}"/>
                                     </f:facet>
 
-                                    <p:dataTable 
-                                        id="tbl" 
-                                        rowIndexVar="rowIndex" 
-                                        value="#{pharmacyBillSearch.bill.billItems}"  
-                                        var="bip" 
-                                        rendered="#{(webUserController.hasPrivilege('ShowInwardFee'))}">
+                                    <p:dataTable
+                                        id="tbl"
+                                        rowIndexVar="rowIndex"
+                                        value="#{pharmacyBillSearch.bill.billItems}"
+                                        var="bip">
 
                                         <p:column>
                                             <f:facet name="header">
@@ -84,7 +93,7 @@
                                             <p:outputLabel value="#{bip.qty}"/>
                                         </p:column>
 
-                                        <p:column style="text-align: right;">
+                                        <p:column style="text-align: right;" rendered="#{webUserController.hasPrivilege('NursingIPBillingViewRates')}">
                                             <f:facet name="header">
                                                 <h:outputLabel value="Gross Value"/>
                                             </f:facet>
@@ -93,7 +102,7 @@
                                             </h:outputLabel>
                                         </p:column>
 
-                                        <p:column style="text-align: right;">
+                                        <p:column style="text-align: right;" rendered="#{webUserController.hasPrivilege('IPBillingViewDiscount')}">
                                             <f:facet name="header">
                                                 <h:outputLabel value="Matrix Value"/>
                                             </f:facet>
@@ -102,7 +111,7 @@
                                             </h:outputLabel>
                                         </p:column>
 
-                                        <p:column style="text-align: right;">
+                                        <p:column style="text-align: right;" rendered="#{webUserController.hasPrivilege('NursingIPBillingViewRates')}">
                                             <f:facet name="header">
                                                 <h:outputLabel value="Net Value"/>
                                             </f:facet>
@@ -113,14 +122,14 @@
 
                                         <p:columnGroup type="footer">
                                             <p:row>
-                                                <p:column  style="text-align: right;" colspan="4">
+                                                <p:column  style="text-align: right;" colspan="4" rendered="#{webUserController.hasPrivilege('NursingIPBillingViewRates')}">
                                                     <f:facet name="footer">
                                                         <h:outputLabel value="#{pharmacyBillSearch.bill.total}">
                                                             <f:convertNumber pattern="#0.00" />
                                                         </h:outputLabel>
                                                     </f:facet>
                                                 </p:column>
-                                                <p:column  style="text-align: right;" colspan="2">
+                                                <p:column  style="text-align: right;" colspan="2" rendered="#{webUserController.hasPrivilege('NursingIPBillingViewRates')}">
                                                     <f:facet name="footer">
                                                         <h:outputLabel value="#{pharmacyBillSearch.bill.netTotal}">
                                                             <f:convertNumber pattern="#0.00" />
@@ -157,7 +166,7 @@
                                     </div>
 
                                     <div class="d-flex justify-content-end gap-2 mt-1">
-                                        <h:panelGroup rendered="#{webUserController.hasPrivilege('IPRequestViewRates')}">
+                                        <h:panelGroup rendered="#{webUserController.hasPrivilege('NursingIPBillingViewRates')}">
                                             <p:outputLabel value="Rate" class="mt-2"></p:outputLabel>
                                             <p:selectOneRadio value="#{pharmacyBillSearch.printBhtIssueBillWithRate}" layout="lineDirection">
                                                 <f:selectItem itemLabel="Without Rate" itemValue="#{false}"/>
@@ -170,31 +179,31 @@
 
                                         <h:panelGroup   id="gpBillPreviewSingle" rendered="#{sessionController.loggedPreference.pharmacyBillPaperType eq 'PosPaper'}">
                                             <h:panelGroup rendered="#{sessionController.loggedPreference.pharmacyBillPrabodha eq false}" >
-                                                <ph:issueBill bill="#{pharmacyBillSearch.bill}" duplicate="true" showRate="#{webUserController.hasPrivilege('IPRequestViewRates') and pharmacyBillSearch.printBhtIssueBillWithRate}" />
+                                                <ph:issueBill bill="#{pharmacyBillSearch.bill}" duplicate="true" showRate="#{webUserController.hasPrivilege('NursingIPBillingViewRates') and pharmacyBillSearch.printBhtIssueBillWithRate}" showDiscount="#{webUserController.hasPrivilege('IPBillingViewDiscount') and pharmacyBillSearch.printBhtIssueBillWithRate}" />
                                             </h:panelGroup>
                                         </h:panelGroup>
 
                                         <h:panelGroup id="gpBillPreviewDouble" rendered="#{sessionController.loggedPreference.pharmacyBillPaperType eq 'PosPaper'}">
                                             <h:panelGroup     rendered="#{sessionController.loggedPreference.pharmacyBillPrabodha eq true}">
-                                                <phi:saleBill_prabodha bill="#{pharmacyBillSearch.bill}" showRate="#{webUserController.hasPrivilege('IPRequestViewRates') and pharmacyBillSearch.printBhtIssueBillWithRate}"></phi:saleBill_prabodha>
+                                                <phi:saleBill_prabodha bill="#{pharmacyBillSearch.bill}" showRate="#{webUserController.hasPrivilege('NursingIPBillingViewRates') and pharmacyBillSearch.printBhtIssueBillWithRate}" showDiscount="#{webUserController.hasPrivilege('IPBillingViewDiscount') and pharmacyBillSearch.printBhtIssueBillWithRate}"></phi:saleBill_prabodha>
                                             </h:panelGroup>
                                         </h:panelGroup>
 
                                         <h:panelGroup id="gpBillPreviewFiveFive" rendered="#{sessionController.loggedPreference.pharmacyBillPaperType eq 'FiveFivePaper'}">
                                             <h:panelGroup rendered="true" >
-                                                <phi:saleBill_five_five bill="#{pharmacyBillSearch.bill}" showRate="#{webUserController.hasPrivilege('IPRequestViewRates') and pharmacyBillSearch.printBhtIssueBillWithRate}"></phi:saleBill_five_five>
+                                                <phi:saleBill_five_five bill="#{pharmacyBillSearch.bill}" showRate="#{webUserController.hasPrivilege('NursingIPBillingViewRates') and pharmacyBillSearch.printBhtIssueBillWithRate}" showDiscount="#{webUserController.hasPrivilege('IPBillingViewDiscount') and pharmacyBillSearch.printBhtIssueBillWithRate}"></phi:saleBill_five_five>
                                             </h:panelGroup>
                                         </h:panelGroup>
 
                                         <h:panelGroup id="gpBillPreviewA4" rendered="#{sessionController.loggedPreference.pharmacyBillPaperType eq 'A4Paper'}">
                                             <h:panelGroup rendered="true" >
-                                                <ph:A4_paper_with_headings bill="#{pharmacyBillSearch.bill}" showRate="#{webUserController.hasPrivilege('IPRequestViewRates') and pharmacyBillSearch.printBhtIssueBillWithRate}"></ph:A4_paper_with_headings>
+                                                <ph:A4_paper_with_headings bill="#{pharmacyBillSearch.bill}" showRate="#{webUserController.hasPrivilege('NursingIPBillingViewRates') and pharmacyBillSearch.printBhtIssueBillWithRate}" showDiscount="#{webUserController.hasPrivilege('IPBillingViewDiscount') and pharmacyBillSearch.printBhtIssueBillWithRate}"></ph:A4_paper_with_headings>
                                             </h:panelGroup>
                                         </h:panelGroup>
 
                                         <h:panelGroup id="gpBillPreviewPosHeader" rendered="#{sessionController.loggedPreference.pharmacyBillPaperType eq 'PosHeaderPaper'}">
                                             <h:panelGroup rendered="true" >
-                                                <phi:saleBill_Header_Inward bill="#{pharmacyBillSearch.bill}" duplicate="true" showRate="#{webUserController.hasPrivilege('IPRequestViewRates') and pharmacyBillSearch.printBhtIssueBillWithRate}" />
+                                                <phi:saleBill_Header_Inward bill="#{pharmacyBillSearch.bill}" duplicate="true" showRate="#{webUserController.hasPrivilege('NursingIPBillingViewRates') and pharmacyBillSearch.printBhtIssueBillWithRate}" showDiscount="#{webUserController.hasPrivilege('IPBillingViewDiscount') and pharmacyBillSearch.printBhtIssueBillWithRate}" />
                                             </h:panelGroup>
                                         </h:panelGroup>
 


### PR DESCRIPTION
## What

Splits medicine-amount visibility on inward pharmacy BHT issue bills into two independent privileges, per #21104:

- **`NursingIPBillingViewRates`** (existing, reused) — gates net rate/net value on both `ward/ward_pharmacy_bht_issue.xhtml` and its reprint page (`ward/ward_pharmacy_reprint_bht_issue_bill_reprint.xhtml`). Reconciles the reprint page off the different privilege it previously used (`IPRequestViewRates`) onto the same one already used by the issue page.
- **`IPBillingViewDiscount`** (new) — gates discount / discount-percent / Matrix Value (margin, the service-charge-equivalent field), independently of rate/value. Named without a "Nursing" prefix per review feedback — it isn't nursing-specific.
- **Item name and quantity now render unconditionally** on both pages — the reprint page's item table was previously wrapped entirely in `ShowInwardFee`, which hid item names too; that gate is removed from the table itself, replaced with per-column gating on just the money fields.
- **Config buttons** added to both pages (`Admin` privilege), wired into `PageMetadataRegistry` (for the shared `PharmacyBillSearch` controller, following the #22995 precedent for pages backed by shared session-scoped beans) and `PharmacySaleBhtController`'s existing page-metadata registration.
- The 5 shared print composites (`issueBill`, `saleBill_prabodha`, `saleBill_five_five`, `A4_paper_with_headings`, `saleBill_Header_Inward`) get a new, purely-additive `showDiscount` attribute (default `true`) so Discount/Discount Percent lines can be gated independently of `showRate` — every other page that calls these composites (return bills, discharge medicine issue, the old BHT issue page, etc.) is unaffected since the default preserves current behavior.

## Design decision

A previous automated pass (`dev-issue-unattended`) correctly identified the privilege split as a design decision outside its authority and stopped. Confirmed with the maintainer before implementing:
1. Reconcile both pages onto `NursingIPBillingViewRates` for rate/value.
2. New dedicated privilege for discount, named `IPBillingViewDiscount` (not `NursingIPBillingViewDiscount`).

## Verification

Tested live against local Payara (department: Main Pharmacy, issuing to Inward — the pages are pharmacy-side operations, not ward-side, despite the `ward/` path prefix) using a real BHT issue bill (`Inward//26/038091`) with a genuine non-zero discount (3.61) and margin (10.35), toggling `IPBillingViewDiscount` on/off via the DB and re-logging in between:

**Reprint page — on-screen item table**, before/after granting `IPBillingViewDiscount`:

| Without `IPBillingViewDiscount` | With `IPBillingViewDiscount` |
|---|---|
| ![no matrix value column](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/21104-reprint-rates-only-no-discount.png) | ![matrix value column visible](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/21104-reprint-with-discount-privilege.png) |

**Reprint page — printed preview** (Five-Five paper, "With Rate" selected; patient details redacted):

| Without `IPBillingViewDiscount` | With `IPBillingViewDiscount` |
|---|---|
| ![no discount line](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/21104-reprint-fivefive-rate-no-discount.png) | ![discount line visible](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/21104-reprint-fivefive-with-discount.png) |

Also confirmed:
- `mvn clean package -DskipTests` builds cleanly; deployed via `asadmin redeploy` to local Payara with no errors in `server.log` across the whole test session.
- Config button visible only for `Admin`-privileged users; item name/qty visible with no privilege in every state tested.
- DB: the new privilege round-tripped correctly through `WEBUSERPRIVILEGE`; test grant removed afterward to restore the dev account's original state.
- The BHT Issue page's diff applies the *identical* privilege pattern (same two privilege names, same config-key combination already proven live on that page's pre-existing rate/value gates) to the newly-split Discount/Net Total header fields and Matrix Value row-expansion field — code-reviewed against the wiring verified live on the reprint page. A live screenshot of this page's own gates wasn't captured because the only request available in the local DB was already fully issued; creating a fresh admission + ward request solely for a screenshot was judged out of proportion given the identical, already-verified wiring.

## Documentation

Updated [Pharmacy-Configuration-and-Privileges](https://github.com/hmislk/hmis/wiki/Pharmacy-Configuration-and-Privileges) — updated the "Issue Medicines for Ward Requests" section and added a new "Reprint BHT Issue Bill" section, both privileges/config options and the Config buttons documented, with the four screenshots above embedded.

Closes #21104

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable visibility for rates, values, discounts, net totals, and related billing details on inward pharmacy bills.
  * Added administrator access to page configuration for BHT issue and reprint pages.
  * Added separate controls for nursing billing rates and discount information.

* **Bug Fixes**
  * Improved consistency of discount and total visibility across bill previews and print formats.
  * Updated bill displays to respect the appropriate access permissions for financial details.
  * Restricted matrix values and available stock details according to access permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->