### PR TITLE
fix(inward): add forceSelection and converter to BHT Issue Add Items autocomplete

### DIFF
--- a/src/main/webapp/ward/ward_pharmacy_bht_issue.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_bht_issue.xhtml
@@ -121,8 +121,10 @@
                                             <p:outputLabel value="Medicines/Devices" ></p:outputLabel>
                                             <p:autoComplete accesskey="i" id="acStock"
                                                             value="#{pharmacySaleBhtController.tmpStock}"
+                                                            converter="stockConverter"
                                                             minQueryLength="3" queryDelay="300" completeMethod="#{stockController.completeAvailableStocks}"
                                                             var="i" itemLabel="#{i.itemBatch.item.name}" itemValue="#{i}" maxResults="10" size="100"
+                                                            forceSelection="true"
                                                             styleClass="w-100"
                                                             inputStyleClass="w-100 form-control">
                                                 <p:column headerText="Item" style="padding: 4px" styleClass="#{commonFunctionsProxy.currentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-fatal': commonFunctionsProxy.dateAfterThreeMonthsCurrentDateTime > i.itemBatch.dateOfExpire ?'ui-messages-warn':''}">


### PR DESCRIPTION
## What changed

`src/main/webapp/ward/ward_pharmacy_bht_issue.xhtml` — the "Medicines/Devices" autocomplete (`acStock`) in the BHT Issue page's "Add Items" panel was missing both `forceSelection="true"` and a `converter`, unlike the sibling "Issuing Bill Item" autocomplete (`Isitem`) elsewhere on the same page, which correctly pairs both.

Two related, compounding gaps found and fixed:

1. **No `forceSelection`**: typing text and clicking **+Add** without actually clicking a suggestion submitted the raw typed string where a `Stock` object was expected, throwing an uncaught `IllegalArgumentException` and a full-page 500.
2. **No `converter`** (found while fixing #1): adding `forceSelection="true"` alone surfaced a second, deeper gap — even a properly *selected* item then failed the same way, because without an explicit `converter="stockConverter"`, PrimeFaces AutoComplete's own submitted-value validation round-trips the item through `Stock.toString()` instead of a real id, and JSF fails to coerce that string back to a `Stock`. The `@FacesConverter(forClass=Stock.class)` registration on `StockController` isn't reliably picked up automatically by AutoComplete's validation path — it needs the explicit `converter=""` attribute, same as `Isitem` already has.

Fixed by adding both attributes, matching the working `Isitem` pattern exactly.

## Verification

Playwright, Main Pharmacy department, local Payara — both scenarios tested against a real BHT request:

- **Typed, not selected**: typed "Panadol" into Medicines/Devices, clicked **+Add** without selecting a suggestion. Before: full-page 500 (`Cannot convert Panadol of type class java.lang.String to class com.divudi.core.entity.pharmacy.Stock`). After: friendly `"Item?"` validation message, no crash.
- **Typed and selected**: typed "Panadol", clicked the "Panadol 500mg tab" suggestion, entered quantity 1, clicked **+Add**. Before (with only `forceSelection` added, no converter): full-page 500 (`Cannot convert com.divudi.core.entity.pharmacy.Stock[ id=13861131 ] of type class java.lang.String to class com.divudi.core.entity.pharmacy.Stock`). After (with `converter` added too): row added correctly to the Issuing Items grid (Gross 3.49, Margin 1.50, Net 4.99), and the Bill Details totals updated correctly to reflect both rows combined (Gross 10.47, Margin 4.50, Net 14.97).

## Documentation

No wiki page update — this is an internal bug fix restoring existing, already-documented autocomplete behavior (matching the pattern the sibling autocomplete already used); no user-visible workflow or screen changed beyond "it no longer crashes."

Closes #23332

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stock selection in the “Add Items” panel.
  * Users must now select a valid item from the autocomplete suggestions, preventing invalid free-text entries.
  * Selected stock values are handled consistently for processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->