### PR TITLE
feat(inward): add Add Outside Charges entry point to Surgery Workbench

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -2083,6 +2083,19 @@ Any `w: 0` is an invisible column. The fix is in the XHTML, not the test: once *
 declares a `width`, **every** column must declare one, or the undeclared ones collapse. Widening the viewport does not
 reveal them — it makes it worse, because the extra space goes to the columns that did declare a width.
 
+## 81. `theater/inward_search_surgery.xhtml`'s "Search All" checkbox does not widen the date filter
+
+`SearchController.searchSurgery()` always applies `b.createdAt between :fromDate
+and :toDate` — the From/To Date calendars default to **today only**. The
+"Search All" checkbox does *not* bypass that; it toggles a separate, required
+"select a Surgery Name to search all" filter (`searchKeyword.activeAdvanceOption`)
+and throws a validation error ("You Need To select Surgury to Search All") if
+checked with no item picked. To find an older surgery bill by BHT/bill number,
+leave "Search All" unchecked and widen the **From Date** via the calendar grid
+(§18) to cover the record's actual `createdAt` — a plain BHT-number search with
+today's default date range silently returns "No records found." for anything
+not created today. Verified while testing issue #23249.
+
 ## Some PrimeFaces buttons need a jQuery-triggered click
 
 Most `p:commandButton`s submit fine with a normal Playwright click — including

--- a/src/main/webapp/theater/patient_surgery.xhtml
+++ b/src/main/webapp/theater/patient_surgery.xhtml
@@ -403,6 +403,19 @@
                                     </p:commandButton>
 
                                     <p:commandButton
+                                        value="Add Outside Charges"
+                                        ajax="false"
+                                        rendered="#{webUserController.hasPrivilege('InwardServicesAndItemsAddOutSideCharges')}"
+                                        action="#{inwardAdditionalChargeController.navigateToAddOutsideChargeFromInpatientProfile()}"
+                                        icon="fa fa-external-link-square-alt"
+                                        class="w-100"
+                                        disabled="#{surgeryBillController.surgeryBill.completed}">
+                                        <f:setPropertyActionListener
+                                            value="#{surgeryBillController.surgeryBill.patientEncounter}"
+                                            target="#{inwardAdditionalChargeController.current.patientEncounter}"/>
+                                    </p:commandButton>
+
+                                    <p:commandButton
                                         value="View Professional Fees"
                                         ajax="false"
                                         action="#{inwardProfessionalBillController.navigateToSurgeryProfessionalFeesList(surgeryBillController.surgeryBill)}"


### PR DESCRIPTION
## Summary

Adds an **Add Outside Charges** button to the Surgery Workbench's "Surgery
Billing" panel (`theater/patient_surgery.xhtml`), so an ad-hoc outside charge
(instruments, consumables not in the regular catalog) can be added against a
surgery's admission without leaving the theatre workflow to find the
admission from the general Inpatient Dashboard first.

Pure JSF-only change — no Java, no new privilege, no DDL. Reuses the
existing pattern from `admission_profile.xhtml` exactly:
- Privilege: `InwardServicesAndItemsAddOutSideCharges`
- Action: `InwardAdditionalChargeController.navigateToAddOutsideChargeFromInpatientProfile()`
- `f:setPropertyActionListener` bound to `surgeryBillController.surgeryBill.patientEncounter`
  (the admission this surgery belongs to) instead of `admissionController.current`

Also adds `disabled="#{surgeryBillController.surgeryBill.completed}"`,
matching the other add-charge buttons already in this panel (`Add Services &
Investigations`, `Direct Issue Medicines`, `Add Timed Services`, `Add
Professional Fees`) — a completed surgery shouldn't get new charges of any
kind.

## Verification

Rebuilt (`mvn clean package -DskipTests`), redeployed locally
(`asadmin deploy --force`), no `server.log` errors. Playwright end-to-end
against the local `coop` DB, THEATRE department, BHT/56755's surgery
(SurgeryBill id 13988664, not completed):

1. Opened the surgery via Theatre > Search Surgery > View Bill.
2. Confirmed the new button renders in the Surgery Billing panel, positioned
   after **Add Professional Fees**:

   ![Add Outside Charges button in the Surgery Billing panel](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23249-surgery-billing-panel-with-button.png)

3. Clicked it — navigated to `inward_bill_outside_charge.xhtml` with the
   correct admission pre-loaded (same BHT/room/consultant as the surgery
   page). Patient details redacted per project policy (synthetic demo data):

   ![Add Outside Charges page navigated to from the Surgery Workbench, with the correct admission pre-loaded](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23249-add-outside-charges-navigated-redacted.png)

4. No exceptions in `server.log` for either step.

The `disabled` binding wasn't independently exercised on a completed surgery
(local `coop` DB currently has none), but it's the identical expression
already proven on this panel's sibling buttons.

## Documentation

- [Theatre — Surgery Workbench](https://github.com/hmislk/hmis/wiki/Theatre-Surgery-Workbench) — new table row + "To Add Outside Charges" section, with screenshot
- [Add Outside Charges](https://github.com/hmislk/hmis/wiki/Add-Outside-Charges) — notes the Surgery Workbench (and Inpatient Dashboard) as pre-loading entry points

Also recorded a Playwright gotcha found while testing
(`theater/inward_search_surgery.xhtml`'s "Search All" checkbox doesn't widen
the default today-only date range) in
`developer_docs/testing/playwright-e2e-workflow.md` §80.

Closes #23249

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **Add Outside Charges** option for eligible surgery encounters.
  * The option is unavailable for completed surgeries and requires the appropriate permission.

* **Documentation**
  * Clarified that surgery searches retain the selected date range.
  * Documented that **Search All** requires a surgery selection; older records may require a wider From Date.
  * Added guidance for accurately validating table column widths in end-to-end tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->