### PR TITLE
fix(inward): catch settlement exceptions in BHT request issue flow

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
@@ -2258,20 +2258,34 @@ public class PharmacySaleBhtController implements Serializable {
 
         // No need to clear billItems - let savePreBillItemsFinally handle it properly
 
-        savePreBillFinally(pt, matrixDepartment, btp, bta);
-        savePreBillItemsFinally(tmpBillItems);
-        transferIssuedStockToPorter(tmpBillItems, getPreBill().getToStaff());
-        billService.createBillFinancialDetailsForInpatientDirectIssueBill(getPreBill());
+        // savePreBillItemsFinally() can throw (e.g. the fresh stock recheck inside
+        // it rejects the settlement) — without this try/catch that RuntimeException
+        // propagated uncaught to the container, crashing to the generic "System
+        // Error" page instead of a normal on-page message. Mirrors the same
+        // try/catch settleBhtIssue() already uses for its equivalent call. Issue #23352.
+        try {
+            savePreBillFinally(pt, matrixDepartment, btp, bta);
+            savePreBillItemsFinally(tmpBillItems);
+            transferIssuedStockToPorter(tmpBillItems, getPreBill().getToStaff());
+            billService.createBillFinancialDetailsForInpatientDirectIssueBill(getPreBill());
 
-        // Calculation Margin
-        updateMargin(getPreBill().getBillItems(), getPreBill(), getPreBill().getFromDepartment(), getPatientEncounter().getPaymentMethod());
-        //pdateBillTotals(getPreBill().getBillItems(),  getPreBill());
+            // Calculation Margin
+            updateMargin(getPreBill().getBillItems(), getPreBill(), getPreBill().getFromDepartment(), getPatientEncounter().getPaymentMethod());
+            //pdateBillTotals(getPreBill().getBillItems(),  getPreBill());
 
-        setPrintBill(getBillFacade().find(getPreBill().getId()));
+            setPrintBill(getBillFacade().find(getPreBill().getId()));
 
-        clearBill();
-        clearBillItem();
-        billPreview = true;
+            clearBill();
+            clearBillItem();
+            billPreview = true;
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, "Error during BHT request settlement for patient encounter: {0}",
+                    new Object[]{getPatientEncounter() != null ? getPatientEncounter().getId() : "unknown"});
+            LOGGER.log(Level.SEVERE, "Settlement failure details", e);
+            JsfUtil.addErrorMessage("Failed to settle bill. Please try again. Error: " + e.getMessage());
+            // DO NOT clear the bill - keep items visible so user doesn't lose their work
+            return false;
+        }
 
         return true;
     }

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
@@ -314,6 +314,20 @@ public class PharmacySaleBhtController implements Serializable {
     // When true, medicines are issued at retail rate with NO inward price-matrix
     // service charge (used by the Issue Discharge Medicines page).
     boolean dischargeIssueMode = false;
+    // Idempotency guards for the two irreversible stock mutations inside a
+    // settlement attempt. batchStockDeduction()/transferIssuedStockToPorter()
+    // each run as their own committed EJB transaction, independent of whatever
+    // happens afterwards (financial-detail creation, margin update, bill
+    // reload). Without these guards, a later step failing lets the settlement
+    // be retried from settleBhtIssueRequestAccept()/settleBhtIssue() with the
+    // bill's items kept visible on purpose — and a retry would re-run the
+    // already-committed deduction/transfer a second time, silently
+    // over-deducting stock. Set true right after each mutation succeeds,
+    // checked (and skipped, not re-applied) on the next attempt for the same
+    // bill; reset in clearBill() once a settlement actually completes.
+    // CodeRabbit review on #23353.
+    private boolean settlementStockDeducted = false;
+    private boolean settlementPorterTransferred = false;
     // Per-prescription conversion report shown on the discharge issue page so the
     // pharmacist sees the original prescription against what was actually resolved
     // (and any low/no-stock shortfall) — prevents silent omissions. Issue #21334.
@@ -1441,22 +1455,28 @@ public class PharmacySaleBhtController implements Serializable {
             throw new RuntimeException(errorMsg);
         }
 
-        try {
-            directIssueBatchService.batchStockDeduction(list);
-            LOGGER.log(Level.INFO, "Successfully processed batch stock deduction for {0} items in Bill ID: {1}",
-                    new Object[]{list.size(), getPreBill().getId()});
-        } catch (Exception e) {
-            String errorMsg = "Failed to process stock deductions. " + e.getMessage();
-            LOGGER.log(Level.SEVERE, "Batch stock deduction failed during BHT settlement: {0}", errorMsg);
-            LOGGER.log(Level.SEVERE, "Bill ID: {0}, Department: {1}, User: {2}",
-                    new Object[]{
-                        getPreBill().getId(),
-                        getPreBill().getDepartment() != null ? getPreBill().getDepartment().getName() : "unknown",
-                        getSessionController().getLoggedUser() != null
-                            ? getSessionController().getLoggedUser().getName() : "unknown"
-                    });
-            JsfUtil.addErrorMessage(errorMsg);
-            throw new RuntimeException(errorMsg);
+        if (!settlementStockDeducted) {
+            try {
+                directIssueBatchService.batchStockDeduction(list);
+                settlementStockDeducted = true;
+                LOGGER.log(Level.INFO, "Successfully processed batch stock deduction for {0} items in Bill ID: {1}",
+                        new Object[]{list.size(), getPreBill().getId()});
+            } catch (Exception e) {
+                String errorMsg = "Failed to process stock deductions. " + e.getMessage();
+                LOGGER.log(Level.SEVERE, "Batch stock deduction failed during BHT settlement: {0}", errorMsg);
+                LOGGER.log(Level.SEVERE, "Bill ID: {0}, Department: {1}, User: {2}",
+                        new Object[]{
+                            getPreBill().getId(),
+                            getPreBill().getDepartment() != null ? getPreBill().getDepartment().getName() : "unknown",
+                            getSessionController().getLoggedUser() != null
+                                ? getSessionController().getLoggedUser().getName() : "unknown"
+                        });
+                JsfUtil.addErrorMessage(errorMsg);
+                throw new RuntimeException(errorMsg);
+            }
+        } else {
+            LOGGER.log(Level.INFO, "Stock already deducted for this settlement attempt (retrying after a later "
+                    + "step failed) — skipping re-deduction for Bill ID: {0}", getPreBill().getId());
         }
 
         getBillFacade().edit(getPreBill());
@@ -1466,9 +1486,18 @@ public class PharmacySaleBhtController implements Serializable {
      * After stock is deducted from the issuing pharmacy, credit the same
      * quantities to the porter's staff stock (with stock history), so the
      * medicines are tracked as carried by the porter on the way to the ward.
+     *
+     * Guarded by settlementPorterTransferred (see field javadoc) so a retry
+     * after a later settlement step fails doesn't credit the porter twice
+     * for the same items.
      */
     private void transferIssuedStockToPorter(List<BillItem> list, Staff porter) {
         if (porter == null) {
+            return;
+        }
+        if (settlementPorterTransferred) {
+            LOGGER.log(Level.INFO, "Porter stock transfer already applied for this settlement attempt "
+                    + "(retrying after a later step failed) — skipping re-transfer.");
             return;
         }
         for (BillItem tbi : list) {
@@ -1478,6 +1507,7 @@ public class PharmacySaleBhtController implements Serializable {
             pbi.setStaffStock(staffStock);
             getPharmaceuticalBillItemFacade().edit(pbi);
         }
+        settlementPorterTransferred = true;
     }
 
     private void savePreBillItemsFinallyRequest(List<BillItem> list) {
@@ -3593,6 +3623,11 @@ public class PharmacySaleBhtController implements Serializable {
         }
         preBill = null;
         userStockContainer = null;
+        // A settlement actually completed — reset the idempotency guards so the
+        // NEXT bill's genuinely-new stock deduction/porter transfer isn't
+        // skipped. See the field javadoc on settlementStockDeducted.
+        settlementStockDeducted = false;
+        settlementPorterTransferred = false;
     }
 
     private void clearBillItem() {


### PR DESCRIPTION
## Summary

`settleBhtIssueRequestAccept()` (the method behind "Issue Medicines" →
confirm on the BHT Issue Request flow) called its settlement methods with
no try/catch. When the fresh, live stock recheck inside
`savePreBillItemsFinally()` correctly rejects a settlement (e.g. another
transaction depleted the exact batch since the page loaded), the
resulting `RuntimeException` propagated uncaught to the container,
crashing the request to the application's generic "System Error -
Unable to Process Request" page instead of a normal on-page message.

Wraps the settlement calls in the same try/catch pattern the sibling
method `settleBhtIssue()` already uses — log SEVERE, show a friendly
`JsfUtil.addErrorMessage`, return `false` (this method's existing
convention for its other validation failures) instead of letting the
exception propagate. The caller (`settlePharmacyBhtIssueAccept()`)
already checks this boolean return and stops correctly on `false`.

The stock-safety check itself was never the problem — it correctly
blocks an over-commit. This is purely a missing try/catch.

## Verified

Playwright, Main Pharmacy department, BHT/56759 (`Inward//26/038105`) —
a fresh, not-yet-issued request for the same item/batch used to find and
file #23352:

- Reduced the auto-assigned batch's real DB stock from 105 → 5 while the
  bill still held qty 10 in-session (simulating a concurrent settlement).
- Selected a porter, clicked **Issue to BHT**, confirmed the dialog.
- **Before**: crashed to the "System Error" page (HTTP 500).
- **After**: no crash — normal page reload with two friendly on-page
  messages (the recheck's own message, then the settlement wrapper's),
  and the bill row stays visible/unchanged, ready to retry.
- Confirmed in DB: the request bill's `COMPLETED`/`FULLYISSUED` flags
  stayed `false`, unaffected by the failed attempt.

![Bill items still intact after the graceful error](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23352-fix-graceful-error-items-intact.png)

## Follow-up fix (CodeRabbit review)

CodeRabbit flagged that `batchStockDeduction()` and
`transferIssuedStockToPorter()` each commit as their own EJB
transaction, independent of whatever runs after them — so making the
failure retryable (as this PR does) could let a retry re-run an
already-committed deduction/porter-credit a second time if a *later*
step (financial-detail creation, margin update) failed for an unrelated
reason.

Added two session-scoped idempotency guards
(`settlementStockDeducted`, `settlementPorterTransferred`) — set true
right after each mutation succeeds, checked and skipped (not re-applied)
on a retry for the same bill, reset in `clearBill()` once a settlement
actually completes. `savePreBillItemsFinally()` is shared by both
`settleBhtIssue()` and `settleBhtIssueRequestAccept()`, so both
settlement paths are covered.

Verified live: a clean, unmanipulated settlement (BHT/56755, 2 units
against 2 available stock) still completes normally end-to-end with the
guards in place — stock deducted exactly once, exactly one settled
BillItem row, normal Bill Preview reached. The double-commit-then-retry
scenario itself was verified by code trace rather than a live forced
mid-sequence fault.

## Documentation

Updated [Inward BHT Issue Against Request](https://github.com/hmislk/hmis/wiki/Inward-BHT-Issue-Against-Request) —
added the new graceful error message to "Understanding Messages".

Closes #23352


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of pharmacy BHT settlement failures.
  * Displays an on-page error message when processing cannot be completed.
  * Preserves bill contents after a failure, preventing data loss.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->