### PR TITLE
fix(channel-api): log session instances withheld from the online booking feed

### DIFF
--- a/src/main/java/com/divudi/ws/channel/ChannelApi.java
+++ b/src/main/java/com/divudi/ws/channel/ChannelApi.java
@@ -76,6 +76,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Random;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import javax.ejb.EJB;
@@ -663,9 +664,27 @@ public class ChannelApi {
         SimpleDateFormat forTime = new SimpleDateFormat("HH:mm:ss");
         SimpleDateFormat forDay = new SimpleDateFormat("E");
 
+        int excludedForZeroTotal = 0;
+
         for (SessionInstance s : sessions) {
 
+            // A zero-total originating session is not offered for online booking.
+            // This is intentional for sessions priced per investigation rather
+            // than per appointment (scanning sessions, for example), and
+            // findActiveChannelSession enforces the same rule so they cannot be
+            // booked by id either.
+            //
+            // It is indistinguishable, however, from a session whose fees were
+            // simply never entered. Log each exclusion so the difference can be
+            // investigated from the server log instead of requiring a database
+            // query to work out why a doctor is absent from the feed.
             if (s.getOriginatingSession().getTotal() == 0) {
+                excludedForZeroTotal++;
+                LOGGER.log(Level.FINE,
+                        "Online booking feed: skipping session instance {0} (originating session {1}) "
+                        + "because the originating session total is zero. Intentional for sessions priced "
+                        + "per investigation; check the session fees if this session was expected to appear.",
+                        new Object[]{s.getId(), s.getOriginatingSession().getId()});
                 continue;
             }
 
@@ -709,6 +728,14 @@ public class ChannelApi {
             session.put("status", sessionStatus);
 
             sessionData.add(session);
+        }
+
+        if (excludedForZeroTotal > 0) {
+            LOGGER.log(Level.INFO,
+                    "Online booking feed: returned {0} of {1} session instance(s); {2} were withheld because "
+                    + "their originating session total is zero. Enable FINE logging on {3} to list them.",
+                    new Object[]{sessionData.size(), sessions.size(), excludedForZeroTotal,
+                        ChannelApi.class.getName()});
         }
 
         Map<String, Object> sessionResults = new HashMap<>();


### PR DESCRIPTION
## Decisions made without approval

| Decision | Why |
|---|---|
| **Delivered the logging half only; the explicit flag is NOT included** | The approved fix replaces the implicit `total == 0` rule with an explicit flag on the session. That requires a **new database column**, and schema changes are outside what this automated run may write. See "What is still outstanding". |
| **Two log levels rather than one** | An INFO line per skipped session on a feed polled continuously by an agent would flood the log. A single INFO summary stays cheap and always-on; the per-session detail sits behind FINE for when someone is actually investigating. |
| **Kept `total == 0` as the exclusion trigger** | Product decision was explicit that these sessions stay excluded — no behaviour change. This PR changes only what gets logged. |
| **No `findActiveChannelSession` change** | It enforces the same rule as a JPQL predicate, so there is no per-row hook to log from. Its behaviour is unchanged and still correct. |

## The problem

A session instance whose originating session has `total == 0` is dropped from `/doctorSessions` with no trace (`ChannelApi.java:668`).

The exclusion is intentional — sessions priced per investigation rather than per appointment are not offered for online booking. But it is indistinguishable from a session whose fees were never entered, and telling them apart requires a database query. On one production dataset this silently hides 11 staff.

## What this changes

Logging only. The same sessions are returned as before.

- **INFO**, once per request when anything was withheld: how many instances were returned, how many were withheld, and how to get the detail.
- **FINE**, once per withheld instance: the session instance id and its originating session id, with a note that this is intentional for per-investigation pricing and that fees should be checked if the session was expected to appear.

## Verification

Local Payara, against a dataset containing exactly two zero-total upcoming instances (confirmed by query).

INFO summary:

> Online booking feed: returned 15 of 17 session instance(s); 2 were withheld because their originating session total is zero. Enable FINE logging on com.divudi.ws.channel.ChannelApi to list them.

15 + 2 = 17 matches the database exactly.

After `set-log-levels com.divudi.ws.channel.ChannelApi=FINE`, both withheld instances were named individually, each identifying its session instance and originating session.

Build: `mvn package` clean.

## What is still outstanding

The rest of #23272 — replacing the implicit `total == 0` test with an explicit "not available for online booking" state, so that a zero total with the flag unset becomes a reportable data error.

That needs a new boolean column on `ServiceSession`. No existing field carries the meaning: `acceptOnlineBookings` means a temporary Hold and still lists the session, and `excludeFromPatientPortal` targets a different channel — reusing either would change unrelated behaviour.

Per this project's convention the column goes in via `/generate-ddl` plus the admin "Add Missing Columns" page, not a migration script. That step needs a human, so this issue stays open.

Note for whoever picks it up: the flag must be an **additional** exclusion reason, not a replacement. Switching the trigger to a column that defaults to `false` would make every currently-hidden zero-total session suddenly visible to booking agents — a regression.

Refs #23272
