### PR TITLE
fix(pharmacy): show original rate, not net rate, on retail sale return bills

### DIFF
--- a/src/main/webapp/resources/pharmacy/returnBill.xhtml
+++ b/src/main/webapp/resources/pharmacy/returnBill.xhtml
@@ -148,7 +148,7 @@
                                 </h:outputLabel>
                             </td>
                             <td>
-                                <h:outputLabel    value="#{bip.netValue/bip.qty}"    styleClass="itemsBlock" >
+                                <h:outputLabel    value="#{bip.rate}"    styleClass="itemsBlock" >
                                     <f:convertNumber pattern="#,##0.00" />
                                 </h:outputLabel>
                             </td>

--- a/src/main/webapp/resources/pharmacy/saleBill_Header_Return.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBill_Header_Return.xhtml
@@ -181,7 +181,7 @@
                                 </h:outputLabel>
                             </td>
                             <td   style="text-align: right; width: 20%" >
-                                <h:outputLabel  styleClass="itemsBlockRight1"   value="#{bip.netRate}" >
+                                <h:outputLabel  styleClass="itemsBlockRight1"   value="#{bip.rate}" >
                                     <f:convertNumber pattern="#,##0.00" />
                                 </h:outputLabel>
                             </td>


### PR DESCRIPTION
## Decisions made without approval (dev-issue-unattended)

This issue was run via the unattended lifecycle skill (user was offline). Judgment calls made along the way, for review:

1. **Scoped the fix to only the two print composites used exclusively by the pharmacy retail sale return flow** (`returnBill.xhtml`, `saleBill_Header_Return.xhtml`). A third composite, `saleBill_five_five.xhtml`, has the **identical** `netValue/qty` bug on its RATE column for the `bill.margin == 0` case, but that template is shared with the *ordinary* (non-return) sale-bill print path (`pharmacy_reprint_bill_sale.xhtml`, `my_pharmacy_bill.xhtml`, `pharmacy_reprint_prebill_sale.xhtml`, etc.). Fixing it here would also change how discounted items display on regular sale receipts for customers who haven't reported this problem — too broad a blast radius for an unattended hotfix. **Recommend filing a separate, deliberate follow-up issue** to decide whether the original-sale rate display should change too.
2. **Left `returnBill_1.xhtml` untouched** — same `netValue/qty` bug pattern, but it's only used by inward/BHT and store issue-return reprints, outside this issue's reported scope (pharmacy retail sale returns specifically).
3. **Did not attempt the requested SL production hotfix deployment.** The issue is flagged "(need as hot fix to SL)" — but `/hotfix-deploy` is explicitly gated to require direct, explicit user invocation and must not be replicated by other means unattended. This PR targets `development` per the normal flow; a human needs to run `/hotfix-deploy` afterward to fast-track this to `southernlanka-prod` if still needed.
4. Branched from `origin/development` as normal, even though the issue requested a hotfix — see point 3.

## Problem

On the pharmacy retail sale return bill (both "Return Item Only" and "Return Item + Payment" flows), the printed **RATE** column for a discounted item showed the discounted/net per-unit rate instead of the original rate the item was sold at. **VALUE** was already correct (net of discount).

Example from the issue: item sold at Rs. 984.00/unit with a discount bringing net to Rs. 915.12; the return bill showed RATE = 915.12 instead of 984.00.

## Root cause

Two return-bill print composites computed the RATE column from the discounted net value/rate instead of `BillItem.rate` (the pre-discount unit rate):

- `src/main/webapp/resources/pharmacy/returnBill.xhtml` (default POS paper format) — used `#{bip.netValue/bip.qty}`
- `src/main/webapp/resources/pharmacy/saleBill_Header_Return.xhtml` (POS Header paper format) — used `#{bip.netRate}` directly

Both are used exclusively by the return flow (confirmed via `grep` across `src/main/webapp`), and are reached from both `PreReturnController` ("Return Item Only") and `SaleReturnController` ("Return Item + Payment") — matching both symptoms described in the issue.

Two sibling return-bill composites (`sale_bill_five_five_custom_3_Return.xhtml`, `saleBill_Retail_Return_Pos_paper_Custom_1.xhtml`) already bind the RATE column to `bip.rate`/`item.rate` correctly, confirming this is the codebase's established, intended pattern — the two fixed files were the outliers.

## Fix

Changed the RATE column binding in both composites to `#{bip.rate}`, matching the already-correct sibling templates. VALUE/discount/net-total bindings are untouched.

## Verification

Reproduced end-to-end on local Payara + local `coop` DB (no compile needed — pure XHTML change):

1. Confirmed via direct DB query that real local return-bill rows already show `RATE != NETRATE` when `DISCOUNTRATE > 0`, with `NETVALUE/QTY == NETRATE` — exactly the buggy computation this PR replaces.
2. Created a fresh retail sale (Paracetamol 125mg Suppo, rate 102.16 × 2, 7.5% "Member" discount scheme) through the app.
3. Returned 1 unit via "Return Item Only".
4. **Before considering the deployed fix**: DB confirms `RATE=102.16`, `NETRATE=94.50`, `DISCOUNTRATE=7.66` on the sale's BillItem — i.e. the correct original rate was always being *stored*, only mis-*displayed*.
5. With the fixed templates copied into the local exploded WAR: the printed return bill now shows **RATE = 102.16** (original) and **VALUE = -94.50** (net of discount, unchanged) — matching the issue's expected result.

## Documentation

Updated the wiki page [`Pharmacy-Return-‐-Items-Only`](https://github.com/hmislk/hmis/wiki/Pharmacy-Return-%E2%80%90-Items-Only) with a new section explaining the RATE vs VALUE distinction on the printed return bill, embedding a redacted screenshot from the verification run above (screenshot cropped to exclude the institution name/address/phone header before publishing).

Closes #23292

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the item rate shown on pharmacy return bills.
  * Return bill line items now display the recorded item rate consistently.
  * Other bill details, totals, payment information, and printing behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->