### PR TITLE
fix(inward): make Enter add the service on Inward Add Services (#23342)

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -1975,6 +1975,19 @@ actually proves the WAR builds and packages the fix correctly. Verified while
 testing issue #22984 (caught an `outputLabel for=` component-id mismatch this
 way in seconds instead of a multi-minute rebuild).
 
+**Caveat — the hot-swap only works if that page has not been rendered yet in
+the current app instance.** With `javax.faces.PROJECT_STAGE=Production` (this
+project's `web.xml`) the Facelets refresh period is `-1`, so a page is compiled
+once and cached for the lifetime of the deployment. Swap the file *before* the
+first hit and the reload picks it up; swap it *after* the page has already been
+rendered once and every subsequent reload silently serves the stale cached
+facelet — the file on disk is right, the browser output is old, and nothing is
+logged. Symptom: your newly added component simply isn't in the rendered page.
+Fix: `asadmin deploy --force` (a new app classloader drops the cache); a browser
+reload or hard refresh will not. Found while verifying issue #23342, where an
+A/B run (original file → reproduce, fixed file → verify) needed a real redeploy
+between the two halves.
+
 ## 75. Inpatient discharge chain has a strict, undocumented order — and Physical Discharge requires the Final Bill to already exist
 
 To reach "Create Final Bill" on `inward_bill_intrim.xhtml` for a fresh test
@@ -2189,6 +2202,38 @@ guessing at specificity.
 
 Found on `inward/pharmacy_bill_return_bht_issue.xhtml` while adding the Return
 Bill Preview highlight (issue #23338).
+
+## 84. A markup-less PrimeFaces component (`p:defaultCommand`, `p:focus`, …) cannot be confirmed by searching the rendered HTML — look for its event handler instead
+
+These components emit no DOM element at all, only a `PrimeFaces.cw(...)` init
+script, and PrimeFaces removes inline scripts from the document once they have
+run. So `document.documentElement.innerHTML.includes('DefaultCommand')` returns
+`false` on a page where the component is present and working — an easy false
+negative that looks like "my fix didn't deploy".
+
+Confirm it the way the widget actually manifests:
+
+```js
+// the widget object (its key is widget_<clientId>, name mangled by minification)
+Object.keys(PrimeFaces.widgets);
+// what p:defaultCommand really does: a namespaced keydown handler on the form
+jQuery._data(document.getElementById('form'), 'events').keydown.map(h => h.namespace);
+// -> ["form:j_idt579"]  ← the defaultCommand's own client id
+```
+
+Then assert the *behaviour* (press Enter, check the URL didn't change and the
+intended action ran), which is the only proof that matters anyway. Found while
+verifying issue #23342.
+
+## 85. `inward_bill_service.xhtml`'s patient search auto-selects on an exact BHT match — no suggestion click needed
+
+Typing a complete BHT number (e.g. `BHT/55359`) into the "Patient Search"
+autocomplete on the Patient Selection screen commits the encounter and re-renders
+straight into the Add Services view, without ever showing an autocomplete panel
+to click. A test that types the BHT and then waits for a `.ui-autocomplete-panel`
+row will time out on a working page. Detect the transition instead — e.g.
+`document.body.innerText.includes('Patient Selection') === false`, or the presence
+of `form:btnAddIx`. Found while verifying issue #23342.
 
 ## Some PrimeFaces buttons need a jQuery-triggered click
 

--- a/src/main/webapp/inward/inward_bill_service.xhtml
+++ b/src/main/webapp/inward/inward_bill_service.xhtml
@@ -157,6 +157,30 @@
                      button below - and navigates the user away to Page Configuration Management.
                      Enter must add the selected service instead. -->
                 <p:defaultCommand target="btnAddIx" />
+                <script type="text/javascript">
+                    //<![CDATA[
+                    // The default command above is form-wide, and PrimeFaces only exempts
+                    // textarea/button/submit/link/.ql-editor from it. Enter inside the item
+                    // list's Filter box would therefore fire Add and bill whichever item was
+                    // already highlighted, which is never what "filter the list" means.
+                    // Swallow Enter there (capture phase, so it never reaches the form).
+                    if (!window.inwardServiceFilterEnterGuard) {
+                        window.inwardServiceFilterEnterGuard = true;
+                        document.addEventListener('keydown', function (e) {
+                            if (e.key !== 'Enter') {
+                                return;
+                            }
+                            var t = e.target;
+                            if (t.classList) {
+                                if (t.classList.contains('ui-selectlistbox-filter')) {
+                                    e.preventDefault();
+                                    e.stopPropagation();
+                                }
+                            }
+                        }, true);
+                    }
+                    //]]>
+                </script>
                 <p:panel>
                     <f:facet name="header">
                         <div class="d-flex justify-content-between">

--- a/src/main/webapp/inward/inward_bill_service.xhtml
+++ b/src/main/webapp/inward/inward_bill_service.xhtml
@@ -152,6 +152,11 @@
             </h:panelGroup>
 
             <h:panelGroup  rendered="#{billBhtController.patientEncounter ne null}">
+                <!-- Without this, pressing Enter falls back to browser implicit submission, which
+                     activates the first submit button of this single page-wide form - the Config
+                     button below - and navigates the user away to Page Configuration Management.
+                     Enter must add the selected service instead. -->
+                <p:defaultCommand target="btnAddIx" />
                 <p:panel>
                     <f:facet name="header">
                         <div class="d-flex justify-content-between">


### PR DESCRIPTION
Closes #23342

## Decisions made without approval

This was developed unattended, so every judgment call is listed here first.

| # | Decision | Why |
|---|---|---|
| 1 | Fix with `p:defaultCommand`, not by restructuring the form or reordering buttons | `p:defaultCommand` is already the established pattern for this in the codebase (~50 pages use it, e.g. `admin/items/category.xhtml`). Reordering buttons or splitting the page-wide `h:form` would be a far larger, riskier change for the same outcome. |
| 2 | Target **Add** (`btnAddIx`) | The issue states the expected behaviour explicitly: "The selected service should be added to Added Items section below the same page." |
| 3 | Left it **form-wide** rather than `scope`-limiting it to the item picker, and handled the one genuinely wrong case (the Filter box) with a targeted guard instead | PrimeFaces 14 does support `scope`, but a scoped version would leave Enter still hijacked by Config / New Bill everywhere else on the page — and it could not have fixed the Filter box anyway, since the filter and the list items share the same `form:itm` container. See the note below. |
| 4 | Placed inside the `patientEncounter ne null` panelGroup, not at the top of the form | `p:defaultCommand` resolves its `target` at render time, so an unconditional placement would fail on the patient-selection screen where `btnAddIx` isn't rendered. This placement shares `btnAddIx`'s exact render condition. |
| 5 | Fixed only this page, though the same pattern exists elsewhere | 36 other pages share the shape. Fixing them all unprompted would be well beyond this issue; swept and filed as #23365 instead. |
| 6 | Wiki: added the Enter shortcut + one screenshot to the page for this screen; deliberately did **not** rewrite a second, inaccurate page | Details under Documentation. |

**On decision 3 — why form-wide, and what it needed.** `BillBhtController.addToBill()` clears `currentBillItem` after a successful add and separately blocks adding the same item twice (`BillBhtController.java:1133`), so a stray Enter in most of the form yields a harmless validation message rather than a duplicate line. PrimeFaces also exempts `textarea`, so Enter in **Details** still inserts a newline.

There was one place where that reasoning did not hold, caught in review: `p:selectOneListbox`'s **Filter** box. PrimeFaces' `SelectListbox` widget binds only `keyup` there and never `keydown`, so Enter while filtering reached the form handler and fired Add — billing whichever item happened to be highlighted. The second commit swallows Enter on `.ui-selectlistbox-filter` in the capture phase (on `document`, because the department-button AJAX re-creates the input and would orphan a directly-bound handler). Enter while filtering now does nothing, and the typed filter text and current selection survive, where previously they were wiped by the full submit.

## Problem

`inward/inward_bill_service.xhtml` wraps the entire page in a single `<h:form id="form">`. Nothing declared a default command, so pressing Enter fell back to the browser's **implicit form submission**, which activates the first submit button in the form.

On the Add Services screen that first button is the admin **Config** button:

```xhtml
<p:commandButton value="Config" ... immediate="true"
    action="#{pageAdminController.navigateToPageAdmin('inward/inward_bill_service')}" />
```

`navigateToPageAdmin` returns `/admin/page_configuration_view?faces-redirect=true` — exactly the redirect the reporter described, mid-bill.

Confirmed empirically in the browser before writing any fix:

```js
document.getElementById('form').querySelector('button[type=submit]')
// -> { id: "form:j_idt584", text: "Config" }
```

Worth noting: for a user **without** the `Admin` privilege the Config button doesn't render, and the first submit button becomes **New Bill** — `billBhtController.resetBillData`. Same root cause, but that variant silently discards the unsettled cart instead of just navigating away.

## Fix

```xhtml
<h:panelGroup rendered="#{billBhtController.patientEncounter ne null}">
    <p:defaultCommand target="btnAddIx" />
```

One line (plus a comment explaining why it must not be removed).

## Verification

Local Payara + local DB, driven with Playwright. Because the fix had to be proved against the *actual* broken behaviour, the run was done as an A/B: the pre-fix page from `origin/development` first, then the fixed build.

**Before** — select a service, press Enter, and the browser lands on Page Configuration Management:

![Before: pressing Enter lands on Page Configuration Management](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23342-before-enter-redirects-to-config.png)

*Pre-fix page: after selecting a service and pressing Enter the browser is at `/faces/admin/page_configuration_view.xhtml`, with the unsettled cart lost.*

**After** — same steps on the fixed build; Enter adds the service and the page stays put:

![After: Enter adds the service to Added Items](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23342-enter-key-adds-service.png)

*Enter after selecting a service adds it straight to Added Items; the page does not navigate. Patient and referring-doctor panels hidden for publication.*

Checks run:

| Check | Result |
|---|---|
| Pre-fix: select service → Enter | Redirected to `/faces/admin/page_configuration_view.xhtml` — issue reproduced exactly |
| Post-fix: select service → Enter | Stayed on `/faces/inward/inward_bill_service.xhtml`; item appeared in Added Items with correct rate and Net Total |
| Post-fix: full **Settle** | Bill persisted — one bill, one item, correct net value (verified by direct DB query on `bill` / `billitem`) |
| Post-fix: **Config** button clicked deliberately | Still navigates to Page Configuration Management, as intended |
| Post-fix: item selected, then Enter **inside the Filter box** | Nothing billed; filter text and highlighted item both preserved; no navigation (the case raised in review) |
| Post-fix: Enter in the **Details** textarea | Newline inserted, no submit, nothing billed |
| Print-preview state (`btnAddIx` **not rendered**, `p:defaultCommand` still is) | Page renders cleanly, no `ComponentNotFoundException` — JSF `findComponent` resolves against the *component tree*, which still holds the component that `rendered="#{!billBhtController.printPreview}"` (line 253) suppressed from output |
| DefaultCommand actually bound | `jQuery._data(form,'events').keydown[0].namespace` → the defaultCommand's client id |

Test data: an existing active admission in the local DB was used — no records were created by hand, and the bill was generated through the app itself.

## Documentation

- **Updated** — [Add Services and Investigations (Inward)](https://github.com/hmislk/hmis/wiki/Add-services-and-Investigations): documents the Enter shortcut (and the Details-box exception) under "Add a service or investigation", with the verified screenshot embedded. Both statements are directly verified by this run.
- **Not changed, flagged for a human** — `Finance-Inpatient-Service-Bills.md` also documents this screen and contains several claims that contradict the code: it names the controller as `InwardPaymentController` (the page's own registered metadata says `BillBhtController`), and its step 8 says "Click **Save** to generate the service bill" when the page's button is **Settle**. These are verifiable errors, but correcting a whole page's technical reference is outside what this fix exercised, so it is filed as #23366 rather than rewritten unattended.
- `developer_docs/testing/playwright-e2e-workflow.md` gains three learnings from this run, including a correction to §74: the exploded-WAR XHTML hot-swap only works *before* a page has been rendered once, because Facelets caches compiled pages for the deployment's lifetime under `PROJECT_STAGE=Production`. Afterwards only a real redeploy clears it — the file on disk is right, the rendered page is stale, and nothing is logged.

## Follow-up (filed as separate issues)

- **#23365** — the same Enter-hijack shape on **36 other pages**. A proper sweep (form open/close tracking, not just a grep) found 25 where Enter fires the **Config** button exactly as here, and 11 where it fires something else — including **Start Shift** on `cashier/index.xhtml`, **Return Items** on `pharmacy/pharmacy_return_withouttresing.xhtml`, and **Inpatient Dashboard** on `ward/ward_pharmacy_bht_issue.xhtml`, which discards an unsettled cart. 19 further pages already declare a `p:defaultCommand` and are excluded.
- **#23366** — the `Finance-Inpatient-Service-Bills` wiki page, which documents this same screen with a wrong controller name and a "Save" button that does not exist, and duplicates the accurate `Add-services-and-Investigations` page.
