### PR TITLE
fix(pharmacy): stop double-subtracting discount on sale return totals

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/SaleReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/SaleReturnController.java
@@ -1203,15 +1203,17 @@ public class SaleReturnController implements Serializable, com.divudi.bean.commo
     private void calTotal() {
         double grossTotal = 0.0;
         double discount = 0;
+        double netTotal = 0;
 
         for (BillItem p : getBillItems()) {
-            grossTotal += p.getNetRate() * p.getQty();
+            grossTotal += p.getRate() * p.getQty();
             discount += p.getDiscountRate() * p.getQty();
+            netTotal += p.getNetRate() * p.getQty();
 
         }
         getReturnBill().setDiscount(discount);
         getReturnBill().setTotal(grossTotal);
-        getReturnBill().setNetTotal(grossTotal - discount);
+        getReturnBill().setNetTotal(netTotal);
 
         //  return grossTotal;
     }


### PR DESCRIPTION
## Decisions made without approval

- **Matched this fix to two pre-existing open issues (#14325, #15841) instead of filing a new one.** Both describe this exact symptom (Gross Amount / Discount Receivable / Receivable Amount wrong on `pharmacy_bill_return_retail.xhtml`), both are already assigned to the reporter, and both were previously triaged as "needs detailed investigation" / "needs data to test" — this PR supplies that missing root cause and a concrete repro. No new issue filed to avoid duplicating the existing tracking.
- **Reproduction environment: local `coop` DB, not Southern Lanka production.** The task's hard limits forbid writing to any remote/production database (staging-hosted URLs pointed at real production DBs count as remote). Southern Lanka production bill `SLHPHA/SPB/26/001254` was read via the read-only Costing Data API to confirm root cause math against real numbers; the actual sale + return reproduction (to prove the fix) was done locally against a synthetic bill created through the app (`OP/SALE/37282`), per the "generate test data through the app" guidance.
- **No wiki update.** [Pharmacy ‐ Return Items and Payments](https://github.com/hmislk/hmis.wiki.git) is a brief workflow guide with no screenshots and no claims about discount arithmetic — nothing on that page is demonstrably wrong, so it was left untouched per the "only publish what you can verify" rule.

## Problem

On the pharmacy retail sale return screen (`pharmacy/pharmacy_bill_return_retail.xhtml`), returning a discounted sale double-subtracted the discount. Reported from Southern Lanka production:

- Original sale `SLHPHA/SPB/26/001254`: Total 1,824.75, Discount −91.24 (5%), Net Total 1,733.51
- On the return screen, "Discount Receivable" showed 91.24 again, and "Receivable Amount" computed to 1,642.27 instead of the correct 1,733.51 for a full return.

## Root cause

`SaleReturnController.calTotal()` (fired by `onEdit()` on every Returning Qty edit):

```java
grossTotal += p.getNetRate() * p.getQty();   // netRate is ALREADY rate - discountRate
discount += p.getDiscountRate() * p.getQty();
...
getReturnBill().setNetTotal(grossTotal - discount);  // subtracts discount a 2nd time
```

`BillItem.netRate` is set at sale time as `rate - discountRate` everywhere in the sale controllers (e.g. `PharmacySaleForCashierController.java:2358`). `calTotal()` used `netRate` (already net of discount) as if it were the gross rate, then subtracted the discount again — mislabeling the "Total" field as gross while it was actually already-discounted, and computing "Net Total" as discount-of-discount.

This is a longstanding bug present since the file was first created (`8a7120793c`), not a regression.

The persisted-total path used after a return is actually saved, `updateReturnTotal()`, was already correct (`netTotal += b.getNetValue()`, no re-subtraction) — only the live pre-save `calTotal()` display/validation path had the bug, but that's what the user sees and what multi-payment-method validation checks against before save.

## Fix

`calTotal()` now mirrors the correct pattern already used in `updateReturnTotal()`:

```java
grossTotal += p.getRate() * p.getQty();      // true gross, not net
discount += p.getDiscountRate() * p.getQty();
netTotal += p.getNetRate() * p.getQty();     // already net; not discounted again
...
getReturnBill().setNetTotal(netTotal);
```

## Verification

Reproduced and fixed locally end-to-end (`localhost:9090/rh`, `coop` local DB, OPD Pharmacy department):

1. Created a discounted retail sale via the app: 10 × My C Plus Tablet @ 45.99, Member discount scheme (7.5%) → Total 459.90, Discount 34.4925, Net Total 425.4075 (`OP/SALE/37282`).
2. Opened the return screen for that bill, clicked "Fill All" (triggers the buggy `onEdit`/`calTotal` path):
   - **Before fix** (predicted from the math, same pattern as the SL screenshot): Receivable Amount would show 425.41 − 34.49 = 390.92
   - **After fix**: Gross Amount 459.90, Discount Receivable 34.49, Receivable Amount **425.41** — correct, matches the original sale's Net Total exactly
3. Completed the return; verified the persisted return bill in the DB matches the original sale exactly (sign-inverted): Total −459.90, Discount 34.4925, Net Total **−425.4075**.

## Test plan

- [x] Reproduced the bug's root cause via git archaeology + code reading
- [x] Verified original Southern Lanka bill numbers via the read-only Costing Data API
- [x] Created a discounted sale locally through the app
- [x] Confirmed the return screen shows correct (non-double-discounted) totals after the fix
- [x] Completed the return and confirmed the persisted bill totals are correct
- [x] `mvn compile` passes

Closes #14325
Closes #15841