### PR TITLE
fix(inward): Medicine Issue tabs stay empty when Interim Bill reached via Find Inpatient search

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -1222,6 +1222,9 @@ public class BhtSummeryController implements Serializable {
     }
 
     public List<Bill> getEtuMedicineIssues() {
+        if (etuMedicineIssues == null && patientEncounter != null) {
+            etuMedicineIssues = getInwardBean().fetchIssueTable(getPatientEncounter(), BillType.PharmacyBhtPre, childPatientEncouters, DepartmentType.Etu);
+        }
         return etuMedicineIssues;
     }
 
@@ -1230,6 +1233,9 @@ public class BhtSummeryController implements Serializable {
     }
 
     public List<Bill> getPharmacyMedicineIssues() {
+        if (pharmacyMedicineIssues == null && patientEncounter != null) {
+            pharmacyMedicineIssues = getInwardBean().fetchIssueTable(getPatientEncounter(), BillType.PharmacyBhtPre, childPatientEncouters, DepartmentType.Pharmacy);
+        }
         return pharmacyMedicineIssues;
     }
 
@@ -1238,6 +1244,9 @@ public class BhtSummeryController implements Serializable {
     }
 
     public List<Bill> getInwardMedicineIssues() {
+        if (inwardMedicineIssues == null && patientEncounter != null) {
+            inwardMedicineIssues = getInwardBean().fetchIssueTable(getPatientEncounter(), BillType.PharmacyBhtPre, childPatientEncouters, DepartmentType.Inward);
+        }
         return inwardMedicineIssues;
     }
 
@@ -1246,6 +1255,9 @@ public class BhtSummeryController implements Serializable {
     }
 
     public List<Bill> getTheatreMedicineIssues() {
+        if (theatreMedicineIssues == null && patientEncounter != null) {
+            theatreMedicineIssues = getInwardBean().fetchIssueTable(getPatientEncounter(), BillType.PharmacyBhtPre, childPatientEncouters, DepartmentType.Theatre);
+        }
         return theatreMedicineIssues;
     }
 
@@ -1254,6 +1266,9 @@ public class BhtSummeryController implements Serializable {
     }
 
     public List<Bill> getStoreMedicineIssues() {
+        if (storeMedicineIssues == null && patientEncounter != null) {
+            storeMedicineIssues = getInwardBean().fetchIssueTable(getPatientEncounter(), BillType.PharmacyBhtPre, childPatientEncouters, DepartmentType.Store);
+        }
         return storeMedicineIssues;
     }
 
