### PR TITLE
fix(inward): correct outside-charge Amount pre-fill, require+lock Outside Institution, add Inward Charge Type column

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardAdditionalChargeController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardAdditionalChargeController.java
@@ -244,6 +244,15 @@ public class InwardAdditionalChargeController implements Serializable {
     }
 
     public void clearFromInstitution() {
+        // All charges on a bill must come from the same Outside Institution
+        // (BillFee.institution is stamped per charge in saveBillFee()) — once
+        // a charge has been added, block the change here too (the "Change"
+        // button is already hidden client-side once billItemList is
+        // non-empty). Start a New Bill to pick a different institution.
+        if (!getBillItemList().isEmpty()) {
+            JsfUtil.addErrorMessage("Cannot change Outside Institution after a charge has been added. Click New Bill to start over.");
+            return;
+        }
         getCurrent().setFromInstitution(null);
     }
 
@@ -339,6 +348,7 @@ public class InwardAdditionalChargeController implements Serializable {
                 bf.setCreater(getSessionController().getLoggedUser());
                 bf.setPatienEncounter(getCurrent().getPatientEncounter());
                 bf.setPatient(getCurrent().getPatient());
+                bf.setInstitution(getCurrent().getFromInstitution());
                 bf.setFeeValue(f.getFee());
                 bf.setFeeGrossValue(f.getFee());
                 bf.setFeeDiscount(0.0);
@@ -357,6 +367,7 @@ public class InwardAdditionalChargeController implements Serializable {
             bf.setBillItem(bt);
             bf.setCreatedAt(new Date());
             bf.setCreater(getSessionController().getLoggedUser());
+            bf.setInstitution(getCurrent().getFromInstitution());
             bf.setFeeGrossValue(getCurrent().getTotal());
             bf.setFeeValue(getCurrent().getTotal());
             getBillFeeFacade().create(bf);
@@ -425,11 +436,27 @@ public class InwardAdditionalChargeController implements Serializable {
         return itemFacade.findByJpql(jpql, params);
     }
 
+    /**
+     * Pre-fills the Amount field when an item is picked. Sums the same
+     * site-scoped {@link ItemFee} list {@link #saveBillFee(BillItem)} will
+     * persist, rather than {@code Item.getTotal()} — a legacy denormalized
+     * column ({@code ItemFeeController.calTot()}) that sums every fee for
+     * the item with no site/department scoping. Before this fix an item
+     * with both a Site Fee (1000) and a Department Fee (1000) pre-filled
+     * Amount as 2000, disagreeing with the Fee Breakdown grid's scoped
+     * total (1000) for the same bill item (issue #23311 follow-up).
+     */
     public void onItemSelect() {
-        if (selectedItem != null && selectedItem.getTotal() != null && selectedItem.getTotal() > 0) {
-            getCurrent().setTotal(selectedItem.getTotal());
-        }
         if (selectedItem != null) {
+            double scopedFeeTotal = 0.0;
+            for (ItemFee f : resolveOutsideChargeFees(selectedItem)) {
+                scopedFeeTotal += f.getFee();
+            }
+            if (scopedFeeTotal > 0) {
+                getCurrent().setTotal(scopedFeeTotal);
+            } else if (selectedItem.getTotal() != null && selectedItem.getTotal() > 0) {
+                getCurrent().setTotal(selectedItem.getTotal());
+            }
             inwardChargeType = selectedItem.getInwardChargeType();
         }
     }

--- a/src/main/java/com/divudi/bean/inward/InwardAdditionalChargeController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardAdditionalChargeController.java
@@ -448,14 +448,16 @@ public class InwardAdditionalChargeController implements Serializable {
      */
     public void onItemSelect() {
         if (selectedItem != null) {
-            double scopedFeeTotal = 0.0;
-            for (ItemFee f : resolveOutsideChargeFees(selectedItem)) {
-                scopedFeeTotal += f.getFee();
-            }
-            if (scopedFeeTotal > 0) {
+            List<ItemFee> itemFees = resolveOutsideChargeFees(selectedItem);
+            if (!itemFees.isEmpty()) {
+                double scopedFeeTotal = 0.0;
+                for (ItemFee f : itemFees) {
+                    scopedFeeTotal += f.getFee();
+                }
                 getCurrent().setTotal(scopedFeeTotal);
-            } else if (selectedItem.getTotal() != null && selectedItem.getTotal() > 0) {
-                getCurrent().setTotal(selectedItem.getTotal());
+            } else {
+                Double itemTotal = selectedItem.getTotal();
+                getCurrent().setTotal(itemTotal == null ? 0.0 : itemTotal);
             }
             inwardChargeType = selectedItem.getInwardChargeType();
         }

--- a/src/main/webapp/inward/inward_bill_outside_charge.xhtml
+++ b/src/main/webapp/inward/inward_bill_outside_charge.xhtml
@@ -352,9 +352,12 @@
                                                         itemLabel="#{ins.name}"
                                                         forceSelection="true"
                                                         minQueryLength="2"
+                                                        required="true"
+                                                        requiredMessage="Please select the Outside Institution"
                                                         placeholder="Type institution name...">
                                             <p:column>#{ins.name}</p:column>
                                         </p:autoComplete>
+                                        <p:message for="acFromIns" display="text" styleClass="text-danger d-block mt-1"/>
                                     </div>
                                 </div>
                             </p:panel>
@@ -368,8 +371,12 @@
                                     <h:outputText value=" #{inwardAdditionalChargeController.current.fromInstitution.name}" class="mx-2 fw-bold"/>
                                     <p:commandButton value="Change" icon="fa fa-pencil"
                                                      class="ui-button-secondary ui-button-sm ms-3"
+                                                     rendered="#{empty inwardAdditionalChargeController.billItemList}"
                                                      ajax="false"
                                                      action="#{inwardAdditionalChargeController.clearFromInstitution}"/>
+                                    <h:panelGroup rendered="#{not empty inwardAdditionalChargeController.billItemList}" styleClass="text-muted ms-3" style="font-size:0.875em;">
+                                        (Click New Bill to use a different institution)
+                                    </h:panelGroup>
                                 </f:facet>
                                 <div class="row m-1">
                                     <div class="col-3 d-flex align-items-center">
@@ -486,13 +493,17 @@
                                             <p:column style="width:2.5rem">
                                                 <p:rowToggler/>
                                             </p:column>
-                                            <p:column>
+                                            <p:column style="width:3rem;">
                                                 <f:facet name="header">No</f:facet>
                                                 <h:outputLabel value="#{rowIndex+1}"/>
                                             </p:column>
                                             <p:column>
                                                 <f:facet name="header">Item</f:facet>
                                                 <h:outputLabel value="#{bif.item.name}"/>
+                                            </p:column>
+                                            <p:column>
+                                                <f:facet name="header">Inward Charge Type</f:facet>
+                                                <h:outputLabel value="#{bif.inwardChargeType.label}"/>
                                             </p:column>
                                             <p:column>
                                                 <f:facet name="header">Amount</f:facet>

--- a/src/main/webapp/inward/inward_bill_outside_charge.xhtml
+++ b/src/main/webapp/inward/inward_bill_outside_charge.xhtml
@@ -503,7 +503,7 @@
                                             </p:column>
                                             <p:column>
                                                 <f:facet name="header">Inward Charge Type</f:facet>
-                                                <h:outputLabel value="#{bif.inwardChargeType.label}"/>
+                                                <h:outputText value="#{bif.inwardChargeType.label}"/>
                                             </p:column>
                                             <p:column>
                                                 <f:facet name="header">Amount</f:facet>


### PR DESCRIPTION
## Summary

Follow-up to #23311. The fee-scoping fix merged in #23312 correctly scoped
the persisted `BillFee` rows (Fee Breakdown grid) to the logged site, but a
few related gaps on the same page remained:

1. **Amount field disagreed with its own Fee Breakdown total.** The Amount
   field pre-filled (and got saved onto `BillItem.netValue`/`grossValue`)
   from `Item.getTotal()` — a legacy denormalized column that sums **every**
   fee configured for the item with no site/department scoping. So an item
   with both a Site Fee (1000) and a Department Fee (1000) still showed
   Amount = 2000, even though its own Fee Breakdown correctly showed only
   the 1000 site fee.
2. **Outside Institution wasn't recorded per fee**, and could be changed
   mid-bill even after charges from a different institution had already
   been added.
3. **Clicking Add without an Outside Institution** only showed a toast
   message — the field itself gave no visual indication.
4. Minor table issues: the "No" column took disproportionate width for a
   1-2 digit row number, and there was no way to see an item's configured
   Inward Charge Type without expanding the row.

## Root cause

`InwardAdditionalChargeController.onItemSelect()` pre-filled Amount from
`selectedItem.getTotal()`. That field is set by
`ItemFeeController.calTot()`, which sums **all** `ItemFee` rows for the
item (Site Fee + Department Fee) with no scoping — completely independent
of the site-scoped resolution `saveBillFee()` already used (added in
#23312) to persist the actual `BillFee` rows. The two code paths could
disagree for the same bill item.

## Fix

- `onItemSelect()`: pre-fill Amount from the same site-scoped `ItemFee`
  list `resolveOutsideChargeFees()` resolves (and `saveBillFee()` will
  persist), falling back to the legacy `Item.getTotal()` only when that
  scoped list is empty.
- `saveBillFee()`: stamp `BillFee.institution` with the bill's
  `fromInstitution` on both the scoped-fee branch and the no-`ItemFee`
  fallback branch.
- `clearFromInstitution()`: refuse to clear the Outside Institution once a
  charge has already been added; the "Change" button is hidden
  client-side in the same case (start a **New Bill** to bill a different
  institution).
- `inward_bill_outside_charge.xhtml`: Outside Institution autocomplete is
  now `required="true"` with an inline `p:message`, so the field
  highlights red when Add is clicked without one selected; added a new
  "Inward Charge Type" column next to Item; narrowed the "No" column.

## Verification

- Amount now pre-fills at **1000** (was 2000) for the same fixture used in
  #23312 (item with both a Site Fee and a Department Fee configured).
- Clicking Add without an Outside Institution selected highlights the
  field in red with an inline message (screenshot below).
- POS / A4 / Five-Five print composites for this bill all render
  correctly (visually verified).
- `mvn clean package -DskipTests`: BUILD SUCCESS.

## Documentation

Updated the [Add-Outside-Charges wiki page](https://github.com/hmislk/hmis/wiki/Add-Outside-Charges)
with a new "Follow-up fixes" section covering all of the above.

## Evidence

![Outside Institution required-field highlight, and the Amount field pre-filled with the corrected site-scoped total](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/issue-23311-followup-institution-required-and-amount-fix.png)

Patient details panel redacted (synthetic test data).

Closes #23311

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added required validation for selecting an Outside Institution, with visible error messages.
  * Added bill item numbering and an Inward Charge Type column.
  * Item amounts now prefill from applicable site fees or the item total when no fee is available.

* **Bug Fixes**
  * Prevented changing the Outside Institution after bill items have been added.
  * Ensured selected institution details are retained when recording bill fees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->