### PR TITLE
fix(pharmacy): correct Gross/Service Charge/Discount/Net on BHT Issue Return print previews

### DIFF
--- a/src/main/webapp/inward/pharmacy_bill_return_bht_issue.xhtml
+++ b/src/main/webapp/inward/pharmacy_bill_return_bht_issue.xhtml
@@ -293,24 +293,30 @@
 
                                 <h:panelGroup   id="gpBillPreviewSingle2" rendered="#{sessionController.departmentPreference.pharmacyBillPaperType eq 'PosPaper' and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is A4', false) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is FiveFive', true) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is POS', false)}">
                                     <div >
-                                        <h:panelGroup rendered="#{sessionController.departmentPreference.pharmacyBillPrabodha eq false}" > 
-                                            <ph:issueBill  bill="#{bhtIssueReturnController.bill}"/>
+                                        <h:panelGroup rendered="#{sessionController.departmentPreference.pharmacyBillPrabodha eq false}" >
+                                            <ph:issueBill  bill="#{bhtIssueReturnController.bill}"
+                                                           showRate="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}"
+                                                           showDiscount="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates') and webUserController.hasPrivilege('IPBillingViewDiscount')}"/>
                                         </h:panelGroup>
                                     </div>
                                 </h:panelGroup>
 
-                                <h:panelGroup id="gpBillPreviewDouble2" rendered="#{sessionController.departmentPreference.pharmacyBillPaperType eq 'PosPaper' and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is A4', false) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is FiveFive', true) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is POS', false)}"> 
+                                <h:panelGroup id="gpBillPreviewDouble2" rendered="#{sessionController.departmentPreference.pharmacyBillPaperType eq 'PosPaper' and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is A4', false) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is FiveFive', true) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is POS', false)}">
                                     <div >
-                                        <h:panelGroup     rendered="#{sessionController.departmentPreference.pharmacyBillPrabodha eq true}"> 
-                                            <phi:saleBill_prabodha bill="#{bhtIssueReturnController.bill}"></phi:saleBill_prabodha>
+                                        <h:panelGroup     rendered="#{sessionController.departmentPreference.pharmacyBillPrabodha eq true}">
+                                            <phi:saleBill_prabodha bill="#{bhtIssueReturnController.bill}"
+                                                                   showRate="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}"
+                                                                   showDiscount="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates') and webUserController.hasPrivilege('IPBillingViewDiscount')}"></phi:saleBill_prabodha>
                                         </h:panelGroup>
                                     </div>
                                 </h:panelGroup>
 
-                                <h:panelGroup id="gpBillPreviewFiveFive2" rendered="#{sessionController.departmentPreference.pharmacyBillPaperType eq 'FiveFivePaper' and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is A4', false) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is FiveFive', true) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is POS', false)}"> 
+                                <h:panelGroup id="gpBillPreviewFiveFive2" rendered="#{sessionController.departmentPreference.pharmacyBillPaperType eq 'FiveFivePaper' and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is A4', false) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is FiveFive', true) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is POS', false)}">
                                     <div >
-                                        <h:panelGroup rendered="#{sessionController.departmentPreference.pharmacyBillPrabodha eq false}" > 
-                                            <phi:saleBill_five_five bill="#{bhtIssueReturnController.bill}"></phi:saleBill_five_five>
+                                        <h:panelGroup rendered="#{sessionController.departmentPreference.pharmacyBillPrabodha eq false}" >
+                                            <phi:saleBill_five_five bill="#{bhtIssueReturnController.bill}"
+                                                                    showRate="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}"
+                                                                    showDiscount="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates') and webUserController.hasPrivilege('IPBillingViewDiscount')}"></phi:saleBill_five_five>
                                         </h:panelGroup>
                                     </div>
                                 </h:panelGroup>
@@ -353,29 +359,37 @@
                                 </h:panelGroup>
 
                                 <h:panelGroup   id="gpBillPreviewSingle" rendered="#{sessionController.departmentPreference.pharmacyBillPaperType eq 'PosPaper' and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is A4', false) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is FiveFive', true) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is POS', false)}">
-                                    <h:panelGroup rendered="#{sessionController.departmentPreference.pharmacyBillPrabodha eq false}" > 
-                                        <phi:returnBill bill="#{bhtIssueReturnController.returnBill}"/>
+                                    <h:panelGroup rendered="#{sessionController.departmentPreference.pharmacyBillPrabodha eq false}" >
+                                        <phi:returnBill bill="#{bhtIssueReturnController.returnBill}"
+                                                        showRate="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}"
+                                                        showDiscount="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates') and webUserController.hasPrivilege('IPBillingViewDiscount')}"/>
                                     </h:panelGroup>
                                 </h:panelGroup>
 
-                                <h:panelGroup id="gpBillPreviewDouble" rendered="#{sessionController.departmentPreference.pharmacyBillPaperType eq 'PosPaper' and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is A4', false) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is FiveFive', true) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is POS', false)}"> 
+                                <h:panelGroup id="gpBillPreviewDouble" rendered="#{sessionController.departmentPreference.pharmacyBillPaperType eq 'PosPaper' and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is A4', false) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is FiveFive', true) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is POS', false)}">
                                     <div >
