### PR TITLE
fix(pharmacy): deliver transfer request notifications to subscribers

### DIFF
--- a/src/main/java/com/divudi/bean/common/NotificationController.java
+++ b/src/main/java/com/divudi/bean/common/NotificationController.java
@@ -93,6 +93,14 @@ public class NotificationController implements Serializable {
             case PHARMACY_TRANSFER_REQUEST:
                 createPharmacyTransferRequestNotifications(bill);
                 break;
+            // The approval (PRE) flow is what pharmacy_transfer_request.xhtml actually
+            // uses: the ward saves a PHARMACY_TRANSFER_REQUEST_PRE bill and only some of
+            // those ever get finalized/approved into a PHARMACY_TRANSFER_REQUEST. Without
+            // this case the PRE bill fell through to the default AssertionError below, so
+            // subscribers were never notified of a request when it was raised.
+            case PHARMACY_TRANSFER_REQUEST_PRE:
+                createPharmacyTransferRequestNotifications(bill);
+                break;
             case PHARMACY_ORDER:
                 createPharmacyOrderRequest(bill);
                 break;
@@ -383,7 +391,7 @@ public class NotificationController implements Serializable {
             return null;
         }
 
-        if (bt == BillTypeAtomic.PHARMACY_TRANSFER_REQUEST) {
+        if (bt == BillTypeAtomic.PHARMACY_TRANSFER_REQUEST || bt == BillTypeAtomic.PHARMACY_TRANSFER_REQUEST_PRE) {
             message = configOptionController.getLongTextValueByKey("Message Template for Pharmacy Transfer Request Notification", OptionScope.APPLICATION, null, null, null);
         }
 

--- a/src/main/java/com/divudi/bean/common/UserNotificationController.java
+++ b/src/main/java/com/divudi/bean/common/UserNotificationController.java
@@ -552,11 +552,16 @@ public class UserNotificationController implements Serializable {
                 break;
             case SMS:
                 for (WebUser u : notificationUsers) {
-                    if (u == null) {
+                    if (u == null || u.getWebUserPerson() == null) {
                         continue;
                     }
                     String number = u.getWebUserPerson().getMobile();
-                    sendSmsForUserSubscriptions(number);
+                    // A subscriber with no mobile number on file would otherwise create an
+                    // Sms row with a null recipient and hand it to the gateway.
+                    if (number == null || number.trim().isEmpty()) {
+                        continue;
+                    }
+                    sendSmsForUserSubscriptions(number, n);
                 }
                 break;
             case SYSTEM_NOTIFICATION:
@@ -580,11 +585,15 @@ public class UserNotificationController implements Serializable {
     }
 
     public void sendSmsForUserSubscriptions(String userMobNumber) {
+        sendSmsForUserSubscriptions(userMobNumber, null);
+    }
+
+    public void sendSmsForUserSubscriptions(String userMobNumber, Notification notification) {
         Sms e = new Sms();
         e.setCreatedAt(new Date());
         e.setCreater(sessionController.getLoggedUser());
         e.setReceipientNumber(userMobNumber);
-        e.setSendingMessage(createSmsForUserNotification());
+        e.setSendingMessage(createSmsForUserNotification(notification));
         e.setDepartment(getSessionController().getLoggedUser().getDepartment());
         e.setInstitution(getSessionController().getLoggedUser().getInstitution());
         e.setPending(false);
@@ -600,21 +609,69 @@ public class UserNotificationController implements Serializable {
     }
 
     public String createSmsForUserNotification() {
-        String template = configOptionController.getLongTextValueByKey("SMS Template for User Notification", OptionScope.APPLICATION, null, null, null);
-        if (template == null || template.isEmpty()) {
-            template = "{patient_name} {appointment_time}";
+        return createSmsForUserNotification(null);
+    }
+
+    /**
+     * Builds the text body of a subscription SMS.
+     *
+     * This used to build a template and then unconditionally {@code return ""},
+     * so every subscription SMS went to the gateway with an empty body. Bill-backed
+     * notifications now describe the bill that triggered them; anything else falls
+     * back to the notification's own message.
+     */
+    public String createSmsForUserNotification(Notification notification) {
+        if (notification != null && notification.getBill() != null) {
+            String billMessage = createSmsBodyForBillNotification(notification.getBill());
+            if (billMessage != null && !billMessage.trim().isEmpty()) {
+                return billMessage;
+            }
         }
-        //TODO: Replace placeholders with actual values
-        template = template.replace("{patient_name}", "")
-                .replace("{doctor}", "")
-                .replace("{appointment_time}", "")
-                .replace("{appointment_date}", "")
-                .replace("{serial_no}", "")
-                .replace("{doc}", "")
-                .replace("{time}", "")
-                .replace("{date}", "")
-                .replace("{No}", "");
-        return "";
+        if (notification != null && notification.getMessage() != null
+                && !notification.getMessage().trim().isEmpty()) {
+            return notification.getMessage().trim();
+        }
+        String template = configOptionController.getLongTextValueByKey("SMS Template for User Notification", OptionScope.APPLICATION, null, null, null);
+        if (template == null || template.trim().isEmpty()) {
+            return "";
+        }
+        return template.trim();
+    }
+
+    /**
+     * "New transfer request PHTRQ-PRE/26/000002 from WARD 4TH FLOOR (7 items) to PHARMACY."
+     * The bill number is what the receiving department needs to find the request, so it
+     * leads; department names and item count let the recipient judge urgency without
+     * logging in.
+     */
+    private String createSmsBodyForBillNotification(Bill bill) {
+        if (bill == null || bill.getBillTypeAtomic() == null) {
+            return null;
+        }
+        String subject;
+        switch (bill.getBillTypeAtomic()) {
+            case PHARMACY_TRANSFER_REQUEST:
+            case PHARMACY_TRANSFER_REQUEST_PRE:
+                subject = "New transfer request";
+                break;
+            default:
+                return null;
+        }
+        StringBuilder sb = new StringBuilder(subject);
+        if (bill.getDeptId() != null && !bill.getDeptId().trim().isEmpty()) {
+            sb.append(" ").append(bill.getDeptId().trim());
+        }
+        if (bill.getFromDepartment() != null && bill.getFromDepartment().getName() != null) {
+            sb.append(" from ").append(bill.getFromDepartment().getName().trim());
+        }
+        int itemCount = bill.getBillItems() == null ? 0 : bill.getBillItems().size();
+        if (itemCount > 0) {
+            sb.append(" (").append(itemCount).append(itemCount == 1 ? " item)" : " items)");
+        }
+        if (bill.getToDepartment() != null && bill.getToDepartment().getName() != null) {
+            sb.append(" to ").append(bill.getToDepartment().getName().trim());
+        }
+        return sb.append(".").toString();
     }
 
     public void createAllertMessage(Notification n) {

--- a/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
@@ -646,6 +646,11 @@ public class TransferRequestController implements Serializable {
     }
 
     public void saveTransferRequestPreBillAndBillItems() {
+        // Captured before the bill is persisted below: this method is re-entered by both
+        // Save and Finalize, and a ward can press Save repeatedly while still adding
+        // items. Only the call that actually creates the request notifies subscribers,
+        // so a request raises exactly one notification no matter how often it is re-saved.
+        boolean newRequest = getTransferRequestBillPre().getId() == null;
         getTransferRequestBillPre().setBillTypeAtomic(BillTypeAtomic.PHARMACY_TRANSFER_REQUEST_PRE);
         getTransferRequestBillPre().setBillType(BillType.PharmacyTransferRequest);
         // fromDepartment (below) = the department creating this request; it is also the
@@ -742,6 +747,9 @@ public class TransferRequestController implements Serializable {
         getTransferRequestBillPre().setBillTypeAtomic(BillTypeAtomic.PHARMACY_TRANSFER_REQUEST_PRE);
         LOGGER.log(Level.FINE, "Finalizing transfer request with {0} items", getBillItems().size());
         getBillFacade().edit(getTransferRequestBillPre());
+        if (newRequest) {
+            notificationController.createNotification(getTransferRequestBillPre());
+        }
     }
 
     public void saveTranserRequestPreBill() {

--- a/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/TransferRequestController.java
@@ -645,7 +645,12 @@ public class TransferRequestController implements Serializable {
         return false;
     }
 
-    public void saveTransferRequestPreBillAndBillItems() {
+    // synchronized because this bean is @SessionScoped and CDI does not serialise
+    // concurrent requests within a session: a double-clicked Save puts two threads on
+    // the same instance, and both would read a null id below -- creating two PRE bills
+    // and, since both would capture newRequest = true, notifying subscribers twice.
+    // Serialising per session is enough; two sessions never share a request bill.
+    public synchronized void saveTransferRequestPreBillAndBillItems() {
         // Captured before the bill is persisted below: this method is re-entered by both
         // Save and Finalize, and a ward can press Save repeatedly while still adding
         // items. Only the call that actually creates the request notifies subscribers,


### PR DESCRIPTION
Closes #23309

## Problem

Subscribing a user to **Transfer Request - SMS** did nothing. Three defects sat between a ward raising a pharmacy transfer request and the subscriber's phone.

1. **The hook was on a dead path.** `notificationController.createNotification()` for transfer requests was called only from `TransferRequestController.request()` — `@Deprecated`, reached only by the legacy `pharmacy_transfer_request_all.xhtml` / `theater_transfer_request.xhtml` pages. The page in real use (`pharmacy_transfer_request.xhtml` → `saveTranserRequestPreBill()`) raised no notification at all.
2. **`PHARMACY_TRANSFER_REQUEST_PRE` was unhandled** in `NotificationController.createNotification(Bill)`, falling through to `default: throw new AssertionError()`.
3. **The SMS body was always empty.** `createSmsForUserNotification()` built a template and then unconditionally `return ""`. Confirmed in deployed bytecode, not just source.

## Changes

- Hook the notification into PRE bill creation, guarded by a `newRequest` flag captured before the persist, so a request notifies **exactly once** regardless of how many times it is re-saved or later finalized.
- Handle `PHARMACY_TRANSFER_REQUEST_PRE` in `NotificationController` (both the dispatch switch and the message-template lookup). The PRE flow is what customers are actually using, and most PRE bills are never approved — hooking only the approved bill type would miss the majority of requests.
- Return a real SMS body. Bill-backed notifications describe the request; the notification's own message and the configured template remain fallbacks.
- Skip subscribers with no mobile number rather than handing the gateway a null recipient.
- Add `sendSmsForUserSubscriptions(String, Notification)` and `createSmsForUserNotification(Notification)` as **overloads** — the existing single-argument signatures are kept and delegate, so no caller breaks.

Example message:

> New transfer request MP/Inward/26/000003 from Inward (2 items) to Main Pharmacy.

## Scope / risk

Notifications stay gated by `TriggerSubscription`. A site with no subscription rows sees no behaviour change — no SMS, no extra rows beyond the `Notification` records that the dispatch already created for other bill types.

## Verification

End to end against a local deployment with an application-wide `TRANSFER_REQUEST_SMS` subscription:

| Step | Result |
|---|---|
| Raise a request with 1 item | 1 `sms` row: `New transfer request MP/Inward/26/000002 from Inward (1 item) to Main Pharmacy.` |
| Press **Save** again on the same request | Still 1 SMS, still 3 `notification` rows — no duplicate |
| **Finalize** that request | Still 1 SMS — no duplicate |
| Raise a second request with 2 items | Its own SMS, plural wording: `... (2 items) ...` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added notifications for pharmacy transfer requests.
  * Added SMS notifications with relevant pharmacy transfer details.
  * SMS messages now use available notification content or configured templates.

* **Bug Fixes**
  * Prevented SMS notifications from being sent when recipient details are incomplete.
  * Prevented duplicate notifications when saving or finalizing an existing transfer request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->