### PR TITLE
fix(inward): separate Final Credit from Final Other in BHT payment breakdown

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtPaymentSummaryReportController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtPaymentSummaryReportController.java
@@ -75,6 +75,7 @@ public class BhtPaymentSummaryReportController implements Serializable {
     private double grandTotalPostFinalPayments;
     private double grandTotalPostFinalCash;
     private double grandTotalPostFinalCard;
+    private double grandTotalPostFinalCredit;
     private double grandTotalPostFinalOther;
     private double grandTotalCreditBilled;
     private double grandTotalCreditSettlement;
@@ -95,6 +96,7 @@ public class BhtPaymentSummaryReportController implements Serializable {
         grandTotalPostFinalPayments = 0;
         grandTotalPostFinalCash = 0;
         grandTotalPostFinalCard = 0;
+        grandTotalPostFinalCredit = 0;
         grandTotalPostFinalOther = 0;
         grandTotalCreditBilled = 0;
         grandTotalCreditSettlement = 0;
@@ -118,6 +120,7 @@ public class BhtPaymentSummaryReportController implements Serializable {
             grandTotalPostFinalPayments += row.getTotalPostFinalPayments();
             grandTotalPostFinalCash += row.getPostFinalCash();
             grandTotalPostFinalCard += row.getPostFinalCard();
+            grandTotalPostFinalCredit += row.getPostFinalCredit();
             grandTotalPostFinalOther += row.getPostFinalOther();
             grandTotalCreditBilled += row.getCreditBilledTotal();
             grandTotalCreditSettlement += row.getCreditSettlementTotal();
@@ -355,6 +358,7 @@ public class BhtPaymentSummaryReportController implements Serializable {
         grandTotalPostFinalPayments = 0;
         grandTotalPostFinalCash = 0;
         grandTotalPostFinalCard = 0;
+        grandTotalPostFinalCredit = 0;
         grandTotalPostFinalOther = 0;
         grandTotalCreditBilled = 0;
         grandTotalCreditSettlement = 0;
@@ -409,6 +413,8 @@ public class BhtPaymentSummaryReportController implements Serializable {
     public double getGrandTotalPostFinalCash() { return grandTotalPostFinalCash; }
 
     public double getGrandTotalPostFinalCard() { return grandTotalPostFinalCard; }
+
+    public double getGrandTotalPostFinalCredit() { return grandTotalPostFinalCredit; }
 
     public double getGrandTotalPostFinalOther() { return grandTotalPostFinalOther; }
 

--- a/src/main/java/com/divudi/core/data/dto/BhtPaymentSummaryDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/BhtPaymentSummaryDTO.java
@@ -117,8 +117,18 @@ public class BhtPaymentSummaryDTO implements Serializable {
         return getPostFinalPaymentForMethod(PaymentMethod.Card);
     }
 
+    /**
+     * Post-final-bill payments made via {@link PaymentMethod#Credit} (settling
+     * the final bill on credit) — broken out from {@link #getPostFinalOther()}
+     * per issue #23262, so a distinct "Final Credit" column can be shown
+     * alongside Final Cash / Final Other.
+     */
+    public double getPostFinalCredit() {
+        return getPostFinalPaymentForMethod(PaymentMethod.Credit);
+    }
+
     public double getPostFinalOther() {
-        return getTotalPostFinalPayments() - getPostFinalCash() - getPostFinalCard();
+        return getTotalPostFinalPayments() - getPostFinalCash() - getPostFinalCard() - getPostFinalCredit();
     }
 
     public void addCreditCompanyBill(double billedAmount, double settledAmount, String companyName) {

--- a/src/main/webapp/inward/inward_report_bht_payment_detail.xhtml
+++ b/src/main/webapp/inward/inward_report_bht_payment_detail.xhtml
@@ -324,7 +324,7 @@
                                 </f:facet>
                             </p:column>
 
-                            <p:column headerText="Post-Final Cash" style="text-align:right; white-space:nowrap;">
+                            <p:column headerText="Final Cash" style="text-align:right; white-space:nowrap;">
                                 <h:outputText value="#{row.postFinalCash}">
                                     <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
                                 </h:outputText>
@@ -335,7 +335,7 @@
                                 </f:facet>
                             </p:column>
 
-                            <p:column headerText="Post-Final Card" style="text-align:right; white-space:nowrap;">
+                            <p:column headerText="Final Card" style="text-align:right; white-space:nowrap;">
                                 <h:outputText value="#{row.postFinalCard}">
                                     <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
                                 </h:outputText>
@@ -346,7 +346,18 @@
                                 </f:facet>
                             </p:column>
 
-                            <p:column headerText="Post-Final Other" style="text-align:right; white-space:nowrap;">
+                            <p:column headerText="Final Credit" style="text-align:right; white-space:nowrap;">
+                                <h:outputText value="#{row.postFinalCredit}">
+                                    <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                </h:outputText>
+                                <f:facet name="footer">
+                                    <h:outputText value="#{bhtPaymentSummaryReportController.grandTotalPostFinalCredit}">
+                                        <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                    </h:outputText>
+                                </f:facet>
+                            </p:column>
+
+                            <p:column headerText="Final Other" style="text-align:right; white-space:nowrap;">
                                 <h:outputText value="#{row.postFinalOther}">
                                     <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
                                 </h:outputText>
@@ -357,7 +368,7 @@
                                 </f:facet>
                             </p:column>
 
-                            <p:column headerText="Total Post-Final Payments" style="text-align:right; white-space:nowrap; font-weight:bold;">
+                            <p:column headerText="Total Final" style="text-align:right; white-space:nowrap; font-weight:bold;">
                                 <h:outputText value="#{row.totalPostFinalPayments}">
                                     <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
                                 </h:outputText>


### PR DESCRIPTION
## Decisions made without approval

- **The "Deposit Cash should exclude Make Payment amounts" part of this issue needed no code change** — I verified `BhtPaymentSummaryReportController.fetchDepositPayments()` already queries only `BillTypeAtomic.INWARD_PAYMENT` (Make Deposit) bills, completely separate from `fetchPostFinalPayments()` (`BillType.PostFinalBillInwardPayment`, i.e. Make Payment). `depositsByMethod` and `postFinalPaymentsByMethod` are two independent maps on `BhtPaymentSummaryDTO` — there is no conflation today. I only implemented the genuinely missing piece: splitting `Credit` out of the "Other" bucket in the post-final breakdown, and renaming the columns to match what the issue asked for (Final Cash/Credit/Other/Total Final).
- **Kept the existing "Final Card" column** (issue's example table only listed Final Cash/Credit/Other/Total Final, omitting Card) rather than removing it — `PaymentMethod.Card` is a real, populated bucket distinct from `Credit`; dropping it would silently lose data with no stated reason to do so. Read the omission as an example simplification, not a removal request.
- **⚠️ This PR conflicts with PR #23286 (#23258)**, which swaps this same results-table markup between `inward_report_bht_payment_summary.xhtml` and `inward_report_bht_payment_detail.xhtml`. Both PRs are based on `origin/development` per this project's branching rule (never base off another unmerged feature branch), so this is an expected, normal git conflict for whichever PR merges second — not a mistake. Documented here so the merge order is deliberate: once #23286 merges, this column change needs to be reapplied to whichever file is then titled "Detail" (call it out in that PR's conflict resolution, or ping me to redo it).

## What changed

- `BhtPaymentSummaryDTO`: added `getPostFinalCredit()` (the `PaymentMethod.Credit` bucket), and `getPostFinalOther()` now subtracts it too (previously Credit-method final payments were silently counted as "Other").
- `BhtPaymentSummaryReportController`: added the matching `grandTotalPostFinalCredit` field/reset/accumulation/getter.
- `inward_report_bht_payment_summary.xhtml`: renamed "Post-Final Cash/Card/Other" → "Final Cash/Card/Credit/Other", added the new Final Credit column, renamed "Total Post-Final Payments" → "Total Final". Java field/getter names were deliberately left as `postFinal*` (not renamed to `final*`) to keep this change small — only the *display* labels changed.

## Testing

Against local Payara/MySQL (`coop` DB): generated the report, confirmed the new "Final Credit" column appears between "Final Card" and "Final Other" with a footer total, and that a BHT with a post-final Cash payment shows it under "Final Cash" as before (value unchanged, only relabeled).

`mvn clean package` succeeds; redeployed locally with no errors in `server.log`.

## Documentation

Updated `Inward-BHT-Deposit-and-Credit-Settlement-Detail-Report.md` (added by #23258's wiki update) to describe the renamed/new columns and the updated Total Balance formula wording.

Closes #23262

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate tracking and display of final bill payments made by credit.
  * Updated payment summaries to distinguish final cash, card, credit, and other payments.
  * Added a grand total for final credit payments.

* **Style**
  * Renamed payment report columns from “Post-Final” to “Final” for clearer presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->