### PR TITLE
fix(inward): scope outside-charge Fee Breakdown to logged site; fix header three-zone layout

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardAdditionalChargeController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardAdditionalChargeController.java
@@ -80,6 +80,8 @@ public class InwardAdditionalChargeController implements Serializable {
     private ConfigOptionController configOptionController;
     @Inject
     private BillBeanController billBeanController;
+    @Inject
+    private com.divudi.bean.common.ItemFeeManager itemFeeManager;
     //////////////
     private BilledBill current;
     private Institution institution;
@@ -296,8 +298,34 @@ public class InwardAdditionalChargeController implements Serializable {
         return temBi;
     }
 
+    /**
+     * Resolves the fee(s) to bill for the selected outside-charge item,
+     * scoped to the logged department's site (issue #23311).
+     * {@link BillBeanController#fillFees(Item)} returns every non-retired
+     * {@code ItemFee} for the item with no institution/department
+     * filtering, so a site-level fee and a department-level fee for the
+     * same item were both being summed onto the bill. Outside Charge items
+     * are only offered by {@link #completeItem(String)} when their
+     * eligible fee is scoped to the logged department's site
+     * ({@code forInstitution = site}), so resolution here uses the same
+     * site scope. Departments without a configured site keep the previous
+     * unscoped lookup, matching {@link #completeItem(String)}'s existing
+     * fallback.
+     */
+    private List<ItemFee> resolveOutsideChargeFees(Item item) {
+        if (item == null) {
+            return new ArrayList<>();
+        }
+        Department department = getSessionController().getDepartment();
+        Institution site = department != null ? department.getSite() : null;
+        if (site != null) {
+            return itemFeeManager.fillFees(item, site, null);
+        }
+        return billBeanController.fillFees(item);
+    }
+
     private void saveBillFee(BillItem bt) {
-        List<ItemFee> itemFees = (selectedItem != null) ? billBeanController.fillFees(selectedItem) : new ArrayList<>();
+        List<ItemFee> itemFees = (selectedItem != null) ? resolveOutsideChargeFees(selectedItem) : new ArrayList<>();
 
         if (!itemFees.isEmpty()) {
             List<BillFee> created = new ArrayList<>();

--- a/src/main/webapp/inward/inward_bill_outside_charge.xhtml
+++ b/src/main/webapp/inward/inward_bill_outside_charge.xhtml
@@ -199,7 +199,10 @@
                                     <p:outputLabel value="Add Outside Charges" class="m-2"/>
                                 </div>
 
-                                <!-- Centre: print actions (print preview only) -->
+                                <!-- Centre: entity navigation buttons (issue #23311 — moved out of
+                                     the right/action zone per the three-zone header guideline).
+                                     Print actions (print preview only) stay here too, out of scope
+                                     for #23311 (print formats are handled separately). -->
                                 <div class="d-flex gap-2 align-items-center">
                                     <h:panelGroup rendered="#{inwardAdditionalChargeController.printPreview}">
                                         <div class="d-flex gap-2">
@@ -225,35 +228,75 @@
                                                 action="#{inwardAdditionalChargeController.makeNull()}" />
                                         </div>
                                     </h:panelGroup>
-                                </div>
-
-                                <!-- Right: navigation buttons -->
-                                <div class="d-flex gap-2">
 
                                     <p:commandButton
                                         value="Inpatient Dashboard"
                                         ajax="false"
                                         icon="fa fa-id-card"
-                                        class="ui-button-secondary"
+                                        class="ui-button-info ui-button-outlined"
                                         action="#{admissionController.navigateToAdmissionProfilePage}">
                                         <f:setPropertyActionListener
                                             value="#{inwardAdditionalChargeController.current.patientEncounter}"
                                             target="#{admissionController.current}" />
                                     </p:commandButton>
 
+                                    <h:panelGroup rendered="#{webUserController.hasPrivilege('InwardSearch')}">
+                                        <div class="d-flex gap-2">
+                                            <p:commandButton
+                                                ajax="false"
+                                                icon="fa fa-search"
+                                                class="ui-button-info ui-button-outlined"
+                                                action="#{patientController.navigateToSearchPatients()}">
+                                            </p:commandButton>
+                                            <p:commandButton
+                                                ajax="false"
+                                                icon="fa fa-user"
+                                                class="ui-button-info ui-button-outlined"
+                                                action="#{patientController.navigateToOpdPatientProfile()}">
+                                                <f:setPropertyActionListener
+                                                    value="#{admissionController.current.patient}"
+                                                    target="#{patientController.current}" >
+                                                </f:setPropertyActionListener>
+                                            </p:commandButton>
+                                            <p:commandButton
+                                                ajax="false"
+                                                icon="fa fa-id-card"
+                                                class="ui-button-info ui-button-outlined"
+                                                action="#{bhtSummeryController.navigateToInpatientProfile()}">
+                                                <f:setPropertyActionListener
+                                                    target="#{admissionController.current}"
+                                                    value="#{inwardAdditionalChargeController.current.patientEncounter}" >
+                                                </f:setPropertyActionListener>
+                                            </p:commandButton>
+                                        </div>
+                                    </h:panelGroup>
+
+                                    <h:panelGroup rendered="#{webUserController.hasPrivilege('NursingWorkBench')}">
+                                        <p:commandButton
+                                            value="Nursing WorkBench"
+                                            action="#{nursingWorkBenchController.navigateToBackNursingWorkBench()}"
+                                            ajax="false"
+                                            class="ui-button-info ui-button-outlined"
+                                            icon="fa fa-arrow-left">
+                                        </p:commandButton>
+                                    </h:panelGroup>
+                                </div>
+
+                                <!-- Right: page actions, ascending importance, primary (Settle)
+                                     rightmost — issue #23311 -->
+                                <div class="d-flex gap-2">
+
                                     <p:commandButton
-                                        class="ui-button-info"
-                                        id="btnSettle"
-                                        icon="fa fa-check"
-                                        value="Settle"
+                                        class="ui-button-secondary"
+                                        value="Clear"
+                                        icon="fa fa-ban"
                                         ajax="false"
                                         rendered="#{!inwardAdditionalChargeController.printPreview}"
-                                        onclick="return confirm('Are you sure you want to settle this bill?');"
-                                        action="#{inwardAdditionalChargeController.settle()}">
+                                        action="#{inwardAdditionalChargeController.reset()}" >
                                     </p:commandButton>
 
                                     <p:commandButton
-                                        class="ui-button-success"
+                                        class="ui-button-warning"
                                         id="btnNew"
                                         icon="fa fa-plus"
                                         value="New Bill"
@@ -263,62 +306,24 @@
                                     </p:commandButton>
 
                                     <p:commandButton
-                                        class="ui-button-danger"
-                                        value="Clear"
-                                        icon="fa fa-ban"
-                                        ajax="false"
-                                        rendered="#{!inwardAdditionalChargeController.printPreview}"
-                                        action="#{inwardAdditionalChargeController.reset()}" >
-                                    </p:commandButton>
-
-                                    <p:commandButton
-                                        class="ui-button-warning "
+                                        class="ui-button-warning"
                                         value="To Add Services"
                                         icon ="fa fa-wrench"
                                         ajax="false"
                                         action="/inward/inward_bill_service?faces-redirect=true" >
                                     </p:commandButton>
 
-                                    <h:panelGroup rendered="#{webUserController.hasPrivilege('InwardSearch')}">
-                                        <div class="d-flex gap-2">
-                                            <p:commandButton
-                                                ajax="false"
-                                                icon="fa fa-search"
-                                                class="ui-button-warning " 
-                                                action="#{patientController.navigateToSearchPatients()}">
-                                            </p:commandButton>
-                                            <p:commandButton
-                                                ajax="false"
-                                                icon="fa fa-user"
-                                                class="ui-button-warning " 
-                                                action="#{patientController.navigateToOpdPatientProfile()}">
-                                                <f:setPropertyActionListener 
-                                                    value="#{admissionController.current.patient}" 
-                                                    target="#{patientController.current}" >
-                                                </f:setPropertyActionListener>
-                                            </p:commandButton>
-                                            <p:commandButton
-                                                ajax="false"
-                                                icon="fa fa-id-card"
-                                                class="ui-button-secondary " 
-                                                action="#{bhtSummeryController.navigateToInpatientProfile()}">
-                                                <f:setPropertyActionListener 
-                                                    target="#{admissionController.current}" 
-                                                    value="#{inwardAdditionalChargeController.current.patientEncounter}" >
-                                                </f:setPropertyActionListener>
-                                            </p:commandButton>
-                                        </div>
-                                    </h:panelGroup>
-
-                                    <h:panelGroup rendered="#{webUserController.hasPrivilege('NursingWorkBench')}">
-                                        <p:commandButton 
-                                            value="Nursing WorkBench" 
-                                            action="#{nursingWorkBenchController.navigateToBackNursingWorkBench()}" 
-                                            ajax="false"
-                                            class="ui-button-operating-theatre"
-                                            icon="fa fa-arrow-left">
-                                        </p:commandButton>
-                                    </h:panelGroup>
+                                    <p:commandButton
+                                        class="ui-button-success"
+                                        id="btnSettle"
+                                        icon="fa fa-check"
+                                        value="Settle"
+                                        ajax="false"
+                                        style="min-width:120px"
+                                        rendered="#{!inwardAdditionalChargeController.printPreview}"
+                                        onclick="return confirm('Are you sure you want to settle this bill?');"
+                                        action="#{inwardAdditionalChargeController.settle()}">
+                                    </p:commandButton>
                                 </div>
                             </div>
                         </f:facet>


### PR DESCRIPTION
## Decisions made without approval

This was run via `dev-issue-unattended` — no human reviewed these before implementation. Please double-check:

1. **Fee resolution scope kept narrow.** `BillBeanController.fillFees(Item)` (the actually-buggy, unscoped method) is shared by Channel booking, OPD, and Inward callers with different semantics — e.g. Channel booking likely wants several distinct fee components (Doctor/Hospital/Agent shares) summed together, which is legitimate there. Rather than changing that shared method's behavior for everyone, the fix adds a site-scoped resolution (`ItemFeeManager.fillFees(item, site, null)`) used only by `InwardAdditionalChargeController.saveBillFee()`. If Outside Charges should instead resolve fees the same way elsewhere in Inward, that's a broader refactor outside this issue's scope.
2. **Precedence: site fee only, department fee ignored entirely.** The reporter's own expected value (1000, "sum of site fees related to the logged institute") and the existing `completeItem()` eligibility filter (which only checks site-level fees) both point to site-only resolution — a department-level fee for the same item is not consulted at all, not even as a fallback. This matches the evidence but is worth a second look if department-level Outside Fees were ever meant to override site-level ones.
3. **Three-zone header restyling touched button colors, not just position.** Per `developer_docs/ui/comprehensive-ui-guidelines.md`, the right zone's `ui-button-success` is reserved for the single rightmost primary action. Settle is now that button (was `ui-button-info`); New Bill and To Add Services moved from `ui-button-success`/`ui-button-warning` to a consistent `ui-button-warning` tier. Purely a styling/ordering change — no `rendered` conditions changed except what's noted below.
4. **"To Add Services" visibility left unchanged.** It previously had no `printPreview` guard (visible even during print preview) unlike its sibling action buttons. I reverted an initial guard I'd added, to avoid an unrelated behavior change — flagging in case that visibility was actually a pre-existing bug worth its own issue.
5. **Wiki: added a new section, did not rewrite `Finance-Inpatient-Outside-Charges.md`.** That page describes a different, apparently outdated field set (free-text Description/External Provider/Date/Requested By fields, `InwardPaymentController`) that doesn't match the current item-based page and controller (`InwardAdditionalChargeController`). That mismatch predates this issue and touches far more than the Fee Breakdown bug, so I left it and am flagging it here rather than rewriting it unattended.

## Summary

Fixes both parts of #23311:

- **Fee Breakdown summing bug**: adding a Site Fee and a Department Fee with identical details for the same outside-charge item caused both to be summed onto the bill (plus a base fee), instead of resolving to the single fee for the logged institution's site.
- **Three-zone header layout**: the Add Outside Charges panel header crammed ~10 buttons into one zone, overflowing/cutting off the rightmost button at normal viewport width.

Print-format issues (item name missing across POS/A4/Five-Five/Custom, three-zone buttons on print pages) are explicitly out of scope — the reporter is handling those in a separate session.

## Root cause

**Part 1**: `BillBeanController.fillFees(Item item)` (`src/main/java/com/divudi/bean/common/BillBeanController.java:395`) fetches every non-retired `ItemFee` for an item with no institution/department filter. `InwardAdditionalChargeController.saveBillFee()` called this directly, so a Site Fee (`forInstitution` = site) and a Department Fee (`forDepartment` = department) for the same item — both legitimately creatable via separate admin tabs — were both included and summed.

**Part 2**: `src/main/webapp/inward/inward_bill_outside_charge.xhtml`'s header facet nominally had three `<div>` zones, but almost every button (navigation and action alike) was placed in the right zone.

## Fix

- Added `InwardAdditionalChargeController.resolveOutsideChargeFees(Item)`, which resolves fees via `ItemFeeManager.fillFees(item, site, null)` — scoped to the logged department's site, matching the same scope `completeItem()`'s eligibility filter already uses. Departments without a configured site keep the previous unscoped behavior (matching `completeItem()`'s existing fallback).
- Restructured the header per `developer_docs/ui/comprehensive-ui-guidelines.md`'s three-zone pattern: navigation buttons (Inpatient Dashboard, patient search/profile/admission-profile icons, Nursing WorkBench) moved to the center zone (`ui-button-info ui-button-outlined`); right zone now holds only Clear → New Bill → To Add Services → Settle, with Settle rightmost as the primary action (`ui-button-success`, `min-width:120px`).

## Verification

Reused the exact fixture from the reporter's demonstration session (patient BHT/56758, item "Inward Ambulance Charges", a Site Fee and a Department Fee both named "Ambulance Company Charge" @ 1000/2000 local/foreigner).

- **Before fix** (bill item 14214906): 3 `BILLFEE` rows — HOSPITAL fEE 2000, Ambulance Company Charge 1000 x2.
- **After fix** (bill item 14214907, same patient/item, rebuilt+redeployed): exactly 1 `BILLFEE` row — Ambulance Company Charge, 1000 — verified both in the UI's Fee Breakdown grid and directly via `SELECT ... FROM BILLFEE ... WHERE BILLITEM_ID = 14214907`.
- Header verified visually in Playwright: three clean zones, no overflow/cutoff, Settle rightmost.
- `mvn clean package`: BUILD SUCCESS, 224/224 tests passing.

## Documentation

Updated [Add-Outside-Charges wiki page](https://github.com/hmislk/hmis/wiki/Add-Outside-Charges) with a new "Fee Breakdown resolves to the logged site's fee only" section, including the verified (redacted) screenshot. `Finance-Inpatient-Outside-Charges.md` was left as-is and flagged above — it appears to describe an older/different implementation of this page.

Closes #23311

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Outside-charge fees are now filtered by the logged department’s site when applicable.
  * Added clearer navigation and action controls to the Add Outside Charges panel.
  * Positioned the primary Settle action prominently alongside reorganized page actions.

* **Style**
  * Updated button placement and outlined styling for improved panel organization.
  * Kept print actions grouped with entity navigation controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->