### PR TITLE
feat(cashier): record all payment methods at shift end, make cash denomination breakdown optional

### DIFF
--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -4085,14 +4085,68 @@ public class FinancialTransactionController implements Serializable {
     public String navigateToRecordShiftEndCash() {
         resetClassVariables();
         Bill startBill = fetchNonClosedShiftStartFundBill();
-        bundle = new ReportTemplateRowBundle();
         if (startBill == null) {
             JsfUtil.addErrorMessage("Shift not yet started.");
             return null;
         }
+
+        // Same payment-gathering steps as navigateToHandoverCreateBillForSelectedShift() —
+        // this is what computes the *HandoverValue figures (cashHandoverValue,
+        // cardHandoverValue, ...) and hasXxxTransaction flags per payment method for the
+        // shift, which this screen shows as the "Expected" reference value next to what
+        // the cashier actually declares.
+        List<Payment> shiftPayments = fetchPaymentsFromShiftStartToEndByDateAndDepartment(startBill, startBill.getReferenceBill());
+        if (shiftPayments != null) {
+            shiftPayments.stream()
+                    .forEach(p -> p.setTransientPaymentHandover(PaymentHandover.USER_COLLECTED));
+        }
+        List<Payment> shiftFloats = fetchShiftFloatsFromShiftStartToEnd(startBill, startBill.getReferenceBill(), sessionController.getLoggedUser());
+        if (shiftFloats != null) {
+            shiftFloats.stream()
+                    .forEach(p -> p.setTransientPaymentHandover(PaymentHandover.FLOATS));
+        }
+        List<Payment> othersPayments = fetchAllPaymentInMyHold(startBill, sessionController.getLoggedUser());
+        if (othersPayments != null) {
+            othersPayments.stream()
+                    .forEach(p -> p.setTransientPaymentHandover(PaymentHandover.OTHER_USERS_COLLECTED_AND_HANDED_OVER));
+        }
+
+        Set<Payment> uniquePaymentSet = new HashSet<>();
+        if (shiftPayments != null) {
+            uniquePaymentSet.addAll(shiftPayments);
+        }
+        if (shiftFloats != null) {
+            uniquePaymentSet.addAll(shiftFloats);
+        }
+        if (othersPayments != null) {
+            uniquePaymentSet.addAll(othersPayments);
+        }
+        List<Payment> allUniquePayments = new ArrayList<>(uniquePaymentSet);
+
+        bundle = generatePaymentBundleForHandovers(startBill,
+                startBill.getReferenceBill(),
+                allUniquePayments,
+                PaymentSelectionMode.SELECT_ALL_FOR_HANDOVER_CREATION
+        );
         bundle.setUser(sessionController.getLoggedUser());
         bundle.setStartBill(startBill);
-        bundle.setDenominationTransactions(denominationTransactionController.createDefaultDenominationTransaction());
+        bundle.setDenominations(sessionController.findDefaultDenominations());
+        bundle.selectAllChildBundles();
+        // Aggregates *Value/*HandoverValue and hasXxxTransaction from the child bundles
+        // without the "zero cashHandoverValue until counted" sync rule that
+        // calculateTotalsByChildBundlesForHandover() applies for the separate handover
+        // flow — here cashHandoverValue is wanted as the system-expected reference figure.
+        bundle.aggregateTotalsFromAllChildBundles();
+
+        boolean requireDenominationBreakdown = configOptionApplicationController.getBooleanValueByKey(
+                "Shift End Cash Handover - Require Denomination Breakdown", false);
+        if (requireDenominationBreakdown) {
+            bundle.setDenominationTransactions(denominationTransactionController.createDefaultDenominationTransaction());
+        } else {
+            bundle.setDenominationTransactions(bundle.createLumpSumCashHandoverTransaction());
+        }
+        bundle.setPaymentMethodHandoverTransactions(bundle.createPaymentMethodHandoverTransactions());
+
         return "/cashier/shift_end_cash_in_hand?faces-redirect=true";
     }
 
@@ -6689,21 +6743,33 @@ public class FinancialTransactionController implements Serializable {
 
         billController.save(currentBill);
 
-        Double cashHandover = 0.0;
+        List<DenominationTransaction> allHandoverTransactions = new ArrayList<>();
         if (bundle.getDenominationTransactions() != null) {
-            for (DenominationTransaction dt : bundle.getDenominationTransactions()) {
-                dt.setBill(currentBill);
-                if (dt.getDenominationValue() != null) {
-                    cashHandover += dt.getDenominationValue();
-                }
-                denominationTransactionController.save(dt);
-            }
+            allHandoverTransactions.addAll(bundle.getDenominationTransactions());
         }
-        currentBill.setTotal(cashHandover);
-        currentBill.setNetTotal(cashHandover);
+        if (bundle.getPaymentMethodHandoverTransactions() != null) {
+            allHandoverTransactions.addAll(bundle.getPaymentMethodHandoverTransactions());
+        }
+
+        Double totalHandover = 0.0;
+        for (DenominationTransaction dt : allHandoverTransactions) {
+            dt.setBill(currentBill);
+            if (dt.getDenominationValue() != null) {
+                totalHandover += dt.getDenominationValue();
+            }
+            denominationTransactionController.save(dt);
+        }
+        currentBill.setTotal(totalHandover);
+        currentBill.setNetTotal(totalHandover);
 
         billController.save(currentBill);
         bundle.setHandoverBill(currentBill);
+        // Combine cash + non-cash rows into one list so the print page — which reads
+        // bundle.denominationTransactions directly, the same field
+        // navigateToViewShiftEndCashInHandBill() re-populates with every
+        // DenominationTransaction row saved against this bill when viewed later —
+        // renders both consistently regardless of entry point.
+        bundle.setDenominationTransactions(allHandoverTransactions);
 
         return "/cashier/shift_end_cash_in_hand_print?faces-redirect=true";
     }

--- a/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
+++ b/src/main/java/com/divudi/bean/cashTransaction/FinancialTransactionController.java
@@ -4110,6 +4110,9 @@ public class FinancialTransactionController implements Serializable {
             othersPayments.stream()
                     .forEach(p -> p.setTransientPaymentHandover(PaymentHandover.OTHER_USERS_COLLECTED_AND_HANDED_OVER));
         }
+        // Fund transfer payments (float-out / float-in between users) change the cash this
+        // user should physically have, same as navigateToHandoverCreateBillForCurrentShift().
+        List<Payment> fundTransferPayments = fetchFundTransferPaymentsForShift(startBill, startBill.getReferenceBill(), sessionController.getLoggedUser());
 
         Set<Payment> uniquePaymentSet = new HashSet<>();
         if (shiftPayments != null) {
@@ -4120,6 +4123,9 @@ public class FinancialTransactionController implements Serializable {
         }
         if (othersPayments != null) {
             uniquePaymentSet.addAll(othersPayments);
+        }
+        if (fundTransferPayments != null) {
+            uniquePaymentSet.addAll(fundTransferPayments);
         }
         List<Payment> allUniquePayments = new ArrayList<>(uniquePaymentSet);
 
@@ -4137,6 +4143,22 @@ public class FinancialTransactionController implements Serializable {
         // calculateTotalsByChildBundlesForHandover() applies for the separate handover
         // flow — here cashHandoverValue is wanted as the system-expected reference figure.
         bundle.aggregateTotalsFromAllChildBundles();
+        // aggregateTotalsFromAllChildBundles() deliberately skips float rows (isFloatRow()),
+        // so the net fund-transfer cash adjustment above has to be folded in separately —
+        // otherwise a float sent/received mid-shift would silently drop out of the
+        // expected cash figure this screen shows.
+        double netFloatCash = 0.0;
+        if (bundle.getBundles() != null) {
+            for (ReportTemplateRowBundle childBundle : bundle.getBundles()) {
+                if (childBundle.isFloatRow()) {
+                    netFloatCash += childBundle.getCashHandoverValue();
+                }
+            }
+        }
+        if (netFloatCash != 0.0) {
+            bundle.setCashValue(bundle.getCashValue() + netFloatCash);
+            bundle.setCashHandoverValue(bundle.getCashHandoverValue() + netFloatCash);
+        }
 
         boolean requireDenominationBreakdown = configOptionApplicationController.getBooleanValueByKey(
                 "Shift End Cash Handover - Require Denomination Breakdown", false);

--- a/src/main/java/com/divudi/core/data/ReportTemplateRowBundle.java
+++ b/src/main/java/com/divudi/core/data/ReportTemplateRowBundle.java
@@ -36,6 +36,8 @@ public class ReportTemplateRowBundle implements Serializable {
 
     private List<ReportTemplateRowBundle> bundles;
     List<DenominationTransaction> denominationTransactions;
+    private List<DenominationTransaction> paymentMethodHandoverTransactions;
+    private double paymentMethodHandoverActualTotal;
     private ReportTemplate reportTemplate;
     private List<ReportTemplateRow> reportTemplateRows;
     private Map<String, List<BillItem>> groupedBillItems;
@@ -3072,13 +3074,40 @@ public class ReportTemplateRowBundle implements Serializable {
         this.denominationTransactions = denominationTransactions;
     }
 
+    public List<DenominationTransaction> getPaymentMethodHandoverTransactions() {
+        return paymentMethodHandoverTransactions;
+    }
+
+    public void setPaymentMethodHandoverTransactions(List<DenominationTransaction> paymentMethodHandoverTransactions) {
+        this.paymentMethodHandoverTransactions = paymentMethodHandoverTransactions;
+    }
+
+    public double getPaymentMethodHandoverActualTotal() {
+        return paymentMethodHandoverActualTotal;
+    }
+
+    public void setPaymentMethodHandoverActualTotal(double paymentMethodHandoverActualTotal) {
+        this.paymentMethodHandoverActualTotal = paymentMethodHandoverActualTotal;
+    }
+
     public void calculateTotalHandoverByDenominationQuantities() {
         denominatorValue = 0.0;
         if (denominationTransactions == null || denominationTransactions.isEmpty()) {
             return;
         }
         for (DenominationTransaction dt : denominationTransactions) {
-            if (dt == null || dt.getDenomination() == null || dt.getDenomination().getDenominationValue() == null) {
+            if (dt == null) {
+                continue;
+            }
+            if (dt.getDenomination() == null) {
+                // Lump-sum cash entry (denomination breakdown disabled) — the
+                // cashier types the total directly, there is no qty to derive it from.
+                if (dt.getDenominationValue() != null) {
+                    denominatorValue += dt.getDenominationValue();
+                }
+                continue;
+            }
+            if (dt.getDenomination().getDenominationValue() == null) {
                 continue;
             }
             if (dt.getDenominationQty() == null) {
@@ -3090,6 +3119,32 @@ public class ReportTemplateRowBundle implements Serializable {
                 denominatorValue += dv;
             }
         }
+    }
+
+    /**
+     * Sums the cashier-entered actual amounts for non-cash payment methods
+     * ({@link #paymentMethodHandoverTransactions}). Mirrors
+     * {@link #calculateTotalHandoverByDenominationQuantities()} for cash.
+     */
+    public void calculateTotalHandoverByPaymentMethodTransactions() {
+        paymentMethodHandoverActualTotal = 0.0;
+        if (paymentMethodHandoverTransactions == null) {
+            return;
+        }
+        for (DenominationTransaction dt : paymentMethodHandoverTransactions) {
+            if (dt != null && dt.getDenominationValue() != null) {
+                paymentMethodHandoverActualTotal += dt.getDenominationValue();
+            }
+        }
+    }
+
+    /**
+     * Combined actual handover total across cash (denomination or lump-sum)
+     * and every other payment method row. Bound to the "Total Collected
+     * Value" figure on the Shift Handover screen.
+     */
+    public double getGrandHandoverActualTotal() {
+        return denominatorValue + paymentMethodHandoverActualTotal;
     }
 
     private List<DenominationTransaction> createDefaultDenominationTransaction(PaymentMethod pm) {
@@ -3105,6 +3160,112 @@ public class ReportTemplateRowBundle implements Serializable {
             dts.add(dt);
         }
         return dts;
+    }
+
+    /**
+     * A single editable row representing the cashier's total cash handover
+     * as a lump sum, used when the "Shift End Cash Handover - Require
+     * Denomination Breakdown" config option is off. No {@link Denomination}
+     * is attached — {@link DenominationTransaction#getDenominationValue()}
+     * is typed directly by the cashier.
+     */
+    public List<DenominationTransaction> createLumpSumCashHandoverTransaction() {
+        List<DenominationTransaction> dts = new ArrayList<>();
+        DenominationTransaction dt = new DenominationTransaction();
+        dt.setPaymentMethod(Cash);
+        dt.setExpectedValue(cashHandoverValue);
+        dts.add(dt);
+        return dts;
+    }
+
+    /**
+     * The payment methods, other than cash, that a shift handover can
+     * reconcile against — mirrors the *HandoverValue fields this bundle
+     * already computes per shift.
+     */
+    private static final List<PaymentMethod> NON_CASH_HANDOVER_PAYMENT_METHODS = Collections.unmodifiableList(Arrays.asList(
+            PaymentMethod.Card,
+            PaymentMethod.Cheque,
+            PaymentMethod.Slip,
+            PaymentMethod.ewallet,
+            PaymentMethod.Voucher,
+            PaymentMethod.Credit,
+            PaymentMethod.Staff,
+            PaymentMethod.IOU,
+            PaymentMethod.Agent,
+            PaymentMethod.OnlineSettlement,
+            PaymentMethod.PatientDeposit,
+            PaymentMethod.Staff_Welfare,
+            PaymentMethod.MultiplePaymentMethods,
+            PaymentMethod.PatientPoints,
+            PaymentMethod.OnCall
+    ));
+
+    /**
+     * The system-expected handover value already computed on this bundle for
+     * the given payment method (see {@code resetTotals()} / the
+     * *HandoverValue fields).
+     */
+    public double getHandoverValueByPaymentMethod(PaymentMethod pm) {
+        if (pm == null) {
+            return 0.0;
+        }
+        switch (pm) {
+            case Cash:
+                return cashHandoverValue;
+            case Card:
+                return cardHandoverValue;
+            case Cheque:
+                return chequeHandoverValue;
+            case Slip:
+                return slipHandoverValue;
+            case ewallet:
+                return eWalletHandoverValue;
+            case Voucher:
+                return voucherHandoverValue;
+            case Credit:
+                return creditHandoverValue;
+            case Staff:
+                return staffHandoverValue;
+            case IOU:
+                return iouHandoverValue;
+            case Agent:
+                return agentHandoverValue;
+            case OnlineSettlement:
+                return onlineSettlementHandoverValue;
+            case PatientDeposit:
+                return patientDepositHandoverValue;
+            case Staff_Welfare:
+                return staffWelfareHandoverValue;
+            case MultiplePaymentMethods:
+                return multiplePaymentMethodsHandoverValue;
+            case PatientPoints:
+                return patientPointsHandoverValue;
+            case OnCall:
+                return onCallHandoverValue;
+            default:
+                return 0.0;
+        }
+    }
+
+    /**
+     * One editable row per non-cash payment method that was actually used
+     * during the shift (non-zero expected handover value), for the cashier
+     * to confirm/enter what they are handing over for it.
+     */
+    public List<DenominationTransaction> createPaymentMethodHandoverTransactions() {
+        List<DenominationTransaction> rows = new ArrayList<>();
+        for (PaymentMethod pm : NON_CASH_HANDOVER_PAYMENT_METHODS) {
+            double expected = getHandoverValueByPaymentMethod(pm);
+            if (Math.abs(expected) < 0.001) {
+                continue;
+            }
+            DenominationTransaction dt = new DenominationTransaction();
+            dt.setPaymentMethod(pm);
+            dt.setExpectedValue(expected);
+            rows.add(dt);
+        }
+        return rows;
     }
 
     public PaymentMethod getPaymentMethod() {

--- a/src/main/java/com/divudi/core/entity/cashTransaction/DenominationTransaction.java
+++ b/src/main/java/com/divudi/core/entity/cashTransaction/DenominationTransaction.java
@@ -57,6 +57,14 @@ public class DenominationTransaction implements Serializable {
     @javax.persistence.Transient
     private boolean selected;
 
+    /**
+     * System-computed value the cashier is expected to hand over for this
+     * row's payment method, shown for reference next to the actual amount
+     * entered in {@link #denominationValue}. Never persisted.
+     */
+    @javax.persistence.Transient
+    private Double expectedValue;
+
     private boolean cancelled;
     @ManyToOne
     private WebUser cancelledBy;
@@ -224,6 +232,14 @@ public class DenominationTransaction implements Serializable {
 
     public void setSelected(boolean selected) {
         this.selected = selected;
+    }
+
+    public Double getExpectedValue() {
+        return expectedValue;
+    }
+
+    public void setExpectedValue(Double expectedValue) {
+        this.expectedValue = expectedValue;
     }
 
     public boolean isCancelled() {

--- a/src/main/webapp/cashier/shift_end_cash_in_hand.xhtml
+++ b/src/main/webapp/cashier/shift_end_cash_in_hand.xhtml
@@ -99,7 +99,7 @@
                                             <p:outputLabel value="Total Collected Value" />
                                         </h:panelGroup>
                                         <h:panelGroup id="tblCashier">
-                                            <h:outputText value="#{financialTransactionController.bundle.denominatorValue}">
+                                            <h:outputText value="#{financialTransactionController.bundle.grandHandoverActualTotal}">
                                                 <f:convertNumber pattern="#,##0.00" />
                                             </h:outputText>
                                         </h:panelGroup>
@@ -109,11 +109,7 @@
 
                                 <div class="col-6" >
 
-
-
-
-
-                                    <h:panelGroup id="gpDenominations" >
+                                    <h:panelGroup id="gpCash" rendered="#{configOptionApplicationController.getBooleanValueByKey('Shift End Cash Handover - Require Denomination Breakdown', false)}">
                                         <p:dataTable   value="#{financialTransactionController.bundle.denominationTransactions}" var="deno"  >
                                             <p:column title="Denomination">
                                                 <p:outputLabel value="#{deno.denomination.displayName}" ></p:outputLabel>
@@ -133,7 +129,7 @@
                                                         event="blur"
                                                         process="txtDenoQtyHandover"
                                                         listener="#{financialTransactionController.bundle.calculateTotalHandoverByDenominationQuantities()}"
-                                                        update=":#{p:resolveFirstComponentWithId('txtCashHandover',view).clientId} txtDenoVal :#{p:resolveFirstComponentWithId('tblCashier',view).clientId} :growl" ></p:ajax>
+                                                        update="txtDenoVal :#{p:resolveFirstComponentWithId('tblCashier',view).clientId} :growl" ></p:ajax>
                                                 </p:inputText>
                                             </p:column>
                                             <p:column >
@@ -145,6 +141,66 @@
                                             </p:column>
                                         </p:dataTable>
                                     </h:panelGroup>
+
+                                    <h:panelGroup id="gpCashLumpSum" rendered="#{not configOptionApplicationController.getBooleanValueByKey('Shift End Cash Handover - Require Denomination Breakdown', false)}">
+                                        <p:dataTable value="#{financialTransactionController.bundle.denominationTransactions}" var="cashRow" >
+                                            <p:column title="Payment Method">
+                                                <p:outputLabel value="Cash" ></p:outputLabel>
+                                            </p:column>
+                                            <p:column title="Expected">
+                                                <p:outputLabel class="text-end w-100" value="#{cashRow.expectedValue}" >
+                                                    <f:convertNumber pattern="#,##0.00" />
+                                                </p:outputLabel>
+                                            </p:column>
+                                            <p:column title="Actual Handover">
+                                                <p:inputText
+                                                    class="text-end w-100"
+                                                    id="txtCashLumpSum"
+                                                    value="#{cashRow.denominationValue}"
+                                                    style="width: 100%;"
+                                                    label="Cash Handover"
+                                                    onfocus="this.select()">
+                                                    <f:convertNumber pattern="#,##0.00" />
+                                                    <p:ajax
+                                                        event="blur"
+                                                        async="true"
+                                                        process="txtCashLumpSum"
+                                                        listener="#{financialTransactionController.bundle.calculateTotalHandoverByDenominationQuantities()}"
+                                                        update=":#{p:resolveFirstComponentWithId('tblCashier',view).clientId} :growl" ></p:ajax>
+                                                </p:inputText>
+                                            </p:column>
+                                        </p:dataTable>
+                                    </h:panelGroup>
+
+                                    <p:panel header="Other Payment Methods" class="mt-3" rendered="#{not empty financialTransactionController.bundle.paymentMethodHandoverTransactions}">
+                                        <p:dataTable value="#{financialTransactionController.bundle.paymentMethodHandoverTransactions}" var="pmRow" >
+                                            <p:column title="Payment Method">
+                                                <p:outputLabel value="#{pmRow.paymentMethod.label}" ></p:outputLabel>
+                                            </p:column>
+                                            <p:column title="Expected">
+                                                <p:outputLabel class="text-end w-100" value="#{pmRow.expectedValue}" >
+                                                    <f:convertNumber pattern="#,##0.00" />
+                                                </p:outputLabel>
+                                            </p:column>
+                                            <p:column title="Actual Handover">
+                                                <p:inputText
+                                                    class="text-end w-100"
+                                                    id="txtPaymentMethodHandover"
+                                                    value="#{pmRow.denominationValue}"
+                                                    style="width: 100%;"
+                                                    label="#{pmRow.paymentMethod.label} Handover"
+                                                    onfocus="this.select()">
+                                                    <f:convertNumber pattern="#,##0.00" />
+                                                    <p:ajax
+                                                        event="blur"
+                                                        async="true"
+                                                        process="txtPaymentMethodHandover"
+                                                        listener="#{financialTransactionController.bundle.calculateTotalHandoverByPaymentMethodTransactions()}"
+                                                        update=":#{p:resolveFirstComponentWithId('tblCashier',view).clientId} :growl" ></p:ajax>
+                                                </p:inputText>
+                                            </p:column>
+                                        </p:dataTable>
+                                    </p:panel>
                                 </div>
                             </div>
 

--- a/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings_for_shift_end_cash.xhtml
+++ b/src/main/webapp/resources/ezcomp/prints/five_five_paper_with_headings_for_shift_end_cash.xhtml
@@ -67,21 +67,22 @@
 
                 </div>
 
-                <p:dataTable   
-                    value="#{financialTransactionController.bundle.denominationTransactions}" 
+                <p:dataTable
+                    value="#{financialTransactionController.bundle.denominationTransactions}"
                     var="deno"  >
-                    <p:column headerText="Denomination">
-                        <p:outputLabel value="#{deno.denomination.displayName}" ></p:outputLabel>
+                    <p:column headerText="Denomination / Payment Method">
+                        <p:outputLabel value="#{deno.denomination.displayName}" rendered="#{deno.denomination ne null}" ></p:outputLabel>
+                        <p:outputLabel value="#{deno.paymentMethod.label}" rendered="#{deno.denomination eq null}" ></p:outputLabel>
                     </p:column>
-                    <p:column 
+                    <p:column
                         headerText="Number"
                         class="text-end"
                         title="Number">
-                        <p:outputLabel 
-                            class="w-100" 
+                        <p:outputLabel
+                            class="w-100"
                             id="txtDenoQtyHandover"
-                            value="#{deno.denominationQty}" 
-                            style="width: 100%;" 
+                            value="#{deno.denominationQty}"
+                            style="width: 100%;"
                             onfocus="this.select()"/>
                     </p:column>
                     <p:column


### PR DESCRIPTION
## Decisions made without approval

This was run via `dev-issue-unattended`; these judgment calls were made without a live check-in and should be double-checked first:

- **Reused the existing `DenominationTransaction` entity/table for non-cash rows** (`denomination=null`, `paymentMethod` set) instead of adding new columns or a new table. It already carries a `paymentMethod` field and a `bill` reference, so this needed **zero schema changes** — no migration to review or apply.
- Added a `@Transient expectedValue` field to `DenominationTransaction` to show the system-computed reference figure next to the editable actual amount; it is never persisted.
- **All actual-handover fields start blank**, not pre-filled with the expected value — for cash lump-sum entry and every non-cash row alike. This matches the existing per-denomination table's convention (quantities start at 0, forcing an active count) so the reconciliation still catches shortages/overages instead of being satisfiable by clicking through with no input.
- `navigateToRecordShiftEndCash()` now gathers this shift's payments via `generatePaymentBundleForHandovers()` + `aggregateTotalsFromAllChildBundles()` — **not** `calculateTotalsByChildBundlesForHandover()`, which deliberately zeroes `cashHandoverValue` until the cashier counts (documented "SYNC RULE" for the separate handover-creation flow). That zeroing is wrong here since this screen needs the expected value as a reference figure from first render.
- `settleRecordingShiftEndCashInHand()` persists the cash and non-cash rows together and merges them back into `bundle.denominationTransactions` so the print page renders consistently whether reached right after settling or later via the existing "view a past shift-end-cash bill" path (`navigateToViewShiftEndCashInHandBill()`), which already loads every `DenominationTransaction` row for a bill into that same field.
- Config key name follows the issue's own suggestion verbatim: `"Shift End Cash Handover - Require Denomination Breakdown"` (boolean, default `false`).

## Summary

- `shift_end_cash_in_hand.xhtml` now shows, for every non-cash payment method with a non-zero expected value for the shift (Card, Cheque, Slip, e-Wallet, Voucher, Credit, Staff, IOU, Agent, Online Settlement, Patient Deposit, Staff Welfare, Multiple Payment Methods, Patient Points, On Call), a row with the expected value and an editable "Actual Handover" field — mirroring the existing cash-denomination table's UX (`p:ajax` blur commit, live-updating grand total).
- Cash denomination-by-denomination entry is now gated behind the new config option; off by default, the cashier enters a single cash total instead.
- "Total Collected Value" is now the combined actual total across cash + every other payment method (`ReportTemplateRowBundle#getGrandHandoverActualTotal()`), not just the cash figure.
- `settleRecordingShiftEndCashInHand()` persists and sums all payment-method rows onto the `FUND_SHIFT_END_CASH_RECORD` bill, not just cash.
- `five_five_paper_with_headings_for_shift_end_cash.xhtml` prints a payment-method breakdown, falling back to the payment method's label when a row has no denomination.

## Verification

Tested locally end-to-end against real `Payment`/`Bill` records for an open shift (a genuine Card-paid pharmacy sale created via the app's Retail Sale screen hit a pre-existing, unrelated Settle-button issue on this environment — worked around by inserting the Bill/Payment fixture rows directly against the local disposable dev DB, clearly marked as test fixtures in their `COMMENTS` field):

- Entry screen: cash lump-sum row (expected 500.00) and a Card row (expected 250.00) both rendered with editable actual-handover inputs; entering 490 and 250 updated "Total Collected Value" live to 740.00.
- Settle: `FUND_SHIFT_END_CASH_RECORD` bill created with `total = netTotal = 740`; two `DenominationTransaction` rows persisted (`denomination_id = NULL`, `paymentMethod` = Cash/Card, `denominationValue` = 490/250).
- Print receipt showed the 740.00 total broken down into "Cash 490.00" and "Credit Card 250.00" rows.
- Re-verified with the config turned on (via the app's own "Reload Config" admin action, not a redeploy) that the original per-denomination cash table (Rs 1 through Rs 5000) still renders exactly as before, alongside the new "Other Payment Methods" section.

## Documentation

Updated the wiki page [Finance-Starting-and-Ending-a-Shift](https://github.com/hmislk/hmis/wiki/Finance-Starting-and-Ending-a-Shift) — its "Recording Cash in Hand at Shift End" section described cash-only, always-denomination-breakdown behavior; corrected it to describe the new multi-payment-method screen and the new config option, with screenshots of the entry screen and the printed receipt. Also corrected one now-inaccurate table row in [Finance-Denomination-Management](https://github.com/hmislk/hmis/wiki/Finance-Denomination-Management) to note that denomination breakdown at shift end is now conditional on the new config key.

Closes #23359

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Shift-end cash handover now supports both denomination-based and lump-sum cash entry.
  - Record actual handover amounts for non-cash payment methods.
  - View combined cash and payment-method totals before completing the handover.
  - Printouts now identify entries as either denominations or payment methods.

- **Bug Fixes**
  - Corrected total calculations for lump-sum cash entries.
  - Ensured recorded cash and payment-method handovers remain consistent when saved, viewed, and printed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->