-                                        <h:panelGroup     rendered="#{sessionController.departmentPreference.pharmacyBillPrabodha eq true}"> 
-                                            <phi:saleBill_prabodha bill="#{bhtIssueReturnController.returnBill}"></phi:saleBill_prabodha>
+                                        <h:panelGroup     rendered="#{sessionController.departmentPreference.pharmacyBillPrabodha eq true}">
+                                            <phi:saleBill_prabodha bill="#{bhtIssueReturnController.returnBill}"
+                                                                   showRate="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}"
+                                                                   showDiscount="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates') and webUserController.hasPrivilege('IPBillingViewDiscount')}"></phi:saleBill_prabodha>
                                         </h:panelGroup>
                                     </div>
                                 </h:panelGroup>
 
-                                <h:panelGroup id="gpBillPreviewFiveFive" rendered="#{sessionController.departmentPreference.pharmacyBillPaperType eq 'FiveFivePaper' and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is A4', false) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is FiveFive', true) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is POS', false)}"> 
+                                <h:panelGroup id="gpBillPreviewFiveFive" rendered="#{sessionController.departmentPreference.pharmacyBillPaperType eq 'FiveFivePaper' and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is A4', false) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is FiveFive', true) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is POS', false)}">
                                     <div >
-                                        <h:panelGroup rendered="#{sessionController.departmentPreference.pharmacyBillPrabodha eq false}" > 
-                                            <phi:saleBill_five_five bill="#{bhtIssueReturnController.returnBill}"></phi:saleBill_five_five>
+                                        <h:panelGroup rendered="#{sessionController.departmentPreference.pharmacyBillPrabodha eq false}" >
+                                            <phi:saleBill_five_five bill="#{bhtIssueReturnController.returnBill}"
+                                                                    showRate="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}"
+                                                                    showDiscount="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates') and webUserController.hasPrivilege('IPBillingViewDiscount')}"></phi:saleBill_five_five>
                                         </h:panelGroup>
                                     </div>
                                 </h:panelGroup>
 
                                 <h:panelGroup id="gpBillPreviewPosHeader" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is PosHeaderPaper',false)}">
-                                    <phi:saleBill_Header_Return bill="#{bhtIssueReturnController.returnBill}" ></phi:saleBill_Header_Return>
+                                    <phi:saleBill_Header_Return bill="#{bhtIssueReturnController.returnBill}"
+                                                                showRate="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}"
+                                                                showDiscount="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates') and webUserController.hasPrivilege('IPBillingViewDiscount')}"></phi:saleBill_Header_Return>
                                 </h:panelGroup>
 
                             </h:panelGroup>

--- a/src/main/webapp/resources/pharmacy/inward/issueBill.xhtml
+++ b/src/main/webapp/resources/pharmacy/inward/issueBill.xhtml
@@ -374,7 +374,7 @@
                         </tr>
                     </ui:fragment>
                     <ui:fragment rendered="#{cc.attrs.showDiscount}">
-                        <tr>
+                        <tr style="#{cc.attrs.bill.margin ne 0.0 ? '' : 'display:none;'}">
                             <td  class="totalsBlock" style="text-align: left;">
                                 <h:outputLabel  rendered="#{cc.attrs.bill.margin ne 0.0}" value="Service Charge " style="font-weight: bolder!important;"/>
                             </td>

--- a/src/main/webapp/resources/pharmacy/inward/issueBill.xhtml
+++ b/src/main/webapp/resources/pharmacy/inward/issueBill.xhtml
@@ -364,16 +364,26 @@
                     <ui:fragment rendered="#{cc.attrs.showRate}">
                         <tr>
                             <td class="totalsBlock" style="text-align: left; width: 60%;">
-                                <h:outputLabel value="Total" />
+                                <h:outputLabel value="Gross" />
                             </td>
                             <td  class="totalsBlock" style="text-align: right!important; width: 40%; padding-right: 30px;">
-                                <h:outputLabel styleClass="itemTotalIssue" value="0.00" >
+                                <h:outputLabel styleClass="itemTotalIssue" value="#{cc.attrs.bill.total}" >
                                     <f:convertNumber pattern="#,##0.00" />
                                 </h:outputLabel>
                             </td>
                         </tr>
                     </ui:fragment>
                     <ui:fragment rendered="#{cc.attrs.showDiscount}">
+                        <tr>
+                            <td  class="totalsBlock" style="text-align: left;">
+                                <h:outputLabel  rendered="#{cc.attrs.bill.margin ne 0.0}" value="Service Charge " style="font-weight: bolder!important;"/>
+                            </td>
+                            <td  class="totalsBlock" style="text-align: right!important; ; padding-right: 30px;">
+                                <h:outputLabel rendered="#{cc.attrs.bill.margin ne 0.0}"   value="#{cc.attrs.bill.margin}" style="font-weight: bolder!important;" >
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
                         <tr>
                             <td  class="totalsBlock" style="text-align: left;">
                                 <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0}" value="Discount " style="font-weight: bolder!important;"/>

--- a/src/main/webapp/resources/pharmacy/inward_direct_issue_bill_five_five_custom_3.xhtml
+++ b/src/main/webapp/resources/pharmacy/inward_direct_issue_bill_five_five_custom_3.xhtml
@@ -107,6 +107,9 @@
                             <th colspan="3">Item</th>
                             <th style="text-align: right">Qty</th>
                             <th style="text-align: right">Rate</th>
+                            <th style="text-align: right">Gross</th>
+                            <th style="text-align: right">Service Charge</th>
+                            <th style="text-align: right">Discount</th>
                             <th style="text-align: right">Value</th>
                         </tr>
                     </thead>
