### PR TITLE
feat(inward): interim bill Fees and Details - totals, export, tab rename, name fix

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -4767,6 +4767,21 @@ public class BhtSummeryController implements Serializable {
         this.due = due;
     }
 
+    public double getVisibleIssueTotal(List<Bill> issues) {
+        if (issues == null) {
+            return 0.0;
+        }
+        double total = 0.0;
+        for (Bill iss : issues) {
+            boolean visible = (iss instanceof PreBill)
+                    || (iss instanceof RefundBill && iss.getBilledBill() != null);
+            if (visible) {
+                total += iss.getNetTotal();
+            }
+        }
+        return total;
+    }
+
     public Date getCurrentTime() {
         currentTime = Calendar.getInstance().getTime();
 

--- a/src/main/webapp/inward/inward_bill_intrim.xhtml
+++ b/src/main/webapp/inward/inward_bill_intrim.xhtml
@@ -478,7 +478,7 @@
                                 <p:outputLabel value="Fees and Details" class="mx-2"/>
                             </f:facet>
                             <p:tabView  id="tvPt"  rendered="#{bhtSummeryController.patientEncounter ne null}" >
-                                <p:tab id="tabNewPt" title="Room Details" >
+                                <p:tab id="tabNewPt" title="Room Charges" >
                                     <div class="d-flex justify-content-end mb-2">
                                         <p:commandButton
                                             ajax="false"
@@ -486,6 +486,22 @@
                                             icon="fa-solid fa-bed"
                                             class="ui-button-info"
                                             action="#{bhtSummeryController.navigateToPatientRoomDetails()}"/>
+                                        <p:commandButton value="Excel"
+                                                         icon="fas fa-file-excel"
+                                                         class="ui-button-success mx-1"
+                                                         ajax="false">
+                                            <p:dataExporter type="xlsx"
+                                                            target="roomCharges"
+                                                            fileName="Room_Charges" />
+                                        </p:commandButton>
+                                        <p:commandButton value="PDF"
+                                                         icon="fas fa-file-pdf"
+                                                         class="ui-button-danger"
+                                                         ajax="false">
+                                            <p:dataExporter type="pdf"
+                                                            target="roomCharges"
+                                                            fileName="Room_Charges" />
+                                        </p:commandButton>
                                     </div>
                                     <h:panelGroup rendered="#{!bhtSummeryController.patientEncounter.roomAdmitted}">
                                         <div class="d-flex justify-content-center text-muted py-2">
@@ -494,7 +510,7 @@
                                         </div>
                                     </h:panelGroup>
                                     <h:panelGroup rendered="#{bhtSummeryController.patientEncounter.roomAdmitted}">
-                                        <p:dataTable value="#{bhtSummeryController.patientRooms}" var="rm" style="min-width:10em;">
+                                        <p:dataTable id="roomCharges" value="#{bhtSummeryController.patientRooms}" var="rm" style="min-width:10em;">
                                             <p:column headerText="Room" styleClass="text-start">
                                                 <div class="d-flex align-items-center gap-2">
                                                     <h:outputLabel value="#{rm.roomFacilityCharge.name}" style="display: inline;"/>
@@ -578,8 +594,26 @@
                                     </h:panelGroup>
                                 </p:tab>
 
-                                <p:tab id="tabTimed" title="Timed Service Details"  >
-                                    <p:dataTable  value="#{bhtSummeryController.patientItems}" var="pt">
+                                <p:tab id="tabTimed" title="Timed Service Charges"  >
+                                    <div class="d-flex justify-content-end mb-2">
+                                        <p:commandButton value="Excel"
+                                                         icon="fas fa-file-excel"
+                                                         class="ui-button-success mx-1"
+                                                         ajax="false">
+                                            <p:dataExporter type="xlsx"
+                                                            target="timedServiceCharges"
+                                                            fileName="Timed_Service_Charges" />
+                                        </p:commandButton>
+                                        <p:commandButton value="PDF"
+                                                         icon="fas fa-file-pdf"
+                                                         class="ui-button-danger"
+                                                         ajax="false">
+                                            <p:dataExporter type="pdf"
+                                                            target="timedServiceCharges"
+                                                            fileName="Timed_Service_Charges" />
+                                        </p:commandButton>
+                                    </div>
+                                    <p:dataTable id="timedServiceCharges" value="#{bhtSummeryController.patientItems}" var="pt">
                                         <p:column headerText="Service Name" styleClass="text-start">
                                             <h:outputLabel value="#{pt.item.name}"/>
                                         </p:column>
@@ -635,7 +669,25 @@
                                     </p:dataTable>
                                 </p:tab>
 
-                                <p:tab id="tabSer" title="Service Details"  >
+                                <p:tab id="tabSer" title="Service and Investigation Charges"  >
+                                    <div class="d-flex justify-content-end mb-2">
+                                        <p:commandButton value="Excel"
+                                                         icon="fas fa-file-excel"
+                                                         class="ui-button-success mx-1"
+                                                         ajax="false">
+                                            <p:dataExporter type="xlsx"
+                                                            target="service"
+                                                            fileName="Service_and_Investigation_Charges" />
+                                        </p:commandButton>
+                                        <p:commandButton value="PDF"
+                                                         icon="fas fa-file-pdf"
+                                                         class="ui-button-danger"
+                                                         ajax="false">
+                                            <p:dataExporter type="pdf"
+                                                            target="service"
+                                                            fileName="Service_and_Investigation_Charges" />
+                                        </p:commandButton>
+                                    </div>
                                     <p:dataTable id="service" scrollable="true" scrollHeight="300"
                                                  value="#{bhtSummeryController.departmentBillItems}" var="dep">
                                         <p:columnGroup type="header">
@@ -790,11 +842,30 @@
                                     </p:dataTable>
                                 </p:tab>
 
-                                <p:tab title="Medicine Issue">
+                                <p:tab title="Medicine and Consumable Charges">
+                                    <div class="d-flex justify-content-end mb-2">
+                                        <p:commandButton value="Excel"
+                                                         icon="fas fa-file-excel"
+                                                         class="ui-button-success mx-1"
+                                                         ajax="false">
+                                            <p:dataExporter type="xlsx"
+                                                            target="#{configOptionApplicationController.getBooleanValueByKey('Medicine, Sort by the type of department that issued it.', false) ? 'medIssueEtu,medIssuePharmacy,medIssueInward,medIssueTheatre,medIssueStore,medIssueInventory' : 'medIssueFlat'}"
+                                                            fileName="Medicine_and_Consumable_Charges" />
+                                        </p:commandButton>
+                                        <p:commandButton value="PDF"
+                                                         icon="fas fa-file-pdf"
+                                                         class="ui-button-danger"
+                                                         ajax="false">
+                                            <p:dataExporter type="pdf"
+                                                            target="#{configOptionApplicationController.getBooleanValueByKey('Medicine, Sort by the type of department that issued it.', false) ? 'medIssueEtu,medIssuePharmacy,medIssueInward,medIssueTheatre,medIssueStore,medIssueInventory' : 'medIssueFlat'}"
+                                                            fileName="Medicine_and_Consumable_Charges" />
+                                        </p:commandButton>
+                                    </div>
                                     <h:panelGroup rendered="#{not configOptionApplicationController.getBooleanValueByKey('Medicine, Sort by the type of department that issued it.', false)}">
-                                        <p:dataTable 
-                                            value="#{bhtSummeryController.pharmacyIssues}" 
-                                            var="iss" 
+                                        <p:dataTable
+                                            id="medIssueFlat"
+                                            value="#{bhtSummeryController.pharmacyIssues}"
+                                            var="iss"
                                             scrollable="true"
                                             scrollHeight="300"
                                             rowStyleClass="#{((iss.billClass eq 'class com.divudi.core.entity.PreBill')
@@ -899,6 +970,18 @@
                                             .med-issue-tabs .ui-tabs-nav li.ui-state-active .med-tab-pill .fa { color: #fff; }
                                             .med-issue-tabs .med-tab-pill .ui-badge { margin-left: auto; flex: 0 0 auto; min-width: 1.8em; height: 1.8em; line-height: 1.8em; font-size: 1em; border-radius: 50%; }
                                         </style>
+                                        <div class="d-flex justify-content-end mb-2">
+                                            <h:outputLabel value="Total Medicine Issue : " style="font-weight: bold;"/>
+                                            <h:outputLabel value="#{bhtSummeryController.getVisibleIssueTotal(bhtSummeryController.etuMedicineIssues)
+                                                                    + bhtSummeryController.getVisibleIssueTotal(bhtSummeryController.pharmacyMedicineIssues)
+                                                                    + bhtSummeryController.getVisibleIssueTotal(bhtSummeryController.inwardMedicineIssues)
+                                                                    + bhtSummeryController.getVisibleIssueTotal(bhtSummeryController.theatreMedicineIssues)
+                                                                    + bhtSummeryController.getVisibleIssueTotal(bhtSummeryController.storeMedicineIssues)
+                                                                    + bhtSummeryController.getVisibleIssueTotal(bhtSummeryController.inventryMedicineIssues)}"
+                                                           style="font-weight: bold;">
+                                                <f:convertNumber pattern="#,##0.00"/>
+                                            </h:outputLabel>
+                                        </div>
                                         <div class="d-flex justify-content-center w-100">
                                             <p:tabView id="medIssueDeptTabs" styleClass="med-issue-tabs" style="width:100%;">
 
@@ -911,6 +994,7 @@
                                                     </f:facet>
                                                     <ui:decorate template="/inward/inward_bill_intrim_medicine_issue_table.xhtml">
                                                         <ui:param name="issues" value="#{bhtSummeryController.etuMedicineIssues}"/>
+                                                        <ui:param name="tableId" value="medIssueEtu"/>
                                                     </ui:decorate>
                                                 </p:tab>
 
@@ -923,6 +1007,7 @@
                                                     </f:facet>
                                                     <ui:decorate template="/inward/inward_bill_intrim_medicine_issue_table.xhtml">
                                                         <ui:param name="issues" value="#{bhtSummeryController.pharmacyMedicineIssues}"/>
+                                                        <ui:param name="tableId" value="medIssuePharmacy"/>
                                                     </ui:decorate>
                                                 </p:tab>
 
@@ -935,6 +1020,7 @@
                                                     </f:facet>
                                                     <ui:decorate template="/inward/inward_bill_intrim_medicine_issue_table.xhtml">
                                                         <ui:param name="issues" value="#{bhtSummeryController.inwardMedicineIssues}"/>
+                                                        <ui:param name="tableId" value="medIssueInward"/>
                                                     </ui:decorate>
                                                 </p:tab>
 
@@ -947,6 +1033,7 @@
                                                     </f:facet>
                                                     <ui:decorate template="/inward/inward_bill_intrim_medicine_issue_table.xhtml">
                                                         <ui:param name="issues" value="#{bhtSummeryController.theatreMedicineIssues}"/>
+                                                        <ui:param name="tableId" value="medIssueTheatre"/>
                                                     </ui:decorate>
                                                 </p:tab>
 
@@ -959,6 +1046,7 @@
                                                     </f:facet>
                                                     <ui:decorate template="/inward/inward_bill_intrim_medicine_issue_table.xhtml">
                                                         <ui:param name="issues" value="#{bhtSummeryController.storeMedicineIssues}"/>
+                                                        <ui:param name="tableId" value="medIssueStore"/>
                                                     </ui:decorate>
                                                 </p:tab>
 
@@ -971,6 +1059,7 @@
                                                     </f:facet>
                                                     <ui:decorate template="/inward/inward_bill_intrim_medicine_issue_table.xhtml">
                                                         <ui:param name="issues" value="#{bhtSummeryController.inventryMedicineIssues}"/>
+                                                        <ui:param name="tableId" value="medIssueInventory"/>
                                                     </ui:decorate>
                                                 </p:tab>
 
@@ -981,97 +1070,37 @@
 
                                 </p:tab>
 
-                                <p:tab title="Store Issue">
-                                    <p:dataTable value="#{bhtSummeryController.storeIssues}" var="iss" scrollable="true"
-                                                 scrollHeight="300"
-                                                 rowStyleClass="#{((iss.billClass eq 'class com.divudi.core.entity.PreBill')
-                                                                  or
-                                                                  (iss.billedBill ne null
-                                                                  and iss.billClass eq 'class com.divudi.core.entity.RefundBill'))? '':'noDisplayRow'}">
-                                        <p:column headerText="Bill No">
-
-                                            #{iss.deptId}
-                                        </p:column>
-                                        <p:column headerText="Bill Total" >
-                                            <h:outputLabel  value="#{iss.netTotal}">
-                                                <f:convertNumber pattern="#,##0.00"/>
-                                            </h:outputLabel>
-                                        </p:column>
-                                        <p:column headerText="Billed Date">
-                                            <h:outputLabel value="#{iss.createdAt}">
-                                                <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.shortDateFormat}" />
-                                            </h:outputLabel>
-                                            <br/>
-                                            <h:panelGroup rendered="#{iss.cancelled}" >
-                                                <h:outputLabel style="color: red;" value="Cancelled at " />
-                                                <h:outputLabel style="color: red;" rendered="#{iss.cancelled}"
-                                                               value="#{iss.cancelledBill.createdAt}" >
-                                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateFormat}"/>
-                                                </h:outputLabel>
-                                            </h:panelGroup>
-                                        </p:column>
-                                        <p:column headerText="Billed Time" >
-                                            <h:outputLabel value="#{iss.createdAt}">
-                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longTimeFormat}"/>
-                                            </h:outputLabel>
-                                            <br/>
-                                            <h:panelGroup rendered="#{iss.cancelled}" >
-                                                <h:outputLabel style="color: red;" value="Cancelled at " />
-                                                <h:outputLabel style="color: red;" rendered="#{iss.cancelled}"
-                                                               value="#{iss.cancelledBill.createdAt}" >
-                                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longTimeFormat}"/>
-                                                </h:outputLabel>
-                                            </h:panelGroup>
-                                        </p:column>
-                                        <p:column headerText="Billed By">
-                                            <h:outputLabel value="#{iss.creater.webUserPerson.name}"/>
-                                            <br/>
-                                            <h:panelGroup rendered="#{iss.cancelled}" >
-                                                <h:outputLabel style="color: red;" value="Cancelled By " />
-                                                <h:outputLabel style="color: red;" rendered="#{iss.cancelled}"
-                                                               value="#{iss.cancelledBill.creater.webUserPerson.name}" >
-                                                </h:outputLabel>
-                                            </h:panelGroup>
-                                        </p:column>
-                                        <p:column headerText="Checked By">
-                                            <h:outputLabel value="#{iss.checkedBy.webUserPerson.name}"/>
-                                        </p:column>
-                                        <p:column headerText="Checked At">
-                                            <h:outputLabel value="#{iss.checkeAt}">
-                                                <f:convertDateTime  timeZone="Asia/Colombo" pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
-                                            </h:outputLabel>
-                                        </p:column>
-                                        <p:column>
-                                            <p:commandButton 
-                                                ajax="false" 
-                                                action="store_reprint_bill_sale_bht?faces-redirect=true"
-                                                rendered="#{iss.billClass eq 'class com.divudi.core.entity.PreBill'}" 
-                                                value="View Issue"  >
-                                                <f:setPropertyActionListener value="#{iss}" target="#{storeBillSearch.bill}"/>
-                                            </p:commandButton>
-                                            <p:commandButton 
-                                                ajax="false" 
-                                                action="store_reprint_bill_return_bht?faces-redirect=true"
-                                                rendered="#{iss.billClass eq 'class com.divudi.core.entity.RefundBill'}"
-                                                value="View Return"  >
-                                                <f:setPropertyActionListener value="#{iss}" target="#{storeBillSearch.bill}"/>
-                                            </p:commandButton>
-                                        </p:column>
-                                    </p:dataTable>
-                                </p:tab>
-
-                                <p:tab id="tabAdd" title="Out Side Charge Details"  >
-                                    <p:dataTable    
-                                        scrollable="true" 
+                                <p:tab id="tabAdd" title="Outside Charges"  >
+                                    <div class="d-flex justify-content-end mb-2">
+                                        <p:commandButton value="Excel"
+                                                         icon="fas fa-file-excel"
+                                                         class="ui-button-success mx-1"
+                                                         ajax="false">
+                                            <p:dataExporter type="xlsx"
+                                                            target="outsideCharges"
+                                                            fileName="Outside_Charges" />
+                                        </p:commandButton>
+                                        <p:commandButton value="PDF"
+                                                         icon="fas fa-file-pdf"
+                                                         class="ui-button-danger"
+                                                         ajax="false">
+                                            <p:dataExporter type="pdf"
+                                                            target="outsideCharges"
+                                                            fileName="Outside_Charges" />
+                                        </p:commandButton>
+                                    </div>
+                                    <p:dataTable
+                                        id="outsideCharges"
+                                        scrollable="true"
                                         scrollHeight="300"
