### PR TITLE
fix(pharmacy): correct return margin/service charge for discounted items

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/BhtIssueReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/BhtIssueReturnController.java
@@ -530,7 +530,13 @@ public class BhtIssueReturnController implements Serializable {
             bi.setReferenceBill(getBill());
             bi.setReferanceBillItem(i.getBillItem());
             bi.copy(i.getBillItem());
-            bi.setMarginRate(bi.getNetRate() - bi.getRate());
+            // marginRate is never persisted at issue time (only marginValue is - see
+            // InpatientDirectIssueNativeSqlService.settle()'s BILLITEM insert column list),
+            // so it must be reconstructed here. netRate = rate + marginRate - discountRate,
+            // so marginRate = netRate - rate + discountRate. Omitting "+ discountRate"
+            // (the previous formula) understates margin by the discount amount whenever
+            // the original item had a nonzero discount (issue #23334).
+            bi.setMarginRate(bi.getNetRate() - bi.getRate() + bi.getDiscountRate());
             bi.setQty(0.0);
 
             PharmaceuticalBillItem tmp = new PharmaceuticalBillItem();


### PR DESCRIPTION
## Summary

Fixes #23334. During a BHT Issue Return, `BhtIssueReturnController.generateBillComponent()` reconstructed the returning item's `marginRate` as `netRate - rate`. Since `netRate = rate + marginRate - discountRate`, that expression actually equals `marginRate - discountRate`, not `marginRate`. Whenever the original item had a nonzero discount, the return's Service Charge (and, once settled, the persisted `BillItem.marginValue`) was understated by exactly the discount amount — breaking `Gross + Margin - Discount = Net` on the return. A full return should always recover exactly the same figures as the original sale.

## Fix

One-line change: `marginRate` is now reconstructed as `netRate - rate + discountRate`.

```java
bi.setMarginRate(bi.getNetRate() - bi.getRate() + bi.getDiscountRate());
```

## Verification (local Payara, Main Pharmacy, BHT/56759)

Settled a direct-issue bill (Zaart 25mg Tab, qty 4: Gross 49.92 / Margin 19.4688 / Discount 9.7344 / Net 59.6544), then returned it in full.

- Pre-settle "Returning Item" grid: Margin Rate = 4.87 (= 19.4688 / 4)
- Pre-settle "Recievable" totals: Gross 49.92, Margin 19.47, Discount 9.73, Net 59.65 — exact match to the original sale
- Post-settle DB (`BILLITEM`): return row `MARGINVALUE = 19.4688`, `DISCOUNT = 9.7344`, `NETVALUE = 59.6544` — identity `49.92 + 19.4688 − 9.7344 = 59.6544` holds
- Print preview (both Sale Bill and Return Bill panels) shows identical Rate/Gross/Service Charge/Discount/Net

![Sale bill and return bill previews for a discounted item, showing identical Gross, Service Charge, Discount and Net figures](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23334-return-margin-fix-confirmed.png)

## Documentation

Updated [Direct Issue Return to Pharmacy](https://github.com/hmislk/hmis/wiki/Direct-Issue-Return-to-Pharmacy) — Step 4 now notes that a full return recovers the exact original Gross/Margin/Discount/Net even for discounted items, with the evidence screenshot above.

## Test plan

- [x] Settle a discounted direct-issue bill, verify DB figures
- [x] Return the bill in full, verify pre-settle preview and persisted `BILLITEM` match the original
- [x] Confirm `Gross + Margin - Discount = Net` holds on the return
- [x] Confirm print preview shows matching figures on both Sale and Return panels

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01R9KhUsKWNH4djw6AJjx1Hm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected pharmacy return margin calculations to include applicable discounts.
  * Ensured return line margins are accurately preserved when bills are generated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->