### PR TITLE
feat(inward): add Report Order / Final Bill Order for charge type labels

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -2235,6 +2235,33 @@ row will time out on a working page. Detect the transition instead — e.g.
 `document.body.innerText.includes('Patient Selection') === false`, or the presence
 of `form:btnAddIx`. Found while verifying issue #23342.
 
+## 86. A `p:inputText`/`p:inputNumber` bound to a `Map<String, Integer>` entry silently stores the raw `String` — the write is lost with no error until you read it back
+
+Binding a form input to `#{bean.someMap[key]}` where `someMap` is declared `Map<String, Integer>`
+compiles fine and *looks* like it should coerce, because a normal bean property setter
+(`setSomeField(int)`) does get EL's automatic string-to-primitive coercion via reflection on the
+setter's declared parameter type. A `Map` entry gets no such coercion: `MapELResolver.setValue()`
+just calls `map.put(key, value)` with whatever raw type the component submitted — generics are
+erased at the bytecode level, so the resolver has no way to know the map is supposed to hold
+`Integer`. The submitted value lands in the map as a plain `String`.
+
+The failure doesn't surface where you'd look for it. The command button's `update` re-renders the
+component from that same in-memory map object, so the browser still shows the value you just typed
+— it *looks* saved. The real breakage happens the next time server-side code reads the map entry as
+`Integer` (e.g. `Integer order = orderMap.get(key);`) — a `ClassCastException: String cannot be cast
+to Integer` that aborts the whole action method, so nothing after that line (including the actual
+persistence call) ever runs. `p:messages`/`p:growl` stays silent because the exception happens inside
+the JSF lifecycle's invoke-application phase, not inside a `catch` the page bothers to show — the
+only trace is a `SEVERE javax.faces.el.EvaluationException` in `server.log`.
+
+**Fix**: keep the map typed `Map<String, String>` (matching how every other free-text-bound map in
+this codebase already works) and parse the string to the target type only where the value is actually
+consumed — never type a directly-bound map as anything but `String`. **Verification**: a screenshot or
+an in-session AJAX re-read is not proof of a save — the model object doesn't go away just because the
+action method threw. Always confirm with a fresh `SELECT` after the request completes (a full page
+reload session's own display of "the value I set" proves nothing, since it's the same still-open
+transactional model that never got rolled back). Found and fixed while testing issue #23340.
+
 ## Some PrimeFaces buttons need a jQuery-triggered click
 
 Most `p:commandButton`s submit fine with a normal Playwright click — including

--- a/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
+++ b/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
@@ -1405,6 +1405,26 @@ public class ConfigOptionApplicationController implements Serializable {
         saveShortTextOption(key, customLabel == null ? "" : customLabel.trim());
     }
 
