### PR TITLE
fix(channel): block creating channel schedules for non-Consultant staff

### DIFF
--- a/src/main/java/com/divudi/bean/channel/ChannelScheduleController.java
+++ b/src/main/java/com/divudi/bean/channel/ChannelScheduleController.java
@@ -21,6 +21,7 @@ import com.divudi.core.entity.ItemFee;
 import com.divudi.core.entity.ServiceSession;
 import com.divudi.core.entity.SessionNumberGenerator;
 import com.divudi.core.entity.Speciality;
+import com.divudi.core.entity.Consultant;
 import com.divudi.core.entity.Staff;
 import com.divudi.core.facade.DepartmentFacade;
 import com.divudi.core.facade.FeeChangeFacade;
@@ -996,6 +997,20 @@ public class ChannelScheduleController implements Serializable {
 
         if (currentStaff == null) {
             JsfUtil.addErrorMessage("Plaese Select Doctor");
+            return true;
+        }
+
+        // Only Consultants are channelled. The channelling API publishes its
+        // doctor list from Consultant records only, while the session feeds
+        // resolve staff as Doctor (Consultant extends Doctor). A schedule
+        // created for any other staff type is therefore published with a
+        // doctor number that never appears in the doctor list, so booking
+        // agents receive bookable sessions they cannot map. Block it at
+        // creation. Existing schedules stay editable on purpose, so the
+        // sessions already in this state can still be corrected or retired.
+        if (current.getId() == null && !(currentStaff instanceof Consultant)) {
+            JsfUtil.addErrorMessage("Channel sessions can be created only for Consultants. "
+                    + "Please correct the staff record to a Consultant before adding a schedule.");
             return true;
         }
 


### PR DESCRIPTION
## Decisions made without approval

| Decision | Why |
|---|---|
| **Scoped this PR to the prevention guard only** | #23270 has three parts. The other two cannot ship in a code-only PR — see "Deliberately not included". |
| **Guard blocks creation, not editing** | Product owner chose "block outright". But blocking edits too would lock admins out of the records already in the bad state, leaving no way to correct or retire them. Creation-only keeps the cleanup path open. |
| **Validation placed in `checkError()`** | It is the existing gate `saveSelected()` already calls, and already validates the staff selection immediately above. No new call path introduced. |
| **Guarded `ChannelScheduleController` only** | The `ChannelBean` paths generate instances from an existing template and inherit its staff, so they cannot introduce a new non-Consultant. `ClinicScheduleController` is the clinic module, not channelling. |
| **Did not publish test screenshots to the wiki** | They show doctor names from a copy of production data, and a wiki page is as public as an issue. Prose only. |

## What this fixes

Only Consultants are channelled. The API builds its doctor list from `Consultant` records only (`ConsultantController.java:391`), while the session feeds resolve staff as `Doctor` (`ChannelService.java:2842`). Since `Consultant extends Doctor`, the session feeds match both types.

A schedule created for a non-Consultant is therefore published with a doctor number that never appears in the doctor list. Booking agents receive sessions that are genuinely bookable but cannot be matched to any doctor, so the doctor never becomes visible for booking.

The schedule screen's doctor picker offers **all** staff — 906 entries on the local dataset, including non-clinical staff — which is how the state gets created. This rejects it at save time.

## Deliberately not included

**The matching restriction of the session endpoints to `Consultant`.**

Shipping that before the affected staff records are corrected would remove their sessions from the API. Those sessions are currently `Available` and bookable, and are the only working path for the affected doctors — so the restriction on its own is a **regression**, not a fix.

Correct order, both in the same deploy:
1. Correct `staff.DTYPE` for the affected records (needs an EclipseLink L2 cache eviction — see #23273; a `DTYPE` change without one throws `ClassCastException` and takes the doctor list down).
2. Then ship the query restriction.

## Verification

Local Payara, local `coop` database.

**Blocked — staff recorded as `Doctor`:**
Selected a doctor recorded as `DTYPE='Doctor'`, filled every other required field (name, category, start/end time, weekday), saved.

> Error: Channel sessions can be created only for Consultants. Please correct the staff record to a Consultant before adding a schedule.

Database confirms nothing was written — no row matching the test session name, and no new session for that staff id. The two schedules that already existed for that staff member (created 2024) were untouched, confirming existing records stay editable.

**Allowed — staff recorded as `Consultant`:**
Repeated with a Consultant in the **same speciality** as a control, so the only difference was the staff type.

> Information: Saved Successfully

Database confirms the `ServiceSession` row was created against the Consultant's staff id.

Build: `mvn package` clean, 224 tests passing.

## Documentation

Wiki page **Channel Scheduling Overview** updated with a new "Who Can Be Scheduled" section covering the rule, the exact message users will see, why it exists, and how to resolve it. Prose only, for the redaction reason above.

Refs #23270


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented creation of channel sessions when the selected staff member is not a consultant.
  * Existing schedules can still be edited, corrected, or retired as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->