### PR TITLE
fix(inward): include final (post-final-bill) payments in BHT payment log

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtPaymentDetailReportController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtPaymentDetailReportController.java
@@ -1,5 +1,6 @@
 package com.divudi.bean.inward;
 
+import com.divudi.core.data.BillType;
 import com.divudi.core.data.BillTypeAtomic;
 import com.divudi.core.data.PaymentMethod;
 import com.divudi.core.data.dto.BhtPaymentDetailDTO;
@@ -29,7 +30,9 @@ import javax.persistence.TemporalType;
 
 /**
  * Controller for BHT Deposit and Credit Settlement Detail Report.
- * One row per individual payment (deposit payment or CC settlement item).
+ * One row per individual payment (deposit payment, post-final-bill "Make
+ * Payment" settlement, or CC settlement item) - see
+ * {@link com.divudi.core.data.dto.BhtPaymentDetailDTO#getPaymentCategory()}.
  */
 @Named
 @SessionScoped
@@ -55,17 +58,29 @@ public class BhtPaymentDetailReportController implements Serializable {
     private List<BhtPaymentDetailDTO> reportRows;
     private double grandTotal;
     private double grandTotalCcSettlement;
+    private double grandTotalFinalPayments;
     /** Ordered map of payment method → deposit total; only methods with non-zero totals. */
     private Map<PaymentMethod, Double> totalByMethod = new LinkedHashMap<>();
     /** Payment methods in the order they appeared, for UI iteration. */
     private List<PaymentMethod> usedPaymentMethods = new ArrayList<>();
+    /**
+     * Ordered map of payment method → final-payment (post-final-bill "Make
+     * Payment") total. Kept separate from {@link #totalByMethod} (deposits)
+     * per issue #23262 - deposit and final-payment amounts must not be
+     * conflated in a single per-method total.
+     */
+    private Map<PaymentMethod, Double> finalPaymentTotalByMethod = new LinkedHashMap<>();
+    private List<PaymentMethod> usedFinalPaymentMethods = new ArrayList<>();
 
     public void generateReport() {
         reportRows = new ArrayList<>();
         grandTotal = 0;
         grandTotalCcSettlement = 0;
+        grandTotalFinalPayments = 0;
         totalByMethod = new LinkedHashMap<>();
         usedPaymentMethods = new ArrayList<>();
+        finalPaymentTotalByMethod = new LinkedHashMap<>();
+        usedFinalPaymentMethods = new ArrayList<>();
 
         List<PatientEncounter> encounters = fetchEncounters();
         if (encounters == null || encounters.isEmpty()) {
@@ -91,11 +106,43 @@ public class BhtPaymentDetailReportController implements Serializable {
                 row.setAmount(Math.abs(p.getPaidValue()));
                 row.setReferenceNo(p.getReferenceNo());
                 row.setCreditCompanyName("");
+                row.setPaymentCategory("Deposit");
                 reportRows.add(row);
                 double depositAmt = Math.abs(p.getPaidValue());
                 grandTotal += depositAmt;
                 if (p.getPaymentMethod() != null) {
                     totalByMethod.merge(p.getPaymentMethod(), depositAmt, Double::sum);
+                }
+            }
+
+            // Post-final-bill ("Make Payment") payments — one row per Payment record.
+            // Issue #23263: these were never queried here, so a BHT whose only
+            // recorded payment was a post-final settlement (no deposit, no CC
+            // settlement) was silently absent from this report.
+            List<Payment> finalPayments = fetchPostFinalPayments(enc);
+            for (Payment p : finalPayments) {
+                BhtPaymentDetailDTO row = new BhtPaymentDetailDTO();
+                row.setBhtNo(enc.getBhtNo());
+                row.setPatientName(patientName);
+                row.setAdmissionType(enc.getAdmissionType());
+                row.setDateOfAdmission(enc.getDateOfAdmission());
+                row.setDateOfDischarge(enc.getDateOfDischarge());
+                row.setBillNo(p.getBill() != null ? p.getBill().getDeptId() : "");
+                row.setCreatedAt(p.getCreatedAt());
+                row.setPaymentMethod(p.getPaymentMethod());
+                // Signed, not abs() - see fetchPostFinalPayments() javadoc: a
+                // cancelled final payment arrives as a separate negative-amount
+                // row rather than a cancelled flag, so each row must keep its
+                // real sign to show the full transaction trail.
+                row.setAmount(p.getPaidValue());
+                row.setReferenceNo(p.getReferenceNo());
+                row.setCreditCompanyName("");
+                row.setPaymentCategory("Final Payment");
+                reportRows.add(row);
+                grandTotal += p.getPaidValue();
+                grandTotalFinalPayments += p.getPaidValue();
+                if (p.getPaymentMethod() != null) {
+                    finalPaymentTotalByMethod.merge(p.getPaymentMethod(), p.getPaidValue(), Double::sum);
                 }
             }
 
@@ -118,18 +165,24 @@ public class BhtPaymentDetailReportController implements Serializable {
                 row.setAmount(bi.getNetValue());
                 row.setReferenceNo("");
                 row.setCreditCompanyName(companyName);
+                row.setPaymentCategory("CC Settlement");
                 reportRows.add(row);
                 grandTotal += bi.getNetValue();
                 grandTotalCcSettlement += bi.getNetValue();
             }
         }
 
-        // Build ordered list of used payment methods for UI iteration
+        // Build ordered lists of used payment methods for UI iteration
         usedPaymentMethods = new ArrayList<>(totalByMethod.keySet());
+        usedFinalPaymentMethods = new ArrayList<>(finalPaymentTotalByMethod.keySet());
     }
 
     public double getTotalForMethod(PaymentMethod pm) {
         return totalByMethod.getOrDefault(pm, 0.0);
+    }
+
+    public double getTotalForFinalPaymentMethod(PaymentMethod pm) {
+        return finalPaymentTotalByMethod.getOrDefault(pm, 0.0);
     }
 
     private List<PatientEncounter> fetchEncounters() {
@@ -210,6 +263,33 @@ public class BhtPaymentDetailReportController implements Serializable {
     }
 
     /**
+     * Fetch post-final-bill ("Make Payment") payments for this encounter.
+     *
+     * Deliberately does NOT filter on {@code p.cancelled} / {@code p.bill.cancelled}:
+     * mirrors {@link BhtPaymentSummaryReportController#fetchPostFinalPayments}
+     * - cancellation of a post-final-bill payment arrives as a separate
+     * negative-amount row of the same bill type rather than a cancelled flag
+     * on the original, so each row is kept as its own line (with its natural
+     * sign) instead of being filtered or netted here. Issue #23263.
+     */
+    private List<Payment> fetchPostFinalPayments(PatientEncounter enc) {
+        StringBuilder jpql = new StringBuilder("select p from Payment p"
+                + " where p.retired = false"
+                + " and p.bill.retired = false"
+                + " and p.bill.billType = :bt"
+                + " and p.bill.patientEncounter = :enc");
+        Map<String, Object> params = new HashMap<>();
+        params.put("bt", BillType.PostFinalBillInwardPayment);
+        params.put("enc", enc);
+        if (paymentMethod != null) {
+            jpql.append(" and p.paymentMethod = :pm");
+            params.put("pm", paymentMethod);
+        }
+        jpql.append(" order by p.createdAt");
+        return paymentFacade.findByJpql(jpql.toString(), params);
+    }
+
+    /**
      * Fetch BillItems from INPATIENT_CREDIT_COMPANY_PAYMENT_RECEIVED and
      * INPATIENT_CREDIT_COMPANY_PAYMENT_CANCELLATION bills that reference this encounter.
      * Deliberately does NOT filter on bi.bill.cancelled: cancelling a CC payment sets
@@ -246,8 +326,11 @@ public class BhtPaymentDetailReportController implements Serializable {
         reportRows = null;
         grandTotal = 0;
         grandTotalCcSettlement = 0;
+        grandTotalFinalPayments = 0;
         totalByMethod = new LinkedHashMap<>();
         usedPaymentMethods = new ArrayList<>();
+        finalPaymentTotalByMethod = new LinkedHashMap<>();
+        usedFinalPaymentMethods = new ArrayList<>();
     }
 
     private static Date startOfCurrentMonth() {
@@ -295,7 +378,13 @@ public class BhtPaymentDetailReportController implements Serializable {
 
     public double getGrandTotalCcSettlement() { return grandTotalCcSettlement; }
 
+    public double getGrandTotalFinalPayments() { return grandTotalFinalPayments; }
+
     public List<PaymentMethod> getUsedPaymentMethods() { return usedPaymentMethods; }
 
     public Map<PaymentMethod, Double> getTotalByMethod() { return totalByMethod; }
+
+    public List<PaymentMethod> getUsedFinalPaymentMethods() { return usedFinalPaymentMethods; }
+
+    public Map<PaymentMethod, Double> getFinalPaymentTotalByMethod() { return finalPaymentTotalByMethod; }
 }

--- a/src/main/java/com/divudi/core/data/dto/BhtPaymentDetailDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/BhtPaymentDetailDTO.java
@@ -7,7 +7,8 @@ import java.util.Date;
 
 /**
  * DTO for BHT Deposit and Credit Settlement Detail Report.
- * One instance per individual payment (deposit or CC settlement).
+ * One instance per individual payment (deposit, post-final/"Make Payment"
+ * settlement, or CC settlement) - see {@link #getPaymentCategory()}.
  */
 public class BhtPaymentDetailDTO implements Serializable {
 
@@ -22,6 +23,16 @@ public class BhtPaymentDetailDTO implements Serializable {
     private double amount;
     private String referenceNo;
     private String creditCompanyName;
+
+    /**
+     * Distinguishes which kind of transaction this row is: "Deposit"
+     * (Make Deposit), "Final Payment" (Make Payment / post-final-bill
+     * settlement), or "CC Settlement" (credit company payment). Not set by
+     * every caller of this DTO (e.g. {@code BhtDepositDetailReportController}
+     * predates this field) - callers that don't set it leave rows blank
+     * rather than defaulting to a possibly-wrong category.
+     */
+    private String paymentCategory;
 
     public BhtPaymentDetailDTO() {
     }
@@ -58,4 +69,7 @@ public class BhtPaymentDetailDTO implements Serializable {
 
     public String getCreditCompanyName() { return creditCompanyName != null ? creditCompanyName : ""; }
     public void setCreditCompanyName(String creditCompanyName) { this.creditCompanyName = creditCompanyName; }
+
+    public String getPaymentCategory() { return paymentCategory != null ? paymentCategory : ""; }
+    public void setPaymentCategory(String paymentCategory) { this.paymentCategory = paymentCategory; }
 }

--- a/src/main/webapp/inward/inward_report_bht_payment_summary.xhtml
+++ b/src/main/webapp/inward/inward_report_bht_payment_summary.xhtml
@@ -278,6 +278,10 @@
                                 </h:outputText>
                             </p:column>
 
+                            <p:column headerText="Type" style="white-space:nowrap;">
+                                <h:outputText value="#{row.paymentCategory}" />
+                            </p:column>
+
                             <p:column headerText="Bill No" style="white-space:nowrap;">
                                 <h:outputText value="#{row.billNo}" />
                             </p:column>
@@ -308,6 +312,7 @@
 
                             <f:facet name="footer">
                                 <div class="text-end">
+                                    <strong>Deposits — </strong>
                                     <ui:repeat value="#{bhtPaymentDetailReportController.usedPaymentMethods}" var="pm">
                                         <strong>
                                             <h:outputText value="#{pm.label}" />:
@@ -315,8 +320,24 @@
                                         <h:outputText value="#{bhtPaymentDetailReportController.getTotalForMethod(pm)}">
                                             <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
                                         </h:outputText>
-                                        &#160;&#160;&#160;
+                                        &#160;&#160;
                                     </ui:repeat>
+                                    &#160;&#160;&#160;
+                                    <strong>Final Payments — </strong>
+                                    <ui:repeat value="#{bhtPaymentDetailReportController.usedFinalPaymentMethods}" var="pm">
+                                        <strong>
+                                            <h:outputText value="#{pm.label}" />:
+                                        </strong>
+                                        <h:outputText value="#{bhtPaymentDetailReportController.getTotalForFinalPaymentMethod(pm)}">
+                                            <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                        </h:outputText>
+                                        &#160;&#160;
+                                    </ui:repeat>
+                                    <strong>Total Final: </strong>
+                                    <h:outputText value="#{bhtPaymentDetailReportController.grandTotalFinalPayments}">
+                                        <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                    </h:outputText>
+                                    &#160;&#160;&#160;
                                     <strong>CC Settlement: </strong>
                                     <h:outputText value="#{bhtPaymentDetailReportController.grandTotalCcSettlement}">
                                         <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />


### PR DESCRIPTION
## Decisions made without approval

- **Added a "Type" column and split the footer totals** beyond the issue's literal ask (patients "not displayed"). Without a Type column, the newly-visible final-payment rows would look identical to deposit rows (same Payment Method/Amount columns), which seemed likely to relocate the confusion rather than resolve it. Flagging this explicitly since it's an addition, not strictly required by the issue text.
- **⚠️ Same expected merge conflict as PR #23288 (#23262)**: this touches `inward_report_bht_payment_detail.xhtml`'s results-table markup, which PR #23286 (#23258) also swaps between the Summary/Detail files. Both PRs are correctly based on `origin/development` (per this project's branching rule); whichever merges second will need conflict resolution reapplying this change to the file then titled "Detail".

## Root cause

`BhtPaymentDetailReportController.generateReport()` only ever queried two of the three payment types that make up a BHT's financial history: deposit payments (`fetchDepositPayments`, `INWARD_PAYMENT`) and credit-company settlement items (`fetchCreditSettlementItems`). It never queried post-final-bill ("Make Payment") payments at all — so a BHT whose only recorded payment was a final settlement had **zero rows** in this report, regardless of filters.

Verified locally: a BHT with 7 final-payment transactions (two of them cancellation/refund rows) had zero rows in this report before the fix, and correctly shows all 7 (netting to the right total) after.

## What changed

- `BhtPaymentDetailReportController`: added `fetchPostFinalPayments()`, copying the deliberately unfiltered, sign-preserving query pattern from `BhtPaymentSummaryReportController.fetchPostFinalPayments()` — final-payment cancellations arrive as a separate negative-amount row rather than a cancelled flag, so filtering or `abs()`-ing here would drop or corrupt the audit trail.
- `BhtPaymentDetailDTO`: added `paymentCategory` ("Deposit" / "Final Payment" / "CC Settlement"). Additive field; existing callers that don't set it (`BhtDepositDetailReportController`) are unaffected.
- `inward_report_bht_payment_detail.xhtml`: added a "Type" column; footer now shows separate Deposits / Final Payments (+ Total Final) / CC Settlement / Grand Total sections instead of one combined per-method total, keeping deposit and final-payment amounts from being summed together (consistent with #23262's "don't conflate Deposit and Make Payment amounts" concern).

## Testing

Against local Payara/MySQL (`coop` DB): generated the report, confirmed a BHT with only final-payment transactions (no deposits) now appears with all 7 of its payment rows (including 2 negative cancellation rows), correctly tagged "Final Payment" in the new Type column, netting to the correct Total Final in the footer. Confirmed CC Settlement and Deposit rows still show correctly and are tagged accordingly.

`mvn clean package` succeeds; redeployed locally with no errors in `server.log`.

## Documentation

Updated `Inward-BHT-Deposit-and-Credit-Settlement-Summary-Report.md` (this is the page documenting the corrected-post-#23258 "Summary" content) to describe the Type column and the fixed final-payment visibility.

Closes #23263

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added post-final-bill payments to payment detail reports.
  * Categorized transactions as Deposits, Credit Settlements, or Final Payments.
  * Added filtering of final payments by payment method.
  * Added separate final-payment totals, per-method breakdowns, and grand totals.

* **UI Enhancements**
  * Added a Type column to identify each transaction category.
  * Updated report totals to clearly distinguish deposits, final payments, credit settlements, and overall totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->