-                                        value="#{bhtSummeryController.additionalChargeBill}" 
+                                        value="#{bhtSummeryController.additionalChargeBill}"
                                         var="bil"
                                         rowStyleClass="#{((bil.billClass eq 'class com.divudi.core.entity.BilledBill')
                                                          or
                                                          (bil.billedBill eq null
                                                          and bil.billClass eq 'class com.divudi.core.entity.RefundBill'))? '':'noDisplayRow'}">
                                         <p:column headerText="Name">
-                                            #{bil.comments}
+                                            #{bil.singleBillItem.item.name}
                                         </p:column>
                                         <p:column headerText="Cost" >
                                             <h:outputLabel  value="#{bil.total}">
@@ -1141,10 +1170,29 @@
                                 </p:tab>
 
                                 <p:tab id="tabPro" title="Professional Fees"  >
-                                    <p:dataTable 
-                                        scrollable="true" 
+                                    <div class="d-flex justify-content-end mb-2">
+                                        <p:commandButton value="Excel"
+                                                         icon="fas fa-file-excel"
+                                                         class="ui-button-success mx-1"
+                                                         ajax="false">
+                                            <p:dataExporter type="xlsx"
+                                                            target="professionalFees"
+                                                            fileName="Professional_Fees" />
+                                        </p:commandButton>
+                                        <p:commandButton value="PDF"
+                                                         icon="fas fa-file-pdf"
+                                                         class="ui-button-danger"
+                                                         ajax="false">
+                                            <p:dataExporter type="pdf"
+                                                            target="professionalFees"
+                                                            fileName="Professional_Fees" />
+                                        </p:commandButton>
+                                    </div>
+                                    <p:dataTable
+                                        id="professionalFees"
+                                        scrollable="true"
                                         scrollHeight="300"
