### PR TITLE
fix(pharmacy): deduct returned medicine value from Interim Bill Medicine total

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/BhtIssueReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/BhtIssueReturnController.java
@@ -218,6 +218,13 @@ public class BhtIssueReturnController implements Serializable {
         getReturnBill().setBilledBill(getBill());
         getReturnBill().setComments(returnComment);
         getReturnBill().setForwardReferenceBill(getBill().getForwardReferenceBill());
+        // copy() is deliberately not used here (it also overwrites department/institution,
+        // set explicitly below to the returning department), but patientEncounter/patient
+        // still need to be carried over - without them this return bill is invisible to every
+        // patientEncounter-scoped query (Interim Bill Medicine total, Medicine Issue tab), so
+        // the returned value silently never gets deducted (issue #22990).
+        getReturnBill().setPatientEncounter(getBill().getPatientEncounter());
+        getReturnBill().setPatient(getBill().getPatient());
 
         getReturnBill().setTotal(0 - Math.abs(getReturnBill().getTotal()));
         getReturnBill().setNetTotal(0 - Math.abs(getReturnBill().getNetTotal()));
@@ -246,6 +253,10 @@ public class BhtIssueReturnController implements Serializable {
         getReturnBill().setBillType(getBill().getBillType());
         getReturnBill().setBillTypeAtomic(BillTypeAtomic.ISSUE_MEDICINE_ON_REQUEST_INWARD_RETURN);
         getReturnBill().setBilledBill(getBill());
+        // See saveReturnBill() above - patientEncounter/patient must be carried over
+        // explicitly since copy() is not used here (issue #22990).
+        getReturnBill().setPatientEncounter(getBill().getPatientEncounter());
+        getReturnBill().setPatient(getBill().getPatient());
 
         getReturnBill().setForwardReferenceBill(getBill().getForwardReferenceBill());
         getReturnBill().setComments(returnComment);


### PR DESCRIPTION
## Decisions made without approval

- **Root cause chosen over alternative theory**: initial investigation considered whether the "Medicines" category total simply sums cancellation/return bills without a sign flip. That is not the case — `calCostOfIssueByBill` already sums `netTotal` across issue **and** return/cancellation `BillTypeAtomic`s together (by design, so a correctly-linked return bill nets out automatically), and `saveReturnBill()`/`saveReturnIssueBill()` already store the return bill's `netTotal` as negative. The actual defect is narrower: the return bill's `patientEncounter` (and `patient`) were never set, so every `patientEncounter`-scoped query — including that same total query and the Medicine Issue tab listing — silently excludes the return bill entirely. Fixed by carrying those two fields over explicitly, since `Bill.copy()` is deliberately not used here (it would also overwrite department/institution, which are intentionally set to the *returning* department).
- **Did not re-introduce a separate "Returned Medicines" line item** on the Interim Bill, even though the issue's example table shows one. A near-identical design (an always-visible `CancelledReturnedMedicine` breakdown row) was explicitly disabled in a prior issue (#22674) because it double-counted into the bill grand total — the category comment in `InwardChargeType.java` documents this. Since the actually-reported symptom ("value is not correctly deducted") is fully explained and fixed by the `patientEncounter` bug alone, re-opening the double-counting risk to also show a separate line felt like a bigger, unrequested redesign; flagging here in case a maintainer still wants that breakout (it would need a different plumbing than the disabled category, since that one intentionally has no per-return traceability once summed).

## What was found

`BhtIssueReturnController.saveReturnBill()` and `saveReturnIssueBill()` build the return `RefundBill` field-by-field (not via `Bill.copy()`) and never set `patientEncounter`/`patient`. Every place the Interim Bill reads medicine charges for a BHT filters `WHERE b.patientEncounter IN :pe` — both `InwardBeanController#calCostOfIssueByBill` (the "Medicine" charge-type total) and `InwardBeanController#fetchIssueTable` (the Medicine Issue tab's bill list). A return bill with a `null` patientEncounter is invisible to both, even though the return bill itself is created correctly (negative `netTotal`) and prints fine as its own "Return Bill".

## Fix

Explicitly copy `patientEncounter` and `patient` from the original bill onto the return bill in both save paths.

## Verification

Local dev, BHT/56735 (Theatre-issued medicines):
- Baseline Medicine total (DB, `calCostOfIssueByBill`'s own query): **18,661.7314**
- Returned 1× "Atropine 1mg Injection" (net 253.75) via the app's Medicine Issue return workflow
- New return bill's `PATIENTENCOUNTER_ID` confirmed populated (was `NULL` pre-fix)
- Medicine total after return: **18,407.9814** — a drop of exactly 253.75
- Same drop confirmed visually in the Interim Bill's Charges panel: "Theatre Medicine" 18,559.73 → 18,305.98
- Server log checked clean, no exceptions during the flow

## Documentation

Updated the [Interim Bill wiki page](https://github.com/hmislk/hmis/wiki/Intrim-Bill#returned-medicines-are-deducted-from-the-medicine-total) with a new section and a redacted screenshot of the corrected Charges panel.

Closes #22990


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Return bills now retain the correct patient and encounter details when created through direct inward or issue-on-request return workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->