### PR TITLE
fix(inward): separate Deposit / Payment / Post Payment in BHT settlement reports

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtPaymentDetailReportController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtPaymentDetailReportController.java
@@ -30,9 +30,12 @@ import javax.persistence.TemporalType;
 
 /**
  * Controller for BHT Deposit and Credit Settlement Detail Report.
- * One row per individual payment (deposit payment, post-final-bill "Make
- * Payment" settlement, or CC settlement item) - see
- * {@link com.divudi.core.data.dto.BhtPaymentDetailDTO#getPaymentCategory()}.
+ * One row per individual transaction: a "Make a Deposit" (INWARD_DEPOSIT)
+ * payment, a "Make a Payment" (INWARD_PAYMENT) payment, a "Post Final Payment"
+ * (BillType.PostFinalBillInwardPayment) payment, or a CC settlement item -
+ * see {@link com.divudi.core.data.dto.BhtPaymentDetailDTO#getPaymentCategory()}.
+ * The three payment kinds are kept as separate categories and separate
+ * per-method footer totals (issue #23262).
  */
 @Named
 @SessionScoped
@@ -58,29 +61,43 @@ public class BhtPaymentDetailReportController implements Serializable {
     private List<BhtPaymentDetailDTO> reportRows;
     private double grandTotal;
     private double grandTotalCcSettlement;
-    private double grandTotalFinalPayments;
-    /** Ordered map of payment method → deposit total; only methods with non-zero totals. */
-    private Map<PaymentMethod, Double> totalByMethod = new LinkedHashMap<>();
-    /** Payment methods in the order they appeared, for UI iteration. */
+    private double grandTotalPayments;
+    private double grandTotalPostPayments;
+    /**
+     * Ordered map of payment method → "Make a Deposit" (INWARD_DEPOSIT) total;
+     * only methods with non-zero totals.
+     */
+    private Map<PaymentMethod, Double> depositTotalByMethod = new LinkedHashMap<>();
+    /** Deposit payment methods in the order they appeared, for UI iteration. */
+    private List<PaymentMethod> usedDepositMethods = new ArrayList<>();
+    /**
+     * Ordered map of payment method → "Make a Payment" (INWARD_PAYMENT) total.
+     * Kept separate from {@link #depositTotalByMethod} (deposits) and
+     * {@link #postPaymentTotalByMethod} (post-final-bill payments) per issue
+     * #23262 - deposit, payment and post-payment amounts must not be conflated
+     * in a single per-method total.
+     */
+    private Map<PaymentMethod, Double> paymentTotalByMethod = new LinkedHashMap<>();
     private List<PaymentMethod> usedPaymentMethods = new ArrayList<>();
     /**
-     * Ordered map of payment method → final-payment (post-final-bill "Make
-     * Payment") total. Kept separate from {@link #totalByMethod} (deposits)
-     * per issue #23262 - deposit and final-payment amounts must not be
-     * conflated in a single per-method total.
+     * Ordered map of payment method → post-final-bill ("Post Final Payment")
+     * total. Kept separate from deposits and payments per issue #23262.
      */
-    private Map<PaymentMethod, Double> finalPaymentTotalByMethod = new LinkedHashMap<>();
-    private List<PaymentMethod> usedFinalPaymentMethods = new ArrayList<>();
+    private Map<PaymentMethod, Double> postPaymentTotalByMethod = new LinkedHashMap<>();
+    private List<PaymentMethod> usedPostPaymentMethods = new ArrayList<>();
 
     public void generateReport() {
         reportRows = new ArrayList<>();
         grandTotal = 0;
         grandTotalCcSettlement = 0;
-        grandTotalFinalPayments = 0;
-        totalByMethod = new LinkedHashMap<>();
+        grandTotalPayments = 0;
+        grandTotalPostPayments = 0;
+        depositTotalByMethod = new LinkedHashMap<>();
+        usedDepositMethods = new ArrayList<>();
+        paymentTotalByMethod = new LinkedHashMap<>();
         usedPaymentMethods = new ArrayList<>();
-        finalPaymentTotalByMethod = new LinkedHashMap<>();
-        usedFinalPaymentMethods = new ArrayList<>();
+        postPaymentTotalByMethod = new LinkedHashMap<>();
+        usedPostPaymentMethods = new ArrayList<>();
 
         List<PatientEncounter> encounters = fetchEncounters();
         if (encounters == null || encounters.isEmpty()) {
@@ -91,7 +108,7 @@ public class BhtPaymentDetailReportController implements Serializable {
             String patientName = enc.getPatient() != null && enc.getPatient().getPerson() != null
                     ? enc.getPatient().getPerson().getNameWithTitle() : "";
 
-            // Deposit payments — one row per Payment record
+            // "Make a Deposit" (INWARD_DEPOSIT) payments — one row per Payment record
             List<Payment> deposits = fetchDepositPayments(enc);
             for (Payment p : deposits) {
                 BhtPaymentDetailDTO row = new BhtPaymentDetailDTO();
@@ -111,16 +128,43 @@ public class BhtPaymentDetailReportController implements Serializable {
                 double depositAmt = Math.abs(p.getPaidValue());
                 grandTotal += depositAmt;
                 if (p.getPaymentMethod() != null) {
-                    totalByMethod.merge(p.getPaymentMethod(), depositAmt, Double::sum);
+                    depositTotalByMethod.merge(p.getPaymentMethod(), depositAmt, Double::sum);
                 }
             }
 
-            // Post-final-bill ("Make Payment") payments — one row per Payment record.
+            // "Make a Payment" (INWARD_PAYMENT) payments — one row per Payment
+            // record. Issue #23262: kept a separate category from deposits and
+            // from post-final-bill payments.
+            List<Payment> payments = fetchPayments(enc);
+            for (Payment p : payments) {
+                BhtPaymentDetailDTO row = new BhtPaymentDetailDTO();
+                row.setBhtNo(enc.getBhtNo());
+                row.setPatientName(patientName);
+                row.setAdmissionType(enc.getAdmissionType());
+                row.setDateOfAdmission(enc.getDateOfAdmission());
+                row.setDateOfDischarge(enc.getDateOfDischarge());
+                row.setBillNo(p.getBill() != null ? p.getBill().getDeptId() : "");
+                row.setCreatedAt(p.getCreatedAt());
+                row.setPaymentMethod(p.getPaymentMethod());
+                row.setAmount(Math.abs(p.getPaidValue()));
+                row.setReferenceNo(p.getReferenceNo());
+                row.setCreditCompanyName("");
+                row.setPaymentCategory("Payment");
+                reportRows.add(row);
+                double paymentAmt = Math.abs(p.getPaidValue());
+                grandTotal += paymentAmt;
+                grandTotalPayments += paymentAmt;
+                if (p.getPaymentMethod() != null) {
+                    paymentTotalByMethod.merge(p.getPaymentMethod(), paymentAmt, Double::sum);
+                }
+            }
+
+            // Post-final-bill ("Post Final Payment") payments — one row per Payment record.
             // Issue #23263: these were never queried here, so a BHT whose only
             // recorded payment was a post-final settlement (no deposit, no CC
             // settlement) was silently absent from this report.
-            List<Payment> finalPayments = fetchPostFinalPayments(enc);
-            for (Payment p : finalPayments) {
+            List<Payment> postPayments = fetchPostFinalPayments(enc);
+            for (Payment p : postPayments) {
                 BhtPaymentDetailDTO row = new BhtPaymentDetailDTO();
                 row.setBhtNo(enc.getBhtNo());
                 row.setPatientName(patientName);
@@ -131,18 +175,18 @@ public class BhtPaymentDetailReportController implements Serializable {
                 row.setCreatedAt(p.getCreatedAt());
                 row.setPaymentMethod(p.getPaymentMethod());
                 // Signed, not abs() - see fetchPostFinalPayments() javadoc: a
-                // cancelled final payment arrives as a separate negative-amount
-                // row rather than a cancelled flag, so each row must keep its
-                // real sign to show the full transaction trail.
+                // cancelled post-final payment arrives as a separate
+                // negative-amount row rather than a cancelled flag, so each row
+                // must keep its real sign to show the full transaction trail.
                 row.setAmount(p.getPaidValue());
                 row.setReferenceNo(p.getReferenceNo());
                 row.setCreditCompanyName("");
-                row.setPaymentCategory("Final Payment");
+                row.setPaymentCategory("Post Payment");
                 reportRows.add(row);
                 grandTotal += p.getPaidValue();
-                grandTotalFinalPayments += p.getPaidValue();
+                grandTotalPostPayments += p.getPaidValue();
                 if (p.getPaymentMethod() != null) {
-                    finalPaymentTotalByMethod.merge(p.getPaymentMethod(), p.getPaidValue(), Double::sum);
+                    postPaymentTotalByMethod.merge(p.getPaymentMethod(), p.getPaidValue(), Double::sum);
                 }
             }
 
@@ -173,16 +217,21 @@ public class BhtPaymentDetailReportController implements Serializable {
         }
 
         // Build ordered lists of used payment methods for UI iteration
-        usedPaymentMethods = new ArrayList<>(totalByMethod.keySet());
-        usedFinalPaymentMethods = new ArrayList<>(finalPaymentTotalByMethod.keySet());
+        usedDepositMethods = new ArrayList<>(depositTotalByMethod.keySet());
+        usedPaymentMethods = new ArrayList<>(paymentTotalByMethod.keySet());
+        usedPostPaymentMethods = new ArrayList<>(postPaymentTotalByMethod.keySet());
     }
 
-    public double getTotalForMethod(PaymentMethod pm) {
-        return totalByMethod.getOrDefault(pm, 0.0);
+    public double getTotalForDepositMethod(PaymentMethod pm) {
+        return depositTotalByMethod.getOrDefault(pm, 0.0);
     }
 
-    public double getTotalForFinalPaymentMethod(PaymentMethod pm) {
-        return finalPaymentTotalByMethod.getOrDefault(pm, 0.0);
+    public double getTotalForPaymentMethod(PaymentMethod pm) {
+        return paymentTotalByMethod.getOrDefault(pm, 0.0);
+    }
+
+    public double getTotalForPostPaymentMethod(PaymentMethod pm) {
+        return postPaymentTotalByMethod.getOrDefault(pm, 0.0);
     }
 
     private List<PatientEncounter> fetchEncounters() {
@@ -244,6 +293,31 @@ public class BhtPaymentDetailReportController implements Serializable {
     }
 
     private List<Payment> fetchDepositPayments(PatientEncounter enc) {
+        StringBuilder jpql = new StringBuilder("select p from Payment p"
+                + " where p.retired = false"
+                + " and p.cancelled = false"
+                + " and p.bill.retired = false"
+                + " and p.bill.cancelled = false"
+                + " and p.bill.billTypeAtomic = :bta"
+                + " and p.bill.patientEncounter = :enc");
+        Map<String, Object> params = new HashMap<>();
+        params.put("bta", BillTypeAtomic.INWARD_DEPOSIT);
+        params.put("enc", enc);
+        if (paymentMethod != null) {
+            jpql.append(" and p.paymentMethod = :pm");
+            params.put("pm", paymentMethod);
+        }
+        jpql.append(" order by p.createdAt");
+        return paymentFacade.findByJpql(jpql.toString(), params);
+    }
+
+    /**
+     * Fetch "Make a Payment" (INWARD_PAYMENT) payments for this encounter -
+     * payments toward the bill made any time during the stay. Kept separate
+     * from deposits (INWARD_DEPOSIT) and post-final-bill payments
+     * (BillType.PostFinalBillInwardPayment). Issue #23262.
+     */
+    private List<Payment> fetchPayments(PatientEncounter enc) {
         StringBuilder jpql = new StringBuilder("select p from Payment p"
                 + " where p.retired = false"
                 + " and p.cancelled = false"
@@ -326,11 +400,14 @@ public class BhtPaymentDetailReportController implements Serializable {
         reportRows = null;
         grandTotal = 0;
         grandTotalCcSettlement = 0;
-        grandTotalFinalPayments = 0;
-        totalByMethod = new LinkedHashMap<>();
+        grandTotalPayments = 0;
+        grandTotalPostPayments = 0;
+        depositTotalByMethod = new LinkedHashMap<>();
+        usedDepositMethods = new ArrayList<>();
+        paymentTotalByMethod = new LinkedHashMap<>();
         usedPaymentMethods = new ArrayList<>();
-        finalPaymentTotalByMethod = new LinkedHashMap<>();
-        usedFinalPaymentMethods = new ArrayList<>();
+        postPaymentTotalByMethod = new LinkedHashMap<>();
+        usedPostPaymentMethods = new ArrayList<>();
     }
 
     private static Date startOfCurrentMonth() {
@@ -378,13 +455,19 @@ public class BhtPaymentDetailReportController implements Serializable {
 
     public double getGrandTotalCcSettlement() { return grandTotalCcSettlement; }
 
-    public double getGrandTotalFinalPayments() { return grandTotalFinalPayments; }
+    public double getGrandTotalPayments() { return grandTotalPayments; }
+
+    public double getGrandTotalPostPayments() { return grandTotalPostPayments; }
+
+    public List<PaymentMethod> getUsedDepositMethods() { return usedDepositMethods; }
+
+    public Map<PaymentMethod, Double> getDepositTotalByMethod() { return depositTotalByMethod; }
 
     public List<PaymentMethod> getUsedPaymentMethods() { return usedPaymentMethods; }
 
-    public Map<PaymentMethod, Double> getTotalByMethod() { return totalByMethod; }
+    public Map<PaymentMethod, Double> getPaymentTotalByMethod() { return paymentTotalByMethod; }
 
-    public List<PaymentMethod> getUsedFinalPaymentMethods() { return usedFinalPaymentMethods; }
+    public List<PaymentMethod> getUsedPostPaymentMethods() { return usedPostPaymentMethods; }
 
-    public Map<PaymentMethod, Double> getFinalPaymentTotalByMethod() { return finalPaymentTotalByMethod; }
+    public Map<PaymentMethod, Double> getPostPaymentTotalByMethod() { return postPaymentTotalByMethod; }
 }

--- a/src/main/java/com/divudi/bean/inward/BhtPaymentSummaryReportController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtPaymentSummaryReportController.java
@@ -30,8 +30,12 @@ import javax.persistence.TemporalType;
  * Controller for BHT Deposit and Credit Settlement Summary Report.
  * Issue #19345
  *
- * One row per PatientEncounter (BHT). Columns show deposit totals broken down
- * by PaymentMethod plus a combined credit-settlement column.
+ * One row per PatientEncounter (BHT). Money-in is shown as three separate
+ * PaymentMethod-broken-down column groups (issue #23262):
+ * "Make a Deposit" (BillTypeAtomic.INWARD_DEPOSIT),
+ * "Make a Payment" (BillTypeAtomic.INWARD_PAYMENT) and
+ * "Post Final Payment" (BillType.PostFinalBillInwardPayment),
+ * plus a Grand Total column and a combined credit-settlement column.
  */
 @Named
 @SessionScoped
@@ -72,6 +76,11 @@ public class BhtPaymentSummaryReportController implements Serializable {
     private double grandTotalDepositCash;
     private double grandTotalDepositCard;
     private double grandTotalDepositOther;
+    private double grandTotalPayments;
+    private double grandTotalPaymentCash;
+    private double grandTotalPaymentCard;
+    private double grandTotalPaymentCredit;
+    private double grandTotalPaymentOther;
     private double grandTotalPostFinalPayments;
     private double grandTotalPostFinalCash;
     private double grandTotalPostFinalCard;
@@ -82,6 +91,7 @@ public class BhtPaymentSummaryReportController implements Serializable {
     private double grandTotalCreditBalance;
     private double grandTotalFinalBills;
     private double grandTotalBalance;
+    private double grandTotalAllMoneyIn;
 
     // -------------------------------------------------------------------------
     // Main generate method
@@ -93,6 +103,11 @@ public class BhtPaymentSummaryReportController implements Serializable {
         grandTotalDepositCash = 0;
         grandTotalDepositCard = 0;
         grandTotalDepositOther = 0;
+        grandTotalPayments = 0;
+        grandTotalPaymentCash = 0;
+        grandTotalPaymentCard = 0;
+        grandTotalPaymentCredit = 0;
+        grandTotalPaymentOther = 0;
         grandTotalPostFinalPayments = 0;
         grandTotalPostFinalCash = 0;
         grandTotalPostFinalCard = 0;
@@ -103,6 +118,7 @@ public class BhtPaymentSummaryReportController implements Serializable {
         grandTotalCreditBalance = 0;
         grandTotalFinalBills = 0;
         grandTotalBalance = 0;
+        grandTotalAllMoneyIn = 0;
 
         List<PatientEncounter> encounters = fetchEncounters();
         if (encounters == null || encounters.isEmpty()) {
@@ -117,6 +133,11 @@ public class BhtPaymentSummaryReportController implements Serializable {
             grandTotalDepositCash += row.getDepositCash();
             grandTotalDepositCard += row.getDepositCard();
             grandTotalDepositOther += row.getDepositOther();
+            grandTotalPayments += row.getTotalPayments();
+            grandTotalPaymentCash += row.getPaymentCash();
+            grandTotalPaymentCard += row.getPaymentCard();
+            grandTotalPaymentCredit += row.getPaymentCredit();
+            grandTotalPaymentOther += row.getPaymentOther();
             grandTotalPostFinalPayments += row.getTotalPostFinalPayments();
             grandTotalPostFinalCash += row.getPostFinalCash();
             grandTotalPostFinalCard += row.getPostFinalCard();
@@ -127,6 +148,7 @@ public class BhtPaymentSummaryReportController implements Serializable {
             grandTotalCreditBalance += row.getCreditBalance();
             grandTotalFinalBills += row.getFinalBillTotal();
             grandTotalBalance += row.getTotalBalance();
+            grandTotalAllMoneyIn += row.getTotalAllMoneyIn();
         }
     }
 
@@ -218,10 +240,16 @@ public class BhtPaymentSummaryReportController implements Serializable {
         row.setDateOfDischarge(enc.getDateOfDischarge());
         row.setAdmissionType(enc.getAdmissionType());
 
-        // --- deposit payments ---
+        // --- "Make a Deposit" payments (INWARD_DEPOSIT) ---
         List<Payment> depositPayments = fetchDepositPayments(enc);
         for (Payment p : depositPayments) {
             row.addDeposit(p.getPaymentMethod(), Math.abs(p.getPaidValue()));
+        }
+
+        // --- "Make a Payment" payments (INWARD_PAYMENT) ---
+        List<Payment> payments = fetchPayments(enc);
+        for (Payment p : payments) {
+            row.addPayment(p.getPaymentMethod(), Math.abs(p.getPaidValue()));
         }
 
         // --- post-final-bill payments ---
@@ -267,10 +295,30 @@ public class BhtPaymentSummaryReportController implements Serializable {
     }
 
     /**
-     * Fetch all Payment records linked to INWARD_PAYMENT bills for this encounter.
-     * Payment bills link to the encounter via bill.patientEncounter directly.
+     * Fetch all Payment records linked to INWARD_DEPOSIT ("Make a Deposit") bills
+     * for this encounter. Deposit bills link to the encounter via
+     * bill.patientEncounter directly.
      */
     private List<Payment> fetchDepositPayments(PatientEncounter enc) {
+        String jpql = "select p from Payment p"
+                + " where p.retired = false"
+                + " and p.bill.retired = false"
+                + " and p.bill.cancelled = false"
+                + " and p.bill.billTypeAtomic = :bta"
+                + " and p.bill.patientEncounter = :enc";
+        Map<String, Object> params = new HashMap<>();
+        params.put("bta", BillTypeAtomic.INWARD_DEPOSIT);
+        params.put("enc", enc);
+        return paymentFacade.findByJpql(jpql, params);
+    }
+
+    /**
+     * Fetch all Payment records linked to INWARD_PAYMENT ("Make a Payment") bills
+     * for this encounter — payments toward the bill made any time during the
+     * stay, kept separate from deposits (INWARD_DEPOSIT) and from post-final-bill
+     * payments (BillType.PostFinalBillInwardPayment). Issue #23262.
+     */
+    private List<Payment> fetchPayments(PatientEncounter enc) {
         String jpql = "select p from Payment p"
                 + " where p.retired = false"
                 + " and p.bill.retired = false"
@@ -355,6 +403,11 @@ public class BhtPaymentSummaryReportController implements Serializable {
         grandTotalDepositCash = 0;
         grandTotalDepositCard = 0;
         grandTotalDepositOther = 0;
+        grandTotalPayments = 0;
+        grandTotalPaymentCash = 0;
+        grandTotalPaymentCard = 0;
+        grandTotalPaymentCredit = 0;
+        grandTotalPaymentOther = 0;
         grandTotalPostFinalPayments = 0;
         grandTotalPostFinalCash = 0;
         grandTotalPostFinalCard = 0;
@@ -365,6 +418,7 @@ public class BhtPaymentSummaryReportController implements Serializable {
         grandTotalCreditBalance = 0;
         grandTotalFinalBills = 0;
         grandTotalBalance = 0;
+        grandTotalAllMoneyIn = 0;
     }
 
     // -------------------------------------------------------------------------
@@ -408,6 +462,16 @@ public class BhtPaymentSummaryReportController implements Serializable {
 
     public double getGrandTotalDepositOther() { return grandTotalDepositOther; }
 
+    public double getGrandTotalPayments() { return grandTotalPayments; }
+
+    public double getGrandTotalPaymentCash() { return grandTotalPaymentCash; }
+
+    public double getGrandTotalPaymentCard() { return grandTotalPaymentCard; }
+
+    public double getGrandTotalPaymentCredit() { return grandTotalPaymentCredit; }
+
+    public double getGrandTotalPaymentOther() { return grandTotalPaymentOther; }
+
     public double getGrandTotalPostFinalPayments() { return grandTotalPostFinalPayments; }
 
     public double getGrandTotalPostFinalCash() { return grandTotalPostFinalCash; }
@@ -427,4 +491,6 @@ public class BhtPaymentSummaryReportController implements Serializable {
     public double getGrandTotalFinalBills() { return grandTotalFinalBills; }
 
     public double getGrandTotalBalance() { return grandTotalBalance; }
+
+    public double getGrandTotalAllMoneyIn() { return grandTotalAllMoneyIn; }
 }

--- a/src/main/java/com/divudi/core/data/dto/BhtPaymentDetailDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/BhtPaymentDetailDTO.java
@@ -7,8 +7,8 @@ import java.util.Date;
 
 /**
  * DTO for BHT Deposit and Credit Settlement Detail Report.
- * One instance per individual payment (deposit, post-final/"Make Payment"
- * settlement, or CC settlement) - see {@link #getPaymentCategory()}.
+ * One instance per individual payment ("Make a Deposit", "Make a Payment",
+ * "Post Final Payment", or CC settlement) - see {@link #getPaymentCategory()}.
  */
 public class BhtPaymentDetailDTO implements Serializable {
 
@@ -26,11 +26,13 @@ public class BhtPaymentDetailDTO implements Serializable {
 
     /**
      * Distinguishes which kind of transaction this row is: "Deposit"
-     * (Make Deposit), "Final Payment" (Make Payment / post-final-bill
-     * settlement), or "CC Settlement" (credit company payment). Not set by
-     * every caller of this DTO (e.g. {@code BhtDepositDetailReportController}
-     * predates this field) - callers that don't set it leave rows blank
-     * rather than defaulting to a possibly-wrong category.
+     * ("Make a Deposit" / INWARD_DEPOSIT), "Payment" ("Make a Payment" /
+     * INWARD_PAYMENT), "Post Payment" ("Post Final Payment" /
+     * BillType.PostFinalBillInwardPayment), or "CC Settlement" (credit company
+     * payment). Not set by every caller of this DTO (e.g.
+     * {@code BhtDepositDetailReportController} predates this field) - callers
+     * that don't set it leave rows blank rather than defaulting to a
+     * possibly-wrong category.
      */
     private String paymentCategory;
 

--- a/src/main/java/com/divudi/core/data/dto/BhtPaymentSummaryDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/BhtPaymentSummaryDTO.java
@@ -30,8 +30,11 @@ public class BhtPaymentSummaryDTO implements Serializable {
     private Date dateOfDischarge;
     private AdmissionType admissionType;
 
-    /** Sum of deposit bill payments, keyed by payment method. */
+    /** Sum of "Make a Deposit" (INWARD_DEPOSIT) bill payments, keyed by payment method. */
     private Map<PaymentMethod, Double> depositsByMethod = new EnumMap<>(PaymentMethod.class);
+
+    /** Sum of "Make a Payment" (INWARD_PAYMENT) bill payments, keyed by payment method. */
+    private Map<PaymentMethod, Double> paymentsByMethod = new EnumMap<>(PaymentMethod.class);
 
     /** Sum of post-final-bill payments, keyed by payment method. */
     private Map<PaymentMethod, Double> postFinalPaymentsByMethod = new EnumMap<>(PaymentMethod.class);
@@ -86,6 +89,39 @@ public class BhtPaymentSummaryDTO implements Serializable {
         return getTotalDeposits() - getDepositCash() - getDepositCard();
     }
 
+    public double getTotalPayments() {
+        return paymentsByMethod.values().stream().mapToDouble(Double::doubleValue).sum();
+    }
+
+    public double getPaymentForMethod(PaymentMethod method) {
+        return paymentsByMethod.getOrDefault(method, 0.0);
+    }
+
+    public void addPayment(PaymentMethod method, double amount) {
+        if (method == null) {
+            LOG.log(Level.WARNING, "BHT {0}: payment of {1} has null PaymentMethod — amount dropped from totals",
+                    new Object[]{bhtNo, amount});
+            return;
+        }
+        paymentsByMethod.merge(method, amount, Double::sum);
+    }
+
+    public double getPaymentCash() {
+        return getPaymentForMethod(PaymentMethod.Cash);
+    }
+
+    public double getPaymentCard() {
+        return getPaymentForMethod(PaymentMethod.Card);
+    }
+
+    public double getPaymentCredit() {
+        return getPaymentForMethod(PaymentMethod.Credit);
+    }
+
+    public double getPaymentOther() {
+        return getTotalPayments() - getPaymentCash() - getPaymentCard() - getPaymentCredit();
+    }
+
     public double getTotalPostFinalPayments() {
         return postFinalPaymentsByMethod.values().stream().mapToDouble(Double::doubleValue).sum();
     }
@@ -129,6 +165,11 @@ public class BhtPaymentSummaryDTO implements Serializable {
 
     public double getPostFinalOther() {
         return getTotalPostFinalPayments() - getPostFinalCash() - getPostFinalCard() - getPostFinalCredit();
+    }
+
+    /** Deposits + payments + post-final-bill payments — every money-in stream for this BHT. */
+    public double getTotalAllMoneyIn() {
+        return getTotalDeposits() + getTotalPayments() + getTotalPostFinalPayments();
     }
 
     public void addCreditCompanyBill(double billedAmount, double settledAmount, String companyName) {
@@ -203,6 +244,10 @@ public class BhtPaymentSummaryDTO implements Serializable {
         return depositsByMethod;
     }
 
+    public Map<PaymentMethod, Double> getPaymentsByMethod() {
+        return paymentsByMethod;
+    }
+
     public Map<PaymentMethod, Double> getPostFinalPaymentsByMethod() {
         return postFinalPaymentsByMethod;
     }
@@ -248,17 +293,18 @@ public class BhtPaymentSummaryDTO implements Serializable {
     }
 
     /**
-     * Balance = final bill net total − (deposits + post-final payments + credit billed).
+     * Balance = final bill net total − (deposits + payments + post-final payments + credit billed).
      * Positive means amount still due; negative means overpayment / refund due.
      * Returns 0 when no final bill exists — checked via finalBillNumber presence,
      * not finalBillTotal, so a genuine final bill with a zero net total still
-     * nets out any deposits/post-final payments/credit billed instead of being
-     * mistaken for "no final bill".
+     * nets out any deposits/payments/post-final payments/credit billed instead of
+     * being mistaken for "no final bill".
      */
     public double getTotalBalance() {
         if (finalBillNumber == null || finalBillNumber.isBlank()) {
             return 0.0;
         }
-        return finalBillTotal - getTotalDeposits() - getTotalPostFinalPayments() - creditBilledTotal;
+        return finalBillTotal - getTotalDeposits() - getTotalPayments()
+                - getTotalPostFinalPayments() - creditBilledTotal;
     }
 }

--- a/src/main/webapp/inward/inward_report_bht_payment_detail.xhtml
+++ b/src/main/webapp/inward/inward_report_bht_payment_detail.xhtml
@@ -9,14 +9,18 @@
     <!--
         Issue #23258: this page's title/URL/menu entry is "...Detail", but its
         results table is intentionally bound to bhtPaymentSummaryReportController
-        (one row per PatientEncounter/BHT, with the full deposit/post-final/
-        credit-settlement/final-bill breakdown) - not a typo. Related issues
-        #23260/#23262/#23263 (filed against "the Detail report") describe
-        exactly this controller's column set (Deposit Cash, Post-Final columns,
-        Total Balance, post-payment-only patients), confirming the reporter's
-        mental model: "Detail" = the full per-BHT financial breakdown, "Summary"
-        = the plain payment log now shown on inward_report_bht_payment_summary.xhtml.
-        See BhtPaymentSummaryReportController's javadoc for the underlying data.
+        (one row per PatientEncounter/BHT, with the full deposit / payment /
+        post-payment / credit-settlement / final-bill breakdown) - not a typo.
+        Related issues #23260/#23262/#23263 (filed against "the Detail report")
+        describe exactly this controller's column set (Deposit / Payment / Post
+        Payment column groups, Total Balance, post-payment-only patients),
+        confirming the reporter's mental model: "Detail" = the full per-BHT
+        financial breakdown, "Summary" = the plain payment log now shown on
+        inward_report_bht_payment_summary.xhtml. Issue #23262 further split the
+        one-time "Payments" bucket into three: "Make a Deposit" (INWARD_DEPOSIT),
+        "Make a Payment" (INWARD_PAYMENT) and "Post Final Payment"
+        (BillType.PostFinalBillInwardPayment). See BhtPaymentSummaryReportController's
+        javadoc for the underlying data.
     -->
     <h:body>
         <ui:composition template="/inward/inward_reports.xhtml">
@@ -324,7 +328,62 @@
                                 </f:facet>
                             </p:column>
 
-                            <p:column headerText="Final Cash" style="text-align:right; white-space:nowrap;">
+                            <p:column headerText="Payment Cash" style="text-align:right; white-space:nowrap;">
+                                <h:outputText value="#{row.paymentCash}">
+                                    <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                </h:outputText>
+                                <f:facet name="footer">
+                                    <h:outputText value="#{bhtPaymentSummaryReportController.grandTotalPaymentCash}">
+                                        <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                    </h:outputText>
+                                </f:facet>
+                            </p:column>
+
+                            <p:column headerText="Payment Card" style="text-align:right; white-space:nowrap;">
+                                <h:outputText value="#{row.paymentCard}">
+                                    <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                </h:outputText>
+                                <f:facet name="footer">
+                                    <h:outputText value="#{bhtPaymentSummaryReportController.grandTotalPaymentCard}">
+                                        <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                    </h:outputText>
+                                </f:facet>
+                            </p:column>
+
+                            <p:column headerText="Payment Credit" style="text-align:right; white-space:nowrap;">
+                                <h:outputText value="#{row.paymentCredit}">
+                                    <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                </h:outputText>
+                                <f:facet name="footer">
+                                    <h:outputText value="#{bhtPaymentSummaryReportController.grandTotalPaymentCredit}">
+                                        <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                    </h:outputText>
+                                </f:facet>
+                            </p:column>
+
+                            <p:column headerText="Payment Other" style="text-align:right; white-space:nowrap;">
+                                <h:outputText value="#{row.paymentOther}">
+                                    <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                </h:outputText>
+                                <f:facet name="footer">
+                                    <h:outputText value="#{bhtPaymentSummaryReportController.grandTotalPaymentOther}">
+                                        <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                    </h:outputText>
+                                </f:facet>
+                            </p:column>
+
+                            <p:column headerText="Total Payments" style="text-align:right; white-space:nowrap; font-weight:bold;">
+                                <h:outputText value="#{row.totalPayments}">
+                                    <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                </h:outputText>
+                                <f:facet name="footer">
+                                    <h:outputText value="#{bhtPaymentSummaryReportController.grandTotalPayments}">
+                                        <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                    </h:outputText>
+                                </f:facet>
+                            </p:column>
+
+                            <p:column headerText="Post Payment Cash" style="text-align:right; white-space:nowrap;">
                                 <h:outputText value="#{row.postFinalCash}">
                                     <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
                                 </h:outputText>
@@ -335,7 +394,7 @@
                                 </f:facet>
                             </p:column>
 
-                            <p:column headerText="Final Card" style="text-align:right; white-space:nowrap;">
+                            <p:column headerText="Post Payment Card" style="text-align:right; white-space:nowrap;">
                                 <h:outputText value="#{row.postFinalCard}">
                                     <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
                                 </h:outputText>
@@ -346,7 +405,7 @@
                                 </f:facet>
                             </p:column>
 
-                            <p:column headerText="Final Credit" style="text-align:right; white-space:nowrap;">
+                            <p:column headerText="Post Payment Credit" style="text-align:right; white-space:nowrap;">
                                 <h:outputText value="#{row.postFinalCredit}">
                                     <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
                                 </h:outputText>
@@ -357,7 +416,7 @@
                                 </f:facet>
                             </p:column>
 
-                            <p:column headerText="Final Other" style="text-align:right; white-space:nowrap;">
+                            <p:column headerText="Post Payment Other" style="text-align:right; white-space:nowrap;">
                                 <h:outputText value="#{row.postFinalOther}">
                                     <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
                                 </h:outputText>
@@ -368,12 +427,23 @@
                                 </f:facet>
                             </p:column>
 
-                            <p:column headerText="Total Final" style="text-align:right; white-space:nowrap; font-weight:bold;">
+                            <p:column headerText="Total Post Payments" style="text-align:right; white-space:nowrap; font-weight:bold;">
                                 <h:outputText value="#{row.totalPostFinalPayments}">
                                     <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
                                 </h:outputText>
                                 <f:facet name="footer">
                                     <h:outputText value="#{bhtPaymentSummaryReportController.grandTotalPostFinalPayments}">
+                                        <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                    </h:outputText>
+                                </f:facet>
+                            </p:column>
+
+                            <p:column headerText="Grand Total" style="text-align:right; white-space:nowrap; font-weight:bold;">
+                                <h:outputText value="#{row.totalAllMoneyIn}">
+                                    <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                </h:outputText>
+                                <f:facet name="footer">
+                                    <h:outputText value="#{bhtPaymentSummaryReportController.grandTotalAllMoneyIn}">
                                         <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
                                     </h:outputText>
                                 </f:facet>
@@ -446,6 +516,16 @@
                                 <div class="text-end">
                                     <strong>Grand Total Deposits: </strong>
                                     <h:outputText value="#{bhtPaymentSummaryReportController.grandTotalDeposits}">
+                                        <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                    </h:outputText>
+                                    &#160;&#160;&#160;
+                                    <strong>Grand Total Payments: </strong>
+                                    <h:outputText value="#{bhtPaymentSummaryReportController.grandTotalPayments}">
+                                        <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                    </h:outputText>
+                                    &#160;&#160;&#160;
+                                    <strong>Grand Total Post Payments: </strong>
+                                    <h:outputText value="#{bhtPaymentSummaryReportController.grandTotalPostFinalPayments}">
                                         <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
                                     </h:outputText>
                                     &#160;&#160;&#160;

--- a/src/main/webapp/inward/inward_report_bht_payment_summary.xhtml
+++ b/src/main/webapp/inward/inward_report_bht_payment_summary.xhtml
@@ -313,28 +313,43 @@
                             <f:facet name="footer">
                                 <div class="text-end">
                                     <strong>Deposits — </strong>
-                                    <ui:repeat value="#{bhtPaymentDetailReportController.usedPaymentMethods}" var="pm">
+                                    <ui:repeat value="#{bhtPaymentDetailReportController.usedDepositMethods}" var="pm">
                                         <strong>
                                             <h:outputText value="#{pm.label}" />:
                                         </strong>
-                                        <h:outputText value="#{bhtPaymentDetailReportController.getTotalForMethod(pm)}">
+                                        <h:outputText value="#{bhtPaymentDetailReportController.getTotalForDepositMethod(pm)}">
                                             <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
                                         </h:outputText>
                                         &#160;&#160;
                                     </ui:repeat>
                                     &#160;&#160;&#160;
-                                    <strong>Final Payments — </strong>
-                                    <ui:repeat value="#{bhtPaymentDetailReportController.usedFinalPaymentMethods}" var="pm">
+                                    <strong>Payments — </strong>
+                                    <ui:repeat value="#{bhtPaymentDetailReportController.usedPaymentMethods}" var="pm">
                                         <strong>
                                             <h:outputText value="#{pm.label}" />:
                                         </strong>
-                                        <h:outputText value="#{bhtPaymentDetailReportController.getTotalForFinalPaymentMethod(pm)}">
+                                        <h:outputText value="#{bhtPaymentDetailReportController.getTotalForPaymentMethod(pm)}">
                                             <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
                                         </h:outputText>
                                         &#160;&#160;
                                     </ui:repeat>
-                                    <strong>Total Final: </strong>
-                                    <h:outputText value="#{bhtPaymentDetailReportController.grandTotalFinalPayments}">
+                                    <strong>Total Payments: </strong>
+                                    <h:outputText value="#{bhtPaymentDetailReportController.grandTotalPayments}">
+                                        <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                    </h:outputText>
+                                    &#160;&#160;&#160;
+                                    <strong>Post Payments — </strong>
+                                    <ui:repeat value="#{bhtPaymentDetailReportController.usedPostPaymentMethods}" var="pm">
+                                        <strong>
+                                            <h:outputText value="#{pm.label}" />:
+                                        </strong>
+                                        <h:outputText value="#{bhtPaymentDetailReportController.getTotalForPostPaymentMethod(pm)}">
+                                            <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
+                                        </h:outputText>
+                                        &#160;&#160;
+                                    </ui:repeat>
+                                    <strong>Total Post Payments: </strong>
+                                    <h:outputText value="#{bhtPaymentDetailReportController.grandTotalPostPayments}">
                                         <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
                                     </h:outputText>
                                     &#160;&#160;&#160;


### PR DESCRIPTION
Closes #23262

## Problem

Retest of #23262 (2026-08-29) still showed **Make a Payment** amounts under the **Deposit** columns of the BHT Deposit and Credit Settlement reports, and genuine **Make a Deposit** bills missing entirely.

Root cause: PR #22807 / commit `a9449a57de` bulk-repointed both report controllers' `fetchDepositPayments()` from `BillTypeAtomic.INWARD_DEPOSIT` → `INWARD_PAYMENT`. The inpatient Billing panel has **three** money-in buttons, each with a distinct bill type:

| Button | `BillType` | `BillTypeAtomic` |
|---|---|---|
| Make a Deposit | `InwardPaymentBill` | `INWARD_DEPOSIT` |
| Make a Payment | `InwardPaymentBill` | `INWARD_PAYMENT` |
| Post Final Payment | `PostFinalBillInwardPayment` | `POST_FINAL_BILL_INWARD_PAYMENT` |

After the repoint, the "Deposit" columns queried `INWARD_PAYMENT` (Make a Payment), so real deposits were dropped and payments were mislabelled.

## What changed

**Detail report** (`inward_report_bht_payment_detail.xhtml` → `BhtPaymentSummaryReportController` / `BhtPaymentSummaryDTO`)
- `fetchDepositPayments()` repointed back to `INWARD_DEPOSIT`; new `fetchPayments()` for `INWARD_PAYMENT`.
- DTO: new `paymentsByMethod` map + `getPaymentCash/Card/Credit/Other` / `getTotalPayments`; new `getTotalAllMoneyIn()`. `getTotalBalance()` now also subtracts `getTotalPayments()`.
- Controller: matching `grandTotalPayment*` + `grandTotalAllMoneyIn` fields (reset / accumulate / getters).
- XHTML: new **Payment Cash/Card/Credit/Other + Total Payments** column group; existing "Final *" columns renamed **Post Payment ***; new **Grand Total** column; footer summary line gains "Grand Total Payments" and "Grand Total Post Payments".

**Summary report** (`inward_report_bht_payment_summary.xhtml` → `BhtPaymentDetailReportController` / `BhtPaymentDetailDTO`)
- `fetchDepositPayments()` repointed to `INWARD_DEPOSIT`; new `fetchPayments()` for `INWARD_PAYMENT`; new per-encounter loop emitting `Type = "Payment"` rows.
- Existing "Final Payment" category renamed **"Post Payment"**; internal `finalPayment*` names → `postPayment*`; deposit `totalByMethod` → `depositTotalByMethod` / `usedDepositMethods`.
- XHTML footer: new "Payments — <per method>" block; "Final Payments —" → "Post Payments —"; "Total Final:" → "Total Post Payments:".

Out of scope: deposit/payment cancellation & refund rollup (no workflow exists yet, per #22804 non-goals); `BillType`/`BillTypeAtomic` enum changes; the #23258 controller/page-title swap (kept).

## Testing (local Payara + `coop` DB)

On **BHT/57241** (discharged, final bill confirmed): recorded **Make a Deposit** Rs 5,000 Cash, **Make a Payment** Rs 3,000 Cash, **Make a Payment** Rs 2,000 Card. Post Final Payment could not be exercised (final bill already fully credit-settled → balance due Rs 0); that code path is unchanged by this PR — only its column labels were renamed.

**Detail report** — Deposit Cash 5,000 · Total Deposits 5,000 · Payment Cash 3,000 · Payment Card 2,000 · Total Payments 5,000 · Total Post Payments 0 · **Grand Total 10,000**:

![Detail report with three payment column groups](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23262-detail-three-payment-groups.png)

**Summary report** — rows: `Deposit`/Cash/5,000, `Payment`/Cash/3,000, `Payment`/Credit Card/2,000; footer totals each stream separately:

![Summary report with Deposit/Payment distinguished by Type](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23262-summary-three-payment-groups.png)

**DB cross-check:** report per-bucket sums equal `SUM(Payment.paidValue)` grouped by `billTypeAtomic` — `INWARD_DEPOSIT` = 5,000, `INWARD_PAYMENT` = 5,000.

`mvn clean package -DskipTests` succeeds; redeployed locally with no errors in `server.log`.

## Documentation

Both wiki pages updated (columns/Type values, formulas, new screenshots):
- [BHT Deposit and Credit Settlement Detail Report](https://github.com/hmislk/hmis/wiki/Inward-BHT-Deposit-and-Credit-Settlement-Detail-Report)
- [BHT Deposit and Credit Settlement Summary Report](https://github.com/hmislk/hmis/wiki/Inward-BHT-Deposit-and-Credit-Settlement-Summary-Report)

🤖 Generated with [Claude Code](https://claude.com/claude-code)