-                                        value="#{bhtSummeryController.profesionallFee}" 
+                                        value="#{bhtSummeryController.profesionallFee}"
                                         var="pf"
                                         rowStyleClass="#{pf.bill.billClass eq 'class com.divudi.core.entity.BilledBill' ? '':'noDisplayRow'}">
 
@@ -1229,10 +1277,29 @@
                                     </p:dataTable>
                                 </p:tab>
 
-                                <p:tab id="tabDoc" title="Assisting Fees"  >
-                                    <p:dataTable  
-                                        scrollable="true" 
-                                        scrollHeight="300"  
+                                <p:tab id="tabDoc" title="Assistant Charges"  >
+                                    <div class="d-flex justify-content-end mb-2">
+                                        <p:commandButton value="Excel"
+                                                         icon="fas fa-file-excel"
+                                                         class="ui-button-success mx-1"
+                                                         ajax="false">
+                                            <p:dataExporter type="xlsx"
+                                                            target="assistantCharges"
+                                                            fileName="Assistant_Charges" />
+                                        </p:commandButton>
+                                        <p:commandButton value="PDF"
+                                                         icon="fas fa-file-pdf"
+                                                         class="ui-button-danger"
+                                                         ajax="false">
+                                            <p:dataExporter type="pdf"
+                                                            target="assistantCharges"
+                                                            fileName="Assistant_Charges" />
+                                        </p:commandButton>
+                                    </div>
+                                    <p:dataTable
+                                        id="assistantCharges"
+                                        scrollable="true"
+                                        scrollHeight="300"
                                         value="#{bhtSummeryController.doctorAndNurseFee}"
                                         var="pf"
                                         rowStyleClass="#{pf.bill.billClass eq 'class com.divudi.core.entity.BilledBill' ? '':'noDisplayRow'}">
