### PR TITLE
fix(inventory-reports): make Add to Stock Bills cost columns visible and total them in exports

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -2061,6 +2061,28 @@ window.setTimeout = function (fn, delay) { return delay >= 2500 ? 0 : window.__o
 The real growl then stays rendered for the screenshot (nothing about the message is faked — only the dismissal is
 deferred). Reload the page afterwards to drop the patch. Verified while testing issue #23206.
 
+## 80. A `p:dataTable` column present in `browser_snapshot` can still be 0px wide and invisible to the user — measure `offsetWidth`
+
+PrimeFaces renders its DataTable with `table-layout: fixed`. Under that layout the browser honours the columns that
+carry an explicit `width` first and hands the leftovers to the rest — and when the widths already declared exceed the
+table width, "the rest" gets **zero**. Those columns still render their `<th>`/`<td>` with the correct text, so they
+appear in `browser_snapshot`, in `get_page_text`, and in `innerText`. They are simply not on screen.
+
+This is how issue #23224 was misdiagnosed at first: the accessibility snapshot listed all 17 headers including
+`COST RATE` and `COST VALUE`, the footer totals were right, and the DB reconciled — so the report looked finished. The
+columns the user was asking for were 0px wide, exactly as their screenshot showed.
+
+Whenever a report "already has" a column a user says is missing, measure before concluding:
+
+```js
+[...document.querySelectorAll('.ui-datatable thead th')]
+    .map(th => ({ h: th.innerText.trim(), w: Math.round(th.offsetWidth) }))
+```
+
+Any `w: 0` is an invisible column. The fix is in the XHTML, not the test: once *any* `p:column` on a fixed-layout table
+declares a `width`, **every** column must declare one, or the undeclared ones collapse. Widening the viewport does not
+reveal them — it makes it worse, because the extra space goes to the columns that did declare a width.
+
 ## Some PrimeFaces buttons need a jQuery-triggered click
 
 Most `p:commandButton`s submit fine with a normal Playwright click — including

--- a/src/main/java/com/divudi/bean/report/PharmacyReportController.java
+++ b/src/main/java/com/divudi/bean/report/PharmacyReportController.java
@@ -14686,7 +14686,8 @@ public class PharmacyReportController implements Serializable {
                 addSpanningCell(table, String.format("%.2f", billNetTotal), rowSpan, createNetTotalCell(""));
 
                 // This cell acts as a placeholder for the payment methods that will be added below
-                PdfPCell paymentPlaceholder = createDataCell(billDto.getPaymentMethod().toString());
+                PdfPCell paymentPlaceholder = createDataCell(
+                        billDto.getPaymentMethod() != null ? billDto.getPaymentMethod().toString() : "");
                 paymentPlaceholder.setRowspan(rowSpan);
                 table.addCell(paymentPlaceholder);
 
@@ -14760,10 +14761,14 @@ public class PharmacyReportController implements Serializable {
     private void addPaymentBreakdownRows(PdfPTable table, CostOfGoodSoldBillDTO billDto) {
         Map<PaymentMethod, Double> paymentBreakdown = getPaymentBreakdown(billDto);
 
+        // A bill can carry no payment method at all - the export must still
+        // produce its row rather than abort the whole PDF part-written.
+        PaymentMethod billPaymentMethod = billDto.getPaymentMethod();
+
         // Handle single payment method case
-        if (!"MultiplePaymentMethods".equals(billDto.getPaymentMethod().toString())) {
-            String methodName = billDto.getPaymentMethod().toString();
-            double total = billDto.getNetTotal();
+        if (billPaymentMethod != PaymentMethod.MultiplePaymentMethods) {
+            String methodName = billPaymentMethod != null ? billPaymentMethod.toString() : "";
+            double total = billDto.getNetTotal() != null ? billDto.getNetTotal() : 0.0;
             addPaymentMethodRow(table, methodName, total);
         } else {
             for (Map.Entry<PaymentMethod, Double> entry : paymentBreakdown.entrySet()) {
@@ -14845,7 +14850,9 @@ public class PharmacyReportController implements Serializable {
      * Totals row spanning all 15 columns: the label covers columns 1-7, then
      * each money total sits under the column it totals (Cost Value, Purchase
      * Value, Net Total, MRP Value). Values come from the controller totals
-     * accumulated during processing so the PDF matches the on-screen footer.
+     * accumulated during processing so the PDF matches the on-screen footer -
+     * which, as {@link #createTotalRow} explains, is not necessarily the sum of
+     * the rows printed above.
      */
     private void addGrandTotalRow(PdfPTable table, double grandTotal) {
         PdfPCell totalLabel = new PdfPCell(new Phrase("Total",
@@ -16694,10 +16701,19 @@ public class PharmacyReportController implements Serializable {
 
     /**
      * Totals row for the cost-of-goods-sold bill exports. The values come from
-     * the controller totals accumulated while the report was processed - not
-     * from re-summing the exported rows - so the spreadsheet matches the
-     * on-screen footer exactly, including the negative reference bills and the
-     * pre-add-to-stock bills that are netted at total level only.
+     * the controller totals accumulated while the report was processed, not
+     * from re-summing the exported rows, so the spreadsheet always matches the
+     * on-screen footer.
+     * <p>
+     * Those two are deliberately not the same thing. A reference bill settled
+     * outside the period is added to {@code cogsBillDtos} by
+     * {@link #retrieveNegativeReferenceBills}, so it appears as ordinary rows,
+     * but only its bill total is flipped negative - the item quantities and
+     * rates stay positive while the accumulated totals subtract them. Bills
+     * with no items are skipped by {@link #populateDataRows} yet still counted
+     * in the net total. Summing a value column in the spreadsheet can therefore
+     * disagree with this row; the accumulated figure is the report's answer,
+     * and it is the one shown on screen.
      */
     private void createTotalRow(Sheet sheet, int rowIndex) {
         Row totalRow = sheet.createRow(rowIndex);

--- a/src/main/java/com/divudi/bean/report/PharmacyReportController.java
+++ b/src/main/java/com/divudi/bean/report/PharmacyReportController.java
@@ -14629,7 +14629,9 @@ public class PharmacyReportController implements Serializable {
             PdfPTable table = new PdfPTable(15);
             table.setWidthPercentage(100);
             table.setSpacingBefore(10);
-            float[] columnWidths = {1.2f, 1.8f, 3.5f, 1.5f, 2.2f, 1f, 1.5f, 1.5f, 1.5f, 1.5f, 2f, 3.5f, 1.5f, 2f, 1.5f};
+            // COST VALUE and PURCHASE VALUE carry the grand totals, which wrap onto
+            // two lines at 1.5f, so those two columns are given a little more room.
+            float[] columnWidths = {1.2f, 1.8f, 3.5f, 1.5f, 2.2f, 1f, 1.5f, 1.9f, 1.5f, 1.9f, 2f, 3.5f, 1.5f, 2f, 1.5f};
             table.setWidths(columnWidths);
 
             addHeaderRow(table);
@@ -14688,14 +14690,18 @@ public class PharmacyReportController implements Serializable {
                 paymentPlaceholder.setRowspan(rowSpan);
                 table.addCell(paymentPlaceholder);
 
-                addSpanningCell(table, "", rowSpan, createEmptyCell()); // MRP
-                addSpanningCell(table, "", rowSpan, createEmptyCell()); // MRP Value
+                // MRP and MRP Value are item-level figures, so they are added per
+                // row. iText places them in columns 13/14 because the bill-level
+                // cells on either side are already held by their rowspan.
+                addMrpCells(table, item);
+
                 addSpanningCell(table, String.format("%.2f", billDiscount), rowSpan, createDataCell(""));
 
                 isFirstItem = false;
             } else {
                 // For all subsequent items, only add the item-specific cells.
                 addItemCells(table, item);
+                addMrpCells(table, item);
             }
         }
 
@@ -14707,12 +14713,17 @@ public class PharmacyReportController implements Serializable {
         table.addCell(createItemNameCell(item.getItemName() != null ? item.getItemName() : "-"));
         table.addCell(createDataCell(item.getItemCode() != null ? item.getItemCode().toString() : "-"));
         table.addCell(createDataCell(item.getBatchNo() != null ? item.getBatchNo() : "-"));
-        table.addCell(createDataCell(String.valueOf(item.getQty().intValue())));
-        table.addCell(createDataCell(String.format("%.2f", item.getCostRate())));
+        table.addCell(createDataCell(String.valueOf((long) safeDouble(item.getQty()))));
+        table.addCell(createDataCell(String.format("%.2f", safeDouble(item.getCostRate()))));
         table.addCell(createDataCell(String.format("%.2f", calculateCostValue(item))));
-        table.addCell(createDataCell(String.format("%.2f", item.getRetailRate())));
-        table.addCell(createDataCell(String.format("%.2f", calculateItemValue(item))));
+        table.addCell(createDataCell(String.format("%.2f", safeDouble(item.getPurchaseRate()))));
+        table.addCell(createDataCell(String.format("%.2f", calculatePurchaseValue(item))));
 
+    }
+
+    private void addMrpCells(PdfPTable table, BillItemDTO item) {
+        table.addCell(createDataCell(String.format("%.2f", safeDouble(item.getRetailRate()))));
+        table.addCell(createDataCell(String.format("%.2f", calculateItemValue(item))));
     }
 
 // Individual payment method row
@@ -14815,7 +14826,7 @@ public class PharmacyReportController implements Serializable {
     private void addHeaderRow(PdfPTable table) {
         String[] headers = {
             "Date", "Doc. No", "NAME", "CODE", "BATCH NO", "QTY",
-            "COST RATE", "COST VALUE", "RATE", "VALUE", "Net Total",
+            "COST RATE", "COST VALUE", "PURCHASE RATE", "PURCHASE VALUE", "Net Total",
             "Payment Mode/Modes", "MRP", "MRP Value", "Discount"
         };
 
@@ -14830,20 +14841,38 @@ public class PharmacyReportController implements Serializable {
         }
     }
 
+    /**
+     * Totals row spanning all 15 columns: the label covers columns 1-7, then
+     * each money total sits under the column it totals (Cost Value, Purchase
+     * Value, Net Total, MRP Value). Values come from the controller totals
+     * accumulated during processing so the PDF matches the on-screen footer.
+     */
     private void addGrandTotalRow(PdfPTable table, double grandTotal) {
         PdfPCell totalLabel = new PdfPCell(new Phrase("Total",
                 FontFactory.getFont(FontFactory.HELVETICA_BOLD, 10)));
-        totalLabel.setColspan(14);
+        totalLabel.setColspan(7);
         totalLabel.setHorizontalAlignment(Element.ALIGN_RIGHT);
         totalLabel.setPadding(5);
         totalLabel.setBorder(Rectangle.BOX);
         table.addCell(totalLabel);
 
-        PdfPCell totalValue = new PdfPCell(new Phrase(String.format("%.2f", grandTotal),
+        table.addCell(createTotalCell(String.format("%.2f", totalCostValue)));   // COST VALUE
+        table.addCell(createTotalCell(""));                                      // PURCHASE RATE
+        table.addCell(createTotalCell(String.format("%.2f", totalPurchaseValue))); // PURCHASE VALUE
+        table.addCell(createTotalCell(String.format("%.2f", grandTotal)));        // Net Total
+        table.addCell(createTotalCell(""));                                       // Payment Mode/Modes
+        table.addCell(createTotalCell(""));                                       // MRP
+        table.addCell(createTotalCell(String.format("%.2f", totalRetailValue)));  // MRP Value
+        table.addCell(createTotalCell(""));                                       // Discount
+    }
+
+    private PdfPCell createTotalCell(String content) {
+        PdfPCell cell = new PdfPCell(new Phrase(content != null ? content : "",
                 FontFactory.getFont(FontFactory.HELVETICA_BOLD, 10)));
-        totalValue.setHorizontalAlignment(Element.ALIGN_CENTER);
-        totalValue.setBorder(Rectangle.BOX);
-        table.addCell(totalValue);
+        cell.setHorizontalAlignment(Element.ALIGN_CENTER);
+        cell.setPadding(5);
+        cell.setBorder(Rectangle.BOX);
+        return cell;
     }
 
     private PdfPCell createDateCell(String content) {
@@ -14932,10 +14961,20 @@ public class PharmacyReportController implements Serializable {
         return 0.0;
     }
 
+    private double calculatePurchaseValue(BillItemDTO item) {
+        if (item.getPurchaseRate() != null && item.getQty() != null) {
+            return item.getPurchaseRate() * item.getQty();
+        }
+        return 0.0;
+    }
+
     private void addSummary(Document document, double grandTotal) throws DocumentException {
         document.add(new Paragraph(" "));
         document.add(new Paragraph("Summary:", FontFactory.getFont(FontFactory.HELVETICA_BOLD, 12)));
         document.add(new Paragraph("Total Bills: " + (cogsBillDtos != null ? cogsBillDtos.size() : 0)));
+        document.add(new Paragraph("Total Cost Value: " + String.format("%.2f", totalCostValue)));
+        document.add(new Paragraph("Total Purchase Value: " + String.format("%.2f", totalPurchaseValue)));
+        document.add(new Paragraph("Total MRP Value: " + String.format("%.2f", totalRetailValue)));
         document.add(new Paragraph("Grand Total: " + String.format("%.2f", grandTotal)));
     }
 
@@ -16580,7 +16619,8 @@ public class PharmacyReportController implements Serializable {
                 rowIndex = pharmacyController.addMetaDataToExcelSheet(workbook, sheet, rowIndex, "Pharmacy Sales Report", filters);
             }
             createHeaderRow(sheet, rowIndex);
-            populateDataRows(sheet, bills, rowIndex + 1);
+            int nextRow = populateDataRows(sheet, bills, rowIndex + 1);
+            createTotalRow(sheet, nextRow);
 
             workbook.write(out);
             context.responseComplete();
@@ -16593,7 +16633,7 @@ public class PharmacyReportController implements Serializable {
     private void createHeaderRow(Sheet sheet, int rowIndex) {
         String[] headers = {
             "Date", "Doc. No", "NAME", "CODE", "BATCH NO", "QTY", "COST RATE",
-            "COST VALUE", "RATE", "VALUE", "Net Total", "Payment Mode/Modes",
+            "COST VALUE", "PURCHASE RATE", "PURCHASE VALUE", "Net Total", "Payment Mode/Modes",
             "MRP", "MRP Value", "Discount"
         };
         Row headerRow = sheet.createRow(rowIndex);
@@ -16603,7 +16643,11 @@ public class PharmacyReportController implements Serializable {
         }
     }
 
-    private void populateDataRows(Sheet sheet, List<CostOfGoodSoldBillDTO> bills, int startRow) {
+    /**
+     * Writes one row per bill item and returns the index of the first row after
+     * the data block, so the caller can append the totals row there.
+     */
+    private int populateDataRows(Sheet sheet, List<CostOfGoodSoldBillDTO> bills, int startRow) {
         AtomicInteger rowNum = new AtomicInteger(startRow);
         for (CostOfGoodSoldBillDTO bill : bills) {
             List<BillItemDTO> billItems = bill.getBillItems();
@@ -16620,23 +16664,52 @@ public class PharmacyReportController implements Serializable {
                     row.createCell(1).setCellValue(bill.getBillDeptId() != null ? bill.getBillDeptId() : "");
                 }
 
+                double qty = safeDouble(item.getQty());
+                double costRate = safeDouble(item.getCostRate());
+                double purchaseRate = safeDouble(item.getPurchaseRate());
+                double retailRate = safeDouble(item.getRetailRate());
+
                 row.createCell(2).setCellValue(item.getItemName() != null ? item.getItemName() : "");
                 row.createCell(3).setCellValue(item.getItemCode() != null ? item.getItemCode() : "");
                 row.createCell(4).setCellValue(item.getBatchNo() != null ? item.getBatchNo() : "");
-                row.createCell(5).setCellValue(item.getQty());
-                row.createCell(6).setCellValue(item.getCostRate());
-                row.createCell(7).setCellValue(item.getQty() * item.getCostRate());
-                row.createCell(8).setCellValue(item.getRetailRate());
-                row.createCell(9).setCellValue(item.getQty() * item.getRetailRate());
+                row.createCell(5).setCellValue(qty);
+                row.createCell(6).setCellValue(costRate);
+                row.createCell(7).setCellValue(qty * costRate);
+                row.createCell(8).setCellValue(purchaseRate);
+                row.createCell(9).setCellValue(qty * purchaseRate);
+                row.createCell(12).setCellValue(retailRate);
+                row.createCell(13).setCellValue(qty * retailRate);
 
                 if (i == 0) {
-                    row.createCell(10).setCellValue(bill.getNetTotal());
-                    String paymentModes = formatPaymentMethods(bill.getPaymentMethod().toString(), bill);
+                    row.createCell(10).setCellValue(safeDouble(bill.getNetTotal()));
+                    String paymentModes = bill.getPaymentMethod() != null
+                            ? formatPaymentMethods(bill.getPaymentMethod().toString(), bill) : "";
                     row.createCell(11).setCellValue(paymentModes);
-                    row.createCell(14).setCellValue(bill.getDiscount());
+                    row.createCell(14).setCellValue(safeDouble(bill.getDiscount()));
                 }
             }
         }
+        return rowNum.get();
+    }
+
+    /**
+     * Totals row for the cost-of-goods-sold bill exports. The values come from
+     * the controller totals accumulated while the report was processed - not
+     * from re-summing the exported rows - so the spreadsheet matches the
+     * on-screen footer exactly, including the negative reference bills and the
+     * pre-add-to-stock bills that are netted at total level only.
+     */
+    private void createTotalRow(Sheet sheet, int rowIndex) {
+        Row totalRow = sheet.createRow(rowIndex);
+        totalRow.createCell(0).setCellValue("Total");
+        totalRow.createCell(7).setCellValue(totalCostValue);
+        totalRow.createCell(9).setCellValue(totalPurchaseValue);
+        totalRow.createCell(10).setCellValue(safeDouble(netTotal));
+        totalRow.createCell(13).setCellValue(totalRetailValue);
+    }
+
+    private double safeDouble(Double value) {
+        return value != null ? value : 0.0;
     }
 
     private String formatPaymentMethods(String paymentMethod, CostOfGoodSoldBillDTO bill) {

--- a/src/main/webapp/reports/inventoryReports/add_to_stock_bills.xhtml
+++ b/src/main/webapp/reports/inventoryReports/add_to_stock_bills.xhtml
@@ -246,7 +246,7 @@
                                 </f:facet>
                             </p:column>
 
-                            <p:column headerText="Bill Number" sortBy="#{b.billDeptId}" width="16em">
+                            <p:column headerText="Bill Number" sortBy="#{b.billDeptId}" width="10em">
                                 <p:commandLink value="#{b.billDeptId}" action="#{billSearch.navigateToViewBillByAtomicBillType()}" ajax="false" styleClass="ui-button-info">
                                     <f:setPropertyActionListener value="#{b.bill}" target="#{billSearch.bill}" />
                                 </p:commandLink>
@@ -259,7 +259,7 @@
                                 <h:outputText value="-" rendered="#{b.bill.referenceBill eq null}" />
                             </p:column>
 
-                            <p:column headerText="Ref. Bill Number" width="16em">
+                            <p:column headerText="Ref. Bill Number" width="10em">
                                 <h:panelGroup rendered="#{b.bill.referenceBill ne null}">
                                     <p:commandLink value="#{b.bill.referenceBill.deptId}" action="#{billSearch.navigateToViewBillByAtomicBillType()}" ajax="false" styleClass="ui-button-warning">
                                         <f:setPropertyActionListener value="#{b.bill.referenceBill}" target="#{billSearch.bill}" />
@@ -268,32 +268,32 @@
                                 <h:outputText value="-" rendered="#{b.bill.referenceBill eq null}" />
                             </p:column>
 
-                            <p:column headerText="NAME" width="50em">
+                            <p:column headerText="NAME" width="20em">
                                 <ui:repeat value="#{b.billItemsMap.values()}" var="biObject" >
                                     <h:outputText value="#{biObject.itemName}" /><p:divider/><br/>
                                 </ui:repeat>
                             </p:column>
-                            <p:column headerText="CODE">
+                            <p:column headerText="CODE" width="8em">
                                 <ui:repeat value="#{b.billItemsMap.values()}" var="biObject">
                                     <h:outputText value="#{biObject.itemCode}" /><p:divider/><br/>
                                 </ui:repeat>
                             </p:column>
-                            <p:column headerText="BATCH NO">
+                            <p:column headerText="BATCH NO" width="8em">
                                 <ui:repeat value="#{b.billItemsMap.values()}" var="biObject">
                                     <h:outputText value="#{biObject.batchNo}" /><p:divider/><br/>
                                 </ui:repeat>
                             </p:column>
-                            <p:column headerText="QTY">
+                            <p:column headerText="QTY" width="5em" class="text-end">
                                 <ui:repeat value="#{b.billItemsMap.values()}" var="biObject">
                                     <h:outputText value="#{biObject.qty}" ><f:convertNumber pattern="#,##0"/></h:outputText><p:divider/><br/>
                                 </ui:repeat>
                             </p:column>
-                            <p:column headerText="COST RATE">
+                            <p:column headerText="COST RATE" width="7em" class="text-end">
                                 <ui:repeat value="#{b.billItemsMap.values()}" var="biObject">
                                     <h:outputText value="#{biObject.costRate}" ><f:convertNumber pattern="#,##0.00"/></h:outputText><p:divider/><br/>
                                 </ui:repeat>
                             </p:column>
-                            <p:column headerText="COST VALUE">
+                            <p:column headerText="COST VALUE" width="8em" class="text-end">
                                 <ui:repeat value="#{b.billItemsMap.values()}" var="biObject">
                                     <h:outputText value="#{biObject.qty * biObject.costRate}" ><f:convertNumber pattern="#,##0.00"/></h:outputText><p:divider/><br/>
                                 </ui:repeat>
@@ -303,12 +303,12 @@
                                     </h:outputText>
                                 </f:facet>
                             </p:column>
-                            <p:column headerText="PURCHASE RATE">
+                            <p:column headerText="PURCHASE RATE" width="7em" class="text-end">
                                 <ui:repeat value="#{b.billItemsMap.values()}" var="biObject">
                                     <h:outputText value="#{biObject.purchaseRate}" ><f:convertNumber pattern="#,##0.00"/></h:outputText><p:divider/><br/>
                                 </ui:repeat>
                             </p:column>
-                            <p:column headerText="PURCHASE VALUE">
+                            <p:column headerText="PURCHASE VALUE" width="8em" class="text-end">
                                 <ui:repeat value="#{b.billItemsMap.values()}" var="biObject">
                                     <h:outputText value="#{biObject.qty * biObject.purchaseRate}" ><f:convertNumber pattern="#,##0.00"/></h:outputText><p:divider/>   <br/>
                                 </ui:repeat>


### PR DESCRIPTION
﻿Closes #23224

## What was wrong

The report already declared `CODE`, `BATCH NO`, `QTY`, `COST RATE`, `COST VALUE`, `PURCHASE RATE` and `PURCHASE VALUE` columns — but none of them carried a `width`. PrimeFaces renders the DataTable with `table-layout: fixed`, so the columns that *did* declare a width consumed the whole table and these seven collapsed to **0px**.

Measured on the running app before the fix, at a 1600px viewport:

```
NAME             w=832
CODE             w=0
BATCH NO         w=0
QTY              w=0
COST RATE        w=0
COST VALUE       w=0
PURCHASE RATE    w=0
PURCHASE VALUE   w=0
MRP              w=160
```

The cells rendered their values (`130.00` was in the DOM) — they just had no width, so the user saw the item name run straight into MRP. That is exactly the screenshot on the issue.

## What changed

**1. Column widths (`add_to_stock_bills.xhtml`).** Every column now declares a width, so none can collapse. `NAME` drops from `50em` to `20em` so the row is not needlessly wide; the value columns are right-aligned.

**2. Export totals (`PharmacyReportController`).** The Excel export had **no totals row at all**, and the PDF totalled only Net Total. Both now close with a Total row carrying **Total Cost Value**, **Total Purchase Value**, **Net Total** and **Total MRP Value**, and the PDF repeats them in its Summary block.

The totals come from the controller totals accumulated during processing, not from re-summing the exported rows — so they match the on-screen footer, including the negative reference bills and pre-add-to-stock bills that are netted at total level only.

**3. Export column corrections.** In both exports the columns headed `RATE`/`VALUE` actually held MRP; they are relabelled `PURCHASE RATE`/`PURCHASE VALUE` and repointed at the purchase rate. The `MRP`/`MRP Value` columns — previously left blank in Excel and empty rowspan cells in the PDF — are now populated per item. Null quantities and rates no longer throw while writing a row.

These two export methods are shared with `reports/inventoryReports/opd_sale.xhtml`, which has the identical on-screen column set and footer, so it gets the same corrected exports.

## Verification

Built and deployed locally, ran the report for **16 Apr 2026, all institutions/sites/departments** against the local `coop` database (50 bills).

Reconciled against the database:

| | Cost Value | Purchase Value | Net Total |
|---|---|---|---|
| 49 settle-at-cashier bills (SQL) | 8,765.70 | 8,950.61 | 10,286.18 |
| + 1 pre-add-to-stock bill (SQL) | 569.04 | 675.62 | 575.90 |
| **Expected** | **9,334.74** | **9,626.23** | **10,862.08** |
| Report footer | 9,334.75 | 9,626.23 | 10,862.08 |
| Excel Total row | 9334.7473 | 9626.2274 | 10862.08 |
| PDF Total row + Summary | 9334.75 | 9626.23 | 10862.08 |

Column widths after the fix: `COST RATE` 144px, `COST VALUE` 160px, `PURCHASE RATE` 144px, `PURCHASE VALUE` 160px — previously all 0.

### The report, cost columns now visible

![Add to Stock Bills report with Cost Rate and Cost Value](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23224-add-to-stock-bills-report.png)

### PDF export Total row and Summary

![PDF export totals](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23224-add-to-stock-bills-pdf-totals.png)

Excel `Total` row (row 103) as written:

```
A=Total | H=9334.7473 | J=9626.227400000002 | K=10862.080000000002 | N=11282.080000000002
```

## Documentation

Wiki page updated: [Add-to-Stock-Bills-Configuration](https://github.com/hmislk/hmis/wiki/Add-to-Stock-Bills-Configuration)

It now documents the 15 export columns and the Total row, and carries both screenshots above. Two statements on that page did not match the system and were corrected: cost rate has **no** fallback to purchase rate (a batch with no cost rate contributes 0.00), and exports are **not** limited by the page size.

Also added [§80 to the Playwright E2E workflow doc](https://github.com/hmislk/hmis/blob/23224-add-to-stock-bills-cost-columns/developer_docs/testing/playwright-e2e-workflow.md) — a fixed-layout DataTable column can be present in an accessibility snapshot and still be 0px wide, which is how this issue first read as "already implemented". Measure `offsetWidth` before concluding a column exists.

## Noted, not changed

- `reports/inventoryReports/opd_sale.xhtml` has the **same** zero-width column defect, plus an orphaned `p:columnGroup type="header"` declaring 15 columns for a 17-column table. Out of scope for this issue; worth a follow-up.
- The PDF is still titled "Pharmacy Sales Report" even when launched from Add to Stock Bills (the `selectReportName` actionListener result is unused). Left alone deliberately — it affects both reports sharing the method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pharmacy PDF and Excel reports now show purchase, cost, net, and MRP rates and values in clearly separated columns.
  * Excel reports include an itemized MRP column and a totals row.
  * PDF summaries now include cost, purchase, and MRP totals.

* **Bug Fixes**
  * Reports handle missing payment methods and numeric values more reliably.
  * Inventory report columns now use improved widths, alignment, and readability.

* **Documentation**
  * Added guidance for diagnosing zero-width columns in fixed-layout data tables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->