@@ -121,16 +124,37 @@
                                     </h:outputLabel>
                                 </td>
                                 <td  style="text-align: right">
-                                    <h:outputLabel 
+                                    <h:outputLabel
                                         rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}"
                                         value="#{item.netRate}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
                                 </td>
-                                <td style="text-align: right">
-                                    <h:outputLabel 
+                                <td  style="text-align: right">
+                                    <h:outputLabel
                                         rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}"
-                                        value="#{item.netValue}">
+                                        value="#{item.grossValue lt 0 ? -item.grossValue : item.grossValue}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                                <td  style="text-align: right">
+                                    <h:outputLabel
+                                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}"
+                                        value="#{item.marginValue lt 0 ? -item.marginValue : item.marginValue}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                                <td  style="text-align: right">
+                                    <h:outputLabel
+                                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}"
+                                        value="#{item.discount lt 0 ? -item.discount : item.discount}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                                <td style="text-align: right">
+                                    <h:outputLabel
+                                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}"
+                                        value="#{item.netValue lt 0 ? -item.netValue : item.netValue}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
                                 </td>
@@ -144,12 +168,38 @@
 
                 <!-- Totals Table -->
                 <table class="total-table">
+                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}">
+                        <tr>
+                            <td>Gross:</td>
+                            <td style="text-align: right;">
+                                <h:outputLabel value="#{cc.attrs.bill.total lt 0 ? -cc.attrs.bill.total : cc.attrs.bill.total}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>Service Charge:</td>
+                            <td style="text-align: right;">
+                                <h:outputLabel value="#{cc.attrs.bill.margin lt 0 ? -cc.attrs.bill.margin : cc.attrs.bill.margin}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>Discount:</td>
+                            <td style="text-align: right;">
+                                <h:outputLabel value="#{cc.attrs.bill.discount lt 0 ? -cc.attrs.bill.discount : cc.attrs.bill.discount}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                    </h:panelGroup>
                     <tr>
                         <td >Total:</td>
                         <td style="text-align: right;">
-                            <h:outputLabel 
+                            <h:outputLabel
                                 rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}"
-                                value="#{cc.attrs.bill.netTotal}">
+                                value="#{cc.attrs.bill.netTotal lt 0 ? -cc.attrs.bill.netTotal : cc.attrs.bill.netTotal}">
                                 <f:convertNumber pattern="#,##0.00" />
                             </h:outputLabel>
                         </td>

--- a/src/main/webapp/resources/pharmacy/inward_direct_issue_return_bill_five_five_custom_3.xhtml
+++ b/src/main/webapp/resources/pharmacy/inward_direct_issue_return_bill_five_five_custom_3.xhtml
@@ -99,6 +99,9 @@
                             <th colspan="3">Item</th>
                             <th style="text-align: right">Qty</th>
                             <th style="text-align: right">Rate</th>
+                            <th style="text-align: right">Gross</th>
+                            <th style="text-align: right">Service Charge</th>
+                            <th style="text-align: right">Discount</th>
                             <th style="text-align: right">Value</th>
                         </tr>
                     </thead>
@@ -113,12 +116,37 @@
                                     </h:outputLabel>
                                 </td>
                                 <td  style="text-align: right">
-                                    <h:outputLabel value="#{item.netRate}">
+                                    <h:outputLabel
+                                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}"
+                                        value="#{item.netRate}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                                <td  style="text-align: right">
+                                    <h:outputLabel
+                                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}"
+                                        value="#{item.grossValue lt 0 ? -item.grossValue : item.grossValue}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                                <td  style="text-align: right">
+                                    <h:outputLabel
+                                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}"
+                                        value="#{item.marginValue lt 0 ? -item.marginValue : item.marginValue}">
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                                <td  style="text-align: right">
+                                    <h:outputLabel
+                                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}"
+                                        value="#{item.discount lt 0 ? -item.discount : item.discount}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
                                 </td>
                                 <td style="text-align: right">
-                                    <h:outputLabel value="#{item.netValue}">
+                                    <h:outputLabel
+                                        rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}"
+                                        value="#{item.netValue lt 0 ? -item.netValue : item.netValue}">
                                         <f:convertNumber pattern="#,##0.00" />
                                     </h:outputLabel>
                                 </td>
@@ -132,10 +160,38 @@
 
                 <!-- Totals Table -->
                 <table class="total-table">
+                    <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}">
+                        <tr>
+                            <td>Gross:</td>
+                            <td style="text-align: right;">
+                                <h:outputLabel value="#{cc.attrs.bill.total lt 0 ? -cc.attrs.bill.total : cc.attrs.bill.total}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>Service Charge:</td>
+                            <td style="text-align: right;">
+                                <h:outputLabel value="#{cc.attrs.bill.margin lt 0 ? -cc.attrs.bill.margin : cc.attrs.bill.margin}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>Discount:</td>
+                            <td style="text-align: right;">
+                                <h:outputLabel value="#{cc.attrs.bill.discount lt 0 ? -cc.attrs.bill.discount : cc.attrs.bill.discount}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                    </h:panelGroup>
                     <tr>
                         <td >Total:</td>
                         <td style="text-align: right;">