@@ -1318,9 +1385,28 @@
                                     </p:dataTable>
                                 </p:tab>
 
-                                <p:tab id="tabP" title="Payments"  >
-                                    <p:dataTable  
-                                        scrollable="true" 
+                                <p:tab id="tabP" title="Deposits &amp; Payments"  >
+                                    <div class="d-flex justify-content-end mb-2">
+                                        <p:commandButton value="Excel"
+                                                         icon="fas fa-file-excel"
+                                                         class="ui-button-success mx-1"
+                                                         ajax="false">
+                                            <p:dataExporter type="xlsx"
+                                                            target="depositsPayments"
+                                                            fileName="Deposits_and_Payments" />
+                                        </p:commandButton>
+                                        <p:commandButton value="PDF"
+                                                         icon="fas fa-file-pdf"
+                                                         class="ui-button-danger"
+                                                         ajax="false">
+                                            <p:dataExporter type="pdf"
+                                                            target="depositsPayments"
+                                                            fileName="Deposits_and_Payments" />
+                                        </p:commandButton>
+                                    </div>
+                                    <p:dataTable
+                                        id="depositsPayments"
+                                        scrollable="true"
                                         scrollHeight="300"
                                         value="#{bhtSummeryController.paymentBill}"
                                         var="p"
@@ -1395,8 +1481,27 @@
                                     </p:dataTable>
                                 </p:tab>
 
