### PR TITLE
fix(inward): stop Inward Charge Type Labels from being editable via Application Options

### DIFF
--- a/src/main/java/com/divudi/bean/common/ConfigOptionController.java
+++ b/src/main/java/com/divudi/bean/common/ConfigOptionController.java
@@ -401,6 +401,7 @@ public class ConfigOptionController implements Serializable {
             int importedCount = 0;
             int updatedCount = 0;
             int skippedCount = 0;
+            int skippedInwardLabelCount = 0;
 
             for (int i = 1; i < lines.length; i++) {
                 String line = lines[i].trim();
@@ -418,7 +419,7 @@ public class ConfigOptionController implements Serializable {
                     if (optionKey != null && !optionKey.trim().isEmpty() && isInwardChargeTypeLabelKey(optionKey.trim())) {
                         // Inward Charge Type Labels are managed exclusively via
                         // inward/inward_charge_type_labels.xhtml - see saveOption().
-                        skippedCount++;
+                        skippedInwardLabelCount++;
                         continue;
                     }
 
@@ -492,7 +493,11 @@ public class ConfigOptionController implements Serializable {
                 message += updatedCount + " options updated. ";
             }
             if (skippedCount > 0) {
-                message += skippedCount + " existing options skipped.";
+                message += skippedCount + " existing options skipped. ";
+            }
+            if (skippedInwardLabelCount > 0) {
+                message += skippedInwardLabelCount
+                        + " Inward Charge Type Label option(s) skipped; manage them from the Inward Charge Type Labels page.";
             }
             JsfUtil.addSuccessMessage(message);
 
@@ -1092,6 +1097,10 @@ public class ConfigOptionController implements Serializable {
 
     public void retireDuplicateGroup(ConfigOptionDuplicateGroup g) {
         if (g == null || g.getOptions() == null || g.getOptions().size() < 2) {
+            return;
+        }
+        if (isInwardChargeTypeLabelKey(g.getOptions().get(0).getOptionKey())) {
+            JsfUtil.addErrorMessage("Inward Charge Type Labels can only be changed from the Inward Charge Type Labels page.");
             return;
         }
         g.getOptions().sort((a, b) -> a.getId().compareTo(b.getId()));

--- a/src/main/java/com/divudi/bean/common/ConfigOptionController.java
+++ b/src/main/java/com/divudi/bean/common/ConfigOptionController.java
@@ -45,6 +45,17 @@ import org.primefaces.model.file.UploadedFile;
 @SessionScoped
 public class ConfigOptionController implements Serializable {
 
+    /**
+     * Prefix shared by every Inward Charge Type Label ConfigOption key
+     * (e.g. "Inward Charge Type Label - ROOM_CHARGE"). These options are
+     * dedicated a single-purpose editor at inward/inward_charge_type_labels.xhtml
+     * (InwardChargeTypeLabelController); editing them from the generic
+     * Application Options screen created two out-of-sync places to change the
+     * same value (issue #23257), so this generic screen refuses to
+     * create/edit/delete them.
+     */
+    private static final String INWARD_CHARGE_TYPE_LABEL_KEY_PREFIX = "Inward Charge Type Label - ";
+
     @EJB
     private ConfigOptionFacade optionFacade;
 
@@ -238,6 +249,10 @@ public class ConfigOptionController implements Serializable {
             JsfUtil.addErrorMessage("Nothing Selected");
             return;
         }
+        if (isInwardChargeTypeLabelKey(delo.getOptionKey())) {
+            JsfUtil.addErrorMessage("Inward Charge Type Labels can only be changed from the Inward Charge Type Labels page.");
+            return;
+        }
         Map<String, Object> before = new HashMap<>();
         before.put("optionKey", delo.getOptionKey());
         before.put("optionValue", delo.getOptionValue());
@@ -266,8 +281,14 @@ public class ConfigOptionController implements Serializable {
         }
 
         int deletedCount = 0;
+        int skippedInwardLabelCount = 0;
         for (ConfigOption option : selectedOptions) {
             if (option != null) {
+                if (isInwardChargeTypeLabelKey(option.getOptionKey())) {
+                    skippedInwardLabelCount++;
+                    continue;
+                }
+
                 Map<String, Object> before = new HashMap<>();
                 before.put("optionKey", option.getOptionKey());
                 before.put("optionValue", option.getOptionValue());
@@ -291,7 +312,12 @@ public class ConfigOptionController implements Serializable {
         selectedOptions.clear();
         configOptionApplicationController.loadApplicationOptions();
         listApplicationOptions();
-        JsfUtil.addSuccessMessage("Deleted " + deletedCount + " options");
+        String message = "Deleted " + deletedCount + " options";
+        if (skippedInwardLabelCount > 0) {
+            message += ". Skipped " + skippedInwardLabelCount
+                    + " Inward Charge Type Label option(s) - change those from the Inward Charge Type Labels page.";
+        }
+        JsfUtil.addSuccessMessage(message);
     }
 
     public StreamedContent exportSelectedOptions() {
@@ -388,6 +414,13 @@ public class ConfigOptionController implements Serializable {
                     String optionValue = parts[1];
                     String valueTypeStr = parts[2];
                     String enumType = parts.length > 3 ? parts[3] : null;
+
+                    if (optionKey != null && !optionKey.trim().isEmpty() && isInwardChargeTypeLabelKey(optionKey.trim())) {
+                        // Inward Charge Type Labels are managed exclusively via
+                        // inward/inward_charge_type_labels.xhtml - see saveOption().
+                        skippedCount++;
+                        continue;
+                    }
 
                     if (optionKey != null && !optionKey.trim().isEmpty()) {
                         OptionValueType valueType;
@@ -531,9 +564,22 @@ public class ConfigOptionController implements Serializable {
         JsfUtil.addSuccessMessage("Saved");
     }
 
+    /**
+     * Inward Charge Type Labels are edited exclusively via
+     * inward/inward_charge_type_labels.xhtml (InwardChargeTypeLabelController).
+     * See {@link #INWARD_CHARGE_TYPE_LABEL_KEY_PREFIX}.
+     */
+    public boolean isInwardChargeTypeLabelKey(String optionKey) {
+        return optionKey != null && optionKey.startsWith(INWARD_CHARGE_TYPE_LABEL_KEY_PREFIX);
+    }
+
     public void saveOption(ConfigOption option) {
         if (option == null) {
             JsfUtil.addErrorMessage("Nothing to save");
+            return;
+        }
+        if (isInwardChargeTypeLabelKey(option.getOptionKey())) {
+            JsfUtil.addErrorMessage("Inward Charge Type Labels can only be changed from the Inward Charge Type Labels page.");
             return;
         }
         Map<String, Object> before = null;

--- a/src/main/webapp/admin/institutions/admin_mange_application_options.xhtml
+++ b/src/main/webapp/admin/institutions/admin_mange_application_options.xhtml
@@ -127,7 +127,7 @@
                             </p:column>
 
                             <p:column width="14em" style="padding: 7px;" >
-                                <div class="text-center w-100">
+                                <h:panelGroup layout="block" styleClass="text-center w-100" rendered="#{!configOptionController.isInwardChargeTypeLabelKey(option.optionKey)}">
                                     <p:commandButton
                                         icon="pi pi-pencil"
                                         styleClass="ui-button-success mx-1"
@@ -145,7 +145,12 @@
                                         action="#{configOptionController.deleteOption(option)}"
                                         title="Delete Option">
                                     </p:commandButton>
-                                </div>
+                                </h:panelGroup>
+                                <h:panelGroup styleClass="text-center w-100 d-block text-muted" rendered="#{configOptionController.isInwardChargeTypeLabelKey(option.optionKey)}"
+                                              title="Edit this label from Inward &gt; Inward Charge Type Labels instead">
+                                    <i class="pi pi-lock" style="font-size: 0.9em;"></i>
+                                    <h:outputText value=" Managed on Inward Charge Type Labels page" style="font-size: 0.8em;"/>
+                                </h:panelGroup>
                                 <f:facet name="exportable">
                                     <h:outputText value="" />
                                 </f:facet>


### PR DESCRIPTION
## Decisions made without approval

- **Approach chosen from the issue creator's own comment**, not an open design question: [buddhika75 wrote on #23257](https://github.com/hmislk/hmis/issues/23257#issuecomment) that only `inward/inward_charge_type_labels.xhtml` should be allowed to edit these labels, and the Application Options edit path should be removed. Implemented exactly that (removal, not a cache/sync fix reconciling two write paths).
- **Scope of the lock**: extended beyond just the Edit dialog to also block single delete, bulk delete, and CSV import (replace/create) for `Inward Charge Type Label - *` keys via the generic `ConfigOptionController`, since all of those write paths bypass the dedicated page the same way the Edit dialog did. This wasn't explicitly asked for in the issue but follows directly from "the change from Application Options should be removed."
- **Wiki edit**: added a new, verified section to `Admin-Inpatient-Charge-Type-Labels.md` describing the lock, with a screenshot. The page previously said nothing about Application Options at all (so nothing there was factually wrong), this is a documented addition, not a correction.

## Root cause

`Inward Charge Type Label - *` are `ConfigOption` (APPLICATION scope) rows, editable both from the purpose-built `inward/inward_charge_type_labels.xhtml` page and from the generic `Admin → Application Options` screen (`ConfigOptionController`). Having two independent edit surfaces for the same keys is what the issue is about — not a caching bug (`ConfigOptionApplicationController`'s app-scoped cache is in fact refreshed on every save/delete/import in `ConfigOptionController`).

## Fix

- `ConfigOptionController.isInwardChargeTypeLabelKey(String)` — new helper matching the `Inward Charge Type Label - ` key prefix.
- Guarded `saveOption`, `deleteOption`, `bulkDeleteSelectedOptions`, and CSV import (`importOptionsFromFile`) to reject/skip these keys, each with a message pointing back to the dedicated page.
- `admin_mange_application_options.xhtml`: rows for these keys now show a "🔒 Managed on Inward Charge Type Labels page" note instead of the Edit/Delete buttons.
  - First pass used `<div rendered="...">` on a plain HTML tag — Facelets doesn't evaluate `rendered` on non-JSF elements, so the buttons still rendered for every row despite the note also showing. Caught this via a Playwright screenshot (buttons + note both visible) and fixed by switching to `h:panelGroup layout="block" rendered="..."`, per this project's own JSF convention (never a raw `<div>` for conditional rendering).

## Testing

Against local Payara/MySQL (`coop` DB), logged in as an Admin-role test account:
1. Set a custom label for `AdmissionFee` on `inward/inward_charge_type_labels.xhtml` → saved, persisted in `CONFIGOPTION`.
2. Opened `Admin → Application Options`, filtered to the key → confirmed the value displays read-only with the lock note, no Edit/Delete buttons (screenshot).
3. Filtered to a normal (non-charge-label) key → confirmed Edit/Delete buttons still present there, unaffected.
4. Re-opened the dedicated page → confirmed the value read back correctly with no propagation delay.
5. Reverted the test value back to blank on the dedicated page (local DB, no cleanup strictly required, done anyway).

`mvn clean package` succeeds; redeployed locally with no errors in `server.log`.

## Documentation

Updated `Admin-Inpatient-Charge-Type-Labels.md` in the wiki with a new "Editing is only possible from this page" section and a screenshot of the locked Application Options row.

Closes #23257

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted editing, deletion, bulk deletion, and CSV import of Inward Charge Type Labels through the generic options editor.
  * Prevented creation of duplicate or conflicting label entries outside the dedicated management page.

* **User Experience**
  * Inward Charge Type Label options now appear locked in the generic editor.
  * Added guidance directing users to the dedicated Inward Charge Type Labels page for changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->