-                            <h:outputLabel value="#{cc.attrs.bill.netTotal}">
+                            <h:outputLabel
+                                rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}"
+                                value="#{cc.attrs.bill.netTotal lt 0 ? -cc.attrs.bill.netTotal : cc.attrs.bill.netTotal}">
                                 <f:convertNumber pattern="#,##0.00" />
                             </h:outputLabel>
                         </td>

--- a/src/main/webapp/resources/pharmacy/returnBill.xhtml
+++ b/src/main/webapp/resources/pharmacy/returnBill.xhtml
@@ -10,6 +10,8 @@
     <cc:interface>
         <cc:attribute name="bill" />
         <cc:attribute name="duplicate" />
+        <cc:attribute name="showRate" default="true" />
+        <cc:attribute name="showDiscount" default="true" />
     </cc:interface>
 
     <!-- IMPLEMENTATION -->
@@ -113,19 +115,33 @@
                             <h:outputLabel value="QTY"  styleClass="itemHeadings" ></h:outputLabel>
                         </td>
 
-                        <td  style="width:15%;">
-                            <h:outputLabel value="RATE"  styleClass="itemHeadings" ></h:outputLabel>
-                        </td>
+                        <ui:fragment rendered="#{cc.attrs.showRate}">
+                            <td  style="width:15%;">
+                                <h:outputLabel value="RATE"  styleClass="itemHeadings" ></h:outputLabel>
+                            </td>
 
-                        <td  style="width:20%;">
-                            <h:outputLabel value="VALUE"  styleClass="itemHeadings" ></h:outputLabel>
-                        </td>
+                            <td  style="width:15%;">
+                                <h:outputLabel value="GROSS"  styleClass="itemHeadings" ></h:outputLabel>
+                            </td>
+                        </ui:fragment>
+
+                        <ui:fragment rendered="#{cc.attrs.showDiscount}">
+                            <td  style="width:15%;">
+                                <h:outputLabel value="SERV.CHG"  styleClass="itemHeadings" ></h:outputLabel>
+                            </td>
+                        </ui:fragment>
+
+                        <ui:fragment rendered="#{cc.attrs.showRate}">
+                            <td  style="width:20%;">
+                                <h:outputLabel value="VALUE"  styleClass="itemHeadings" ></h:outputLabel>
+                            </td>
+                        </ui:fragment>
                     </tr>
 
                     <tr>
-                        <td colspan="4" style="width: 100%">
+                        <td colspan="6" style="width: 100%">
                             <div class="billline">
-                                <h:outputLabel value="-------------------------------------------------"   />                           
+                                <h:outputLabel value="-------------------------------------------------"   />
                             </div>
                         </td>
 
@@ -133,7 +149,7 @@
                     <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
 
                         <tr>
-                            <td colspan="4" style="overflow: visible;">
+                            <td colspan="6" style="overflow: visible;">
                                 <h:outputLabel value="#{bip.item.name}"  styleClass="itemsBlock"  >
                                 </h:outputLabel>
                             </td>
@@ -147,16 +163,32 @@
                                     <f:convertNumber pattern="#,##0.00" />
                                 </h:outputLabel>
                             </td>
-                            <td>
-                                <h:outputLabel    value="#{bip.rate}"    styleClass="itemsBlock" >
-                                    <f:convertNumber pattern="#,##0.00" />
-                                </h:outputLabel>
-                            </td>
-                            <td>
-                                <h:outputLabel    value="#{bip.netValue}"    styleClass="itemsBlock"  >
-                                    <f:convertNumber pattern="#,##0.00" />
-                                </h:outputLabel>
-                            </td>
+                            <ui:fragment rendered="#{cc.attrs.showRate}">
+                                <td>
+                                    <h:outputLabel    value="#{bip.rate}"    styleClass="itemsBlock" >
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                                <td>
+                                    <h:outputLabel    value="#{bip.grossValue}"    styleClass="itemsBlock" >
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                            </ui:fragment>
+                            <ui:fragment rendered="#{cc.attrs.showDiscount}">
+                                <td>
+                                    <h:outputLabel    value="#{bip.marginValue}"    styleClass="itemsBlock" >
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                            </ui:fragment>
+                            <ui:fragment rendered="#{cc.attrs.showRate}">
+                                <td>
+                                    <h:outputLabel    value="#{bip.netValue}"    styleClass="itemsBlock"  >
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                            </ui:fragment>
                         </tr>
                     </ui:repeat>
                 </table>
@@ -170,26 +202,52 @@
 
                 <table style="width: 87%; margin-left: 8%; margin-right: 3%">
 
