### PR TITLE
fix(pharmacy): BHT direct issue print Discount/Service Charge + dedicated print privilege

### DIFF
--- a/src/main/java/com/divudi/bean/common/UserPrivilageController.java
+++ b/src/main/java/com/divudi/bean/common/UserPrivilageController.java
@@ -849,6 +849,7 @@ public class UserPrivilageController implements Serializable {
         TreeNode PharmacySearchInpatientDirectIssueReturnsbyBill = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacySearchInpatientDirectIssueReturnsbyBill, "Pharmacy Search Inpatient Direct Issue Returns by Bill"), InpatientMedicationManagementNode);
         TreeNode PharmacysSearchInpatientDirectIssueReturnsbyItem = new DefaultTreeNode(new PrivilegeHolder(Privileges.PharmacysSearchInpatientDirectIssueReturnsbyItem, "Pharmacy Search Inpatient Direct Issue Returns by Item"), InpatientMedicationManagementNode);
         TreeNode NursingIPBillingViewRates = new DefaultTreeNode(new PrivilegeHolder(Privileges.NursingIPBillingViewRates, "Nursing IP Billing View Rates"), InpatientMedicationManagementNode);
+        TreeNode IPBillingViewDiscount = new DefaultTreeNode(new PrivilegeHolder(Privileges.IPBillingViewDiscount, "IP Billing View Discount"), InpatientMedicationManagementNode);
         TreeNode IPRequestViewRates = new DefaultTreeNode(new PrivilegeHolder(Privileges.IPRequestViewRates, "IP Request View Rates"), InpatientMedicationManagementNode);
 
         TreeNode ProcumentNode = new DefaultTreeNode("Pharmacy Procument", pharmacyNode);

--- a/src/main/java/com/divudi/bean/pharmacy/InpatientDirectIssueNativeSqlController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/InpatientDirectIssueNativeSqlController.java
@@ -194,10 +194,19 @@ public class InpatientDirectIssueNativeSqlController implements Serializable {
             pbd.setBillNo(bill.getDeptId());
             pbd.setCreatedAt(bill.getCreatedAt());
             double tot = 0.0;
+            double grossTot = 0.0;
+            double marginTot = 0.0;
+            double discountTot = 0.0;
             for (BillItemData bid : billItemDataList) {
                 tot += Math.abs(bid.getNetValue());
+                grossTot += Math.abs(bid.getGrossValue());
+                marginTot += Math.abs(bid.getMarginValue());
+                discountTot += Math.abs(bid.getDiscountValue());
             }
             pbd.setNetTotal(tot);
+            pbd.setTotal(grossTot);
+            pbd.setMargin(marginTot);
+            pbd.setDiscount(discountTot);
 
             printBill = pbd;
             List<BillItemData> printCopy = new ArrayList<>();
@@ -210,6 +219,8 @@ public class InpatientDirectIssueNativeSqlController implements Serializable {
                 p.setNetRate(src.getNetRate());
                 p.setNetValue(Math.abs(src.getNetValue()));
                 p.setGrossValue(Math.abs(src.getGrossValue()));
+                p.setMarginValue(Math.abs(src.getMarginValue()));
+                p.setDiscountValue(Math.abs(src.getDiscountValue()));
                 p.setDoe(src.getDoe());
                 printCopy.add(p);
             }

--- a/src/main/webapp/resources/pharmacy/inward_direct_issue_bill_native_a4.xhtml
+++ b/src/main/webapp/resources/pharmacy/inward_direct_issue_bill_native_a4.xhtml
@@ -71,8 +71,8 @@
                             <td class="r"><h:outputText value="#{item.qty}"><f:convertNumber integerOnly="true"/></h:outputText></td>
                             <td class="r"><h:outputText rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}" value="#{item.netRate}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
                             <td class="r"><h:outputText rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}" value="#{item.grossValue lt 0 ? -item.grossValue : item.grossValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
