### PR TITLE
fix(service): resolve service category across all category subtypes

### DIFF
--- a/src/main/java/com/divudi/service/service/ServiceApiService.java
+++ b/src/main/java/com/divudi/service/service/ServiceApiService.java
@@ -15,6 +15,7 @@ import com.divudi.core.data.dto.service.ServiceResponseDTO;
 import com.divudi.core.data.dto.service.ServiceSearchResultDTO;
 import com.divudi.core.data.dto.service.ServiceUpdateRequestDTO;
 import com.divudi.core.data.inward.InwardChargeType;
+import com.divudi.core.entity.Category;
 import com.divudi.core.entity.Department;
 import com.divudi.core.entity.Institution;
 import com.divudi.core.entity.Item;
@@ -25,6 +26,7 @@ import com.divudi.core.entity.Speciality;
 import com.divudi.core.entity.Staff;
 import com.divudi.core.entity.WebUser;
 import com.divudi.core.entity.inward.InwardService;
+import com.divudi.core.facade.CategoryFacade;
 import com.divudi.core.facade.DepartmentFacade;
 import com.divudi.core.facade.InstitutionFacade;
 import com.divudi.core.facade.InwardServiceFacade;
@@ -66,6 +68,9 @@ public class ServiceApiService implements Serializable {
 
     @EJB
     private ServiceCategoryFacade serviceCategoryFacade;
+
+    @EJB
+    private CategoryFacade categoryFacade;
 
     @EJB
     private ItemFacade itemFacade;
@@ -233,9 +238,12 @@ public class ServiceApiService implements Serializable {
 
         // Resolve optional associations
         if (request.getCategoryId() != null) {
-            ServiceCategory category = serviceCategoryFacade.find(request.getCategoryId());
-            if (category == null) {
-                throw new Exception("ServiceCategory not found with ID: " + request.getCategoryId());
+            // Category (not ServiceCategoryFacade) is used here since a service's category
+            // can be any Category subtype already in use in the system (Category,
+            // ServiceCategory, ...), not only rows created specifically as ServiceCategory.
+            Category category = categoryFacade.find(request.getCategoryId());
+            if (category == null || category.isRetired()) {
+                throw new Exception("Category not found with ID: " + request.getCategoryId());
             }
             service.setCategory(category);
         }
@@ -348,9 +356,12 @@ public class ServiceApiService implements Serializable {
         }
 
         if (request.getCategoryId() != null) {
-            ServiceCategory category = serviceCategoryFacade.find(request.getCategoryId());
-            if (category == null) {
-                throw new Exception("ServiceCategory not found with ID: " + request.getCategoryId());
+            // Category (not ServiceCategoryFacade) is used here since a service's category
+            // can be any Category subtype already in use in the system (Category,
+            // ServiceCategory, ...), not only rows created specifically as ServiceCategory.
+            Category category = categoryFacade.find(request.getCategoryId());
+            if (category == null || category.isRetired()) {
+                throw new Exception("Category not found with ID: " + request.getCategoryId());
             }
             service.setCategory(category);
         }


### PR DESCRIPTION
## Summary
- `ServiceApiService.createService()`/`updateService()` resolved `categoryId` via `ServiceCategoryFacade.find(id)`, which only loads rows whose JPA discriminator is `ServiceCategory`. Categories services actually need (e.g. "Dialysis") often already exist as plain `Category` rows, so the API returned a 404 even though the category existed.
- Same fix pattern as #23278: both methods now resolve `categoryId` via the base `CategoryFacade`, covering all category subtypes. The `ServiceCategory`-specific CRUD endpoints (`/services/categories/*`) are unchanged.

## Test plan
- [x] Compiled clean
- [x] Verified against `rh_prod_08_05`: cross-checked a client-supplied Service.csv, found 1 mismatched service category, fixed it via the corrected API, confirmed 0 remaining mismatches and no duplicate categories created

Closes #23277

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Service creation and updates now support all applicable category types.
  * Retired or unavailable categories are rejected during service changes.
  * Category validation is more consistent when assigning services to categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->