### PR TITLE
fix(inward): block duplicate batch add, add Expiry column, gate substitute icon

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
@@ -2440,6 +2440,41 @@ public class PharmacySaleBhtController implements Serializable {
         return false;
     }
 
+    /**
+     * Same FEFO greedy-take logic as {@link com.divudi.ejb.PharmacyBean#depleteStockForQty(java.util.List, double)},
+     * but treats each Stock's available quantity as already reduced by whatever
+     * {@code reservedQtyByStockId} says an earlier requested line in the same
+     * {@link #generateIssueBillComponentsForBhtRequest(Bill)} pass already took from
+     * it. Needed because that method caches the raw Stock list per AMP
+     * (rawStockByAmpId) — without this, two requested lines resolving to the same
+     * AMP would both see the same unreduced Stock.getStock() figures and could both
+     * get auto-assigned the same batch. Never mutates the Stock entities themselves —
+     * purely in-memory bookkeeping against the passed-in map. CodeRabbit review on
+     * #23343.
+     */
+    private List<StockQty> depleteStockForQtyExcludingReserved(List<Stock> rawStocks, double qty, Map<Long, Double> reservedQtyByStockId) {
+        List<StockQty> list = new ArrayList<>();
+        if (rawStocks == null) {
+            return list;
+        }
+        double toAddQty = qty;
+        for (Stock s : rawStocks) {
+            double reserved = s.getId() != null ? reservedQtyByStockId.getOrDefault(s.getId(), 0.0) : 0.0;
+            double available = s.getStock() - reserved;
+            if (available <= 0) {
+                continue;
+            }
+            if (available >= toAddQty) {
+                list.add(new StockQty(s, toAddQty));
+                break;
+            } else {
+                toAddQty = toAddQty - available;
+                list.add(new StockQty(s, available));
+            }
+        }
+        return list;
+    }
+
     public void addBillItem() {
 
         if (getPreBill() == null) {
@@ -3111,6 +3146,16 @@ public class PharmacySaleBhtController implements Serializable {
         // stock. Populated lazily per request so a VTM shared by multiple requested lines
         // is only queried once. Issue #23055.
         Map<Long, List<Amp>> ampsByVtmId = new HashMap<>();
+        // Tracks how much of each Stock (by id) has already been assigned to an earlier
+        // requested line within THIS generation pass. rawStockByAmpId caches the raw
+        // Stock list per AMP so repeated requested lines for the same medicine don't
+        // re-query, but that means two lines resolving to the same AMP would otherwise
+        // see the exact same (unmodified) Stock.getStock() figures and could both get
+        // auto-assigned the same batch. This map is purely in-memory bookkeeping — it
+        // never mutates the Stock entities themselves (they're JPA-managed; touching
+        // their qty field here would risk a premature, unintended stock deduction on
+        // flush, before the bill is even settled). CodeRabbit review on #23343.
+        Map<Long, Double> reservedQtyByStockId = new HashMap<>();
 
         for (BillItem i : b.getBillItems()) {
             if (i.getItem() == null) {
@@ -3219,7 +3264,7 @@ public class PharmacySaleBhtController implements Serializable {
                 }
 
                 List<Stock> rawStocks = rawStockByAmpId.computeIfAbsent(candidate.getId(), id -> pharmacyBean.getRawStockListForAmp(candidate, dept));
-                List<StockQty> stockQtys = pharmacyBean.depleteStockForQty(rawStocks, candidateQty);
+                List<StockQty> stockQtys = depleteStockForQtyExcludingReserved(rawStocks, candidateQty, reservedQtyByStockId);
                 if (stockQtys == null || stockQtys.isEmpty()) {
                     continue;
                 }
@@ -3282,6 +3327,19 @@ public class PharmacySaleBhtController implements Serializable {
                 selectedStockQtys = null;
                 isSubstitute = false;
                 selectedCandidateQty = issuableQty;
+            }
+
+            // Reserve what this line actually consumed so a later requested line
+            // resolving to the same AMP/stock sees reduced availability instead of
+            // being offered the same batch again. Must happen only for the finally
+            // selected candidate, not the ones evaluated and discarded above.
+            if (selectedStockQtys != null) {
+                for (StockQty sq : selectedStockQtys) {
+                    if (sq.getStock() == null || sq.getStock().getId() == null || sq.getQty() <= 0) {
+                        continue;
+                    }
+                    reservedQtyByStockId.merge(sq.getStock().getId(), sq.getQty(), Double::sum);
+                }
             }
 
             if (selectedStockQtys != null && !selectedStockQtys.isEmpty()) {

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
@@ -2426,6 +2426,20 @@ public class PharmacySaleBhtController implements Serializable {
         return false;
     }
 
+    private boolean isBatchAlreadyInBill(Long stockId) {
+        if (stockId == null) {
+            return false;
+        }
+        for (BillItem bItem : getBillItems()) {
+            if (bItem.getPharmaceuticalBillItem() != null
+                    && bItem.getPharmaceuticalBillItem().getStock() != null
+                    && Objects.equals(bItem.getPharmaceuticalBillItem().getStock().getId(), stockId)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public void addBillItem() {
 
         if (getPreBill() == null) {
@@ -2592,11 +2606,11 @@ public class PharmacySaleBhtController implements Serializable {
             return;
         }
 
-//        if (checkItemBatch()) {
-//            errorMessage = "This batch is already there in the bill.";
-//            UtilityController.addErrorMessage("Already added this item batch");
-//            return;
-//        }
+        if (isBatchAlreadyInBill(getTmpStock().getId())) {
+            errorMessage = "This batch is already in the bill.";
+            JsfUtil.addErrorMessage("This batch is already in the bill. Edit the existing row's quantity instead.");
+            return;
+        }
 //        if (CheckDateAfterOneMonthCurrentDateTime(getStock().getItemBatch().getDateOfExpire())) {
 //            errorMessage = "This batch is Expire With in 31 Days.";
 //            UtilityController.addErrorMessage("This batch is Expire With in 31 Days.");

--- a/src/main/webapp/ward/ward_pharmacy_bht_issue.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_bht_issue.xhtml
@@ -387,6 +387,7 @@
                                     icon="pi pi-refresh"
                                     id="btnSelectSubstitute"
                                     title="Select a Substitute"
+                                    rendered="#{bItm.referanceBillItem != null}"
                                     action="#{pharmacySaleBhtController.prepareSubstitute(bItm)}"
                                     update=":#{p:resolveFirstComponentWithId('substituteDlg',view).clientId}"
                                     oncomplete="PF('substituteDialog').show();"
@@ -419,6 +420,12 @@
                                     </p:autoComplete>
                                 </f:facet>
                             </p:cellEditor>
+                        </p:column>
+
+                        <p:column headerText="Expiry" style="width:7rem; padding: 6px;">
+                            <h:outputText value="#{bItm.pharmaceuticalBillItem.stock.itemBatch.dateOfExpire}">
+                                <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}"/>
+                            </h:outputText>
                         </p:column>
 
                         <p:column headerText="Qty"


### PR DESCRIPTION
## Summary

Fixes three related gaps in the BHT Issue "Issuing Items" grid found and
filed as #23336:

- **Part A** — the same stock batch could be added to the bill twice (once
  auto-assigned to a requested item, once again via **+ Add**), with no
  warning. `addBillItemNew()` now blocks it with a new
  `isBatchAlreadyInBill()` check against the actual `getBillItems()` list.
  The pre-existing `checkItemBatch()`/`selectedStockId` guard was dead code
  and, even if simply un-commented, would never fire — it reads a field
  (`selectedStockId`) that `addBillItemNew()`'s code path (which uses
  `tmpStock` instead) never populates.
- **Part B** — the grid gains an **Expiry** column, so a batch's expiry is
  visible at a glance instead of only in the per-row expansion panel.
- **Part C** — the **Select a Substitute** icon no longer renders on a
  manually-added row that has no requested item to substitute against
  (`referanceBillItem == null`).

- **Part D** (found by CodeRabbit review) — the automatic issuing-batch
  assignment (`generateIssueBillComponentsForBhtRequest()`) had the same
  class of bug on a different path: when a request has two lines for the
  same medicine, both could get auto-assigned the same batch if combined
  demand exceeded actual stock — the per-AMP raw-stock cache was reused
  across lines with no reservation tracking. Added an in-memory
  `reservedQtyByStockId` map and `depleteStockForQtyExcludingReserved()`
  (never mutates `Stock` entities) so a later line sees reduced
  availability instead of being offered the same already-claimed batch.

## Verified

Playwright, Main Pharmacy department, BHT/56760 (`Inward//26/038097`) —
same request used to investigate/file the issue:

- Picked the exact batch already auto-assigned to the requested row
  (`TEST18280B`, "Zaart 50mg Tab") and clicked **+ Add** — blocked with
  *"This batch is already in the bill. Edit the existing row's quantity
  instead."*; grid still showed only the one original row.
- Picked a genuinely different batch ("Zaart 25mg Tab") and clicked
  **+ Add** — added normally as its own row, confirming no false-positive
  block.
- Confirmed the Expiry column renders correctly for both the requested row
  and the manually-added row.
- Confirmed the requested row still shows **Select a Substitute**; the
  manually-added row does not.

![+ Add blocked for a duplicate batch — grid still shows only the original row](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23336-fix-duplicate-blocked.png)

![Expiry column on both rows; substitute icon only on the requested row](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23336-fix-expiry-column-and-icon-gating.png)

No persisted-data verification needed for Parts A/C — pure guard/rendering
changes (a blocked add never reaches the facade layer). Part B is a
read-only display of already-persisted data.

**Part D verified live** on an existing genuine case, BHT/56746 (Inward
dept): two requested lines for "Panadol 500mg tab", 15 and 6 units, against
only 3 units of actual stock. Before this fix both lines would have been
offered the same 3-unit batch; after the fix the first line claims the 3
units and the second correctly shows no batch assigned (Stock Availability
Report: "Available: 0 ... No stock found").

![Two requested lines for the same low-stock medicine; only the first line gets a batch](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23336-fix-reservation-low-stock.png)

## Documentation

Updated [Inward BHT Issue Against Request](https://github.com/hmislk/hmis/wiki/Inward-BHT-Issue-Against-Request) —
added an "Adding Extra Items Manually" section documenting the Add Items
panel (previously undocumented), the new duplicate-batch guard and its
error message, and the new Expiry column.

Closes #23336


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added expiry dates to the ward pharmacy issuing-items table.
  - Prevented adding the same medicine batch more than once to a bill.

- **Bug Fixes**
  - The “Select a Substitute” option now appears only when a substitute reference is available.
  - Improved stock allocation when generating issue bills to prevent the same stock from being assigned across multiple requested items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->