-                    <tr>
-                        <td  class="totalsBlock" style="text-align: left;">
-                            <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0}" value="Discount (#{cc.attrs.bill.discountPercentPharmacy} %)"/>
-                        </td>
-                        <td  class="totalsBlock" style="text-align: right!important; ">
-                            <h:outputLabel rendered="#{cc.attrs.bill.discount ne 0.0}"   value="#{cc.attrs.bill.discount}" >
-                                <f:convertNumber pattern="#,##0.00" />
-                            </h:outputLabel>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td  class="totalsBlock" style="text-align: left;">
-                            <h:outputLabel  rendered="#{cc.attrs.bill.netTotal ne 0.0}"    value="Total" />
-                        </td>
-                        <td  class="totalsBlock" style="text-align: right!important; ">
-                            <h:outputLabel  rendered="#{cc.attrs.bill.netTotal ne 0.0}"    value="#{cc.attrs.bill.netTotal}">
-                                <f:convertNumber pattern="#,##0.00" />
-                            </h:outputLabel>
-                        </td>
-                    </tr>
+                    <ui:fragment rendered="#{cc.attrs.showRate}">
+                        <tr>
+                            <td  class="totalsBlock" style="text-align: left;">
+                                <h:outputLabel  rendered="#{cc.attrs.bill.total ne 0.0}" value="Gross"/>
+                            </td>
+                            <td  class="totalsBlock" style="text-align: right!important; ">
+                                <h:outputLabel  rendered="#{cc.attrs.bill.total ne 0.0}"   value="#{cc.attrs.bill.total}" >
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                    </ui:fragment>
+                    <ui:fragment rendered="#{cc.attrs.showDiscount}">
+                        <tr>
+                            <td  class="totalsBlock" style="text-align: left;">
+                                <h:outputLabel  rendered="#{cc.attrs.bill.margin ne 0.0}" value="Service Charge"/>
+                            </td>
+                            <td  class="totalsBlock" style="text-align: right!important; ">
+                                <h:outputLabel  rendered="#{cc.attrs.bill.margin ne 0.0}"   value="#{cc.attrs.bill.margin}" >
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td  class="totalsBlock" style="text-align: left;">
+                                <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0}" value="Discount (#{cc.attrs.bill.discountPercentPharmacy} %)"/>
+                            </td>
+                            <td  class="totalsBlock" style="text-align: right!important; ">
+                                <h:outputLabel rendered="#{cc.attrs.bill.discount ne 0.0}"   value="#{cc.attrs.bill.discount}" >
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                    </ui:fragment>
+                    <ui:fragment rendered="#{cc.attrs.showRate}">
+                        <tr>
+                            <td  class="totalsBlock" style="text-align: left;">
+                                <h:outputLabel  rendered="#{cc.attrs.bill.netTotal ne 0.0}"    value="Net Total" />
+                            </td>
+                            <td  class="totalsBlock" style="text-align: right!important; ">
+                                <h:outputLabel  rendered="#{cc.attrs.bill.netTotal ne 0.0}"    value="#{cc.attrs.bill.netTotal}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                    </ui:fragment>
 
 
                 </table>

--- a/src/main/webapp/resources/pharmacy/returnBill.xhtml
+++ b/src/main/webapp/resources/pharmacy/returnBill.xhtml
@@ -139,7 +139,7 @@
                     </tr>
 
                     <tr>
-                        <td colspan="6" style="width: 100%">
+                        <td colspan="#{2 + (cc.attrs.showRate ? 3 : 0) + (cc.attrs.showDiscount ? 1 : 0)}" style="width: 100%">
                             <div class="billline">
                                 <h:outputLabel value="-------------------------------------------------"   />
                             </div>
@@ -149,7 +149,7 @@
                     <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
 
                         <tr>
-                            <td colspan="6" style="overflow: visible;">
+                            <td colspan="#{2 + (cc.attrs.showRate ? 3 : 0) + (cc.attrs.showDiscount ? 1 : 0)}" style="overflow: visible;">
                                 <h:outputLabel value="#{bip.item.name}"  styleClass="itemsBlock"  >
                                 </h:outputLabel>
                             </td>
@@ -215,7 +215,7 @@
                         </tr>
                     </ui:fragment>
                     <ui:fragment rendered="#{cc.attrs.showDiscount}">
-                        <tr>
+                        <tr style="#{cc.attrs.bill.margin ne 0.0 ? '' : 'display:none;'}">
                             <td  class="totalsBlock" style="text-align: left;">
                                 <h:outputLabel  rendered="#{cc.attrs.bill.margin ne 0.0}" value="Service Charge"/>
                             </td>

--- a/src/main/webapp/resources/pharmacy/saleBill_Header_Return.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBill_Header_Return.xhtml
@@ -11,6 +11,8 @@
     <cc:interface>
         <cc:attribute name="bill" />
         <cc:attribute name="duplicate" />
+        <cc:attribute name="showRate" default="true" />
+        <cc:attribute name="showDiscount" default="true" />
     </cc:interface>
 
     <!-- IMPLEMENTATION -->
@@ -147,16 +149,30 @@
                             <h:outputLabel value="QTY"  styleClass="itemHeadings1" ></h:outputLabel>
                         </td>
 
-                        <td  style="width:20%;text-align: right;">
-                            <h:outputLabel value="RATE"  styleClass="itemHeadings1" ></h:outputLabel>
-                        </td>
+                        <ui:fragment rendered="#{cc.attrs.showRate}">
+                            <td  style="width:20%;text-align: right;">
+                                <h:outputLabel value="RATE"  styleClass="itemHeadings1" ></h:outputLabel>
+                            </td>
 
-                        <td  style="width:20%;text-align: right;">
-                            <h:outputLabel value="VALUE"  styleClass="itemHeadings1" ></h:outputLabel>
-                        </td>
+                            <td  style="width:20%;text-align: right;">
+                                <h:outputLabel value="GROSS"  styleClass="itemHeadings1" ></h:outputLabel>
+                            </td>
+                        </ui:fragment>
+
+                        <ui:fragment rendered="#{cc.attrs.showDiscount}">
+                            <td  style="width:20%;text-align: right;">
+                                <h:outputLabel value="SERV.CHG"  styleClass="itemHeadings1" ></h:outputLabel>
+                            </td>
+                        </ui:fragment>
+
+                        <ui:fragment rendered="#{cc.attrs.showRate}">
+                            <td  style="width:20%;text-align: right;">
+                                <h:outputLabel value="VALUE"  styleClass="itemHeadings1" ></h:outputLabel>
+                            </td>
+                        </ui:fragment>
                     </tr>
                     <tr>
-                        <td colspan="4" style="width: 100%">
+                        <td colspan="6" style="width: 100%">
                             <div class="billline1">
                                     <hr/>
                             </div>
@@ -166,7 +182,7 @@
                     <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
 
                         <tr>
-                            <td colspan="4" style="overflow: visible;">
+                            <td colspan="6" style="overflow: visible;">
                                 <h:outputLabel value="#{bip.item.name}"  styleClass="itemsBlock1" style="text-transform: capitalize!important;"  >
                                 </h:outputLabel>
                             </td>
@@ -180,16 +196,32 @@
                                     <f:convertNumber integerOnly="true" />
                                 </h:outputLabel>
                             </td>
-                            <td   style="text-align: right; width: 20%" >
-                                <h:outputLabel  styleClass="itemsBlockRight1"   value="#{bip.rate}" >
-                                    <f:convertNumber pattern="#,##0.00" />
-                                </h:outputLabel>
-                            </td>
-                            <td  style="text-align: right; width: 20%" >
-                                <h:outputLabel styleClass="itemsBlockRight1"   value="#{bip.netValue}"    >
-                                    <f:convertNumber pattern="#,##0.00" />
-                                </h:outputLabel>
-                            </td>
+                            <ui:fragment rendered="#{cc.attrs.showRate}">
+                                <td   style="text-align: right; width: 20%" >
+                                    <h:outputLabel  styleClass="itemsBlockRight1"   value="#{bip.rate}" >
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                                <td   style="text-align: right; width: 20%" >
+                                    <h:outputLabel  styleClass="itemsBlockRight1"   value="#{bip.grossValue}" >
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                            </ui:fragment>
+                            <ui:fragment rendered="#{cc.attrs.showDiscount}">
+                                <td   style="text-align: right; width: 20%" >
+                                    <h:outputLabel  styleClass="itemsBlockRight1"   value="#{bip.marginValue}" >
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                            </ui:fragment>
+                            <ui:fragment rendered="#{cc.attrs.showRate}">
+                                <td  style="text-align: right; width: 20%" >
+                                    <h:outputLabel styleClass="itemsBlockRight1"   value="#{bip.netValue}"    >
+                                        <f:convertNumber pattern="#,##0.00" />
+                                    </h:outputLabel>
+                                </td>
+                            </ui:fragment>
 
                         </tr>
 
@@ -217,12 +249,25 @@
 
                 <table style="width: 100%;">
 
+                    <ui:fragment rendered="#{cc.attrs.showRate}">
                     <tr>
                         <td class="totalsBlock1" style="text-align: left; width: 60%;">
-                            <h:outputLabel rendered="#{cc.attrs.bill.discount ne 0.0}" value="Total" />
+                            <h:outputLabel rendered="#{cc.attrs.bill.total ne 0.0}" value="Gross" />
                         </td>
                         <td  class="totalsBlock1" style="text-align: right!important; width: 40%;">
-                            <h:outputLabel rendered="#{cc.attrs.bill.discount ne 0.0}" value="#{cc.attrs.bill.total}" >
+                            <h:outputLabel rendered="#{cc.attrs.bill.total ne 0.0}" value="#{cc.attrs.bill.total}" >
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                    </ui:fragment>
+                    <ui:fragment rendered="#{cc.attrs.showDiscount}">
+                    <tr>
+                        <td  class="totalsBlock1" style="text-align: left;">
+                            <h:outputLabel  rendered="#{cc.attrs.bill.margin ne 0.0}" value="Service Charge " style="font-weight: bolder!important;"/>
+                        </td>
+                        <td  class="totalsBlock1" style="text-align: right!important; ;">
+                            <h:outputLabel rendered="#{cc.attrs.bill.margin ne 0.0}"   value="#{cc.attrs.bill.margin}" style="font-weight: bolder!important;" >
                                 <f:convertNumber pattern="#,##0.00" />
                             </h:outputLabel>
                         </td>
@@ -237,6 +282,8 @@
                             </h:outputLabel>
                         </td>
                     </tr>
+                    </ui:fragment>
+                    <ui:fragment rendered="#{cc.attrs.showRate}">
                     <tr>
                         <td  class="totalsBlock1" style="text-align: left;">
                             <h:outputLabel    value="Net Total" />
@@ -244,10 +291,12 @@
                         <td  class="totalsBlock1" style="text-align: right!important;font-weight: bold; ;">
                             <h:outputLabel    value="#{cc.attrs.bill.netTotal}">
                                 <f:convertNumber pattern="#,##0.00" />
-                            </h:outputLabel>                          
-                        </td>                        
+                            </h:outputLabel>
+                        </td>
                     </tr>
+                    </ui:fragment>
 
+                    <ui:fragment rendered="#{cc.attrs.showDiscount}">
                     <tr>
 
                         <td  class="totalsBlock1" style="text-align: left;">
@@ -262,6 +311,7 @@
 
                         </td>
                     </tr>
+                    </ui:fragment>
 
                     <h:panelGroup rendered="#{(configOptionApplicationController.getBooleanValueByKey('Allow Tendered Amount for pharmacy sale for cashier') or cc.attrs.bill.billType eq 'PharmacySale' or cc.attrs.bill.billType eq 'PharmacyWholeSale') and cc.attrs.bill.paymentMethod eq 'Cash'}">
                         <tr >

--- a/src/main/webapp/resources/pharmacy/saleBill_Header_Return.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBill_Header_Return.xhtml
@@ -172,7 +172,7 @@
                         </ui:fragment>
                     </tr>
                     <tr>
-                        <td colspan="6" style="width: 100%">
+                        <td colspan="#{2 + (cc.attrs.showRate ? 3 : 0) + (cc.attrs.showDiscount ? 1 : 0)}" style="width: 100%">
                             <div class="billline1">
                                     <hr/>
                             </div>
@@ -182,7 +182,7 @@
                     <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
 
                         <tr>
-                            <td colspan="6" style="overflow: visible;">
+                            <td colspan="#{2 + (cc.attrs.showRate ? 3 : 0) + (cc.attrs.showDiscount ? 1 : 0)}" style="overflow: visible;">
                                 <h:outputLabel value="#{bip.item.name}"  styleClass="itemsBlock1" style="text-transform: capitalize!important;"  >
                                 </h:outputLabel>
                             </td>
@@ -262,7 +262,7 @@
                     </tr>
                     </ui:fragment>
                     <ui:fragment rendered="#{cc.attrs.showDiscount}">
-                    <tr>
+                    <tr style="#{cc.attrs.bill.margin ne 0.0 ? '' : 'display:none;'}">
                         <td  class="totalsBlock1" style="text-align: left;">
                             <h:outputLabel  rendered="#{cc.attrs.bill.margin ne 0.0}" value="Service Charge " style="font-weight: bolder!important;"/>
                         </td>

--- a/src/main/webapp/resources/pharmacy/saleBill_five_five.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBill_five_five.xhtml
@@ -402,6 +402,19 @@
                         </tr>
                     </h:panelGroup>
 
+                    <h:panelGroup rendered="#{cc.attrs.bill.margin ne 0.0 and cc.attrs.showDiscount}">
+                        <tr>
+                            <td  class="totalsBlock" style="text-align: left;">
+                                <h:outputLabel value="Service Charge " style="font-weight: bolder!important;"/>
+                            </td>
+                            <td  class="totalsBlock" style="text-align: right!important; ; padding-right: 0px;">
+                                <h:outputLabel value="#{cc.attrs.bill.margin}" style="font-weight: bolder!important;" >
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputLabel>
+                            </td>
+                        </tr>
+                    </h:panelGroup>
+
                     <h:panelGroup rendered="#{cc.attrs.bill.discount ne 0.0 and cc.attrs.showDiscount}">
                         <tr>
                             <td  class="totalsBlock" style="text-align: left;">

--- a/src/main/webapp/resources/pharmacy/saleBill_prabodha.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBill_prabodha.xhtml
@@ -319,6 +319,16 @@
                     <ui:fragment rendered="#{cc.attrs.showDiscount}">
                     <tr>
                         <td  class="totalsBlock" style="text-align: left;">
+                            <h:outputLabel  rendered="#{cc.attrs.bill.margin ne 0.0}" value="Service Charge " style="font-weight: bolder!important;"/>
+                        </td>
+                        <td  class="totalsBlock" style="text-align: right!important; ; padding-right: 30px;">
+                            <h:outputLabel rendered="#{cc.attrs.bill.margin ne 0.0}"   value="#{cc.attrs.bill.margin}" style="font-weight: bolder!important;" >
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td  class="totalsBlock" style="text-align: left;">
                             <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0}" value="Discount " style="font-weight: bolder!important;"/>
                         </td>
                         <td  class="totalsBlock" style="text-align: right!important; ; padding-right: 30px;">