-                                <p:tab id="tabPostFinalP" title="Post Final Payments"  >
+                                <p:tab id="tabPostFinalP" title="Post Final Payment"  >
+                                    <div class="d-flex justify-content-end mb-2">
+                                        <p:commandButton value="Excel"
+                                                         icon="fas fa-file-excel"
+                                                         class="ui-button-success mx-1"
+                                                         ajax="false">
+                                            <p:dataExporter type="xlsx"
+                                                            target="postFinalPayment"
+                                                            fileName="Post_Final_Payment" />
+                                        </p:commandButton>
+                                        <p:commandButton value="PDF"
+                                                         icon="fas fa-file-pdf"
+                                                         class="ui-button-danger"
+                                                         ajax="false">
+                                            <p:dataExporter type="pdf"
+                                                            target="postFinalPayment"
+                                                            fileName="Post_Final_Payment" />
+                                        </p:commandButton>
+                                    </div>
                                     <p:dataTable
+                                        id="postFinalPayment"
                                         scrollable="true"
                                         scrollHeight="300"
                                         value="#{bhtSummeryController.postFinalPaymentBill}"

--- a/src/main/webapp/inward/inward_bill_intrim_medicine_issue_table.xhtml
+++ b/src/main/webapp/inward/inward_bill_intrim_medicine_issue_table.xhtml
@@ -5,6 +5,7 @@
                 xmlns:p="http://primefaces.org/ui">
 
     <p:dataTable
