### PR TITLE
feat(inward): filter Add Outside Charges item field to outside-fee-eligible items

### DIFF
--- a/src/main/java/com/divudi/bean/common/ItemController.java
+++ b/src/main/java/com/divudi/bean/common/ItemController.java
@@ -4266,6 +4266,13 @@ public class ItemController implements Serializable {
                     + " WHERE im.retired = false ";
             HashMap<String, Object> parameters = new HashMap<>();
             if (institution != null) {
+                // NOTE: deliberately not filtering out outsideChargeMapping=true
+                // mappings here (issue #23250) — this is a live runtime item-listing
+                // path (ITEMS_MAPPED_TO_LOGGED_INSTITUTION strategy) and a
+                // projection query that otherwise never needs to touch the new
+                // column; adding the filter would make it require
+                // OUTSIDECHARGEMAPPING to exist in the DB from the moment this
+                // deploys, ahead of the admin's "Add Missing Fields" DDL step.
                 jpql += " and im.institution=:ins ";
                 parameters.put("ins", institution);
             }

--- a/src/main/java/com/divudi/bean/common/ItemMappingController.java
+++ b/src/main/java/com/divudi/bean/common/ItemMappingController.java
@@ -53,6 +53,11 @@ public class ItemMappingController implements Serializable {
     private Item item;
     private ItemMapping selectedItemMapping;
     private List<Item> selectedItems;
+    // Outside-charge-specific mapping page state (issue #23250, Mode B) —
+    // kept separate from `institution`/`department` above so the general
+    // mapping pages and this one don't clobber each other's selection when
+    // both are open in the same session.
+    private Institution outsideChargeSite;
 
     public void addAllSelectedItemsToInstitution() {
         if (selectedItems == null) {
@@ -121,10 +126,14 @@ public class ItemMappingController implements Serializable {
     }
 
     public boolean mappingExists(Item i, Institution ins) {
+        // Excludes outside-charge-only mappings (issue #23250) so this
+        // general-purpose check/reactivate path never hijacks a row created
+        // by the dedicated outside-charge mapping page.
         String jpql = "select pavan "
                 + " from ItemMapping pavan "
                 + " where pavan.institution=:ins "
-                + " and pavan.item=:item ";
+                + " and pavan.item=:item "
+                + " and pavan.outsideChargeMapping=false ";
         Map m = new HashMap<>();
         m.put("ins", ins);
         m.put("item", i);
@@ -139,10 +148,12 @@ public class ItemMappingController implements Serializable {
     }
 
     public ItemMapping findItemMapping(Item i, Institution ins) {
+        // Excludes outside-charge-only mappings (issue #23250) — see mappingExists(Item, Institution).
         String jpql = "select pavan "
                 + " from ItemMapping pavan "
                 + " where pavan.institution=:ins "
-                + " and pavan.item=:item ";
+                + " and pavan.item=:item "
+                + " and pavan.outsideChargeMapping=false ";
         Map m = new HashMap<>();
         m.put("ins", ins);
         m.put("item", i);
@@ -239,14 +250,111 @@ public class ItemMappingController implements Serializable {
             JsfUtil.addErrorMessage("Institution");
             return;
         }
+        // Excludes outside-charge-only mappings (issue #23250) — see mappingExists(Item, Institution).
         String jpql = "SELECT im "
                 + "FROM ItemMapping im "
                 + "WHERE im.retired=false "
-                + "and im.institution = :inst";
+                + "and im.institution = :inst "
+                + "and im.outsideChargeMapping=false";
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("inst", institution);
         List<ItemMapping> itemMappings = getFacade().findByJpql(jpql, parameters);
         items = itemMappings;
+    }
+
+    // ------------------------------------------------------------------
+    // Outside Charge Item Mapping (issue #23250, Mode B) — item eligibility
+    // for the Inward "Add Outside Charges" Item field, opt-in via the
+    // "Inward Outside Charge Requires Item Mapping" config key, keyed to
+    // the department's SITE (Department.getSite()), not the bare
+    // department. Kept on the same ItemMapping table but always guarded by
+    // outsideChargeMapping=true so it never overlaps with the generic
+    // mapping methods above.
+    // ------------------------------------------------------------------
+    public void addAllSelectedItemsToOutsideChargeSite() {
+        if (selectedItems == null || selectedItems.isEmpty()) {
+            JsfUtil.addErrorMessage("No Items Selected");
+            return;
+        }
+        if (outsideChargeSite == null) {
+            JsfUtil.addErrorMessage("No Site Selected");
+            return;
+        }
+        if (items == null) {
+            items = new ArrayList<>();
+        }
+        for (Item i : selectedItems) {
+            ItemMapping im = findOutsideChargeItemMapping(i, outsideChargeSite);
+            if (im == null) {
+                im = new ItemMapping();
+                im.setItem(i);
+                im.setInstitution(outsideChargeSite);
+                im.setOutsideChargeMapping(true);
+                im.setCreater(sessionController.getLoggedUser());
+                im.setCreatedAt(new Date());
+                getFacade().create(im);
+                items.add(im);
+            } else if (im.isRetired()) {
+                im.setRetired(false);
+                getFacade().edit(im);
+                items.add(im);
+            }
+        }
+        selectedItems = new ArrayList<>();
+        JsfUtil.addSuccessMessage("All Added");
+    }
+
+    public ItemMapping findOutsideChargeItemMapping(Item i, Institution site) {
+        String jpql = "select im "
+                + " from ItemMapping im "
+                + " where im.institution=:site "
+                + " and im.item=:item "
+                + " and im.outsideChargeMapping=true ";
+        Map<String, Object> m = new HashMap<>();
+        m.put("site", site);
+        m.put("item", i);
+        List<ItemMapping> ims = getFacade().findByJpql(jpql, m);
+        if (ims == null || ims.isEmpty()) {
+            return null;
+        }
+        return ims.get(0);
+    }
+
+    public void fillItemMappingsForSelectedOutsideChargeSite() {
+        if (outsideChargeSite == null) {
+            JsfUtil.addErrorMessage("Site ?");
+            return;
+        }
+        String jpql = "SELECT im "
+                + "FROM ItemMapping im "
+                + "WHERE im.retired=false "
+                + "AND im.institution = :site "
+                + "AND im.outsideChargeMapping=true";
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("site", outsideChargeSite);
+        items = getFacade().findByJpql(jpql, parameters);
+    }
+
+    public void removeSelectedItemMappingForOutsideChargeSite() {
+        if (selectedItemMappings == null || selectedItemMappings.isEmpty()) {
+            JsfUtil.addErrorMessage("Nothing selected");
+            return;
+        }
+        removeSelectedItemMapping();
+        fillItemMappingsForSelectedOutsideChargeSite();
+    }
+
+    // Navigation method for managing Outside Charge Item Mappings
+    public String navigateToManageOutsideChargeItemMappings() {
+        return "/admin/items/manage_outside_charge_item_mappings?faces-redirect=true";
+    }
+
+    public Institution getOutsideChargeSite() {
+        return outsideChargeSite;
+    }
+
+    public void setOutsideChargeSite(Institution outsideChargeSite) {
+        this.outsideChargeSite = outsideChargeSite;
     }
 
     // Navigation method for managing Department Item Mappings
@@ -261,6 +369,14 @@ public class ItemMappingController implements Serializable {
 
     public List<Item> completeItemByInstitution(String qry, Institution institution) {
         List<Item> results;
+        // NOTE: deliberately NOT filtering out outsideChargeMapping=true rows here.
+        // This is a live OPD/Optician/Collecting-Centre billing autocomplete path
+        // (a projection query that otherwise never needs to touch the new column),
+        // and adding that filter would make it require OUTSIDECHARGEMAPPING to exist
+        // in the DB from the moment this deploys, before an admin has necessarily
+        // run the "Add Missing Fields" DDL step (issue #23250). The admin-only
+        // mapping-management methods below already require that column regardless
+        // (they SELECT the full entity), so the isolation is enforced there instead.
         String jpql = "SELECT im.item FROM ItemMapping im "
                 + "WHERE (LOWER(im.item.name) LIKE :qry OR LOWER(im.item.fullName) LIKE :qry OR LOWER(im.item.code) LIKE :qry) "
                 + "AND im.institution = :institution "
@@ -304,6 +420,10 @@ public class ItemMappingController implements Serializable {
 
     public List<Item> fillItemByInstitution(Institution institution) {
         List<Item> results;
+        // NOTE: deliberately not filtering outsideChargeMapping here — see
+        // completeItemByInstitution(String, Institution) above. Also, outside-charge
+        // mappings never set `department`, so they cannot match `im.department.institution`
+        // regardless.
         String jpql = "SELECT im.item FROM ItemMapping im "
                 + " WHERE im.retired = false "
                 + " AND im.department.institution = :ins "
@@ -386,9 +506,11 @@ public class ItemMappingController implements Serializable {
         List<ItemMapping> list;
         String jpql;
         HashMap<String, Object> parameters = new HashMap<>();
+        // Excludes outside-charge-only mappings (issue #23250) — see mappingExists(Item, Institution).
         jpql = "SELECT im FROM ItemMapping im "
                 + "WHERE im.institution = :institution "
                 + "AND im.retired = false "
+                + "AND im.outsideChargeMapping = false "
                 + "ORDER BY im.item.name";
         parameters.put("institution", institution);
         list = getFacade().findByJpql(jpql, parameters);

--- a/src/main/java/com/divudi/bean/inward/InwardAdditionalChargeController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardAdditionalChargeController.java
@@ -20,11 +20,13 @@ import com.divudi.core.data.BillClassType;
 import com.divudi.core.data.BillNumberSuffix;
 import com.divudi.core.data.BillType;
 import com.divudi.core.data.BillTypeAtomic;
+import com.divudi.core.data.FeeType;
 import com.divudi.core.data.inward.InwardChargeType;
 import com.divudi.ejb.BillNumberGenerator;
 import com.divudi.core.entity.BillFee;
 import com.divudi.core.entity.BillItem;
 import com.divudi.core.entity.BilledBill;
+import com.divudi.core.entity.Department;
 import com.divudi.core.entity.Fee;
 import com.divudi.core.entity.PatientEncounter;
 import com.divudi.core.facade.BillFeeFacade;
@@ -343,15 +345,56 @@ public class InwardAdditionalChargeController implements Serializable {
         this.itemComment = itemComment;
     }
 
+    /**
+     * Autocomplete backing the Item field on Add Outside Charges (issue
+     * #23250). Restricted to items that are actually eligible for an
+     * outside charge:
+     * <ul>
+     * <li><b>Mode A (default):</b> among the item's non-retired site-level
+     * {@code ItemFee}s for the logged department's site, the only fee type
+     * present is {@link FeeType#OtherInstitution} (Outside Fee).</li>
+     * <li><b>Mode B (opt-in via config key "Inward Outside Charge Requires
+     * Item Mapping"):</b> the item must also be explicitly mapped to that
+     * site on the Outside Charge Item Mapping page
+     * ({@code ItemMapping.outsideChargeMapping = true}).</li>
+     * </ul>
+     * The site is the logged department's <b>site</b>
+     * ({@link Department#getSite()}), not the bare department — matching
+     * how site-level fees are already scoped elsewhere in Inward billing
+     * (see {@code BillBhtController}). If the logged department has no site
+     * configured, this falls back to the original unrestricted behavior
+     * (any non-retired Service/InwardService item) rather than returning an
+     * empty list, so departments without a site configured are not broken.
+     */
     public List<Item> completeItem(String qry) {
+        Department department = getSessionController().getDepartment();
+        Institution site = department != null ? department.getSite() : null;
+
         java.util.Map<String, Object> params = new java.util.HashMap<>();
         params.put("name", "%" + qry.toUpperCase() + "%");
-        return itemFacade.findByJpql(
-                "select i from Item i where i.retired=false "
+        String jpql = "select i from Item i where i.retired=false "
                 + "and (type(i) = InwardService or type(i) = Service) "
-                + "and upper(i.name) like :name "
-                + "order by i.name",
-                params);
+                + "and upper(i.name) like :name ";
+
+        if (site != null) {
+            params.put("site", site);
+            params.put("outsideFeeType", FeeType.OtherInstitution);
+            jpql += "and exists (select 1 from ItemFee f1 where f1.item = i "
+                    + "and f1.forInstitution = :site and f1.retired = false "
+                    + "and f1.feeType = :outsideFeeType) "
+                    + "and not exists (select 1 from ItemFee f2 where f2.item = i "
+                    + "and f2.forInstitution = :site and f2.retired = false "
+                    + "and f2.feeType <> :outsideFeeType) ";
+
+            if (configOptionController.getBooleanValueByKey("Inward Outside Charge Requires Item Mapping", false)) {
+                jpql += "and exists (select 1 from ItemMapping im where im.item = i "
+                        + "and im.institution = :site and im.retired = false "
+                        + "and im.outsideChargeMapping = true) ";
+            }
+        }
+
+        jpql += "order by i.name";
+        return itemFacade.findByJpql(jpql, params);
     }
 
     public void onItemSelect() {

--- a/src/main/java/com/divudi/core/entity/ItemMapping.java
+++ b/src/main/java/com/divudi/core/entity/ItemMapping.java
@@ -45,6 +45,16 @@ public class ItemMapping implements Serializable {
     @Temporal(TemporalType.TIMESTAMP)
     private Date retiredAt;
 
+    /**
+     * Distinguishes a mapping created specifically for the outside-charge
+     * item filter (Add Outside Charges, Mode B / issue #23250) from any other
+     * general-purpose use of this table (OPD/Optician/Collecting Centre item
+     * catalogs, etc.). Existing generic institution-scoped queries filter
+     * this out so an outside-charge-only mapping does not leak into
+     * unrelated features that also key off {@link #institution}.
+     */
+    private boolean outsideChargeMapping;
+
     public Long getId() {
         return id;
     }
@@ -142,6 +152,14 @@ public class ItemMapping implements Serializable {
 
     public void setRetiredAt(Date retiredAt) {
         this.retiredAt = retiredAt;
+    }
+
+    public boolean isOutsideChargeMapping() {
+        return outsideChargeMapping;
+    }
+
+    public void setOutsideChargeMapping(boolean outsideChargeMapping) {
+        this.outsideChargeMapping = outsideChargeMapping;
     }
 
 }

--- a/src/main/webapp/admin/items/index.xhtml
+++ b/src/main/webapp/admin/items/index.xhtml
@@ -23,11 +23,18 @@
                                         action="#{itemMappingController.navigateToManageDepartmentItemMappings}" />
 
                                     <!-- Button to navigate to Manage Institution Item Mappings -->
-                                    <p:commandButton 
-                                        class="w-100"  
-                                        ajax="false" 
-                                        value="Manage Institution Item Mappings" 
+                                    <p:commandButton
+                                        class="w-100"
+                                        ajax="false"
+                                        value="Manage Institution Item Mappings"
                                         action="#{itemMappingController.navigateToManageInstitutionItemMappings}" />
+
+                                    <!-- Button to navigate to Manage Outside Charge Item Mappings (issue #23250) -->
+                                    <p:commandButton
+                                        class="w-100"
+                                        ajax="false"
+                                        value="Manage Outside Charge Item Mappings"
+                                        action="#{itemMappingController.navigateToManageOutsideChargeItemMappings}" />
                                 </div>
 
                             </p:tab>

--- a/src/main/webapp/admin/items/manage_outside_charge_item_mappings.xhtml
+++ b/src/main/webapp/admin/items/manage_outside_charge_item_mappings.xhtml
@@ -1,0 +1,163 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/admin/items/index.xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:p="http://primefaces.org/ui">
+    <ui:define name="item">
+
+        <h:panelGroup>
+            <h:form id="form">
+                <p:growl />
+                <p:panel header="Manage Outside Charge Item Mapping">
+                    <h:panelGroup layout="block" style="margin-bottom: 1em;">
+                        <p:outputLabel value="Mode B (opt-in) for Inward &gt; Add Outside Charges: when the &quot;Inward Outside Charge Requires Item Mapping&quot; config key is ON for a department, an item must be mapped here to the department's SITE (in addition to having an Outside Fee) before it appears in the Item field." />
+                    </h:panelGroup>
+
+                    <div class="row">
+                        <div class="col-6">
+                            <p:panelGrid columns="2">
+                                <p:outputLabel value="Site" />
+                                <p:autoComplete
+                                    value="#{itemMappingController.outsideChargeSite}"
+                                    completeMethod="#{institutionController.completeSite}"
+                                    var="pasindu"
+                                    itemLabel="#{pasindu.name}"
+                                    itemValue="#{pasindu}"
+                                    maxResults="20">
+                                </p:autoComplete>
+                                <p:commandButton
+                                    value="Fill Items Added For Site"
+                                    ajax="false"
+                                    class="ui-button-warning"
+                                    icon="fas fa-spinner"
+                                    action="#{itemMappingController.fillItemMappingsForSelectedOutsideChargeSite()}">
+                                </p:commandButton>
+                                <p:commandButton
+                                    value="Add Items to Site"
+                                    ajax="false"
+                                    class="ui-button-success"
+                                    icon="fas fa-plus"
+                                    action="#{itemMappingController.addAllSelectedItemsToOutsideChargeSite()}">
+                                </p:commandButton>
+                            </p:panelGrid>
+                        </div>
+                    </div>
+
+                    <div class="row">
+                        <div class="col-6">
+                            <p:dataTable
+                                value="#{itemController.items}"
+                                var="item"
+                                rowKey="#{item.id}"
+                                selection="#{itemMappingController.selectedItems}"
+                                paginator="true"
+                                paginatorPosition="bottom"
+                                rows="10"
+                                selectionMode="multiple"
+                                paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                currentPageReportTemplate="{startRecord}-{endRecord} of {totalRecords} records"
+                                rowsPerPageTemplate="5,10,{ShowAll|'All'}">
+                                <f:facet name="header">
+                                    <p:outputLabel value="All Items" style="font-weight: 700;"></p:outputLabel>
+                                </f:facet>
+
+                                <p:column selectionBox="true" width="15"></p:column>
+
+                                <p:column
+                                    headerText="Name"
+                                    sortBy="#{item.name}"
+                                    filterBy="#{item.name}"
+                                    filterMatchMode="contains">
+                                    <h:outputText value="#{item.name}"></h:outputText>
+                                </p:column>
+
+                                <p:column headerText="Created At" sortBy="#{item.createdAt}" filterBy="#{item.createdAt}" filterMatchMode="contains">
+                                    <h:outputText value="#{item.createdAt eq null ? 'N/A':item.createdAt}"></h:outputText>
+                                </p:column>
+
+                                <p:column
+                                    headerText="Institution"
+                                    sortBy="#{item.institution.name}"
+                                    filterBy="#{item.institution.name}"
+                                    filterMatchMode="contains">
+                                    <h:outputText value="#{item.institution.name}"></h:outputText>
+                                </p:column>
+                                <p:column
+                                    headerText="Department"
+                                    sortBy="#{item.department.name}"
+                                    filterBy="#{item.department.name}"
+                                    filterMatchMode="contains">
+                                    <h:outputText value="#{item.department.name}"></h:outputText>
+                                </p:column>
+                                <p:column
+                                    width="100"
+                                    headerText="Base Value">
+                                    <h:outputText value="#{item.total}"></h:outputText>
+                                </p:column>
+                            </p:dataTable>
+                        </div>
+                        <div class="col-6">
+
+                            <p:dataTable
+                                value="#{itemMappingController.items}"
+                                rowKey="#{im.id}"
+                                selection="#{itemMappingController.selectedItemMappings}"
+                                var="im"
+                                rows="100"
+                                selectionMode="multiple"
+                                paginator="true"
+                                paginatorPosition="bottom"
+                                paginatorTemplate="{CurrentPageReport} {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                currentPageReportTemplate="{startRecord}-{endRecord} of {totalRecords} records"
+                                rowsPerPageTemplate="5,10,{ShowAll|'All'}">
+                                <f:facet name="header">
+                                    <div class="d-flex align-items-center justify-content-between">
+                                        <div>
+                                            <p:outputLabel value="Items Mapped for Outside Charges"></p:outputLabel>
+                                        </div>
+                                        <div>
+                                            <p:commandButton
+                                                style="float: right;"
+                                                value="Remove Selected"
+                                                ajax="false"
+                                                class="ui-button-danger"
+                                                icon="fas fa-trash"
+                                                action="#{itemMappingController.removeSelectedItemMappingForOutsideChargeSite()}"></p:commandButton>
+                                        </div>
+                                    </div>
+                                </f:facet>
+
+                                <p:column selectionBox="true" width="15"></p:column>
+
+                                <p:column
+                                    headerText="Name"
+                                    sortBy="#{im.item.name}"
+                                    filterBy="#{im.item.name}"
+                                    filterMatchMode="contains">
+                                    <h:outputText value="#{im.item.name}"></h:outputText>
+                                </p:column>
+                                <p:column
+                                    headerText="Site"
+                                    sortBy="#{im.institution.name}"
+                                    filterBy="#{im.institution.name}"
+                                    filterMatchMode="contains">
+                                    <h:outputText value="#{im.institution.name}"></h:outputText>
+                                </p:column>
+                                <p:column
+                                    width="100"
+                                    headerText="Base Value">
+                                    <h:outputText value="#{im.item.total}"></h:outputText>
+                                </p:column>
+
+                            </p:dataTable>
+                        </div>
+                    </div>
+
+                </p:panel>
+            </h:form>
+        </h:panelGroup>
+    </ui:define>
+</ui:composition>


### PR DESCRIPTION
## Decisions made without approval (dev-issue-unattended)

- **Reused the existing `ItemMapping` table** for the new Mode B mapping
  (its `institution` field already models a "site") instead of creating a
  new entity/table, by adding one new boolean column
  `outsideChargeMapping` to distinguish this purpose from `ItemMapping`'s
  other, unrelated uses (OPD/Optician/Collecting-Centre item catalogs,
  "Investigations and Services" institution mapping). A brand-new table
  would be schema design beyond this run's DDL-generation-only exception
  (see Hard limits in the `dev-issue-unattended` skill), so I stayed within
  a single new column on an existing table.
- **Left four live-runtime, projection-only `ItemMapping` queries
  unfiltered** (`completeItemByInstitution`, `fillItemByInstitution`,
  `fillItemLightByInstitution`,
  `ItemController.fillInvestigationsAndServicesMapping`) — these back
  OPD/Optician/Collecting-Centre billing autocomplete and the
  `ITEMS_MAPPED_TO_LOGGED_INSTITUTION` inward item-listing strategy, and as
  projections they don't otherwise need the new column at all. Adding a
  `outsideChargeMapping=false` filter there would make them require the new
  column to exist in the DB the instant this deploys, ahead of the admin
  applying the DDL. I *did* add that filter to the admin-only, full-entity
  `SELECT im FROM ItemMapping im ...` queries (the existing Manage
  Department/Institution Item Mappings pages), since those already require
  the column regardless of any filter (a full-entity fetch reads every
  mapped column) — so the filter there is free correctness with no added
  blast radius.
  **Trade-off:** an item mapped only for outside-charge purposes could
  still surface in those four unrelated pickers if the same site/institution
  also uses them for OPD/Optician/Collecting-Centre/investigation listing.
  This is a narrow, opt-in-only (Mode B, default off) exposure — flagging
  it here for a human to weigh rather than fixing it, since a fix would
  require the new column on paths that don't otherwise need it.
- **Site source is `Department.getSite()`**, not the bare department or the
  bill's "outside institution" — matches the existing scoping pattern in
  `BillBhtController` for site-based fees. Departments with no site
  configured (66 of 95 non-retired departments in the local `coop` DB) keep
  the original, unrestricted item list rather than showing nothing.

## Problem

The Item field on Add Outside Charges listed every non-retired
Service/InwardService item, with no restriction to items that actually have
an outside fee configured (`InwardAdditionalChargeController.completeItem()`
was a blanket type + name-match query, no join to `ItemFee`).

## Fix

- **Mode A (default, always on):** an item is listed only if, among its
  non-retired site-level `ItemFee`s for the logged department's site, the
  *only* fee type present is `FeeType.OtherInstitution` (Outside Fee).
- **Mode B (opt-in via new config key `Inward Outside Charge Requires Item
  Mapping`, department-scoped through `ConfigOptionController`):** the item
  must *also* be explicitly mapped to the site on a new admin page, **Manage
  Outside Charge Item Mappings** (Admin > Manage Items/Services > Item
  Mapping).

## Verification

End-to-end via Playwright + DB against the local `coop` database (Galle
site, Inward department):

- Created three `ItemFee` scenarios at the Galle site: an item with only an
  Outside Fee, an item with only an Own-Institution ("Hospital") fee, and an
  item with both.
- Item field search returned **only** the Outside-Fee-only item; the
  Own-Institution-only item and the mixed item were both excluded; a plain
  no-fee item was also excluded (reproducing the original bug's absence).
- Added the eligible item as a real outside charge and confirmed it
  persisted correctly in `BILLITEM`.
- The new Manage Outside Charge Item Mappings page renders and is wired up
  correctly (Mode B); its full CRUD flow needs the pending DDL column
  applied first (see below), which per this run's hard limits stays a human
  step via the admin UI — not something this run applies, even locally.

## ⚠️ DDL required before/at deploy

This PR adds one new column, `ITEMMAPPING.OUTSIDECHARGEMAPPING`
(`tinyint(1) default 0`). `tmp/createDDL.jdbc` has been regenerated (212
`CREATE TABLE` / 5280 `ADD COLUMN` statements, consistent with the
documented baseline). **Apply it via Admin > Manage Metadata > Add Missing
Fields before or immediately at deploy** — until then, any full-entity
`ItemMapping` read will fail, which affects the pre-existing Manage
Department/Institution Item Mappings admin pages as well as the new one
(same as any other new mapped column, per project policy). The four
runtime billing-autocomplete paths listed above are unaffected either way.

## Documentation

Updated the [Add Outside Charges](https://github.com/hmislk/hmis/wiki/Add-Outside-Charges)
wiki page with a new section describing the filtering behavior, plus a
screenshot showing the Item field returning only the eligible match out of
three same-named items.

Closes #23250

🤖 Generated with [Claude Code](https://claude.com/claude-code)