@@ -1262,6 +1277,9 @@ public class BhtSummeryController implements Serializable {
     }
 
     public List<Bill> getInventryMedicineIssues() {
+        if (inventryMedicineIssues == null && patientEncounter != null) {
+            inventryMedicineIssues = getInwardBean().fetchIssueTable(getPatientEncounter(), BillType.PharmacyBhtPre, childPatientEncouters, DepartmentType.Inventry);
+        }
         return inventryMedicineIssues;
     }
 

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -4245,6 +4245,24 @@ public class BhtSummeryController implements Serializable {
 
     public void setPatientEncounter(PatientEncounter patientEncounter) {
 //        makeNull();
+        Long previousId = this.patientEncounter == null ? null : this.patientEncounter.getId();
+        Long newId = patientEncounter == null ? null : patientEncounter.getId();
+        if (!java.util.Objects.equals(previousId, newId)) {
+            // The six Medicine Issue lists (and childPatientEncouters) are lazily
+            // recomputed by their getters (see getEtuMedicineIssues() etc.) so the
+            // Interim Bill page still populates even when createTables() is skipped
+            // (issue #23350). That lazy-init means a stale, non-null list from a
+            // previously viewed encounter would otherwise leak into this encounter's
+            // view instead of being recomputed - clear them here whenever the
+            // encounter actually changes.
+            etuMedicineIssues = null;
+            pharmacyMedicineIssues = null;
+            inwardMedicineIssues = null;
+            theatreMedicineIssues = null;
+            storeMedicineIssues = null;
+            inventryMedicineIssues = null;
+            childPatientEncouters = null;
+        }
         this.patientEncounter = patientEncounter;
         invalidateUnifiedGanttBarsCache();
     }


### PR DESCRIPTION
## Summary

Fixes #23350. **Note: the root cause claimed in the original issue was wrong** — the issue's title/history documents that investigation pivot; see the issue comments for the full trail.

The actual bug: navigating to the Interim Bill page via the **"Find Inpatient" search panel's "Continue" button** never invokes `BhtSummeryController.createIntrimBillTable()`/`createTables()` — confirmed via targeted server-side logging placed at the literal first line of that method, which never fired despite the button's POST returning HTTP 200 and the page rendering a seemingly-complete view. I was unable to pin down the exact JSF/PrimeFaces mechanism behind this despite ruling out:

- Playwright-click artifacts (reproduced identically via keyboard selection)
- JSF validation/conversion failures (`FacesContext.getMessageList()` empty, `isValidationFailed()` false)
- Incorrect client-side entity resolution (added and instrumented an explicit `PatientEncounterConverter` — it resolved the entity correctly on every call, and the action *still* never fired; reverted since it didn't fix anything)

The page still renders what looks like a complete "Inward Payment Bill" view because sibling fields like `getPatientRooms()` and `getDepartmentBillItems()` already have lazy-init getters (`if (x == null) x = compute();`) that silently backfill data during render regardless of whether `createTables()` ran. The 6 Medicine Issue department fields (`etuMedicineIssues`, `pharmacyMedicineIssues`, etc.) had no such fallback — plain getters — so they stayed permanently `null`, leaving every Medicine Issue sub-tab empty even when real bills existed for the admission.

Confirmed via direct SQL and via a different navigation path (Inpatient Dashboard's own "Interim Bill" button, which *does* correctly invoke `createTables()`) that the underlying `fetchIssueTable` JPQL is correct and returns the right bills when actually invoked — this issue was never about a JPQL bug.

## Fix

Applied the same lazy-init pattern already used by `getPatientRooms()`/`getDepartmentBillItems()` in this same class to all 6 Medicine Issue getters, so they self-heal during render regardless of whether the action method ran:

```java
public List<Bill> getPharmacyMedicineIssues() {
    if (pharmacyMedicineIssues == null && patientEncounter != null) {
        pharmacyMedicineIssues = getInwardBean().fetchIssueTable(getPatientEncounter(), BillType.PharmacyBhtPre, childPatientEncouters, DepartmentType.Pharmacy);
    }
    return pharmacyMedicineIssues;
}
```

This is a pragmatic fix for the observable symptom, not a fix for whatever silently skips the button's action method — that deeper mechanism remains unidentified and would need an attached Java debugger to trace further.

## Verification (local Payara, Main Pharmacy, BHT/56759)

Reproduced the original bug end-to-end via "Find Inpatient" → "Continue", then confirmed after the fix:

- **Total Medicine Issue: 200.55** (previously 0.00)
- **Pharmacy** sub-tab badge: **10** bills (previously 0), all correctly listed with a **Total: 200.55** footer row matching the header total
- ETU/Inward/Theatre/Store/Inventory correctly remain 0 (genuinely no data there)

![Pharmacy sub-tab showing all 10 bills and correct 200.55 totals after the fix](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23350-pharmacy-subtab-fixed.png)

## Documentation

No wiki changes — the Medicine Issue totals feature (added in #23339) is already documented correctly on [Intrim-Bill](https://github.com/hmislk/hmis/wiki/Intrim-Bill); this fix restores already-documented intended behavior rather than changing it.

## Test plan

- [x] Reproduced the empty-tabs symptom via Find Inpatient → Continue before the fix
- [x] Confirmed the fix via the same flow: Total Medicine Issue and Pharmacy sub-tab now show correct data
- [x] Confirmed ETU/Inward/Theatre/Store/Inventory correctly remain empty (no false positives)
- [x] Confirmed the underlying `fetchIssueTable` JPQL itself was never the problem (returns correct results via a working navigation path)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01R9KhUsKWNH4djw6AJjx1Hm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved medicine-issue loading for department-specific patient encounters.
  * Data is now retrieved only when needed, helping reduce unnecessary loading and improve responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->