+        id="#{tableId}"
         value="#{issues}"
         var="iss"
         rowIndexVar="rowIndex"
@@ -103,6 +104,24 @@
             </div>
 
         </p:column>
+
+        <p:columnGroup type="footer">
+            <p:row>
+                <p:column colspan="3" footerText="Total"/>
+                <p:column style="text-align: right;">
+                    <f:facet name="footer">
+                        <h:outputLabel value="#{bhtSummeryController.getVisibleIssueTotal(issues)}">
+                            <f:convertNumber pattern="#,##0.00"/>
+                        </h:outputLabel>
+                    </f:facet>
+                </p:column>
+                <p:column/>
+                <p:column/>
+                <p:column/>
+                <p:column/>
+                <p:column/>
+            </p:row>
+        </p:columnGroup>
     </p:dataTable>
 
 </ui:composition>


### PR DESCRIPTION
## Summary

Fixes #23339. Five related enhancements to the Interim Bill's "Fees and Details" panel (`inward/inward_bill_intrim.xhtml`):

1. **Medicine Issue totals** — a footer row per department sub-tab (ETU/Pharmacy/Inward/Theatre/Store/Inventory) plus an overall "Total Medicine Issue" figure, via a new `BhtSummeryController.getVisibleIssueTotal(List<Bill>)` helper that sums only the visible rows (same PreBill/RefundBill filter already used for row display).
2. **Removed the legacy "Store Issue" tab** — superseded by Pharmacy handling all issues (including its own Store sub-tab under Medicine Issue). The backing `storeIssues` data/beans are untouched since `inward_bill_intrim_estimate.xhtml` still uses them.
3. **Excel/PDF export** on all 9 remaining tabs, via the existing `p:dataExporter` pattern already used elsewhere in this codebase. Medicine Issue exports either the flat table or all 6 department sub-tabs as separate sheets, depending on the department-split config.
4. **Tab titles renamed**: Room Charges, Timed Service Charges, Service and Investigation Charges, Medicine and Consumable Charges, Outside Charges, Professional Fees (unchanged), Assistant Charges, Deposits & Payments, Post Final Payment.
5. **Fixed the Outside Charges "Name" column** — was bound to `bil.comments` (almost always empty); now reads `bil.singleBillItem.item.name`, the same relationship this tab already reads successfully for "Inward Charge Type" one column over.

