### PR TITLE
fix(inward): make Fees tab Item Name column render its width

### DIFF
--- a/src/main/webapp/inward/inward_bill_service.xhtml
+++ b/src/main/webapp/inward/inward_bill_service.xhtml
@@ -656,7 +656,7 @@
                                                             <h:outputLabel value="#{rowIndex+1}"/>
                                                         </p:column>
 
-                                                        <p:column style="min-width: 14em;">
+                                                        <p:column width="14em">
                                                             <f:facet name="header">Item Name</f:facet>
                                                             <h:outputLabel value="#{bif.billItem.item.name}"/>
                                                         </p:column>


### PR DESCRIPTION
## Decisions made without approval

This was run via `dev-issue-unattended`, so these judgment calls were made without a live checkpoint:

- **Root cause required live reproduction, not just reading code.** The "Item Name" column already existed in the Fees tab markup (added by #22310, merged 2026-07-22, before this issue was filed) with no `rendered` guard. Reading the code alone suggested the bug was already fixed. Reproducing in the browser via Playwright showed the column header text was present in the DOM but its `offsetWidth` was `0px` — a CSS/layout bug, not a missing-markup bug. This matches the reporter's own hypothesis passed in via the run arguments ("hidden column ... due to lack of horizontal space").
- **Did not touch `theater/inward_bill_surgery_service.xhtml`**, which has an identical-looking "Item Name" column (same #22310 commit touched both files). That table declares no `width` attribute on any column, so it uses normal `table-layout: auto` and does not hit this bug — out of scope for #23346.
- **Updated the wiki page** `Add-services-and-Investigations.md` (Fees tab bullet) to mention the Item Name column and embedded a verification screenshot, since the existing text omitted it.

## Root cause

The Fees tab's inner `<table>` (PrimeFaces `p:dataTable`, id `feeTable`) computes with `table-layout: fixed`. Every column in this table declares an explicit `p:column width="Xem"` attribute **except** Item Name, which only had `style="min-width: 14em;"`. Under fixed table layout, column widths are allocated purely from declared `width`s on the first row; a column with no declared width gets no allocation and collapses to `0px`, regardless of any `min-width` CSS — so the column (and its data) was rendered but invisible.

Confirmed via Playwright:
```
{ text: "Item Name", width: "", offsetWidth: 0 }   // before
{ text: "Item Name", width: "14em", offsetWidth: 224 }  // after
```

## Fix

Changed the column declaration to use the same `width="14em"` attribute convention as every sibling column in this table:

```diff
- <p:column style="min-width: 14em;">
+ <p:column width="14em">
      <f:facet name="header">Item Name</f:facet>
      <h:outputLabel value="#{bif.billItem.item.name}"/>
  </p:column>
```

## Verification

- Rebuilt and redeployed to local Payara.
- Logged in as `buddhika`, selected the **Inward** department, opened **Inward Add Services** for an active local admission (BHT/56760).
- Added an X-RAY service, opened the **Fees** tab: before the fix, the row showed `No | Unit Rate | Qty | ...` with no name column (matching the reporter's screenshot); after the fix, `Item Name` renders as a proper column and shows "X RAY" for each fee row.
- No errors in `server.log` across build/deploy/reproduction/fix cycles.

## Documentation

Updated [Add-services-and-Investigations](https://github.com/hmislk/hmis/wiki/Add-services-and-Investigations) — Fees tab bullet now mentions the Item Name column, with a verification screenshot embedded.

Closes #23346

🤖 Generated with dev-issue-unattended

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the Fees tab’s “Item Name” column to use a consistent fixed width for improved table layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->