-                            <td class="r"><h:outputText rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}" value="#{item.marginValue lt 0 ? -item.marginValue : item.marginValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
-                            <td class="r"><h:outputText rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}" value="#{item.discountValue lt 0 ? -item.discountValue : item.discountValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                            <td class="r"><h:outputText rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates') and webUserController.hasPrivilege('IPBillingViewDiscount')}" value="#{item.marginValue lt 0 ? -item.marginValue : item.marginValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
+                            <td class="r"><h:outputText rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates') and webUserController.hasPrivilege('IPBillingViewDiscount')}" value="#{item.discountValue lt 0 ? -item.discountValue : item.discountValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
                             <td class="r"><h:outputText rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}" value="#{item.netValue lt 0 ? -item.netValue : item.netValue}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td>
                         </tr>
                     </ui:repeat>
@@ -82,8 +82,12 @@
             <table class="totals">
                 <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}">
                     <tr><td>Gross</td><td class="r"><h:outputText value="#{cc.attrs.bill.total}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td></tr>
+                </h:panelGroup>
+                <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates') and webUserController.hasPrivilege('IPBillingViewDiscount')}">
                     <tr><td>Service Charge</td><td class="r"><h:outputText value="#{cc.attrs.bill.margin}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td></tr>
                     <tr><td>Discount</td><td class="r"><h:outputText value="#{cc.attrs.bill.discount}"><f:convertNumber pattern="#,##0.00"/></h:outputText></td></tr>
+                </h:panelGroup>
+                <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}">
                     <tr><td><strong>Net Total</strong></td><td class="r"><strong><h:outputText value="#{cc.attrs.bill.netTotal}"><f:convertNumber pattern="#,##0.00"/></h:outputText></strong></td></tr>
                 </h:panelGroup>
                 <tr><td>No of Items</td><td class="r"><h:outputText value="#{cc.attrs.items.size()}"><f:convertNumber integerOnly="true"/></h:outputText></td></tr>

--- a/src/main/webapp/resources/pharmacy/inward_direct_issue_bill_native_five_five.xhtml
+++ b/src/main/webapp/resources/pharmacy/inward_direct_issue_bill_native_five_five.xhtml
@@ -61,8 +61,8 @@
                             <td>#{item.itemName}</td>
                             <td style="text-align: right"><h:outputLabel value="#{item.qty}"><f:convertNumber integerOnly="true"/></h:outputLabel></td>
                             <td style="text-align: right"><h:outputLabel rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}" value="#{item.grossValue lt 0 ? -item.grossValue : item.grossValue}"><f:convertNumber pattern="#,##0.00"/></h:outputLabel></td>
-                            <td style="text-align: right"><h:outputLabel rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}" value="#{item.marginValue lt 0 ? -item.marginValue : item.marginValue}"><f:convertNumber pattern="#,##0.00"/></h:outputLabel></td>
-                            <td style="text-align: right"><h:outputLabel rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}" value="#{item.discountValue lt 0 ? -item.discountValue : item.discountValue}"><f:convertNumber pattern="#,##0.00"/></h:outputLabel></td>
+                            <td style="text-align: right"><h:outputLabel rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates') and webUserController.hasPrivilege('IPBillingViewDiscount')}" value="#{item.marginValue lt 0 ? -item.marginValue : item.marginValue}"><f:convertNumber pattern="#,##0.00"/></h:outputLabel></td>
+                            <td style="text-align: right"><h:outputLabel rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates') and webUserController.hasPrivilege('IPBillingViewDiscount')}" value="#{item.discountValue lt 0 ? -item.discountValue : item.discountValue}"><f:convertNumber pattern="#,##0.00"/></h:outputLabel></td>
                             <td style="text-align: right"><h:outputLabel rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}" value="#{item.netValue lt 0 ? -item.netValue : item.netValue}"><f:convertNumber pattern="#,##0.00"/></h:outputLabel></td>
                         </tr>
                     </ui:repeat>