## Verification (local Payara, Main Pharmacy, BHT/56759)

- All 9 renamed tabs render correctly; Store Issue tab confirmed removed.
- Excel and PDF export tested on Room Charges — both download real, non-empty files.
- Medicine Issue footer/total logic verified correct by inspection and confirmed to render. While testing I found a **separate, pre-existing bug**: `InwardBeanController.fetchIssueTable`'s department-filtered overload returns an empty list even when matching bills exist in the DB (confirmed via raw SQL against the same test admission). This is unrelated to this PR's changes — I didn't touch that method — and is filed separately as #23350.
- The Outside Charges "Name" fix couldn't be exercised end-to-end (local DB has no Outside Institution/Item test data), but is verified by code inspection: `Bill.singleBillItem` is a real persisted relationship, set at bill-creation time (`InwardAdditionalChargeController.java:192`), and this same tab already successfully reads a different field off the same relationship one column over.

![Fees and Details panel with renamed tabs and Excel/PDF export buttons on each tab](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23339-fees-details-tabs-renamed-export.png)

## Documentation

Updated [Intrim-Bill](https://github.com/hmislk/hmis/wiki/Intrim-Bill) (tab list, Store Issue removal, export buttons, Medicine Issue totals) and fixed stale tab names in [Finance-Inpatient-Interim-Bills](https://github.com/hmislk/hmis/wiki/Finance-Inpatient-Interim-Bills).

## Follow-up filed

#23350 — pre-existing bug in `fetchIssueTable`'s department-filtered overload, discovered while verifying this PR.

## Test plan

- [x] Confirm all 9 tabs render with correct renamed titles
- [x] Confirm Store Issue tab is gone; confirm `inward_bill_intrim_estimate.xhtml` unaffected
- [x] Excel/PDF export downloads real files on at least one tab
- [x] Outside Charges Name binding verified by code inspection (no test data locally to exercise end-to-end)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01R9KhUsKWNH4djw6AJjx1Hm