@@ -650,6 +660,16 @@
                     </tr>
                     </ui:fragment>
                     <ui:fragment rendered="#{cc.attrs.showDiscount}">
+                    <tr>
+                        <td  class="totalsBlock" style="text-align: left;">
+                            <h:outputLabel  rendered="#{cc.attrs.bill.margin ne 0.0}" value="Service Charge " style="font-weight: bolder!important;"/>
+                        </td>
+                        <td  class="totalsBlock" style="text-align: right!important; ; padding-right: 30px;">
+                            <h:outputLabel rendered="#{cc.attrs.bill.margin ne 0.0}"   value="#{cc.attrs.bill.margin}" style="font-weight: bolder!important;" >
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputLabel>
+                        </td>
+                    </tr>
                     <tr>
                         <td  class="totalsBlock" style="text-align: left;">
                             <h:outputLabel  rendered="#{cc.attrs.bill.discount ne 0.0}" value="Discount " style="font-weight: bolder!important;"/>

--- a/src/main/webapp/resources/pharmacy/saleBill_prabodha.xhtml
+++ b/src/main/webapp/resources/pharmacy/saleBill_prabodha.xhtml
@@ -317,7 +317,7 @@
                     </tr>
                     </ui:fragment>
                     <ui:fragment rendered="#{cc.attrs.showDiscount}">
