### PR TITLE
fix(inward): fix BHT Issue grid layout, row-edit UX, and financial breakdown

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -2096,36 +2096,47 @@ leave "Search All" unchecked and widen the **From Date** via the calendar grid
 today's default date range silently returns "No records found." for anything
 not created today. Verified while testing issue #23249.
 
-## 82. `p:dataTable`'s `rowEdit`/`rowEditCancel` (and a `p:ajax` nested inside a `p:cellEditor`) hardcode their own AJAX `update` target — extra ids you add are silently dropped
+## 82. Any AJAX call from inside an editable `p:dataTable`'s row scope has its `update` target silently constrained to the table itself — extra ids you add are dropped, even on a plain `p:commandButton`
 
-`ward_pharmacy_bht_issue.xhtml`'s "Issuing Items" grid needed both the
-row-edit checkmark AND the inline item-swap autocomplete to also refresh a
-separate `billDetailsPanel` outside the table. The obvious fix —
-`update="itemList billDetailsPanel"` on the `p:ajax event="rowEdit"` (and on
-a `p:ajax event="itemSelect"` nested inside an autocomplete that itself
-lives inside a `p:cellEditor`) — compiles and deploys with no error, but the
-extra id is silently dropped at runtime: the browser's actual AJAX request
-always sends `javax.faces.partial.render=<table-id>` only, never the second
-id, no matter what `update=""` says server-side. This survives a normal
-`asadmin deploy --force`, a full `undeploy`+`deploy`, and even a full
-`stop-domain`/`start-domain` — it isn't a caching artifact, it's how
-PrimeFaces DataTable's `bindEditEvents()` widget code generates these two
-specific events: it constructs its own `PrimeFaces.ab({...u:this.id...})`
-call client-side, hardcoded to the table's own id, ignoring the
-server-rendered `update` value entirely for `rowEdit`/`rowEditCancel` (and,
-transitively, for any `p:ajax` nested inside that table's own cell editors).
+`ward_pharmacy_bht_issue.xhtml`'s "Issuing Items" grid needed the row-edit
+checkmark, the inline item-swap autocomplete, AND the row's delete
+(trash) button to also refresh a separate `billDetailsPanel` outside the
+table. The obvious fix — add `billDetailsPanel` to each component's own
+`update=""` (`p:ajax event="rowEdit"`, a `p:ajax event="itemSelect"` nested
+inside an autocomplete that itself lives inside a `p:cellEditor`, and even
+a completely ordinary `p:commandButton` in a row with no cellEditor/rowEdit
+involvement at all) — compiles and deploys with no error, but the extra id
+is silently dropped at runtime in **all three cases**: the browser's actual
+AJAX request always sends `javax.faces.partial.render=<table-id>` only,
+never the second id, no matter what `update=""` says server-side. Confirmed
+by reading the button's own rendered `onclick` directly off the live DOM
+(`document.querySelector('button.ui-button-danger').getAttribute('onclick')`)
+— the compiled `PrimeFaces.ab({...})` call has `u:"<table-id>"` baked in
+verbatim, already missing the second id before the click ever happens. This
+survives a normal `asadmin deploy --force`, a full `undeploy`+`deploy`, and
+even a full `stop-domain`/`start-domain` — it isn't a caching artifact. A
+component genuinely *outside* the table (e.g. a `p:remoteCommand` declared
+as the table's sibling) is unaffected and can update `billDetailsPanel`
+freely — so this isn't about the DataTable's own `rowEdit`/`rowEditCancel`
+widget behaviors specifically (as originally assumed here); it's the row
+*scope* itself, for anything nested inside it.
 
 Confirm this is what's happening by reading the actual request body
 Playwright captured (`browser_network_request` with `part: "request-body"`)
-and checking `javax.faces.partial.render=` — not by re-reading the source
-XHTML, which will keep looking correct.
+— or the rendered `onclick` off the live DOM for a plain button — and
+checking for the missing id, not by re-reading the source XHTML, which will
+keep looking correct.
 
 Fix: add a `p:remoteCommand name="refreshX" update="theOtherPanel"` once,
-elsewhere in the same form, then set `oncomplete="refreshX();"` on the
-`rowEdit`/`rowEditCancel`/nested-`itemSelect` `p:ajax` tags instead of
-trying to widen their own `update`. The remote command fires as a second,
-independent AJAX call that isn't subject to the same hardcoding. Verified
-while fixing issue #23328.
+elsewhere in the same form (outside the table), then set
+`oncomplete="refreshX();"` on every row-scoped component that needs the
+extra update — `rowEdit`/`rowEditCancel`, a nested `itemSelect`, or a plain
+`p:commandButton` alike — instead of trying to widen their own `update`.
+The remote command fires as a second, independent AJAX call that isn't
+subject to the same row-scope constraint. Verified while fixing issue
+#23328 (including a CodeRabbit-caught follow-up: the row's delete button
+needed the identical treatment, not just the two components fixed in the
+original pass).
 
 ## Some PrimeFaces buttons need a jQuery-triggered click
 

--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -2096,6 +2096,37 @@ leave "Search All" unchecked and widen the **From Date** via the calendar grid
 today's default date range silently returns "No records found." for anything
 not created today. Verified while testing issue #23249.
 
+## 82. `p:dataTable`'s `rowEdit`/`rowEditCancel` (and a `p:ajax` nested inside a `p:cellEditor`) hardcode their own AJAX `update` target — extra ids you add are silently dropped
+
+`ward_pharmacy_bht_issue.xhtml`'s "Issuing Items" grid needed both the
+row-edit checkmark AND the inline item-swap autocomplete to also refresh a
+separate `billDetailsPanel` outside the table. The obvious fix —
+`update="itemList billDetailsPanel"` on the `p:ajax event="rowEdit"` (and on
+a `p:ajax event="itemSelect"` nested inside an autocomplete that itself
+lives inside a `p:cellEditor`) — compiles and deploys with no error, but the
+extra id is silently dropped at runtime: the browser's actual AJAX request
+always sends `javax.faces.partial.render=<table-id>` only, never the second
+id, no matter what `update=""` says server-side. This survives a normal
+`asadmin deploy --force`, a full `undeploy`+`deploy`, and even a full
+`stop-domain`/`start-domain` — it isn't a caching artifact, it's how
+PrimeFaces DataTable's `bindEditEvents()` widget code generates these two
+specific events: it constructs its own `PrimeFaces.ab({...u:this.id...})`
+call client-side, hardcoded to the table's own id, ignoring the
+server-rendered `update` value entirely for `rowEdit`/`rowEditCancel` (and,
+transitively, for any `p:ajax` nested inside that table's own cell editors).
+
+Confirm this is what's happening by reading the actual request body
+Playwright captured (`browser_network_request` with `part: "request-body"`)
+and checking `javax.faces.partial.render=` — not by re-reading the source
+XHTML, which will keep looking correct.
+
+Fix: add a `p:remoteCommand name="refreshX" update="theOtherPanel"` once,
+elsewhere in the same form, then set `oncomplete="refreshX();"` on the
+`rowEdit`/`rowEditCancel`/nested-`itemSelect` `p:ajax` tags instead of
+trying to widen their own `update`. The remote command fires as a second,
+independent AJAX call that isn't subject to the same hardcoding. Verified
+while fixing issue #23328.
+
 ## Some PrimeFaces buttons need a jQuery-triggered click
 
 Most `p:commandButton`s submit fine with a normal Playwright click — including

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
@@ -455,7 +455,7 @@ public class PharmacySaleBhtController implements Serializable {
     public void onEditing(RowEditEvent event) {
         BillItem tmp = (BillItem) event.getObject();
 
-        if (tmp.getQty() == null || tmp.getQty() <= 0) {
+        if (tmp.getQty() == null || !Double.isFinite(tmp.getQty()) || tmp.getQty() <= 0) {
             setZeroToQty(tmp);
             recalculateEditedIssueRow(tmp);
             JsfUtil.addErrorMessage("Can not enter a minus value");
@@ -2648,7 +2648,12 @@ public class PharmacySaleBhtController implements Serializable {
         getBillItems().remove(b);
         issuingSelections.remove(b);
 
-        calTotal();
+        // calTotal() operates on the unrelated preBill.getBillItems() list, not the
+        // grid actually rendered here — it left billItemTotal/Gross/Margin/Discount
+        // stale after a deletion. calCurrentBillItemTotal() is the helper this
+        // controller already uses elsewhere for the real billItems list. CodeRabbit
+        // review on #23330.
+        calCurrentBillItemTotal(getBillItems());
     }
 
     public void calculateBillItemListner(AjaxBehaviorEvent event) {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
@@ -340,6 +340,9 @@ public class PharmacySaleBhtController implements Serializable {
     private BillBeanController billBean;
     private Stock tmpStock;
     private Double billItemTotal;
+    private Double billItemGrossTotal;
+    private Double billItemMarginTotal;
+    private Double billItemDiscountTotal;
 
     public void selectSurgeryBillListener() {
         patientEncounter = getBatchBill().getPatientEncounter();
@@ -452,15 +455,14 @@ public class PharmacySaleBhtController implements Serializable {
     public void onEditing(RowEditEvent event) {
         BillItem tmp = (BillItem) event.getObject();
 
-        tmp.setQty(tmp.getPharmaceuticalBillItem().getQtyInUnit());
-        if (tmp.getPharmaceuticalBillItem().getQtyInUnit() <= 0) {
+        if (tmp.getQty() == null || tmp.getQty() <= 0) {
             setZeroToQty(tmp);
             recalculateEditedIssueRow(tmp);
             JsfUtil.addErrorMessage("Can not enter a minus value");
             return;
         }
         Stock fetchedStock = tmp.getPharmaceuticalBillItem().getStock();
-        if (fetchedStock != null && tmp.getPharmaceuticalBillItem().getQtyInUnit() > fetchedStock.getStock()) {
+        if (fetchedStock != null && tmp.getQty() > fetchedStock.getStock()) {
             setZeroToQty(tmp);
             recalculateEditedIssueRow(tmp);
             JsfUtil.addErrorMessage("No Sufficient Stocks?");
@@ -469,8 +471,8 @@ public class PharmacySaleBhtController implements Serializable {
 
         if (tmp.getReferanceBillItem() != null) {
             double remaining = getRemainingQuantityForItem(tmp.getReferanceBillItem());
-            if (tmp.getPharmaceuticalBillItem().getQtyInUnit() > remaining) {
-                JsfUtil.addErrorMessage("Cannot issue " + tmp.getPharmaceuticalBillItem().getQtyInUnit()
+            if (tmp.getQty() > remaining) {
+                JsfUtil.addErrorMessage("Cannot issue " + tmp.getQty()
                         + " units of " + tmp.getItem().getName() + ". Only " + remaining + " units remaining to be issued.");
                 tmp.setQty(remaining);
                 tmp.getPharmaceuticalBillItem().setQtyInUnit((float) remaining);
@@ -495,14 +497,16 @@ public class PharmacySaleBhtController implements Serializable {
      * verification: request 20, issue 10 → bill said 458.70, stock moved 10,
      * COGS saw +10 instead of -10).
      *
-     * Uses qty (not qtyInUnit) because the UI binds directly to qty for editing;
-     * qtyInUnit is not updated by JSF and retains its original value.
+     * The Qty column's cellEditor binds directly to BillItem.qty (kept positive
+     * by convention throughout this controller), not to the internal negative
+     * PharmaceuticalBillItem.qty mirror, so tmp.getQty() is the authoritative
+     * just-edited value.
      */
     private void recalculateEditedIssueRow(BillItem tmp) {
         if (tmp == null || tmp.getPharmaceuticalBillItem() == null) {
             return;
         }
-        double editedQty = Math.abs(tmp.getPharmaceuticalBillItem().getQty());
+        double editedQty = Math.abs(tmp.getQty());
         tmp.setQty(editedQty);
         tmp.getPharmaceuticalBillItem().setQtyInUnit((float) (0 - editedQty));
         tmp.getPharmaceuticalBillItem().setQty(0 - editedQty);
@@ -2049,7 +2053,8 @@ public class PharmacySaleBhtController implements Serializable {
             financeDetails.setValueAtRetailRate(BigDecimal.valueOf(selectedSubstituteStock.getItemBatch().getRetailsaleRate()).multiply(qty));
         }
 
-        calculateBillTotalsForTransferIssue(getPreBill());
+        calculateRates(itemForSubstitution);
+        calCurrentBillItemTotal(getBillItems());
 
         JsfUtil.addSuccessMessage("Stock replaced successfully.");
     }
@@ -3380,8 +3385,14 @@ public class PharmacySaleBhtController implements Serializable {
 
     public void calCurrentBillItemTotal(List<BillItem> billItems) {
         billItemTotal = 0.0;
+        billItemGrossTotal = 0.0;
+        billItemMarginTotal = 0.0;
+        billItemDiscountTotal = 0.0;
         for (BillItem bi : billItems) {
             billItemTotal += bi.getNetValue();
+            billItemGrossTotal += bi.getGrossValue();
+            billItemMarginTotal += bi.getMarginValue();
+            billItemDiscountTotal += bi.getDiscount();
         }
     }
 
@@ -3804,6 +3815,30 @@ public class PharmacySaleBhtController implements Serializable {
 
     public void setBillItemTotal(Double billItemTotal) {
         this.billItemTotal = billItemTotal;
+    }
+
+    public Double getBillItemGrossTotal() {
+        return billItemGrossTotal;
+    }
+
+    public void setBillItemGrossTotal(Double billItemGrossTotal) {
+        this.billItemGrossTotal = billItemGrossTotal;
+    }
+
+    public Double getBillItemMarginTotal() {
+        return billItemMarginTotal;
+    }
+
+    public void setBillItemMarginTotal(Double billItemMarginTotal) {
+        this.billItemMarginTotal = billItemMarginTotal;
+    }
+
+    public Double getBillItemDiscountTotal() {
+        return billItemDiscountTotal;
+    }
+
+    public void setBillItemDiscountTotal(Double billItemDiscountTotal) {
+        this.billItemDiscountTotal = billItemDiscountTotal;
     }
 
     // DTO-based properties and methods for improved performance

--- a/src/main/webapp/ward/ward_pharmacy_bht_issue.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_bht_issue.xhtml
@@ -256,10 +256,16 @@
                                                rendered="#{pharmacySaleBhtController.bhtRequestBill.priority ne null
                                                            and pharmacySaleBhtController.bhtRequestBill.priority.name() ne 'NORMAL'}"
                                                style="background-color:#{pharmacySaleBhtController.bhtRequestBill.priority.priorityColor}; color:#212529;"></p:tag>
+                                        <p:outputLabel value="Gross Value" rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}" ></p:outputLabel>
+                                        <p:outputLabel value=":" rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}" ></p:outputLabel>
+                                        <p:outputLabel value="#{pharmacySaleBhtController.billItemGrossTotal}" rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}" ><f:convertNumber pattern="#,##0.00" /></p:outputLabel>
                                         <p:outputLabel value="Discount" rendered="#{webUserController.hasPrivilege('IPBillingViewDiscount')}" ></p:outputLabel>
                                         <p:outputLabel value=":" rendered="#{webUserController.hasPrivilege('IPBillingViewDiscount')}" ></p:outputLabel>
-                                        <p:outputLabel value="#{pharmacySaleBhtController.bhtRequestBill.discount}" rendered="#{webUserController.hasPrivilege('IPBillingViewDiscount')}" ><f:convertNumber pattern="#,##0.00" /></p:outputLabel>
-                                        <p:outputLabel value="Net Total" rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}" ></p:outputLabel>
+                                        <p:outputLabel value="#{pharmacySaleBhtController.billItemDiscountTotal}" rendered="#{webUserController.hasPrivilege('IPBillingViewDiscount')}" ><f:convertNumber pattern="#,##0.00" /></p:outputLabel>
+                                        <p:outputLabel value="Margin" rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}" ></p:outputLabel>
+                                        <p:outputLabel value=":" rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}" ></p:outputLabel>
+                                        <p:outputLabel value="#{pharmacySaleBhtController.billItemMarginTotal}" rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}" ><f:convertNumber pattern="#,##0.00" /></p:outputLabel>
+                                        <p:outputLabel value="Net Value" rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}" ></p:outputLabel>
                                         <p:outputLabel value=":" rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}" ></p:outputLabel>
                                         <p:outputLabel value="#{pharmacySaleBhtController.billItemTotal}" rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}" ><f:convertNumber pattern="#,##0.00" /></p:outputLabel>
                                         <p:outputLabel value="Comment" ></p:outputLabel>
@@ -334,6 +340,16 @@
                         .auto-substituted-row { background-color: #FFF3CD !important; }
                         .auto-substituted-row td { background-color: #FFF3CD !important; }
                     </style>
+                    <!-- p:dataTable's own rowEdit/rowEditCancel behaviors (and a p:ajax nested inside
+                         a cellEditor, like the autocomplete's itemSelect below) hardcode their AJAX
+                         "update" target to the table itself client-side — extra ids added to the
+                         update="" attribute on those specific events are silently ignored, no matter
+                         what the server-rendered markup says. Verified live: the browser's actual
+                         request always sends javax.faces.partial.render=itemList only, even with
+                         update="itemList billDetailsPanel" in the source and after a full app/domain
+                         redeploy. p:remoteCommand + oncomplete is the standard workaround: it issues a
+                         second, independent AJAX call that can update billDetailsPanel freely. Issue #23328. -->
+                    <p:remoteCommand name="refreshBillDetails" update="billDetailsPanel" />
                     <p:dataTable
                         var="bItm"
                         value="#{pharmacySaleBhtController.billItems}"
@@ -342,8 +358,8 @@
                         sortBy="#{bItm.searialNo}"
                         rowStyleClass="#{bItm.autoSubstituted ? 'auto-substituted-row' : ''}"
                         editable="true">
-                        <p:ajax event="rowEdit" listener="#{pharmacySaleBhtController.onEditing}" update="itemList" />
-                        <p:ajax event="rowEditCancel" listener="#{pharmacySaleBhtController.onEditing}" update="itemList" />
+                        <p:ajax event="rowEdit" listener="#{pharmacySaleBhtController.onEditing}" update="itemList" oncomplete="refreshBillDetails();" />
+                        <p:ajax event="rowEditCancel" listener="#{pharmacySaleBhtController.onEditing}" update="itemList" oncomplete="refreshBillDetails();" />
 
                         <!-- Description/Comment/Batch No/Expiry are detail fields, not needed to scan the
                              list at a glance — moved into the row-expansion panel below instead of forcing
@@ -374,35 +390,57 @@
                         </p:column>
 
                         <p:column headerText="Issuing Bill Item" style="padding: 6px;">
-                            <p:autoComplete id="Isitem"
-                                            value="#{pharmacySaleBhtController.issuingSelections[bItm]}"
-                                            converter="stockConverter"
-                                            completeMethod="#{pharmacySaleBhtController.completeAllDepartmentStock}"
-                                            var="stk"
-                                            itemLabel="#{stk.itemBatch.item.name} (Batch: #{stk.itemBatch.batchNo}, Qty: #{stk.stock})"
-                                            itemValue="#{stk}"
-                                            forceSelection="true"
-                                            minQueryLength="2"
-                                            inputStyleClass="w-100"
-                                            placeholder="#{bItm.item.name}">
-                                <p:ajax event="itemSelect" process="@this"
-                                        listener="#{pharmacySaleBhtController.replaceIssuingBillItem(bItm)}"
-                                        update="itemList" />
-                            </p:autoComplete>
+                            <p:cellEditor>
+                                <f:facet name="output">
+                                    <h:outputText value="#{bItm.item.name}" />
+                                </f:facet>
+                                <f:facet name="input">
+                                    <p:autoComplete id="Isitem"
+                                                    value="#{pharmacySaleBhtController.issuingSelections[bItm]}"
+                                                    converter="stockConverter"
+                                                    completeMethod="#{pharmacySaleBhtController.completeAllDepartmentStock}"
+                                                    var="stk"
+                                                    itemLabel="#{stk.itemBatch.item.name} (Batch: #{stk.itemBatch.batchNo}, Qty: #{stk.stock})"
+                                                    itemValue="#{stk}"
+                                                    forceSelection="true"
+                                                    minQueryLength="2"
+                                                    styleClass="w-100"
+                                                    inputStyleClass="w-100"
+                                                    placeholder="#{bItm.item.name}">
+                                        <p:ajax event="itemSelect" process="@this"
+                                                listener="#{pharmacySaleBhtController.replaceIssuingBillItem(bItm)}"
+                                                update="itemList" oncomplete="refreshBillDetails();" />
+                                    </p:autoComplete>
+                                </f:facet>
+                            </p:cellEditor>
                         </p:column>
 
                         <p:column headerText="Qty"
                                   style="width:6rem; text-align: right; padding: 6px;">
                             <p:cellEditor>
                                 <f:facet name="output">
-                                    <h:outputText value="#{bItm.pharmaceuticalBillItem.qty}" >
+                                    <h:outputText value="#{bItm.qty}" >
                                         <f:convertNumber integerOnly="true" />
                                     </h:outputText>
                                 </f:facet>
                                 <f:facet name="input">
-                                    <p:inputText autocomplete="off" value="#{bItm.pharmaceuticalBillItem.qty}" style="width:96%"/>
+                                    <p:inputText autocomplete="off" value="#{bItm.qty}" style="width:96%"/>
                                 </f:facet>
                             </p:cellEditor>
+                        </p:column>
+
+                        <p:column headerText="Gross Value" style="width:8rem; text-align: right; padding: 6px;"
+                                  rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}">
+                            <h:outputLabel value="#{bItm.grossValue}" style="text-align: right;">
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputLabel>
+                        </p:column>
+
+                        <p:column headerText="Margin" style="width:8rem; text-align: right; padding: 6px;"
+                                  rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}">
+                            <h:outputLabel value="#{bItm.marginValue}" style="text-align: right;">
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputLabel>
                         </p:column>
 
                         <p:column headerText="Net Total"  style="width:8rem; text-align: right; padding: 6px;"
@@ -412,17 +450,29 @@
                             </h:outputLabel>
                         </p:column>
 
-                        <p:column style="width:6rem; text-align: right; padding: 6px;">
-                            <div class="d-flex justify-content-end gap-2">
-                                <p:rowEditor/>
-                                <p:commandButton
-                                    icon="fas fa-trash"
-                                    action="#{pharmacySaleBhtController.removeBillItemFromBhtRequest(bItm)}"
-                                    class="ui-button-danger"
-                                    process="@this"
-                                    update="itemList">
-                                </p:commandButton>
-                            </div>
+                        <p:column headerText="Discount" style="width:8rem; text-align: right; padding: 6px;"
+                                  rendered="#{webUserController.hasPrivilege('IPBillingViewDiscount')}">
+                            <h:outputLabel value="#{bItm.discount}" style="text-align: right;">
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputLabel>
+                        </p:column>
+
+                        <p:column style="width:6rem; text-align: right; padding: 6px; display:flex; justify-content:flex-end; align-items:center; gap:8px;">
+                            <!-- p:rowEditor must render as a DIRECT child of this td — PrimeFaces'
+                                 row-edit click handler is delegated with the selector
+                                 "> tr > td > div.ui-row-editor > a"; a wrapping <div> here (as this
+                                 column used to have) breaks that match and the pencil silently does
+                                 nothing on click. Verified live: with the wrapper, clicking the pencil
+                                 produces no DOM change at all; without it, the row correctly enters
+                                 edit mode. Issue #23328. -->
+                            <p:rowEditor/>
+                            <p:commandButton
+                                icon="fas fa-trash"
+                                action="#{pharmacySaleBhtController.removeBillItemFromBhtRequest(bItm)}"
+                                class="ui-button-danger"
+                                process="@this"
+                                update="itemList">
+                            </p:commandButton>
 
                         </p:column>
 
@@ -479,12 +529,6 @@
                                         <f:convertNumber integerOnly="true" />
                                     </h:outputText>
                                 </h:panelGroup>
-                            </h:panelGroup>
-                            <h:panelGroup layout="block" styleClass="col-md-3" rendered="#{webUserController.hasPrivilege('IPBillingViewDiscount')}">
-                                <strong>Matrix Value: </strong>
-                                <h:outputLabel value="#{bItm.marginValue}">
-                                    <f:convertNumber pattern="#,##0.00" />
-                                </h:outputLabel>
                             </h:panelGroup>
                         </p:rowExpansion>
 

--- a/src/main/webapp/ward/ward_pharmacy_bht_issue.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_bht_issue.xhtml
@@ -340,15 +340,19 @@
                         .auto-substituted-row { background-color: #FFF3CD !important; }
                         .auto-substituted-row td { background-color: #FFF3CD !important; }
                     </style>
-                    <!-- p:dataTable's own rowEdit/rowEditCancel behaviors (and a p:ajax nested inside
-                         a cellEditor, like the autocomplete's itemSelect below) hardcode their AJAX
-                         "update" target to the table itself client-side — extra ids added to the
-                         update="" attribute on those specific events are silently ignored, no matter
-                         what the server-rendered markup says. Verified live: the browser's actual
-                         request always sends javax.faces.partial.render=itemList only, even with
-                         update="itemList billDetailsPanel" in the source and after a full app/domain
-                         redeploy. p:remoteCommand + oncomplete is the standard workaround: it issues a
-                         second, independent AJAX call that can update billDetailsPanel freely. Issue #23328. -->
+                    <!-- ANY AJAX call originating from a component inside this editable p:dataTable's
+                         row scope — the table's own rowEdit/rowEditCancel behaviors, a p:ajax nested
+                         inside a cellEditor (the autocomplete's itemSelect below), and even a plain
+                         p:commandButton in a row (the delete button below) — has its "update" target
+                         silently constrained to the table itself client-side. Extra ids added to
+                         update="" are ignored no matter what the server-rendered markup says; a
+                         component OUTSIDE the table (like this p:remoteCommand) is unaffected and can
+                         update billDetailsPanel freely. Verified live for all three cases: the
+                         browser's actual request always sends javax.faces.partial.render=itemList
+                         only, even with update="itemList billDetailsPanel" in the source and after a
+                         full app/domain redeploy. p:remoteCommand + oncomplete is the standard
+                         workaround: it issues a second, independent AJAX call from outside the table's
+                         row scope. Issue #23328. -->
                     <p:remoteCommand name="refreshBillDetails" update="billDetailsPanel" />
                     <p:dataTable
                         var="bItm"
@@ -471,7 +475,8 @@
                                 action="#{pharmacySaleBhtController.removeBillItemFromBhtRequest(bItm)}"
                                 class="ui-button-danger"
                                 process="@this"
-                                update="itemList">
+                                update="itemList"
+                                oncomplete="refreshBillDetails();">
                             </p:commandButton>
 
                         </p:column>


### PR DESCRIPTION
## Decisions made without approval

This was run under `dev-issue-unattended` for the second half (Playwright verification onward) after the user went offline. Two fixes below were discovered and applied without a pause, beyond the plan approved earlier in the session:

1. **Removed a `<div>` wrapper around `p:rowEditor`** in the Action column — PrimeFaces' row-edit click handler is delegated with the selector `> tr > td > div.ui-row-editor > a`; the wrapper broke that match, so the pencil silently did nothing on click for *any* column, including the pre-existing Qty cellEditor, before this fix. Verified live (real click → zero AJAX requests with the wrapper; correct request → correct edit-mode render without it).
2. **Added a `p:remoteCommand` + `oncomplete` callback** to refresh the Bill Details panel after a row edit or item swap. `p:dataTable`'s `rowEdit`/`rowEditCancel` behaviors (and a `p:ajax` nested inside a cellEditor) hardcode their own AJAX `update` target client-side — `update="itemList billDetailsPanel"` silently only ever sent `itemList` in the actual request, confirmed via the raw request body, and survived a full undeploy+redeploy and a full Payara domain restart (ruled out caching). Documented as a new gotcha in `playwright-e2e-workflow.md` (#82).

Both are minimal, targeted fixes to make the already-approved plan actually work end-to-end — not scope changes.

## What changed

**Part 1 — Layout**: `ward_pharmacy_bht_issue.xhtml` — added the missing `styleClass="w-100"` to the Issuing Bill Item autocomplete so it fills its column, matching the Medicines/Devices autocomplete elsewhere on the same page.

**Part 2 — Row-edit UX**:
- Wrapped the Issuing Bill Item autocomplete in a `p:cellEditor` so the pencil gates it together with Qty, instead of it always being live.
- Fixed `PharmacySaleBhtController.replaceSelectedSubstitute()` to call `calculateRates()` + `calCurrentBillItemTotal()` on the actual `billItems` list instead of the unrelated, usually-empty `preBill` via `calculateBillTotalsForTransferIssue()` — the real root cause of "swapping the item doesn't update rate/value": it was recalculating totals against a `Bill` object that isn't even rendered on screen, using a rate the method never updated either.
- Switched the Qty column to bind `BillItem.qty` (kept positive everywhere else in this controller) instead of the internal negative `PharmaceuticalBillItem.qty` mirror, so the UI never shows a raw negative number to the user. `onEditing()`/`recalculateEditedIssueRow()` updated to read the edited value from the same field.

**Part 3 — Financial breakdown**: added Gross Value/Margin/Discount columns to the grid and a four-line Gross/Discount/Margin/Net breakdown to the Bill Details panel, backed by three new running-total fields on `calCurrentBillItemTotal()`, under the same privilege gates already used for the existing Net Total.

## Verification

Playwright, Main Pharmacy department, BHT/56760 (`Inward//26/038097`), local Payara — logged in, opened the request via **Issue Medicines**, and drove the actual UI (no direct JS/widget-API shortcuts for the final verification pass):

- **Layout**: Issuing Bill Item autocomplete fills its column.
- **Row-edit gating**: clicking the pencil (real click, not simulated) opens Issuing Bill Item and Qty together; confirmed via the actual AJAX response — both cellEditors switch to their input facets.
- **Item swap recalculation**: swapped Zaart 50mg Tab → Zaart 25mg Tab via the inline autocomplete. Grid updated to Gross 249.60 / Margin 107.33 / Net 356.93 = `20 × 12.48` (the new item's rate), confirming the stale-rate bug is fixed.
- **Qty edit**: edited quantity to 10 via the pencil+checkmark; grid updated to Gross 124.80 / Margin 53.66 / Net 178.46; Qty displayed as plain positive `10`, not the internal negative value.
- **Bill Details sync**: confirmed the Bill Details panel (Gross/Margin/Net) matches the grid after both the item swap and the Qty edit — this only started working after the `p:remoteCommand` fix.
- **Select a Substitute dialog**: unchanged trigger, now also correctly recalculating via the same fixed method — verified it swaps the item and keeps totals consistent.
- **End-to-end settlement + DB verification**: selected a porter, settled the bill (`Issue to BHT`), and confirmed in the local DB:
  - `BILLITEM.rate = 12.48` (the swapped item's rate, not the stale original `20.43`)
  - `BILLITEM.qty = 10` (positive), `PHARMACEUTICALBILLITEM.qty = -10` (correct internal stock-out sign)
  - `grossValue = 124.80`, `marginValue = 53.664`, `netValue = 178.464` — matching what was on screen before settling
  - `STOCK.stock` deducted by exactly 10 for the **final** selected batch only (2113 → 2103); the batch swapped away from earlier in the same session was untouched (still 40)
  - `BILL.total`/`netTotal` on the settled bill (124.80 / 178.464) match the UI

A "User Notification Error" toast appeared after settlement — confirmed via server log this fires *after* "Successfully processed batch stock deduction..." completes successfully; it's a pre-existing, unrelated post-settlement notification hook with no detail message, not a regression from this change.

## Documentation

New wiki page: [Inward BHT Issue Against Request](https://github.com/hmislk/hmis/wiki/Inward-BHT-Issue-Against-Request) — no page previously existed for this pharmacy-side "issue against a ward request" screen (as opposed to [Inward BHT Medicine Request](https://github.com/hmislk/hmis/wiki/Inward-BHT-Medicine-Request), which documents the ward-side submission). Linked from [Pharmacy Inward Issue](https://github.com/hmislk/hmis/wiki/Pharmacy-Inward-Issue).

Closes #23328

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Gross Value, Margin, and Discount totals to the BHT issue bill details.
  * Added privilege-controlled Gross Value, Margin, and Discount columns to issuing items.
  * Bill details now refresh automatically after item edits, cancellations, and stock selections.

* **Bug Fixes**
  * Improved quantity validation and recalculation when editing or replacing stock items.
  * Corrected discount and row-level total calculations.

* **Documentation**
  * Documented a Playwright workflow workaround for refreshing DataTable content after row-edit events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->