### PR TITLE
fix(channel-api): stop /doctorAvailability erroring when date is omitted

### DIFF
--- a/src/main/java/com/divudi/ws/channel/ChannelApi.java
+++ b/src/main/java/com/divudi/ws/channel/ChannelApi.java
@@ -482,14 +482,21 @@ public class ChannelApi {
             }
         }
 
-        // Convert dateStr to Date
+        // Convert dateStr to Date. The date is optional: when it is absent the
+        // session lookup falls back to the configured "days to share with online
+        // booking agent" window. SimpleDateFormat.parse(null) throws
+        // NullPointerException rather than ParseException, so a missing date has
+        // to be screened out before parsing - otherwise it escapes this method
+        // and the caller gets an HTML error page instead of JSON.
         SimpleDateFormat formatter = new SimpleDateFormat("dd-MM-yyyy");
         Date date = null;
 
-        try {
-            date = formatter.parse(dateStr);
-        } catch (ParseException e) {
-            date = null;
+        if (dateStr != null && !dateStr.trim().isEmpty()) {
+            try {
+                date = formatter.parse(dateStr);
+            } catch (ParseException e) {
+                date = null;
+            }
         }
 
         // Prepare the resultMap to hold doctor details


### PR DESCRIPTION
## Decisions made without approval

| Decision | Why |
|---|---|
| **Guard before parsing rather than catching `Exception`** | A blank or missing date is a valid, documented request — not an exceptional condition. Screening it out states the intent; widening the catch would hide genuine parse faults too. |
| **Kept malformed-date behaviour as a silent fallback** | The existing `catch (ParseException)` already degraded a bad date to the default window. Changing that to an error would be a behaviour change beyond this bug, and could break agents currently sending odd formats. |
| **No documentation change** | `API_CHANNEL_BOOKING.md` already documents `date` as not required. The doc was right; the code did not match it. Nothing to correct. |

## The bug

`POST /api/channel/doctorAvailability` returned **HTTP 500** with a JSF HTML error page whenever the optional `date` field was omitted.

`SimpleDateFormat.parse(null)` throws `NullPointerException`, not `ParseException`. The catch only handled `ParseException`, so the NPE escaped the resource method and the container rendered its general error page.

The null path was always intended and supported — `ChannelService.findSessionInstance()` falls back to the configured "days to share with online booking agent" window when no date is supplied. Only the parse guard was wrong.

## Verification

Confirmed on a live deployment **before** the fix:

- without `date` → HTTP 500, `<!DOCTYPE html> ... errorPages/generalError`
- with `date` → HTTP 202, correct JSON

After the fix, local Payara, all four inputs return **HTTP 202 with valid JSON** and no HTML error page:

| `date` value | Result |
|---|---|
| omitted entirely | 202, JSON, falls back to default window |
| `"25-08-2026"` (valid) | 202, JSON |
| `"not-a-date"` (malformed) | 202, JSON, falls back to default window |
| `""` (empty string) | 202, JSON, falls back to default window |

Build: `mvn package` clean.

Test fixture note: the local database had no `OnlineBookingAgent` institution, so agency validation rejected requests before they ever reached the date parsing. Set an existing local institution's type to `OnlineBookingAgent` to exercise the real path. Local database only — a disposable test environment.

## Documentation

No wiki change. This is an API-level defect with no user-facing screen, and `developer_docs/api/using-apis/API_CHANNEL_BOOKING.md` already documented `date` as optional — the documentation was correct and the code did not match it.

Closes #23271