-                    <tr>
+                    <tr style="#{cc.attrs.bill.margin ne 0.0 ? '' : 'display:none;'}">
                         <td  class="totalsBlock" style="text-align: left;">
                             <h:outputLabel  rendered="#{cc.attrs.bill.margin ne 0.0}" value="Service Charge " style="font-weight: bolder!important;"/>
                         </td>
@@ -660,7 +660,7 @@
                     </tr>
                     </ui:fragment>
                     <ui:fragment rendered="#{cc.attrs.showDiscount}">
-                    <tr>
+                    <tr style="#{cc.attrs.bill.margin ne 0.0 ? '' : 'display:none;'}">
                         <td  class="totalsBlock" style="text-align: left;">
                             <h:outputLabel  rendered="#{cc.attrs.bill.margin ne 0.0}" value="Service Charge " style="font-weight: bolder!important;"/>
                         </td>


### PR DESCRIPTION
## Decisions made without approval

This was run via `dev-issue-unattended` (no human present to approve mid-flight). Judgment calls made while executing the already-filed, already-scoped issue #23329:

1. **Privilege combination**: wired `showRate`/`showDiscount` using the same combination confirmed for #23317/#23318 — `showRate = config + NursingIPBillingViewRates`, `showDiscount = config + NursingIPBillingViewRates + IPBillingViewDiscount` (AND, not independent gates).
2. **`returnBill.xhtml` scope**: added Service Charge there even though issue #23329's "Required fix" bullet list didn't explicitly name this file — its own findings table documented `returnBill.xhtml` as missing Gross+Service Charge too. Treated that as the authoritative scope over an incomplete bullet.
3. **Sign-convention bug found during my own verification**: my first pass on the `five_five_custom_3` templates' totals table omitted the `lt 0 ? -x : x` abs-conversion every other template in this family uses — a return bill's `netTotal`/`total`/`margin` are stored negative, so the print showed "-17.35" instead of "17.35". Fixed in both my new bindings and one pre-existing binding (`netTotal`) I hadn't otherwise touched, since leaving it inconsistent would look broken.
4. **`saleBill_five_five.xhtml`**: added a new dedicated Service Charge row gated by `showDiscount` (this template previously never showed Service Charge as a distinct figure — it silently folded margin into a combined per-item rate). Left the pre-existing `showRate`-gated Total-label-switch row untouched, to avoid a `showRate`-only user losing their Total figure entirely.

