### PR TITLE
fix(demonstrate-issues): track navigation breadcrumb during non-capture turns

### DIFF
--- a/.claude/skills/demonstrate-issues/SKILL.md
+++ b/.claude/skills/demonstrate-issues/SKILL.md
@@ -142,13 +142,21 @@ letting them drive.
 
 So on every non-capture navigation/narration turn, silently note (don't
 announce it — this isn't a capture, just a running log) the menu
-path/button clicked and, if visible, the resulting page's title/breadcrumb
-and URL (`browser_snapshot`'s Page URL line, or ask if it's not obviously
-inferable from what the user said). Keep only the current admission's
-breadcrumb trail, most recent step last — this is scratch context, not a
-demo record, and gets discarded at end of session. When a capture cue
-finally lands, that trail becomes the "Steps to reproduce" backbone instead
-of having to ask the user to redo the walk.
+path/button clicked and, if visible from context already in front of you,
+the resulting page's title and URL. Don't spend an extra `browser_snapshot`
+call purely to fill in this log — use whatever page context you already
+have (the last snapshot/screenshot taken, or the user's own words). If a
+hop's destination truly isn't inferable that way, leave it unlabeled rather
+than interrupting the flow to ask; a gap in the trail is better than
+breaking the user's narration to ask a tracking question.
+
+Keep only the trail since the last capture (or session start, whichever is
+more recent), most recent step last — this is scratch context, not a demo
+record, and applies to whatever workflow is being demonstrated, not just
+inpatient/admission ones. When a capture cue lands, that trail becomes the
+"Steps to reproduce" backbone for that demo — then clear it before the next
+hop, so a later demo in the same session doesn't inherit an earlier demo's
+steps. Any trail still open at session end is simply discarded.
 
 If a capture already happened and the user later clarifies that demo #N was not
 meant as a bug report (e.g. "no error in this page yet, just gathering

--- a/.claude/skills/demonstrate-issues/SKILL.md
+++ b/.claude/skills/demonstrate-issues/SKILL.md
@@ -131,6 +131,25 @@ the browser to the next thing worth showing, with no bug implied. Follow
 the instruction, but don't treat it as a capture cue on its own; wait for
 the user to actually point out a problem.
 
+### Keep a running navigation breadcrumb, even when not capturing
+
+The user is driving the browser, not you — when they say "I'm on page X"
+or narrate a click, you often can't reconstruct that path from code (it may
+depend on session state: a selected patient, department, in-progress form)
+and the user may not be able to repeat the exact clicks on request. Losing
+the trail forces them to redo manual navigation, which defeats the point of
+letting them drive.
+
+So on every non-capture navigation/narration turn, silently note (don't
+announce it — this isn't a capture, just a running log) the menu
+path/button clicked and, if visible, the resulting page's title/breadcrumb
+and URL (`browser_snapshot`'s Page URL line, or ask if it's not obviously
+inferable from what the user said). Keep only the current admission's
+breadcrumb trail, most recent step last — this is scratch context, not a
+demo record, and gets discarded at end of session. When a capture cue
+finally lands, that trail becomes the "Steps to reproduce" backbone instead
+of having to ask the user to redo the walk.
+
 If a capture already happened and the user later clarifies that demo #N was not
 meant as a bug report (e.g. "no error in this page yet, just gathering
 facts"), treat that as an explicit instruction to drop the prior capture —

--- a/.claude/skills/demonstrate-issues/SKILL.md
+++ b/.claude/skills/demonstrate-issues/SKILL.md
@@ -150,13 +150,24 @@ hop's destination truly isn't inferable that way, leave it unlabeled rather
 than interrupting the flow to ask; a gap in the trail is better than
 breaking the user's narration to ask a tracking question.
 
-Keep only the trail since the last capture (or session start, whichever is
-more recent), most recent step last — this is scratch context, not a demo
-record, and applies to whatever workflow is being demonstrated, not just
-inpatient/admission ones. When a capture cue lands, that trail becomes the
-"Steps to reproduce" backbone for that demo — then clear it before the next
-hop, so a later demo in the same session doesn't inherit an earlier demo's
-steps. Any trail still open at session end is simply discarded.
+**Sanitize before storing, not just before filing.** URLs and page
+titles/breadcrumbs routinely carry patient identifiers (BHT number, PHN,
+patient name) even at this scratch stage — strip or generalize those as
+you log each hop (e.g. `BHT/56757` → `[selected admission]`). Don't rely
+on the step-7 filing-time redaction pass alone for this: by then the trail
+has already been promoted into "Steps to reproduce" text, so anything left
+unredacted here flows straight into the draft issue body.
+
+Keep only the trail since the last completed capture (or session start,
+whichever is more recent), most recent step last — this is scratch
+context, not a demo record, and applies to whatever workflow is being
+demonstrated, not just inpatient/admission ones. When a demo is actually
+captured — not merely cued; a content-free cue (previous section) leaves
+the trail open while it waits for the required description — that trail
+becomes the "Steps to reproduce" backbone for that demo. Clear it once the
+capture is consumed, so a later demo in the same session doesn't inherit
+an earlier demo's steps. Any trail still open at session end is simply
+discarded.
 
 If a capture already happened and the user later clarifies that demo #N was not
 meant as a bug report (e.g. "no error in this page yet, just gathering


### PR DESCRIPTION
## Summary
While demonstrating an issue with the `/demonstrate-issues` skill, navigation narration ("go to inpatient dashboard", "click Add Outside Charges") between bug cues wasn't being recorded anywhere. When a capture cue finally landed, the skill had no way to reconstruct the path the user had driven through — session state (selected patient, department, in-progress form) that can't be inferred from code alone. The user couldn't repeat the exact clicks on request, so evidence capture for that page had to be skipped.

## Change
Adds a rule to `.claude/skills/demonstrate-issues/SKILL.md`: on every non-capture navigation/narration turn, silently track a running breadcrumb (menu path clicked + resulting page title/URL). This is scratch context only — not a demo record — discarded at session end. When a capture cue lands, the breadcrumb becomes the Steps to Reproduce backbone instead of asking the user to redo the walk.

## Testing
JSF/skill-doc-only change (Markdown), no compiled code touched — no build/deploy required per CLAUDE.md testing rules.

Found and fixed live while filing #23250.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Navigation trails now persist across workflows and include page context such as titles, breadcrumbs, and URLs.
  * Capture reproduction steps include a sanitized navigation trail.
* **Bug Fixes**
  * Patient identifiers are removed or generalized before navigation details are stored.
  * Trails are cleared only after an actual capture; content-free cues leave them available for the next description.
  * Unclear destinations no longer trigger unnecessary snapshots or follow-up questions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->