@@ -73,8 +73,12 @@
             <table class="total-table">
                 <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}">
                     <tr><td>Gross:</td><td style="text-align: right;"><h:outputLabel value="#{cc.attrs.bill.total}"><f:convertNumber pattern="#,##0.00"/></h:outputLabel></td></tr>
+                </h:panelGroup>
+                <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates') and webUserController.hasPrivilege('IPBillingViewDiscount')}">
                     <tr><td>Service Charge:</td><td style="text-align: right;"><h:outputLabel value="#{cc.attrs.bill.margin}"><f:convertNumber pattern="#,##0.00"/></h:outputLabel></td></tr>
                     <tr><td>Discount:</td><td style="text-align: right;"><h:outputLabel value="#{cc.attrs.bill.discount}"><f:convertNumber pattern="#,##0.00"/></h:outputLabel></td></tr>
+                </h:panelGroup>
+                <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}">
                     <tr><td>Net Total:</td><td style="text-align: right;"><h:outputLabel value="#{cc.attrs.bill.netTotal}"><f:convertNumber pattern="#,##0.00"/></h:outputLabel></td></tr>
                 </h:panelGroup>
                 <tr><td>No of Items:</td><td><h:outputLabel value="#{cc.attrs.items.size()}"><f:convertNumber integerOnly="true"/></h:outputLabel></td></tr>

--- a/src/main/webapp/resources/pharmacy/inward_direct_issue_bill_native_pos.xhtml
+++ b/src/main/webapp/resources/pharmacy/inward_direct_issue_bill_native_pos.xhtml
@@ -48,8 +48,8 @@
                         <td></td>
                         <td style="text-align:right;"><h:outputLabel value="#{bip.qty}"><f:convertNumber integerOnly="true"/></h:outputLabel></td>
                         <td style="text-align:right;"><h:outputLabel rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}" value="#{bip.grossValue lt 0 ? -bip.grossValue : bip.grossValue}"><f:convertNumber pattern="#,##0.00"/></h:outputLabel></td>
-                        <td style="text-align:right;"><h:outputLabel rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}" value="#{bip.marginValue lt 0 ? -bip.marginValue : bip.marginValue}"><f:convertNumber pattern="#,##0.00"/></h:outputLabel></td>
-                        <td style="text-align:right;"><h:outputLabel rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}" value="#{bip.discountValue lt 0 ? -bip.discountValue : bip.discountValue}"><f:convertNumber pattern="#,##0.00"/></h:outputLabel></td>
+                        <td style="text-align:right;"><h:outputLabel rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates') and webUserController.hasPrivilege('IPBillingViewDiscount')}" value="#{bip.marginValue lt 0 ? -bip.marginValue : bip.marginValue}"><f:convertNumber pattern="#,##0.00"/></h:outputLabel></td>
+                        <td style="text-align:right;"><h:outputLabel rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates') and webUserController.hasPrivilege('IPBillingViewDiscount')}" value="#{bip.discountValue lt 0 ? -bip.discountValue : bip.discountValue}"><f:convertNumber pattern="#,##0.00"/></h:outputLabel></td>
                         <td style="text-align:right;"><h:outputLabel rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}" value="#{bip.netValue lt 0 ? -bip.netValue : bip.netValue}"><f:convertNumber pattern="#,##0.00"/></h:outputLabel></td>
                     </tr>
                 </ui:repeat>
@@ -59,8 +59,12 @@
             <table style="width: 100%; font-size: 11px;">
                 <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}">
                     <tr><td style="text-align:left;">Gross</td><td style="text-align:right;"><h:outputLabel value="#{cc.attrs.bill.total}"><f:convertNumber pattern="#,##0.00"/></h:outputLabel></td></tr>