## Summary

`pharmacy_bill_return_bht_issue.xhtml` renders the original bill and return bill through 7 different paper-format composites per panel. Investigation (documented in #23329) found only 3 of 7 (A4, FiveFive, POS) correctly showed Gross/Service Charge/Discount/Net, consistently privilege-gated. Fixed the other 4/5 composite families:

- **`inward/issueBill.xhtml`**: bill total was hardcoded `"0.00"` instead of bound to `bill.total`; Service Charge was never rendered.
- **`saleBill_prabodha.xhtml`**: Service Charge was never rendered (added to both near-duplicate sections in the file).
- **`saleBill_five_five.xhtml`**: Service Charge was never shown as a distinct figure.
- **`returnBill.xhtml`, `saleBill_Header_Return.xhtml`**: had no `showRate`/`showDiscount` attributes at all — every pricing field rendered unconditionally to any user; Gross/Service Charge were missing entirely.
- **`inward_direct_issue_bill_five_five_custom_3.xhtml` + return-side counterpart**: only showed Rate/Net, missing Gross/Service Charge/Discount; the return-side variant had zero privilege gating.
- **`pharmacy_bill_return_bht_issue.xhtml`**: never passed `showRate`/`showDiscount` into `issueBill`/`saleBill_prabodha`/`saleBill_five_five`, so those composites fell back to `default="true"` on this page.

## Test plan

- [x] Rebuilt and redeployed to local Payara
- [x] Playwright: settled a fresh BHT direct-issue bill (qty 3), returned it in two partial returns (qty 1, then qty 2) through the actual page, both panels, all 4 rendered formats (A4/FiveFive/POS/FiveFiveCustom3)
- [x] All formats showed matching, correct, positive Gross/Service Charge/Discount/Net on both panels, cross-checked against `BILL`/`BILLITEM` DB rows
- [x] Server log checked, no errors

## Discovered but out of scope

`BILL.margin`/`BILL.discount` columns are never populated by `InpatientDirectIssueNativeSqlService.settle()` (only `total`/`netTotal`/`grantTotal` are). The original-bill panel's Service Charge/Discount totals will read 0 for any bill settled via that native path even with full privileges, since the source column itself is 0 — confirmed via direct DB query. This is a gap in the native settle service, a different file entirely, not touched here. Recommend filing as a follow-up issue.

## Documentation

Updated [Direct Issue Return to Pharmacy](https://github.com/hmislk/hmis/wiki/Direct-Issue-Return-to-Pharmacy) with a new section explaining the two-privilege print gate (mirroring #23317/#23318's documentation pattern), plus the confirmation screenshot, and a Permissions-section pointer.

Closes #23329

🤖 Generated with [Claude Code](https://claude.com/claude-code) — unattended (`dev-issue-unattended`)

https://claude.ai/code/session_01R9KhUsKWNH4djw6AJjx1Hm


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Gross, Service Charge, and Discount details to pharmacy sale, return, and inward issue bills.
  * Added configurable visibility for rate, discount, and service-charge information.
  * Updated bill totals to show accurate gross, net, service-charge, and discount values.
  * Added corresponding financial columns to itemized bill receipts.

* **Bug Fixes**
  * Corrected gross total display from a hardcoded value to the actual bill total.
  * Improved handling and formatting of negative financial values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->