### PR TITLE
feat(inward): restructure BHT Issue Return bill preview into tabs with per-item reconciliation

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -2138,6 +2138,58 @@ subject to the same row-scope constraint. Verified while fixing issue
 needed the identical treatment, not just the two components fixed in the
 original pass).
 
+## 83. A page-local `<style>` rule can silently lose to the PrimeFaces theme — verify with a computed-style probe, not a screenshot
+
+A page-local `<style>` block that targets a PrimeFaces sub-part (title bar, row,
+header cell) can look plausible in review and still never apply, because the
+Material theme qualifies the same part with a leading element selector:
+
+```css
+/* theme.css — specificity (0,2,1): two classes PLUS the `body` element */
+body .ui-panel .ui-panel-titlebar { background: #f8f9fa; }
+
+/* page-local — specificity (0,2,0): loses, even though it comes later */
+.my-highlight > .ui-panel-titlebar { background: rgba(13,110,253,.10); }
+```
+
+Later-in-document does **not** save you here: the theme wins on specificity, so
+the rule is simply discarded. Adding the same `body` + owning-class prefix
+restores the win:
+
+```css
+body .ui-panel.my-highlight > .ui-panel-titlebar { background: rgba(13,110,253,.10); }
+```
+
+The trap is that a *partial* application looks like success — an outer `border`
+on the panel itself can land (nothing in the theme sets it) while the title-bar
+`background` on the very next line is dropped, so the screenshot shows "some
+highlight" and the defect passes review.
+
+Don't judge this from a screenshot. Read the computed style, and — when the rule
+is print-scoped — read it under emulated print media (see §43; never click the
+real `p:printer` button):
+
+```js
+async (page) => {
+  const probe = async () => await page.evaluate(() => {
+    const bar = document.querySelector('body .ui-panel.my-highlight > .ui-panel-titlebar');
+    return getComputedStyle(bar).backgroundColor;
+  });
+  await page.emulateMedia({ media: 'screen' }); const onScreen = await probe();
+  await page.emulateMedia({ media: 'print'  }); const onPrint  = await probe();
+  await page.emulateMedia({ media: 'screen' });
+  return { onScreen, onPrint };
+}
+```
+
+To find *which* rule actually won, enumerate `document.styleSheets` for rules the
+element `matches()` and print each one's `selectorText` plus originating
+stylesheet — that names the offending theme selector directly, instead of
+guessing at specificity.
+
+Found on `inward/pharmacy_bill_return_bht_issue.xhtml` while adding the Return
+Bill Preview highlight (issue #23338).
+
 ## Some PrimeFaces buttons need a jQuery-triggered click
 
 Most `p:commandButton`s submit fine with a normal Playwright click — including

--- a/src/main/java/com/divudi/bean/pharmacy/BhtIssueReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/BhtIssueReturnController.java
@@ -23,6 +23,7 @@ import com.divudi.core.entity.inward.RoomCategory;
 import com.divudi.core.entity.PriceMatrix;
 import com.divudi.core.entity.RefundBill;
 import com.divudi.core.entity.pharmacy.PharmaceuticalBillItem;
+import com.divudi.core.data.dto.pharmacy.BhtIssueReturnItemStatusDto;
 import com.divudi.core.facade.BillFacade;
 import com.divudi.core.facade.BillFeeFacade;
 import com.divudi.core.facade.BillItemFacade;
@@ -53,7 +54,8 @@ public class BhtIssueReturnController implements Serializable {
     private List<BillItem> billItems;
     private String returnComment = "";
     private double discountTotal = 0.0;
-    
+    private List<BhtIssueReturnItemStatusDto> runningStatusRows;
+
     
     ///////
     @EJB
@@ -104,8 +106,9 @@ public class BhtIssueReturnController implements Serializable {
         }
         printPreview = false;
         billItems = null;
+        runningStatusRows = null;
         returnComment = "";
-        
+
         if (bill.getDepartment() == null) {
             JsfUtil.addErrorMessage("No Department for the Bill");
             return null;
@@ -203,6 +206,7 @@ public class BhtIssueReturnController implements Serializable {
         returnBill = null;
         printPreview = false;
         billItems = null;
+        runningStatusRows = null;
         returnComment = "";
     }
 
@@ -468,12 +472,70 @@ public class BhtIssueReturnController implements Serializable {
         getBillFacade().edit(getBill());
 
         /// setOnlyReturnValue();
+        buildRunningStatusRows();
         printPreview = true;
         returnComment = "";
         JsfUtil.addSuccessMessage("Successfully Returned");
 
     }
 
+    /**
+     * Builds the per-item quantity reconciliation rows shown on the "Running
+     * Update Status" tab after a return is settled (issue #23338).
+     * <p>
+     * Iterates the ORIGINAL bill's pharmaceutical items rather than
+     * {@link #billItems}: {@link #generateBillComponent()} skips lines whose
+     * balance already reached zero (the {@code if (tmpQty <= 0) { continue; }}
+     * at ~line 549), so a table built from {@code billItems} would silently
+     * omit fully-returned items - exactly the lines a reconciliation view
+     * needs to show (with Balance 0).
+     * <p>
+     * Must run after persistence: {@link PharmacyCalculation#getTotalQty}
+     * is an aggregate over saved return bill items, so it only includes this
+     * settlement once {@link #saveComponent()} has committed.
+     * <p>
+     * {@code getTotalQty(BillItem, BillType)} is deliberately the same call
+     * {@link #generateBillComponent()} (~line 546) and {@link #settle()}'s
+     * validation loop (~line 411) already use, so this table cannot disagree
+     * with the "Balance Qty in Unit" the pre-settle grid shows.
+     */
+    private void buildRunningStatusRows() {
+        runningStatusRows = new ArrayList<>();
+        if (bill == null) {
+            return;
+        }
+        for (PharmaceuticalBillItem originalPbi : getPharmaceuticalBillItemFacade().getPharmaceuticalBillItems(getBill())) {
+            BillItem originalBillItem = originalPbi.getBillItem();
+            if (originalBillItem == null) {
+                continue;
+            }
+
+            double saleQty = Math.abs(originalPbi.getQty());
+
+            // Total returned across ALL returns of this line, including the one just settled.
+            double totalReturnedQty = Math.abs(
+                    getPharmacyRecieveBean().getTotalQty(originalBillItem, getBill().getBillType()));
+
+            // The slice of that total contributed by this settlement.
+            double thisTimeReturnedQty = 0.0;
+            if (returnBill != null && returnBill.getBillItems() != null) {
+                for (BillItem rbi : returnBill.getBillItems()) {
+                    if (rbi.getReferanceBillItem() != null
+                            && rbi.getReferanceBillItem().equals(originalBillItem)) {
+                        thisTimeReturnedQty += Math.abs(rbi.getQty());
+                    }
+                }
+            }
+
+            double previouslyReturnedQty = totalReturnedQty - thisTimeReturnedQty;
+            double balanceQty = saleQty - totalReturnedQty;
+
+            String itemName = originalBillItem.getItem() == null ? "" : originalBillItem.getItem().getName();
+
+            runningStatusRows.add(new BhtIssueReturnItemStatusDto(
+                    itemName, saleQty, previouslyReturnedQty, thisTimeReturnedQty, totalReturnedQty, balanceQty));
+        }
+    }
 
     public InwardBeanController getInwardBean() {
         return inwardBean;
@@ -659,6 +721,17 @@ public class BhtIssueReturnController implements Serializable {
 
     public void setBillItems(List<BillItem> billItems) {
         this.billItems = billItems;
+    }
+
+    public List<BhtIssueReturnItemStatusDto> getRunningStatusRows() {
+        if (runningStatusRows == null) {
+            runningStatusRows = new ArrayList<>();
+        }
+        return runningStatusRows;
+    }
+
+    public void setRunningStatusRows(List<BhtIssueReturnItemStatusDto> runningStatusRows) {
+        this.runningStatusRows = runningStatusRows;
     }
 
     public BillFeeFacade getBillFeeFacade() {

--- a/src/main/java/com/divudi/core/data/dto/pharmacy/BhtIssueReturnItemStatusDto.java
+++ b/src/main/java/com/divudi/core/data/dto/pharmacy/BhtIssueReturnItemStatusDto.java
@@ -1,0 +1,80 @@
+package com.divudi.core.data.dto.pharmacy;
+
+import java.io.Serializable;
+
+/**
+ * Per-item quantity reconciliation row shown on the BHT Issue Return "Running
+ * Update Status" tab (issue #23338). Plain view-model POJO - not a JPQL
+ * constructor DTO, it is never used in a query.
+ */
+public class BhtIssueReturnItemStatusDto implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private String itemName;
+    private double saleQty;
+    private double previouslyReturnedQty;
+    private double thisTimeReturnedQty;
+    private double totalReturnedQty;
+    private double balanceQty;
+
+    public BhtIssueReturnItemStatusDto() {
+    }
+
+    public BhtIssueReturnItemStatusDto(String itemName, double saleQty, double previouslyReturnedQty, double thisTimeReturnedQty, double totalReturnedQty, double balanceQty) {
+        this.itemName = itemName;
+        this.saleQty = saleQty;
+        this.previouslyReturnedQty = previouslyReturnedQty;
+        this.thisTimeReturnedQty = thisTimeReturnedQty;
+        this.totalReturnedQty = totalReturnedQty;
+        this.balanceQty = balanceQty;
+    }
+
+    public String getItemName() {
+        return itemName;
+    }
+
+    public void setItemName(String itemName) {
+        this.itemName = itemName;
+    }
+
+    public double getSaleQty() {
+        return saleQty;
+    }
+
+    public void setSaleQty(double saleQty) {
+        this.saleQty = saleQty;
+    }
+
+    public double getPreviouslyReturnedQty() {
+        return previouslyReturnedQty;
+    }
+
+    public void setPreviouslyReturnedQty(double previouslyReturnedQty) {
+        this.previouslyReturnedQty = previouslyReturnedQty;
+    }
+
+    public double getThisTimeReturnedQty() {
+        return thisTimeReturnedQty;
+    }
+
+    public void setThisTimeReturnedQty(double thisTimeReturnedQty) {
+        this.thisTimeReturnedQty = thisTimeReturnedQty;
+    }
+
+    public double getTotalReturnedQty() {
+        return totalReturnedQty;
+    }
+
+    public void setTotalReturnedQty(double totalReturnedQty) {
+        this.totalReturnedQty = totalReturnedQty;
+    }
+
+    public double getBalanceQty() {
+        return balanceQty;
+    }
+
+    public void setBalanceQty(double balanceQty) {
+        this.balanceQty = balanceQty;
+    }
+}

--- a/src/main/webapp/inward/pharmacy_bill_return_bht_issue.xhtml
+++ b/src/main/webapp/inward/pharmacy_bill_return_bht_issue.xhtml
@@ -309,7 +309,7 @@
                             <div class="col-md-6">
                                 <p:panel >
                                     <f:facet name="header" >
-                                        <h:outputLabel value="Sale Bill Preview" class="mt-2"/>
+                                        <h:outputText value="Sale Bill Preview" styleClass="mt-2"/>
                                         <p:commandButton
                                             value="Print Sale Bill"
                                             icon="fa fa-print"
@@ -375,7 +375,7 @@
                             <div class="col-md-6">
                                 <p:panel styleClass="bht-return-preview-highlight">
                                     <f:facet name="header" >
-                                        <h:outputLabel value="Return Bill Preview" class="mt-2"/>
+                                        <h:outputText value="Return Bill Preview" styleClass="mt-2"/>
                                         <p:commandButton
                                             value="Print Return Bill"
                                             ajax="false"
@@ -486,7 +486,7 @@
                     <p:tab title="Original Bill">
                         <p:panel>
                             <f:facet name="header" >
-                                <h:outputLabel value="Original Bill" class="mt-2"/>
+                                <h:outputText value="Original Bill" styleClass="mt-2"/>
                                 <p:commandButton
                                     value="Print Original Bill"
                                     icon="fa fa-print"

--- a/src/main/webapp/inward/pharmacy_bill_return_bht_issue.xhtml
+++ b/src/main/webapp/inward/pharmacy_bill_return_bht_issue.xhtml
@@ -9,6 +9,36 @@
                 xmlns:phi="http://xmlns.jcp.org/jsf/composite/pharmacy">
 
     <ui:define name="content">
+
+        <style type="text/css">
+            /*
+               Screen-only accent for the Return Bill Preview panel (issue #23338).
+               The class sits on the OUTER p:panel, never on gpBillPreview1 - the node
+               p:printer clones - so printed receipts are unaffected. The @media print
+               block below is a second, belt-and-braces guard.
+
+               The `body .ui-panel...` prefix is required: the Material theme styles the
+               title bar via `body .ui-panel .ui-panel-titlebar`, which out-specifies a
+               plain `.bht-return-preview-highlight > .ui-panel-titlebar` rule.
+            */
+            body .ui-panel.bht-return-preview-highlight {
+                border: 2px solid #0d6efd;
+                box-shadow: 0 0 0 .15rem rgba(13,110,253,.15);
+            }
+            body .ui-panel.bht-return-preview-highlight > .ui-panel-titlebar {
+                background: rgba(13,110,253,.10);
+                border-bottom: 2px solid #0d6efd;
+                font-weight: 600;
+            }
+            @media print {
+                body .ui-panel.bht-return-preview-highlight,
+                body .ui-panel.bht-return-preview-highlight > .ui-panel-titlebar {
+                    border: none;
+                    box-shadow: none;
+                    background: none;
+                }
+            }
+        </style>
         <h:form>
             <h:panelGroup rendered="#{!bhtIssueReturnController.printPreview}" styleClass="alignTop" >
                 <p:panel>
@@ -227,178 +257,303 @@
 
             <p:panel rendered="#{bhtIssueReturnController.printPreview}">
                 <f:facet name="header" >
-                    <h:outputLabel value="Bill Preview" class="mt-2"></h:outputLabel>
-                    <p:commandButton
-                        rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
-                        icon="fas fa-cog"
-                        styleClass="ui-button-secondary ui-button-outlined m-1"
-                        type="button"
-                        title="Service Charge Print Format Settings"
-                        onclick="PF('idiReturnBillPaperConfigDialog').show();" />
-                    <p:commandButton
-                        ajax="false"
-                        icon="fa fa-plus"
-                        class="ui-button-warning"
-                        action="/inward/pharmacy_search_sale_bill_bht"
-                        actionListener="#{searchController.makeListNull}"
-                        value="Pharmacy Sale Search"
-                        style="float: right;"
-                        >
-                    </p:commandButton>
+                    <div class="d-flex justify-content-between align-items-center w-100">
+
+                        <!-- LEFT: title + contextual config -->
+                        <div class="d-flex align-items-center gap-2">
+                            <h:outputText value="Bill Preview"/>
+                            <p:commandButton
+                                rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}"
+                                icon="fas fa-cog"
+                                styleClass="ui-button-secondary ui-button-outlined"
+                                type="button"
+                                title="Service Charge Print Format Settings"
+                                onclick="PF('idiReturnBillPaperConfigDialog').show();" />
+                        </div>
+
+                        <!-- CENTER: entity navigation -->
+                        <div class="d-flex gap-2">
+                            <p:commandButton
+                                id="btnBhtReturnPreviewInpatientDashboard"
+                                ajax="false"
+                                value="Inpatient Dashboard"
+                                icon="fa fa-id-card"
+                                styleClass="ui-button-info ui-button-outlined"
+                                action="#{admissionController.navigateToAdmissionProfilePage}"
+                                rendered="#{bhtIssueReturnController.bill.patientEncounter ne null}">
+                                <f:setPropertyActionListener
+                                    value="#{bhtIssueReturnController.bill.patientEncounter}"
+                                    target="#{admissionController.current}" />
+                            </p:commandButton>
+                        </div>
+
+                        <!-- RIGHT: page actions -->
+                        <div class="d-flex gap-2 align-items-center">
+                            <p:commandButton
+                                ajax="false"
+                                icon="fa fa-plus"
+                                class="ui-button-warning"
+                                action="/inward/pharmacy_search_sale_bill_bht"
+                                actionListener="#{searchController.makeListNull}"
+                                value="Pharmacy Sale Search"
+                                >
+                            </p:commandButton>
+                        </div>
+
+                    </div>
                 </f:facet>
 
-                <div class="d-flex justify-content-end mb-2" >
-                    <div class="d-flex gap-2">
-                        <p:outputLabel value="Paper Type" class="m-2"></p:outputLabel>
-                        <p:selectOneMenu value="#{sessionController.departmentPreference.pharmacyBillPaperType}" class="m-1" style="width: 13em;">
-                            <f:selectItem itemLabel="Please Select Paper Type" />
-                            <f:selectItems value="#{enumController.paperTypes}" />
-                        </p:selectOneMenu>
-                        <p:commandButton ajax="false" icon="fa fa-sync-alt" class="ui-button m-1" title="Redraw Bill"></p:commandButton>
-                    </div>
-                </div>
+                <p:tabView>
+                    <p:tab title="Reprint Bill">
+                        <div class="row">
+                            <div class="col-md-6">
+                                <p:panel >
+                                    <f:facet name="header" >
+                                        <h:outputLabel value="Sale Bill Preview" class="mt-2"/>
+                                        <p:commandButton
+                                            value="Print Sale Bill"
+                                            icon="fa fa-print"
+                                            class="ui-button-info"
+                                            style="float: right;"
+                                            ajax="false" action="#">
+                                            <p:printer target="gpBillPreview2" ></p:printer>
+                                        </p:commandButton>
+                                    </f:facet>
 
-                <div class="row">
-                    <div class="col-md-6">
-                        <p:panel >
+                                    <h:panelGroup   id="gpBillPreview2">
+
+                                        <h:panelGroup id="gpBillPreview2A4Sc" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is A4', false)}">
+                                            <phi:inward_direct_issue_bill_a4 bill="#{bhtIssueReturnController.bill}" duplicate="true" />
+                                        </h:panelGroup>
+
+                                        <h:panelGroup id="gpBillPreview2FiveFiveSc" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is FiveFive', true)}">
+                                            <phi:inward_direct_issue_bill_five_five_sc bill="#{bhtIssueReturnController.bill}" duplicate="true" />
+                                        </h:panelGroup>
+
+                                        <h:panelGroup id="gpBillPreview2PosSc" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is POS', false)}">
+                                            <phi:inward_direct_issue_bill_pos bill="#{bhtIssueReturnController.bill}" duplicate="true" />
+                                        </h:panelGroup>
+
+                                        <h:panelGroup id="gpBillPreviewFiveFiveCustom3Original" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is FiveFiveCustom3',false)}">
+                                            <phi:inward_direct_issue_bill_five_five_custom_3 bill="#{bhtIssueReturnController.bill}"/>
+                                        </h:panelGroup>
+
+                                        <h:panelGroup   id="gpBillPreviewSingle2" rendered="#{sessionController.departmentPreference.pharmacyBillPaperType eq 'PosPaper' and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is A4', false) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is FiveFive', true) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is POS', false)}">
+                                            <div >
+                                                <h:panelGroup rendered="#{sessionController.departmentPreference.pharmacyBillPrabodha eq false}" >
+                                                    <ph:issueBill  bill="#{bhtIssueReturnController.bill}"
+                                                                   showRate="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}"
+                                                                   showDiscount="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates') and webUserController.hasPrivilege('IPBillingViewDiscount')}"/>
+                                                </h:panelGroup>
+                                            </div>
+                                        </h:panelGroup>
+
+                                        <h:panelGroup id="gpBillPreviewDouble2" rendered="#{sessionController.departmentPreference.pharmacyBillPaperType eq 'PosPaper' and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is A4', false) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is FiveFive', true) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is POS', false)}">
+                                            <div >
+                                                <h:panelGroup     rendered="#{sessionController.departmentPreference.pharmacyBillPrabodha eq true}">
+                                                    <phi:saleBill_prabodha bill="#{bhtIssueReturnController.bill}"
+                                                                           showRate="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}"
+                                                                           showDiscount="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates') and webUserController.hasPrivilege('IPBillingViewDiscount')}"></phi:saleBill_prabodha>
+                                                </h:panelGroup>
+                                            </div>
+                                        </h:panelGroup>
+
+                                        <h:panelGroup id="gpBillPreviewFiveFive2" rendered="#{sessionController.departmentPreference.pharmacyBillPaperType eq 'FiveFivePaper' and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is A4', false) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is FiveFive', true) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is POS', false)}">
+                                            <div >
+                                                <h:panelGroup rendered="#{sessionController.departmentPreference.pharmacyBillPrabodha eq false}" >
+                                                    <phi:saleBill_five_five bill="#{bhtIssueReturnController.bill}"
+                                                                            showRate="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}"
+                                                                            showDiscount="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates') and webUserController.hasPrivilege('IPBillingViewDiscount')}"></phi:saleBill_five_five>
+                                                </h:panelGroup>
+                                            </div>
+                                        </h:panelGroup>
+
+                                    </h:panelGroup>
+                                </p:panel>
+
+                            </div>
+                            <div class="col-md-6">
+                                <p:panel styleClass="bht-return-preview-highlight">
+                                    <f:facet name="header" >
+                                        <h:outputLabel value="Return Bill Preview" class="mt-2"/>
+                                        <p:commandButton
+                                            value="Print Return Bill"
+                                            ajax="false"
+                                            style="float: right;"
+                                            icon="fa fa-print"
+                                            class="ui-button-info"
+                                            action="#"  >
+                                            <p:printer target="gpBillPreview1" ></p:printer>
+                                        </p:commandButton>
+                                    </f:facet>
+
+                                    <h:panelGroup   id="gpBillPreview1">
+
+                                        <h:panelGroup id="gpBillPreview1A4Sc" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is A4', false)}">
+                                            <phi:inward_direct_issue_return_bill_a4 bill="#{bhtIssueReturnController.returnBill}" duplicate="true" />
+                                        </h:panelGroup>
+
+                                        <h:panelGroup id="gpBillPreview1FiveFiveSc" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is FiveFive', true)}">
+                                            <phi:inward_direct_issue_return_bill_five_five_sc bill="#{bhtIssueReturnController.returnBill}" duplicate="true" />
+                                        </h:panelGroup>
+
+                                        <h:panelGroup id="gpBillPreview1PosSc" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is POS', false)}">
+                                            <phi:inward_direct_issue_return_bill_pos bill="#{bhtIssueReturnController.returnBill}" duplicate="true" />
+                                        </h:panelGroup>
+
+                                        <h:panelGroup id="gpBillPreviewFiveFiveCustom3" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is FiveFiveCustom3',false)}">
+                                            <phi:inward_direct_issue_return_bill_five_five_custom_3 bill="#{bhtIssueReturnController.returnBill}"/>
+                                        </h:panelGroup>
+
+                                        <h:panelGroup   id="gpBillPreviewSingle" rendered="#{sessionController.departmentPreference.pharmacyBillPaperType eq 'PosPaper' and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is A4', false) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is FiveFive', true) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is POS', false)}">
+                                            <h:panelGroup rendered="#{sessionController.departmentPreference.pharmacyBillPrabodha eq false}" >
+                                                <phi:returnBill bill="#{bhtIssueReturnController.returnBill}"
+                                                                showRate="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}"
+                                                                showDiscount="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates') and webUserController.hasPrivilege('IPBillingViewDiscount')}"/>
+                                            </h:panelGroup>
+                                        </h:panelGroup>
+
+                                        <h:panelGroup id="gpBillPreviewDouble" rendered="#{sessionController.departmentPreference.pharmacyBillPaperType eq 'PosPaper' and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is A4', false) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is FiveFive', true) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is POS', false)}">
+                                            <div >
+                                                <h:panelGroup     rendered="#{sessionController.departmentPreference.pharmacyBillPrabodha eq true}">
+                                                    <phi:saleBill_prabodha bill="#{bhtIssueReturnController.returnBill}"
+                                                                           showRate="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}"
+                                                                           showDiscount="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates') and webUserController.hasPrivilege('IPBillingViewDiscount')}"></phi:saleBill_prabodha>
+                                                </h:panelGroup>
+                                            </div>
+                                        </h:panelGroup>
+
+                                        <h:panelGroup id="gpBillPreviewFiveFive" rendered="#{sessionController.departmentPreference.pharmacyBillPaperType eq 'FiveFivePaper' and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is A4', false) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is FiveFive', true) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is POS', false)}">
+                                            <div >
+                                                <h:panelGroup rendered="#{sessionController.departmentPreference.pharmacyBillPrabodha eq false}" >
+                                                    <phi:saleBill_five_five bill="#{bhtIssueReturnController.returnBill}"
+                                                                            showRate="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}"
+                                                                            showDiscount="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates') and webUserController.hasPrivilege('IPBillingViewDiscount')}"></phi:saleBill_five_five>
+                                                </h:panelGroup>
+                                            </div>
+                                        </h:panelGroup>
+
+                                        <h:panelGroup id="gpBillPreviewPosHeader" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is PosHeaderPaper',false)}">
+                                            <phi:saleBill_Header_Return bill="#{bhtIssueReturnController.returnBill}"
+                                                                        showRate="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}"
+                                                                        showDiscount="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates') and webUserController.hasPrivilege('IPBillingViewDiscount')}"></phi:saleBill_Header_Return>
+                                        </h:panelGroup>
+
+                                    </h:panelGroup>
+                                </p:panel>
+
+                            </div>
+                        </div>
+                    </p:tab>
+
+                    <p:tab title="Running Update Status">
+                        <p:panel header="Item Quantity Reconciliation">
+                            <p:dataTable id="runningStatusTable" var="rs"
+                                         value="#{bhtIssueReturnController.runningStatusRows}"
+                                         emptyMessage="No item quantity details available for this bill.">
+                                <p:column headerText="Item">
+                                    <h:outputText value="#{rs.itemName}" />
+                                </p:column>
+                                <p:column headerText="Sale Qty" style="text-align:right; width:9em;">
+                                    <h:outputText value="#{rs.saleQty}">
+                                        <f:convertNumber pattern="#,##0.####"/>
+                                    </h:outputText>
+                                </p:column>
+                                <p:column headerText="Previously Returned Qty" style="text-align:right; width:12em;">
+                                    <h:outputText value="#{rs.previouslyReturnedQty}">
+                                        <f:convertNumber pattern="#,##0.####"/>
+                                    </h:outputText>
+                                </p:column>
+                                <p:column headerText="This-Time Returning Qty" style="text-align:right; width:12em;">
+                                    <h:outputText value="#{rs.thisTimeReturnedQty}">
+                                        <f:convertNumber pattern="#,##0.####"/>
+                                    </h:outputText>
+                                </p:column>
+                                <p:column headerText="Total Returned Qty" style="text-align:right; width:11em;">
+                                    <h:outputText value="#{rs.totalReturnedQty}">
+                                        <f:convertNumber pattern="#,##0.####"/>
+                                    </h:outputText>
+                                </p:column>
+                                <p:column headerText="Balance Qty" style="text-align:right; width:9em;">
+                                    <h:outputText value="#{rs.balanceQty}">
+                                        <f:convertNumber pattern="#,##0.####"/>
+                                    </h:outputText>
+                                </p:column>
+                            </p:dataTable>
+                        </p:panel>
+                    </p:tab>
+
+                    <p:tab title="Original Bill">
+                        <p:panel>
                             <f:facet name="header" >
-                                <h:outputLabel value="Sale Bill Preview" class="mt-2"/>
-                                <p:commandButton 
-                                    value="Print Sale Bill" 
+                                <h:outputLabel value="Original Bill" class="mt-2"/>
+                                <p:commandButton
+                                    value="Print Original Bill"
                                     icon="fa fa-print"
                                     class="ui-button-info"
                                     style="float: right;"
                                     ajax="false" action="#">
-                                    <p:printer target="gpBillPreview2" ></p:printer>
+                                    <p:printer target="gpBillPreview3" ></p:printer>
                                 </p:commandButton>
                             </f:facet>
 
-                            <h:panelGroup   id="gpBillPreview2">
+                            <div class="d-flex justify-content-center">
+                                    <h:panelGroup   id="gpBillPreview3">
 
-                                <h:panelGroup id="gpBillPreview2A4Sc" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is A4', false)}">
-                                    <phi:inward_direct_issue_bill_a4 bill="#{bhtIssueReturnController.bill}" duplicate="true" />
-                                </h:panelGroup>
-
-                                <h:panelGroup id="gpBillPreview2FiveFiveSc" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is FiveFive', true)}">
-                                    <phi:inward_direct_issue_bill_five_five_sc bill="#{bhtIssueReturnController.bill}" duplicate="true" />
-                                </h:panelGroup>
-
-                                <h:panelGroup id="gpBillPreview2PosSc" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is POS', false)}">
-                                    <phi:inward_direct_issue_bill_pos bill="#{bhtIssueReturnController.bill}" duplicate="true" />
-                                </h:panelGroup>
-
-                                <h:panelGroup id="gpBillPreviewFiveFiveCustom3Original" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is FiveFiveCustom3',false)}">
-                                    <phi:inward_direct_issue_bill_five_five_custom_3 bill="#{bhtIssueReturnController.bill}"/>
-                                </h:panelGroup>
-
-                                <h:panelGroup   id="gpBillPreviewSingle2" rendered="#{sessionController.departmentPreference.pharmacyBillPaperType eq 'PosPaper' and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is A4', false) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is FiveFive', true) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is POS', false)}">
-                                    <div >
-                                        <h:panelGroup rendered="#{sessionController.departmentPreference.pharmacyBillPrabodha eq false}" >
-                                            <ph:issueBill  bill="#{bhtIssueReturnController.bill}"
-                                                           showRate="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}"
-                                                           showDiscount="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates') and webUserController.hasPrivilege('IPBillingViewDiscount')}"/>
+                                        <h:panelGroup id="gpBillPreview3A4Sc" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is A4', false)}">
+                                            <phi:inward_direct_issue_bill_a4 bill="#{bhtIssueReturnController.bill}" duplicate="true" />
                                         </h:panelGroup>
-                                    </div>
-                                </h:panelGroup>
 
-                                <h:panelGroup id="gpBillPreviewDouble2" rendered="#{sessionController.departmentPreference.pharmacyBillPaperType eq 'PosPaper' and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is A4', false) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is FiveFive', true) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is POS', false)}">
-                                    <div >
-                                        <h:panelGroup     rendered="#{sessionController.departmentPreference.pharmacyBillPrabodha eq true}">
-                                            <phi:saleBill_prabodha bill="#{bhtIssueReturnController.bill}"
+                                        <h:panelGroup id="gpBillPreview3FiveFiveSc" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is FiveFive', true)}">
+                                            <phi:inward_direct_issue_bill_five_five_sc bill="#{bhtIssueReturnController.bill}" duplicate="true" />
+                                        </h:panelGroup>
+
+                                        <h:panelGroup id="gpBillPreview3PosSc" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is POS', false)}">
+                                            <phi:inward_direct_issue_bill_pos bill="#{bhtIssueReturnController.bill}" duplicate="true" />
+                                        </h:panelGroup>
+
+                                        <h:panelGroup id="gpBillPreviewFiveFiveCustom3Original3" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is FiveFiveCustom3',false)}">
+                                            <phi:inward_direct_issue_bill_five_five_custom_3 bill="#{bhtIssueReturnController.bill}"/>
+                                        </h:panelGroup>
+
+                                        <h:panelGroup   id="gpBillPreviewSingle3" rendered="#{sessionController.departmentPreference.pharmacyBillPaperType eq 'PosPaper' and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is A4', false) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is FiveFive', true) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is POS', false)}">
+                                            <div >
+                                                <h:panelGroup rendered="#{sessionController.departmentPreference.pharmacyBillPrabodha eq false}" >
+                                                    <ph:issueBill  bill="#{bhtIssueReturnController.bill}"
                                                                    showRate="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}"
-                                                                   showDiscount="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates') and webUserController.hasPrivilege('IPBillingViewDiscount')}"></phi:saleBill_prabodha>
+                                                                   showDiscount="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates') and webUserController.hasPrivilege('IPBillingViewDiscount')}"/>
+                                                </h:panelGroup>
+                                            </div>
                                         </h:panelGroup>
-                                    </div>
-                                </h:panelGroup>
 
-                                <h:panelGroup id="gpBillPreviewFiveFive2" rendered="#{sessionController.departmentPreference.pharmacyBillPaperType eq 'FiveFivePaper' and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is A4', false) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is FiveFive', true) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is POS', false)}">
-                                    <div >
-                                        <h:panelGroup rendered="#{sessionController.departmentPreference.pharmacyBillPrabodha eq false}" >
-                                            <phi:saleBill_five_five bill="#{bhtIssueReturnController.bill}"
-                                                                    showRate="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}"
-                                                                    showDiscount="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates') and webUserController.hasPrivilege('IPBillingViewDiscount')}"></phi:saleBill_five_five>
+                                        <h:panelGroup id="gpBillPreviewDouble3" rendered="#{sessionController.departmentPreference.pharmacyBillPaperType eq 'PosPaper' and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is A4', false) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is FiveFive', true) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is POS', false)}">
+                                            <div >
+                                                <h:panelGroup     rendered="#{sessionController.departmentPreference.pharmacyBillPrabodha eq true}">
+                                                    <phi:saleBill_prabodha bill="#{bhtIssueReturnController.bill}"
+                                                                           showRate="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}"
+                                                                           showDiscount="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates') and webUserController.hasPrivilege('IPBillingViewDiscount')}"></phi:saleBill_prabodha>
+                                                </h:panelGroup>
+                                            </div>
                                         </h:panelGroup>
-                                    </div>
-                                </h:panelGroup>
 
-                            </h:panelGroup>
-                        </p:panel>
+                                        <h:panelGroup id="gpBillPreviewFiveFive3" rendered="#{sessionController.departmentPreference.pharmacyBillPaperType eq 'FiveFivePaper' and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is A4', false) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is FiveFive', true) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is POS', false)}">
+                                            <div >
+                                                <h:panelGroup rendered="#{sessionController.departmentPreference.pharmacyBillPrabodha eq false}" >
+                                                    <phi:saleBill_five_five bill="#{bhtIssueReturnController.bill}"
+                                                                            showRate="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}"
+                                                                            showDiscount="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates') and webUserController.hasPrivilege('IPBillingViewDiscount')}"></phi:saleBill_five_five>
+                                                </h:panelGroup>
+                                            </div>
+                                        </h:panelGroup>
 
-                    </div>
-                    <div class="col-md-6">
-                        <p:panel >
-                            <f:facet name="header" >
-                                <h:outputLabel value="Return Bill Preview" class="mt-2"/>
-                                <p:commandButton 
-                                    value="Print Return Bill" 
-                                    ajax="false" 
-                                    style="float: right;"
-                                    icon="fa fa-print"
-                                    class="ui-button-info"
-                                    action="#"  >
-                                    <p:printer target="gpBillPreview1" ></p:printer>
-                                </p:commandButton>
-                            </f:facet>
-
-                            <h:panelGroup   id="gpBillPreview1">
-
-                                <h:panelGroup id="gpBillPreview1A4Sc" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is A4', false)}">
-                                    <phi:inward_direct_issue_return_bill_a4 bill="#{bhtIssueReturnController.returnBill}" duplicate="true" />
-                                </h:panelGroup>
-
-                                <h:panelGroup id="gpBillPreview1FiveFiveSc" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is FiveFive', true)}">
-                                    <phi:inward_direct_issue_return_bill_five_five_sc bill="#{bhtIssueReturnController.returnBill}" duplicate="true" />
-                                </h:panelGroup>
-
-                                <h:panelGroup id="gpBillPreview1PosSc" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is POS', false)}">
-                                    <phi:inward_direct_issue_return_bill_pos bill="#{bhtIssueReturnController.returnBill}" duplicate="true" />
-                                </h:panelGroup>
-
-                                <h:panelGroup id="gpBillPreviewFiveFiveCustom3" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is FiveFiveCustom3',false)}">
-                                    <phi:inward_direct_issue_return_bill_five_five_custom_3 bill="#{bhtIssueReturnController.returnBill}"/>
-                                </h:panelGroup>
-
-                                <h:panelGroup   id="gpBillPreviewSingle" rendered="#{sessionController.departmentPreference.pharmacyBillPaperType eq 'PosPaper' and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is A4', false) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is FiveFive', true) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is POS', false)}">
-                                    <h:panelGroup rendered="#{sessionController.departmentPreference.pharmacyBillPrabodha eq false}" >
-                                        <phi:returnBill bill="#{bhtIssueReturnController.returnBill}"
-                                                        showRate="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}"
-                                                        showDiscount="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates') and webUserController.hasPrivilege('IPBillingViewDiscount')}"/>
                                     </h:panelGroup>
-                                </h:panelGroup>
-
-                                <h:panelGroup id="gpBillPreviewDouble" rendered="#{sessionController.departmentPreference.pharmacyBillPaperType eq 'PosPaper' and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is A4', false) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is FiveFive', true) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is POS', false)}">
-                                    <div >
-                                        <h:panelGroup     rendered="#{sessionController.departmentPreference.pharmacyBillPrabodha eq true}">
-                                            <phi:saleBill_prabodha bill="#{bhtIssueReturnController.returnBill}"
-                                                                   showRate="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}"
-                                                                   showDiscount="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates') and webUserController.hasPrivilege('IPBillingViewDiscount')}"></phi:saleBill_prabodha>
-                                        </h:panelGroup>
-                                    </div>
-                                </h:panelGroup>
-
-                                <h:panelGroup id="gpBillPreviewFiveFive" rendered="#{sessionController.departmentPreference.pharmacyBillPaperType eq 'FiveFivePaper' and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is A4', false) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is FiveFive', true) and !configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is POS', false)}">
-                                    <div >
-                                        <h:panelGroup rendered="#{sessionController.departmentPreference.pharmacyBillPrabodha eq false}" >
-                                            <phi:saleBill_five_five bill="#{bhtIssueReturnController.returnBill}"
-                                                                    showRate="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}"
-                                                                    showDiscount="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates') and webUserController.hasPrivilege('IPBillingViewDiscount')}"></phi:saleBill_five_five>
-                                        </h:panelGroup>
-                                    </div>
-                                </h:panelGroup>
-
-                                <h:panelGroup id="gpBillPreviewPosHeader" rendered="#{configOptionApplicationController.getBooleanValueByKey('Pharmacy Inward Direct Issue Bill is PosHeaderPaper',false)}">
-                                    <phi:saleBill_Header_Return bill="#{bhtIssueReturnController.returnBill}"
-                                                                showRate="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}"
-                                                                showDiscount="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates') and webUserController.hasPrivilege('IPBillingViewDiscount')}"></phi:saleBill_Header_Return>
-                                </h:panelGroup>
-
-                            </h:panelGroup>
+                            </div>
                         </p:panel>
-
-                    </div>
-                </div>
+                    </p:tab>
+                </p:tabView>
 
             </p:panel>
+
 
         </h:form>
 


### PR DESCRIPTION
Closes #23338

## What changed

All five parts of the issue, scoped to the post-settle `printPreview` panel of `inward/pharmacy_bill_return_bht_issue.xhtml`. The pre-settle entry panel is untouched.

### 1. Legacy Paper Type control removed

The issue asked whether any department still relies on the **Paper Type** dropdown + **Redraw Bill** button. Investigation says no, on every deployment I can inspect:

- The dropdown drives six fallback preview branches, **every one of which also requires `Pharmacy Inward Direct Issue Bill is FiveFive` to be false**.
- `ConfigOptionApplicationController.getBooleanValueByKey(key, default)` *creates* the row with its default when the key is absent, and that key's default is `true`.
- Across local copies of coop / ruhunu / rmh / sl the key is either explicitly `true` (coop) or absent-so-true (the rest) — so those branches never render.
- The dropdown also never persisted anything: it mutated the session-scoped `UserPreference` with no `facade.edit`. The adjacent **Redraw Bill** button had no `action` at all.

The same dropdown still exists independently on ~10 other pages, so removing it here loses nothing.

**The render branches are deliberately left in place.** Removing them would be a real behaviour change for any deployment that has set `FiveFive=false`, and is out of scope for this issue.

### 2. Return Bill Preview highlighted

`styleClass` on the **outer** `p:panel` only — never on `gpBillPreview1`, the node `p:printer` clones — plus a `@media print` reset. Print safety is therefore belt-and-braces, and both halves are verified below.

### 3. New "Running Update Status" tab

Per-item reconciliation: Item | Sale Qty | Previously Returned Qty | This-Time Returning Qty | Total Returned Qty | Balance Qty.

Two design points worth review attention:

- **Driven from the original bill's `PharmaceuticalBillItem`s, not `billItems`.** `generateBillComponent()` does `if (tmpQty <= 0) { continue; }`, so fully-returned lines are absent from `billItems` — and those are precisely the lines a reconciliation view must still show (with Balance 0).
- **Reuses `getTotalQty(BillItem, BillType)`** — the same call `generateBillComponent()` and `settle()`'s validation loop already make — so this table cannot disagree with the "Balance Qty in Unit" the pre-settle grid shows. It is built after persistence, since that aggregate only includes the just-settled return once `saveComponent()` has committed.

`BhtIssueReturnItemStatusDto` is a new plain view-model POJO (not a JPQL constructor DTO). New class only — no existing constructor touched.

### 4. Three tabs

`Reprint Bill` / `Running Update Status` / `Original Bill`, non-dynamic so every print target stays resolvable. The Original Bill tab duplicates the Sale Bill Preview markup with `3`-suffixed ids rather than sharing a `ui:include` — an include would re-emit identical ids in the same view.

### 5. Three-zone header

Per `developer_docs/ui/comprehensive-ui-guidelines.md`: title + cog | **Inpatient Dashboard** | Pharmacy Sale Search.

## Verification

Local Payara, coop DB, Main Pharmacy, bill `MP//26/014530` (7 lines, one already fully returned before this test).

**Three successive partial returns**, to exercise the multi-return case:

| Item | Sale | Previously | This-Time | Total | Balance |
|---|---|---|---|---|---|
| Pantodac 40mg tablet | 10 | 7 | 0 | 7 | 3 |
| Measuring Cup | 1 | 0 | 1 | 1 | 0 |
| D/Needle-18G spc | 2 | 0 | 0 | 0 | 2 |
| Soft roll 6" | 3 | 1 | 0 | 1 | 2 |
| FINETEX 9*9 | 3 | 0 | 0 | 0 | 3 |
| Gypsona 6" (15cm) | 3 | 0 | 0 | 0 | 3 |
| Clexane 60 mg Injection | 1 | 1 | 0 | 1 | 0 |

- `previously + thisTime = total` on every row, and "Previously Returned" is non-zero on three of them.
- **Clexane appears with Balance 0** even though the pre-settle grid drops it — the case part 3 exists for.
- Cross-checked against the DB: `SUM(ABS(PHARMACEUTICALBILLITEM.QTY))` over return items per `REFERANCEBILLITEM_ID` matches Total Returned, and `sale − total` matches Balance, for all 7 rows.
- **Print safety**, via print-media emulation (never clicking `p:printer` — see workflow doc §43): the printer target does not carry the highlight class, and under `media: print` the panel border, box-shadow and title-bar tint all resolve to `none`/transparent.
- **Inpatient Dashboard** button lands on `admission_profile.xhtml` for the correct admission (BHT `OPDCARD/42277`).
- 43 component ids, all unique; XHTML well-formed; printer targets exactly `gpBillPreview2` / `gpBillPreview1` / `gpBillPreview3`.

No schema change, so no `generate-ddl` step.

### One defect caught during verification

The first cut of the highlight looked right in a screenshot but the title-bar tint was silently discarded — the Material theme's `body .ui-panel .ui-panel-titlebar` (specificity 0,2,1) out-specifies a plain `.my-class > .ui-panel-titlebar` (0,2,0). Only the outer border was landing. Fixed by qualifying the selectors, and written up as §83 in the Playwright workflow doc so the next person catches it with a computed-style probe instead of a screenshot.

## Documentation

Wiki page updated with screenshots of all three tabs: [Direct Issue Return to Pharmacy](https://github.com/hmislk/hmis/wiki/Direct-Issue-Return-to-Pharmacy) (see **Step 5 — Bill Preview**).

Note: that page's Step 5 previously claimed the user could reach **Interim Bill** and **Inpatient Dashboard** from this screen — neither was true; those buttons only existed on the *pre-settle* panel. Part 5 makes the Inpatient Dashboard half real, and the Interim Bill claim has been dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019jYzekzdyGhaFeYJw4oqcE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added tabbed return-bill preview navigation for reprinting, quantity status, and original-bill viewing.
  - Added item-level reconciliation showing sold, previously returned, current return, total returned, and remaining quantities.
  - Added navigation to inpatient dashboards and pharmacy sale searches.
  - Added support for A4, POS, custom, and department-specific original-bill layouts.
  - Highlighted the return preview for improved visibility.

- **Documentation**
  - Added guidance for diagnosing theme-related styling issues in Playwright end-to-end tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->