### PR TITLE
fix(inward): stop a rejected BHT settlement from persisting orphan BillItems

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
@@ -1390,12 +1390,29 @@ public class PharmacySaleBhtController implements Serializable {
         //TODO: What is this doing here. Need to investigate
         getBillBean().setSurgeryData(getPreBill(), getBatchBill(), SurgeryBillType.PharmacyItem);
 
-        if (getPreBill().getId() == null) {
-            getPreBill().setCreatedAt(Calendar.getInstance().getTime());
-            getPreBill().setCreater(getSessionController().getLoggedUser());
-            getBillFacade().create(getPreBill());
-        } else {
-            getBillFacade().edit(getPreBill());
+        // Bill.billItems is cascade=ALL, and getPreBill().getBillItems() may already be
+        // aliased to the live Issuing Items grid list (generateIssueBillComponentsForBhtRequest()
+        // sets it when the page is generated, well before settlement). Persisting/merging
+        // the parent Bill here would cascade-persist those items as a side effect — BEFORE
+        // savePreBillItemsFinally()'s stock-sufficiency check even runs — leaving orphan
+        // BillItem rows behind on a rejected settlement. Detach the collection for this
+        // call only; restore the reference right after so validation and the real persist
+        // loop in savePreBillItemsFinally() still see the correct items. BillFacade is a
+        // @Stateless EJB, so create()/edit() each commit as their own transaction — nulling
+        // the reference here has no effect on anything already committed by an earlier
+        // attempt. Issue #23358.
+        List<BillItem> pendingBillItems = getPreBill().getBillItems();
+        getPreBill().setBillItems(null);
+        try {
+            if (getPreBill().getId() == null) {
+                getPreBill().setCreatedAt(Calendar.getInstance().getTime());
+                getPreBill().setCreater(getSessionController().getLoggedUser());
+                getBillFacade().create(getPreBill());
+            } else {
+                getBillFacade().edit(getPreBill());
+            }
+        } finally {
+            getPreBill().setBillItems(pendingBillItems);
         }
 
     }
@@ -1435,6 +1452,27 @@ public class PharmacySaleBhtController implements Serializable {
             getPreBill().setBillItems(new ArrayList<>());
         }
 
+        // Validate BEFORE persisting anything. getPreBill().getBillItems() is
+        // already aliased to `list` (generateIssueBillComponentsForBhtRequest()
+        // does getPreBill().setBillItems(billItems) with the same List object
+        // when the page is generated), so this check needs nothing persisted
+        // first — it only reads each item's already-set stock/qty, never
+        // item.getBill() or item.getId(). Moved ahead of the persist loop below
+        // so a rejected settlement leaves no orphan BillItem behind: previously
+        // this ran AFTER create()/edit(), so a correctly-rejected
+        // insufficient-stock settlement still left a real, persisted BillItem
+        // referencing the original request item, permanently inflating that
+        // item's billed-quantity aggregate and making the request appear
+        // "fully issued" forever even though nothing was actually issued.
+        // Issue #23358.
+        if (!directIssueBatchService.validateBillForSettlement(getPreBill())) {
+            String errorMsg = "One or more items have insufficient stock. Please refresh and try again.";
+            LOGGER.log(Level.SEVERE, "Batch stock validation failed during BHT settlement for Bill ID: {0}",
+                    getPreBill().getId());
+            JsfUtil.addErrorMessage(errorMsg);
+            throw new RuntimeException(errorMsg);
+        }
+
         for (BillItem tbi : list) {
             tbi.setInwardChargeType(InwardChargeType.Medicine);
             tbi.setBill(getPreBill());
@@ -1445,14 +1483,6 @@ public class PharmacySaleBhtController implements Serializable {
             } else {
                 getBillItemFacade().edit(tbi);
             }
-        }
-
-        if (!directIssueBatchService.validateBillForSettlement(getPreBill())) {
-            String errorMsg = "One or more items have insufficient stock. Please refresh and try again.";
-            LOGGER.log(Level.SEVERE, "Batch stock validation failed during BHT settlement for Bill ID: {0}",
-                    getPreBill().getId());
-            JsfUtil.addErrorMessage(errorMsg);
-            throw new RuntimeException(errorMsg);
         }
 
         if (!settlementStockDeducted) {


### PR DESCRIPTION
## Summary

A rejected BHT settlement (e.g. insufficient stock, correctly caught by
#23352's fresh recheck) was still persisting a real `BillItem` row behind
the scenes, referencing the original request's `BillItem`. That orphan row
permanently inflated the "billed" quantity aggregate used to compute
whether a request is fully issued — so a request that failed to settle
once would forever after report **"This request has already been fully
issued"**, even though nothing was actually deducted/issued and the DB's
own `COMPLETED`/`FULLYISSUED` columns correctly still read `0`/`0`.

## Root cause (corrected after a first attempt didn't hold up)

My first attempt reordered `savePreBillItemsFinally()`'s own
`create()`/`edit()` persist loop to run after its stock-validation check.
Live verification showed this **didn't work** — a rejected settlement
still created 2 orphan `BillItem` rows (confirmed via DB query, with
`BILL_ID`/`CREATEDAT` both `NULL`, proving they were never touched by that
method's explicit loop at all).

Traced the actual mechanism: `Bill.billItems` is
`@OneToMany(mappedBy="bill", cascade=CascadeType.ALL, ...)`.
`generateIssueBillComponentsForBhtRequest()` aliases
`getPreBill().getBillItems()` to the **exact same `List` object** as the
live Issuing Items grid, at page-generation time — well before any
settlement attempt. `savePreBillFinally()` — called by both
`settleBhtIssue()` and `settleBhtIssueRequestAccept()` **before**
`savePreBillItemsFinally()` even starts — persists/merges `getPreBill()`
itself. Because `billItems` is already aliased to the real, populated grid
list at that point, and the mapping is `cascade=ALL` (includes `PERSIST`
and `MERGE`), that call alone cascades every item currently in the
collection into the database — regardless of whatever validation runs
afterward. The real persist was happening one method call earlier than the
first fix touched.

## Fix

`savePreBillFinally()` now temporarily detaches `billItems` for the
duration of its own `create()`/`edit()` call (`try`/`finally`), restoring
the reference immediately after so validation and the real persist loop in
`savePreBillItemsFinally()` still see the correct, aliased list exactly as
before. `BillFacade` is a `@Stateless` EJB — `create()`/`edit()` each
commit as their own transaction — so this has no effect on anything
already committed by an earlier attempt.

Kept the (harmless, still reasonable) reordering from the first attempt in
`savePreBillItemsFinally()` as defense-in-depth, even though it wasn't
sufficient on its own.

`savePreBillFinallyRequest()` (used by the separate `settleBhtIssueRequest()`
flow, not the one reported/reproduced) has the same structural shape and is
likely exposed to the same risk — flagged as a probable follow-up, not
fixed here to keep this PR scoped to the verified, reproduced path.

## Verified

Playwright, Main Pharmacy, reusing the exact request/batch the failed
first attempt used (original `BillItem` id `14214889`):

- Reduced the auto-assigned batch's stock to 0, settled → rejected with
  the expected friendly message (unchanged from #23352/#23353).
- **DB check**: `SELECT COUNT(*) FROM BILLITEM WHERE
  REFERANCEBILLITEM_ID=14214889` → **0 new rows** (was 2 with the first
  attempt).
- Restored stock, reopened the same request → opens normally, no more
  false "already fully issued".
- Completed a full clean settlement → succeeded end-to-end: stock deducted
  exactly once (7→2), one correctly-persisted `BillItem` (`BILL_ID`/
  `CREATEDAT` both set), Bill Preview reached, request now genuinely
  `COMPLETED=1`/`FULLYISSUED=1`.
- Cleaned up the 2 malformed orphan rows left by the first attempt's
  verification.

## Documentation

No wiki update — this is an internal data-integrity fix with no visible
behavior change (the same #23352 friendly rejection message shows either
way; the difference is invisible to the user, only in what's left behind
in the DB).

Closes #23358


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented preliminary pharmacy bills from accidentally saving incomplete issuing-item data.
  - Stock availability is now validated before bill items are persisted.
  - Rejected settlements no longer leave behind records that incorrectly show requested items as fully issued.
  - Existing stock deduction and porter-transfer behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->