+                </h:panelGroup>
+                <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates') and webUserController.hasPrivilege('IPBillingViewDiscount')}">
                     <tr><td style="text-align:left;">Service Charge</td><td style="text-align:right;"><h:outputLabel value="#{cc.attrs.bill.margin}"><f:convertNumber pattern="#,##0.00"/></h:outputLabel></td></tr>
                     <tr><td style="text-align:left;">Discount</td><td style="text-align:right;"><h:outputLabel value="#{cc.attrs.bill.discount}"><f:convertNumber pattern="#,##0.00"/></h:outputLabel></td></tr>
+                </h:panelGroup>
+                <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}">
                     <tr><td style="text-align:left; font-weight:bold;">Net Total</td><td style="text-align:right; font-weight:bold;"><h:outputLabel value="#{cc.attrs.bill.netTotal}"><f:convertNumber pattern="#,##0.00"/></h:outputLabel></td></tr>
                 </h:panelGroup>
                 <tr><td style="text-align:left;">No of Items</td><td style="text-align:right;"><h:outputLabel value="#{cc.attrs.items.size()}"><f:convertNumber integerOnly="true"/></h:outputLabel></td></tr>


### PR DESCRIPTION
## Summary
- `InpatientDirectIssueNativeSqlController.settleInpatientDirectIssue()` never populated `PrintBillData.total/margin/discount`, nor copied `BillItemData.marginValue`/`discountValue` onto the printed line-item copies — so every BHT Direct Issue print showed Gross/Service Charge/Discount as 0.00 even though the correct values were already computed and persisted (Net Total was unaffected since it was computed separately). Fixed by accumulating gross/margin/discount alongside the existing net-total loop and copying `marginValue`/`discountValue` onto each print-copy item.
- The existing `IPBillingViewDiscount` privilege (declared in `Privileges.java`, already used on the older `ward_pharmacy_bht_issue.xhtml`/reprint pages) had no tree-node registration in `UserPrivilageController.createPrivilegeHolderTreeNodes()`, so it could never actually be granted via the admin Privileges UI. Registered it there, and wired it into the 5 native print templates (`inward_direct_issue_bill_native_a4/five_five/pos.xhtml` — the other two templates, `five_five_custom_3` and `saleBill_Header_Inward_native`, don't render discount/margin fields at all, so nothing to change there) so Discount/Service Charge on the print now require this privilege in addition to the existing `NursingIPBillingViewRates` gate on Rate/Gross/Net.

## Test plan
- [x] Rebuilt and redeployed to local Payara (`rh-3.0.0`, port 8080/4848)
- [x] Playwright, Main Pharmacy department, self-test BHT/56759 admission:
  - Settled a bill without `IPBillingViewDiscount`: Rate/Gross/Net printed correctly (62.40 / 86.74), Service Charge/Discount correctly **hidden** (not shown as wrong zeros)
  - Granted `IPBillingViewDiscount` via the now-working admin Privileges UI, settled another bill: Gross 12.48, Service Charge 4.87, Discount 0.00, Net 17.35 all printed correctly
  - Verified against `BILLITEM` DB row: `GROSSVALUE=12.48, MARGINVALUE=4.8672, DISCOUNT=0, NETVALUE=17.3472` — exact match
- [x] Server log checked, no errors during redeploy or the test flow

## Documentation
Updated [Direct Issue to BHTs from Pharmacy](https://github.com/hmislk/hmis/wiki/Direct-Issue-to-BHTs-from-Pharmacy) with a new section explaining the two-privilege print gate, plus the confirmation screenshot.

Fixes #23317

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9KhUsKWNH4djw6AJjx1Hm


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated privilege for viewing inpatient billing discounts.
  * Inpatient direct-issue bills now calculate and display gross, margin, and discount totals where permitted.

* **Bug Fixes**
  * Updated A4, receipt, and POS bill formats to restrict margin, discount, and service-charge details based on the new viewing privilege.
  * Preserved existing visibility controls for gross and net totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->