+    public int getInwardChargeTypeReportOrder(InwardChargeType type) {
+        String key = "Inward Charge Type Report Order - " + type.name();
+        Integer v = getIntegerValueByKey(key, (type.ordinal() + 1) * 10);
+        return v == null ? (type.ordinal() + 1) * 10 : v;
+    }
+
+    public void saveInwardChargeTypeReportOrder(InwardChargeType type, int order) {
+        setIntegerValueByKey("Inward Charge Type Report Order - " + type.name(), order);
+    }
+
+    public int getInwardChargeTypeFinalBillOrder(InwardChargeType type) {
+        String key = "Inward Charge Type Final Bill Order - " + type.name();
+        Integer v = getIntegerValueByKey(key, (type.ordinal() + 1) * 10);
+        return v == null ? (type.ordinal() + 1) * 10 : v;
+    }
+
+    public void saveInwardChargeTypeFinalBillOrder(InwardChargeType type, int order) {
+        setIntegerValueByKey("Inward Charge Type Final Bill Order - " + type.name(), order);
+    }
+
     public String getColorValueByKey(String key) {
         ConfigOption option = getApplicationOption(key);
         if (option == null || option.getValueType() != OptionValueType.COLOR) {

--- a/src/main/java/com/divudi/bean/common/ConfigOptionController.java
+++ b/src/main/java/com/divudi/bean/common/ConfigOptionController.java
@@ -56,6 +56,21 @@ public class ConfigOptionController implements Serializable {
      */
     private static final String INWARD_CHARGE_TYPE_LABEL_KEY_PREFIX = "Inward Charge Type Label - ";
 
+    /**
+     * Prefix shared by every Inward Charge Type Report Order ConfigOption key
+     * (e.g. "Inward Charge Type Report Order - ROOM_CHARGE"). Same dedicated
+     * editor as {@link #INWARD_CHARGE_TYPE_LABEL_KEY_PREFIX} (issue #23340).
+     */
+    private static final String INWARD_CHARGE_TYPE_REPORT_ORDER_KEY_PREFIX = "Inward Charge Type Report Order - ";
+
+    /**
+     * Prefix shared by every Inward Charge Type Final Bill Order ConfigOption
+     * key (e.g. "Inward Charge Type Final Bill Order - ROOM_CHARGE"). Same
+     * dedicated editor as {@link #INWARD_CHARGE_TYPE_LABEL_KEY_PREFIX} (issue
+     * #23340).
+     */
+    private static final String INWARD_CHARGE_TYPE_FINAL_BILL_ORDER_KEY_PREFIX = "Inward Charge Type Final Bill Order - ";
+
     @EJB
     private ConfigOptionFacade optionFacade;
 
@@ -570,12 +585,18 @@ public class ConfigOptionController implements Serializable {
     }
 
     /**
-     * Inward Charge Type Labels are edited exclusively via
-     * inward/inward_charge_type_labels.xhtml (InwardChargeTypeLabelController).
-     * See {@link #INWARD_CHARGE_TYPE_LABEL_KEY_PREFIX}.
+     * Inward Charge Type Labels, Report Orders, and Final Bill Orders are all
+     * edited exclusively via inward/inward_charge_type_labels.xhtml
+     * (InwardChargeTypeLabelController). See
+     * {@link #INWARD_CHARGE_TYPE_LABEL_KEY_PREFIX},
+     * {@link #INWARD_CHARGE_TYPE_REPORT_ORDER_KEY_PREFIX}, and
+     * {@link #INWARD_CHARGE_TYPE_FINAL_BILL_ORDER_KEY_PREFIX}.
      */
     public boolean isInwardChargeTypeLabelKey(String optionKey) {
-        return optionKey != null && optionKey.startsWith(INWARD_CHARGE_TYPE_LABEL_KEY_PREFIX);
+        return optionKey != null
+                && (optionKey.startsWith(INWARD_CHARGE_TYPE_LABEL_KEY_PREFIX)
+                || optionKey.startsWith(INWARD_CHARGE_TYPE_REPORT_ORDER_KEY_PREFIX)
+                || optionKey.startsWith(INWARD_CHARGE_TYPE_FINAL_BILL_ORDER_KEY_PREFIX));
     }
 
     public void saveOption(ConfigOption option) {

--- a/src/main/java/com/divudi/bean/inward/InwardChargeTypeLabelController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardChargeTypeLabelController.java
@@ -15,7 +15,10 @@ import javax.faces.view.ViewScoped;
 /**
  * Backing bean for the inward charge type label configuration admin page.
  * Allows hospital admins to set custom display names for each InwardChargeType
- * enum value, stored as application-scoped ConfigOption entries.
+ * enum value, stored as application-scoped ConfigOption entries. Also allows
+ * setting per-type ordering numbers used to order charge type columns in
+ * reports (Report Order) and, in future, on the Final Bill (Final Bill Order)
+ * (issue #23340).
  */
 @Named
 @ViewScoped
@@ -26,15 +29,27 @@ public class InwardChargeTypeLabelController implements Serializable {
 
     private List<InwardChargeType> chargeTypes;
     private Map<String, String> labelMap;
+    private Map<String, String> reportOrderMap;
+    private Map<String, String> finalBillOrderMap;
 
     @PostConstruct
     public void init() {
         chargeTypes = Arrays.asList(InwardChargeType.values());
         labelMap = new HashMap<>();
+        reportOrderMap = new HashMap<>();
+        finalBillOrderMap = new HashMap<>();
         for (InwardChargeType type : chargeTypes) {
             String custom = configOptionApplicationController.getShortTextValueByKey(
                     "Inward Charge Type Label - " + type.name(), "");
             labelMap.put(type.name(), custom == null ? "" : custom);
+            // Kept as String (not Integer) the same way labelMap is: a p:inputText
+            // bound to a Map<String, Integer> entry submits a raw String, since
+            // MapELResolver.setValue() puts the value as-is without consulting the
+            // map's erased generic type — an Integer-typed map caused a
+            // ClassCastException on save (issue #23340 QA). Parsed back to int only
+            // where actually needed, in orderOrDefault().
+            reportOrderMap.put(type.name(), String.valueOf(configOptionApplicationController.getInwardChargeTypeReportOrder(type)));
+            finalBillOrderMap.put(type.name(), String.valueOf(configOptionApplicationController.getInwardChargeTypeFinalBillOrder(type)));
         }
     }
 
@@ -42,12 +57,34 @@ public class InwardChargeTypeLabelController implements Serializable {
         for (InwardChargeType type : chargeTypes) {
             String custom = labelMap.get(type.name());
             configOptionApplicationController.saveInwardChargeTypeLabel(type, custom);
+            configOptionApplicationController.saveInwardChargeTypeReportOrder(type, orderOrDefault(reportOrderMap, type));
+            configOptionApplicationController.saveInwardChargeTypeFinalBillOrder(type, orderOrDefault(finalBillOrderMap, type));
         }
     }
 
     public void saveOne(InwardChargeType type) {
         String custom = labelMap.get(type.name());
         configOptionApplicationController.saveInwardChargeTypeLabel(type, custom);
+        configOptionApplicationController.saveInwardChargeTypeReportOrder(type, orderOrDefault(reportOrderMap, type));
+        configOptionApplicationController.saveInwardChargeTypeFinalBillOrder(type, orderOrDefault(finalBillOrderMap, type));
+    }
+
+    /**
+     * Parses the submitted order string for a type, falling back to the same
+     * ordinal-based default the ConfigOptionApplicationController getters use
+     * when the field was left blank or holds something unparsable (never lets
+     * a bad row block the save).
+     */
+    private int orderOrDefault(Map<String, String> orderMap, InwardChargeType type) {
+        String order = orderMap.get(type.name());
+        if (order == null || order.trim().isEmpty()) {
+            return (type.ordinal() + 1) * 10;
+        }
+        try {
+            return Integer.parseInt(order.trim());
+        } catch (NumberFormatException e) {
+            return (type.ordinal() + 1) * 10;
+        }
     }
 
     public List<InwardChargeType> getChargeTypes() {
@@ -60,5 +97,21 @@ public class InwardChargeTypeLabelController implements Serializable {
 
     public void setLabelMap(Map<String, String> labelMap) {
         this.labelMap = labelMap;
+    }
+
+    public Map<String, String> getReportOrderMap() {
+        return reportOrderMap;
+    }
+
+    public void setReportOrderMap(Map<String, String> reportOrderMap) {
+        this.reportOrderMap = reportOrderMap;
+    }
+
+    public Map<String, String> getFinalBillOrderMap() {
+        return finalBillOrderMap;
+    }
+
+    public void setFinalBillOrderMap(Map<String, String> finalBillOrderMap) {
+        this.finalBillOrderMap = finalBillOrderMap;
     }
 }

--- a/src/main/java/com/divudi/bean/inward/InwardInvoiceJournalController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardInvoiceJournalController.java
@@ -20,6 +20,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.EnumMap;
 import java.util.EnumSet;
@@ -85,8 +86,11 @@ public class InwardInvoiceJournalController implements Serializable {
     /**
      * All InwardChargeType values — drives the dynamic columns in XHTML.
      * Columns where every row has 0 are hidden via rendered="#{...}".
+     * Re-sorted by the admin-configurable Report Order at the top of
+     * {@link #generateReport()}; the inline default here only covers the very
+     * first page render, before the user searches (issue #23340).
      */
-    private final List<InwardChargeType> allChargeTypes = Arrays.asList(InwardChargeType.values());
+    private List<InwardChargeType> allChargeTypes = new ArrayList<>(Arrays.asList(InwardChargeType.values()));
 
     /**
      * Set of charge types that have at least one non-zero value in the current
@@ -109,6 +113,12 @@ public class InwardInvoiceJournalController implements Serializable {
     // -------------------------------------------------------------------------
 
     public void generateReport() {
+        // Recompute the column order from the admin-configurable Report Order
+        // ConfigOption for each InwardChargeType (issue #23340). A stable
+        // sort keeps ordinal order among types the admin has not reordered.
+        allChargeTypes = new ArrayList<>(Arrays.asList(InwardChargeType.values()));
+        allChargeTypes.sort(Comparator.comparingInt(configOptionApplicationController::getInwardChargeTypeReportOrder));
+
         reportRows               = new ArrayList<>();
         columnTotals             = new EnumMap<>(InwardChargeType.class);
         activeChargeTypes        = EnumSet.noneOf(InwardChargeType.class);

--- a/src/main/java/com/divudi/ws/common/ConfigResource.java
+++ b/src/main/java/com/divudi/ws/common/ConfigResource.java
@@ -5,6 +5,7 @@ import com.divudi.bean.common.ConfigOptionApplicationController;
 import com.divudi.core.data.ApiKeyType;
 import com.divudi.core.data.OptionScope;
 import com.divudi.core.data.OptionValueType;
+import com.divudi.core.data.inward.InwardChargeType;
 import com.divudi.core.entity.ApiKey;
 import com.divudi.core.entity.ConfigOption;
 import com.divudi.core.entity.WebUser;
@@ -183,6 +184,40 @@ public class ConfigResource {
         JsonArrayBuilder arrayBuilder = Json.createArrayBuilder();
         for (ConfigOption opt : options) {
             arrayBuilder.add(toJson(opt));
+        }
+        return Response.ok(arrayBuilder.build().toString()).build();
+    }
+
+    /**
+     * Discovery endpoint for the InwardChargeType enum: for every value,
+     * returns its default/custom label plus the two admin-configurable
+     * ordering numbers (Report Order, Final Bill Order) introduced in issue
+     * #23340. Reading each value here also lazily seeds any of their
+     * ConfigOption rows that don't exist yet (same lazy-create behavior as
+     * the dedicated inward_charge_type_labels.xhtml admin page), so a caller
+     * can immediately follow up with PUT /api/config/{key} or
+     * POST /api/config/setInteger/{key}/{value} for any charge type even if
+     * the admin page was never opened.
+     *
+     * GET /api/config/inward-charge-types
+     */
+    @GET
+    @Path("inward-charge-types")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response listInwardChargeTypes(@Context HttpHeaders headers) {
+        if (validateConfigKey(headers) == null) {
+            return unauthorizedResponse();
+        }
+
+        JsonArrayBuilder arrayBuilder = Json.createArrayBuilder();
+        for (InwardChargeType type : InwardChargeType.values()) {
+            JsonObjectBuilder obj = Json.createObjectBuilder()
+                    .add("name", type.name())
+                    .add("defaultLabel", type.getLabel() != null ? type.getLabel() : "")
+                    .add("label", configOptionApplicationController.getInwardChargeTypeLabel(type))
+                    .add("reportOrder", configOptionApplicationController.getInwardChargeTypeReportOrder(type))
+                    .add("finalBillOrder", configOptionApplicationController.getInwardChargeTypeFinalBillOrder(type));
+            arrayBuilder.add(obj);
         }
         return Response.ok(arrayBuilder.build().toString()).build();
     }

--- a/src/main/webapp/inward/inward_charge_type_labels.xhtml
+++ b/src/main/webapp/inward/inward_charge_type_labels.xhtml
@@ -40,7 +40,7 @@
                                 headerText="Enum Name"
                                 sortBy="#{chargeType.name()}"
                                 filterBy="#{chargeType.name()}"
-                                style="width: 25%; padding: 7px;">
+                                style="width: 20%; padding: 7px;">
                                 <h:outputText value="#{chargeType.name()}" style="font-family: monospace; color: #666;"/>
                             </p:column>
 
@@ -48,13 +48,13 @@
                                 headerText="Default Label"
                                 sortBy="#{chargeType.label}"
                                 filterBy="#{chargeType.label}"
-                                style="width: 30%; padding: 7px;">
+                                style="width: 22%; padding: 7px;">
                                 <h:outputText value="#{chargeType.label}"/>
                             </p:column>
 
                             <p:column
                                 headerText="Custom Label"
-                                style="width: 35%; padding: 7px;">
+                                style="width: 25%; padding: 7px;">
                                 <p:inputText
                                     style="width: 100%;"
                                     value="#{inwardChargeTypeLabelController.labelMap[chargeType.name()]}"
@@ -62,8 +62,30 @@
                             </p:column>
 
                             <p:column
+                                headerText="Report Order"
+                                style="width: 12%; padding: 7px;">
+                                <p:inputText
+                                    style="width: 100%; text-align: right;"
+                                    value="#{inwardChargeTypeLabelController.reportOrderMap[chargeType.name()]}"
+                                    title="Report order for #{chargeType.name()}">
+                                    <f:validateRegex pattern="^[0-9]{1,6}$"/>
+                                </p:inputText>
+                            </p:column>
+
+                            <p:column
+                                headerText="Final Bill Order"
+                                style="width: 13%; padding: 7px;">
+                                <p:inputText
+                                    style="width: 100%; text-align: right;"
+                                    value="#{inwardChargeTypeLabelController.finalBillOrderMap[chargeType.name()]}"
+                                    title="Final bill order for #{chargeType.name()}">
+                                    <f:validateRegex pattern="^[0-9]{1,6}$"/>
+                                </p:inputText>
+                            </p:column>
+
+                            <p:column
                                 headerText="Save"
-                                style="width: 10%; padding: 7px; text-align: center;">
+                                style="width: 8%; padding: 7px; text-align: center;">
                                 <p:commandButton
                                     icon="pi pi-save"
                                     styleClass="ui-button-success"


### PR DESCRIPTION
## What

Adds an ordering mechanism for `InwardChargeType` columns, and wires it into the Inward Invoice Journal report.

- Two new per-`InwardChargeType` `ConfigOption` numbers, editable from the existing **Inward Charge Type Labels** page alongside the custom label:
  - **Report Order** — controls the charge-type column order in the Inward Invoice Journal report.
  - **Final Bill Order** — stored/editable now, intentionally **not** consumed by any report/bill yet (Final Bill layout is out of scope for this issue, per discussion).
- Both default to `(ordinal + 1) * 10`, so nothing moves in either the labels page or the report until an admin customizes it. Ties keep the original enum declaration order (stable sort).
- New `GET /api/config/inward-charge-types` discovery endpoint — lists every charge type's label + both order numbers in one call, and seeds any missing `ConfigOption` rows so the existing generic `PUT /api/config/{key}` / `POST /api/config/setInteger/{key}/{value}` endpoints (and the AI chat `manage_config_option` tool) can read/write any type's data without the admin page having been opened first. No new write endpoint or AI chat tool was needed — the generic Config API and `manage_config_option`/`search_config_options` already work against these keys generically.
- Broadened the existing Application Options admin-page guard (issue #23257) to also lock the two new key prefixes, so all three "Inward Charge Type …" option families stay single-sourced to the dedicated page (the generic REST/AI paths are intentionally left open — that's the point of the API section above).

## Bug found & fixed during verification

The first implementation bound the new inputs as `p:inputNumber` against `Map<String, Integer>` entries. JSF's `MapELResolver` doesn't coerce types on map assignment (generics are erased at the bytecode level), so the submitted value landed in the map as a raw `String` — invisible until server-side code read it back as `Integer` and threw a `ClassCastException` that silently aborted the save. The AJAX-refreshed page kept showing the "saved" value regardless, because it was just re-rendering the same in-memory model object that never actually round-tripped to the DB — a `SELECT` after save was needed to catch it. Fixed by switching to `p:inputText` + `Map<String, String>`, matching the already-working Custom Label column's pattern. Documented as a new dev gotcha (`developer_docs/testing/playwright-e2e-workflow.md` §86) so it isn't rediscovered.

## Testing

Local Payara, department **Inward**, `buddhika` user.

1. **Labels page** (`inward_charge_type_labels.xhtml`): added the Report Order / Final Bill Order columns, grouped the room-related charge types (Room Charges, Administration Fee, Linen Charges, Medical Care, MO Charges, Maintain Charges, Nursing Care) with adjacent values 139–146. Confirmed every save round-trips to the DB with a fresh `SELECT` (not just the AJAX-refreshed page) — this is what caught the `ClassCastException` bug above.
2. **Invoice Journal report** (`inward_report_invoice_journal.xhtml`, date range 01–31 Aug 2026, BHT/56753 + BHT/56754): Room Charges (Report Order 139) now renders immediately after Admission Fee and *before* Professional Charge (default Report Order 300) — reversed from their old enum-declaration order (Professional Charge ordinal 29 < Room Charges ordinal 31). Column totals (Room Charges 11,500.00, Professional Charge 3,000.00) unchanged — only display order moved, no calculation regression.
3. Server log clean (no `SEVERE`/exception entries) across all of the above, including the pre-fix reproduction and the post-fix retest.

Screenshots and full write-up posted to the issue: https://github.com/hmislk/hmis/issues/23340#issuecomment-5473381167

## Documentation

- [Admin — Inpatient Charge Type Labels](https://github.com/hmislk/hmis/wiki/Admin-Inpatient-Charge-Type-Labels) — new Report Order / Final Bill Order section, generic Config API usage for REST/AI-agent updates
- [Inpatient Invoice Journal](https://github.com/hmislk/hmis/wiki/Finance-Inpatient-Invoice-Journal) — charge-type column order now driven by Report Order instead of enum declaration order

Closes #23340

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable report and final-bill ordering for inward charge types.
  * Added editable order fields to the Inward Charge Type Labels page with numeric validation.
  * Added an API endpoint to retrieve charge type labels and ordering settings.
* **Improvements**
  * Reports now follow the configured charge type order.
  * Missing ordering settings receive sensible defaults automatically.
* **Documentation**
  * Added troubleshooting guidance for form values mapped to numeric data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->