### PR TITLE
fix(inward): enable investigation discounts via discountAllowed API + department wildcard

### DIFF
--- a/src/main/java/com/divudi/bean/common/PriceMatrixController.java
+++ b/src/main/java/com/divudi/bean/common/PriceMatrixController.java
@@ -1736,16 +1736,15 @@ public class PriceMatrixController implements Serializable {
      * room-charge-type rows.
      */
     /**
-     * NOTE (2026-08, issue #23220): this JPQL calculation path filters
-     * `department` as an exact match only — unlike paymentMethod/admissionType
-     * in this same query, it does NOT wildcard-match rows where the matrix
-     * entry's department is null. This is a known gap, tracked separately in
-     * issue #23237 (https://github.com/hmislk/hmis/issues/23237). It is
-     * intentionally NOT fixed here: the equivalent native-SQL calculation path
-     * (PriceMatrixNativeSqlService.fetchDiscountPct), which is what inpatient
-     * pharmacy issuing actually uses in production, received the fix instead.
-     * This JPQL path is considered legacy/soon-to-be-superseded and should not
-     * be extended further — see #23237 before making changes here.
+     * NOTE (2026-08-31, issue #23237): department now wildcard-matches like
+     * paymentMethod/admissionType do in this same query, mirroring the fix
+     * already applied to the native-SQL path (PriceMatrixNativeSqlService.
+     * fetchDiscountPct) in #23220. This method has a live caller —
+     * InwardBeanController.applyInwardDiscountToBillFee, used by inpatient
+     * service/investigation billing — so the department-exact-match gap was
+     * silently dropping investigation discounts whenever a matrix row was
+     * saved without a department (meant as "any department") against an
+     * investigation that has its own department set. See issue #23308.
      */
     private Double fetchInwardDiscountMatrixPercentCore(PaymentMethod bhtType, PaymentScheme scheme,
             AdmissionType admissionType, Department department, Category category, Item item,
@@ -1777,7 +1776,7 @@ public class PriceMatrixController implements Serializable {
             jpql.append(" and a.paymentScheme is null");
         }
         if (department != null) {
-            jpql.append(" and a.department = :dep");
+            jpql.append(" and (a.department = :dep or a.department is null)");
             params.put("dep", department);
         } else {
             jpql.append(" and a.department is null");

--- a/src/main/java/com/divudi/core/data/dto/investigation/InvestigationCreateRequestDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/investigation/InvestigationCreateRequestDTO.java
@@ -17,6 +17,7 @@ public class InvestigationCreateRequestDTO {
     private String containerName;
     private Long analyzerId;
     private String analyzerName;
+    private Boolean discountAllowed;
 
     public boolean isValid() { return name != null && !name.trim().isEmpty(); }
     public String getName() { return name; }
@@ -51,4 +52,6 @@ public class InvestigationCreateRequestDTO {
     public void setAnalyzerId(Long analyzerId) { this.analyzerId = analyzerId; }
     public String getAnalyzerName() { return analyzerName; }
     public void setAnalyzerName(String analyzerName) { this.analyzerName = analyzerName; }
+    public Boolean getDiscountAllowed() { return discountAllowed; }
+    public void setDiscountAllowed(Boolean discountAllowed) { this.discountAllowed = discountAllowed; }
 }

--- a/src/main/java/com/divudi/core/data/dto/investigation/InvestigationSearchResultDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/investigation/InvestigationSearchResultDTO.java
@@ -18,6 +18,7 @@ public class InvestigationSearchResultDTO {
     private String containerName;
     private Long analyzerId;
     private String analyzerName;
+    private Boolean discountAllowed;
 
     public InvestigationSearchResultDTO() {}
 
@@ -64,4 +65,6 @@ public class InvestigationSearchResultDTO {
     public void setAnalyzerId(Long analyzerId) { this.analyzerId = analyzerId; }
     public String getAnalyzerName() { return analyzerName; }
     public void setAnalyzerName(String analyzerName) { this.analyzerName = analyzerName; }
+    public Boolean getDiscountAllowed() { return discountAllowed; }
+    public void setDiscountAllowed(Boolean discountAllowed) { this.discountAllowed = discountAllowed; }
 }

--- a/src/main/java/com/divudi/core/data/dto/investigation/InvestigationUpdateRequestDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/investigation/InvestigationUpdateRequestDTO.java
@@ -17,12 +17,14 @@ public class InvestigationUpdateRequestDTO {
     private String containerName;
     private Long analyzerId;
     private String analyzerName;
+    private Boolean discountAllowed;
 
     public boolean isValid() {
         return name != null || code != null || printName != null || inactive != null || reportType != null
                 || bypassSampleWorkflow != null || vatable != null || vatPercentage != null
                 || categoryId != null || categoryName != null || sampleId != null || sampleName != null
-                || containerId != null || containerName != null || analyzerId != null || analyzerName != null;
+                || containerId != null || containerName != null || analyzerId != null || analyzerName != null
+                || discountAllowed != null;
     }
     public String getName() { return name; }
     public void setName(String name) { this.name = name; }
@@ -56,4 +58,6 @@ public class InvestigationUpdateRequestDTO {
     public void setAnalyzerId(Long analyzerId) { this.analyzerId = analyzerId; }
     public String getAnalyzerName() { return analyzerName; }
     public void setAnalyzerName(String analyzerName) { this.analyzerName = analyzerName; }
+    public Boolean getDiscountAllowed() { return discountAllowed; }
+    public void setDiscountAllowed(Boolean discountAllowed) { this.discountAllowed = discountAllowed; }
 }

--- a/src/main/java/com/divudi/service/investigation/InvestigationApiService.java
+++ b/src/main/java/com/divudi/service/investigation/InvestigationApiService.java
@@ -61,6 +61,7 @@ public class InvestigationApiService implements Serializable {
         i.setInactive(Boolean.TRUE.equals(req.getInactive()));
         i.setBypassSampleWorkflow(Boolean.TRUE.equals(req.getBypassSampleWorkflow()));
         i.setVatable(Boolean.TRUE.equals(req.getVatable()));
+        i.setDiscountAllowed(Boolean.TRUE.equals(req.getDiscountAllowed()));
         validateVatPercentage(req.getVatPercentage());
         if (req.getVatPercentage() != null) i.setVatPercentage(req.getVatPercentage());
         if (req.getReportType() != null && !req.getReportType().trim().isEmpty()) i.setReportType(InvestigationReportType.valueOf(req.getReportType().trim()));
@@ -86,6 +87,7 @@ public class InvestigationApiService implements Serializable {
         if (req.getInactive() != null) i.setInactive(req.getInactive());
         if (req.getBypassSampleWorkflow() != null) i.setBypassSampleWorkflow(req.getBypassSampleWorkflow());
         if (req.getVatable() != null) i.setVatable(req.getVatable());
+        if (req.getDiscountAllowed() != null) i.setDiscountAllowed(req.getDiscountAllowed());
         validateVatPercentage(req.getVatPercentage());
         if (req.getVatPercentage() != null) i.setVatPercentage(req.getVatPercentage());
         if (req.getReportType() != null && !req.getReportType().trim().isEmpty()) i.setReportType(InvestigationReportType.valueOf(req.getReportType().trim()));
@@ -229,6 +231,7 @@ public class InvestigationApiService implements Serializable {
         InvestigationSearchResultDTO dto = new InvestigationSearchResultDTO(i.getId(), i.getName(), i.getCode(), i.getPrintName(), i.isInactive(), i.getReportType() != null ? i.getReportType().name() : null, i.isBypassSampleWorkflow());
         dto.setVatable(i.isVatable());
         dto.setVatPercentage(i.getVatPercentage());
+        dto.setDiscountAllowed(i.isDiscountAllowed());
         populateLinks(dto, i);
         return dto;
     }
@@ -236,6 +239,7 @@ public class InvestigationApiService implements Serializable {
         InvestigationResponseDTO dto = new InvestigationResponseDTO(i.getId(), i.getName(), i.getCode(), i.getPrintName(), i.isInactive(), i.getReportType() != null ? i.getReportType().name() : null, i.isBypassSampleWorkflow(), m);
         dto.setVatable(i.isVatable());
         dto.setVatPercentage(i.getVatPercentage());
+        dto.setDiscountAllowed(i.isDiscountAllowed());
         populateLinks(dto, i);
         return dto;
     }

--- a/src/main/java/com/divudi/service/service/ServiceApiService.java
+++ b/src/main/java/com/divudi/service/service/ServiceApiService.java
@@ -739,6 +739,49 @@ public class ServiceApiService implements Serializable {
     }
 
     /**
+     * Bulk-update discountAllowed (item-level, not fee-level) on all non-retired
+     * items in a given category. Distinct from {@link #bulkUpdateMargin} above,
+     * which only touches ItemFee.discountAllowed — the inward discount
+     * calculation (InwardBeanController.applyInwardDiscountToBillFee) requires
+     * BOTH Item.discountAllowed and ItemFee.discountAllowed to be true, so both
+     * bulk operations are typically needed together. Works on any Item subtype
+     * (Service, Investigation, ...) since it queries generically by category.
+     */
+    public Map<String, Object> bulkUpdateItemDiscountAllowed(Long categoryId, Boolean discountAllowed, WebUser user) throws Exception {
+        if (categoryId == null) {
+            throw new Exception("categoryId is required");
+        }
+        if (user == null) {
+            throw new Exception("User is required for bulk update");
+        }
+        if (discountAllowed == null) {
+            throw new Exception("discountAllowed is required");
+        }
+
+        String jpql = "SELECT i FROM Item i WHERE i.category.id = :catId AND i.retired = false";
+        Map<String, Object> params = new HashMap<>();
+        params.put("catId", categoryId);
+
+        List<Item> items = itemFacade.findByJpql(jpql, params);
+        int count = 0;
+        for (Item item : items) {
+            item.setDiscountAllowed(discountAllowed);
+            itemFacade.edit(item);
+            count++;
+        }
+
+        Map<String, Object> changes = new HashMap<>();
+        changes.put("categoryId", categoryId);
+        changes.put("discountAllowed", discountAllowed);
+        changes.put("count", count);
+        auditService.logAudit(null, changes, user, "Item", "ITEM_DISCOUNT_ALLOWED_BULK_UPDATED", null);
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("count", count);
+        return result;
+    }
+
+    /**
      * Find fees with marginAllowed disabled (false or null) for items in a category.
      */
     public List<ItemFeeDTO> findFeesWithMarginDisabled(Long categoryId) throws Exception {

--- a/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
+++ b/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
@@ -423,7 +423,10 @@ public class CapabilityStatementResource {
                         "Investigation master management including search, create, update, and activate/deactivate for item import workflows. "
                         + "Category/sample/container(tube)/analyzer(machine) can each be set via an ID referencing an existing row "
                         + "(categoryId, sampleId, containerId, analyzerId — errors if not found) or a name "
-                        + "(categoryName, sampleName, containerName, analyzerName — found-or-created by name if no matching row exists).",
+                        + "(categoryName, sampleName, containerName, analyzerName — found-or-created by name if no matching row exists). "
+                        + "discountAllowed (Item-level flag) is readable/writable on all of GET /search, GET /{id}, POST, PUT — "
+                        + "note this is distinct from the fee-level discountAllowed on /fees below; the inward discount calculation "
+                        + "requires BOTH to be true (see Services /items/bulk-discount-allowed for bulk-setting this one by category).",
                         "API Key",
                         "GET", "POST", "PUT", "PATCH"))
                 .add(resource("Investigation Format", "/api/investigations/{investigationId}/format",
@@ -469,7 +472,11 @@ public class CapabilityStatementResource {
                 .add(resource("Services", "/api/services",
                         "OPD and Inward service management including fees and categories. "
                         + "Fee sub-paths: /{id}/fees (GET fees, POST add), /{id}/fees/{feeId} (PUT update, DELETE remove). "
-                        + "/fees/bulk-margin (POST bulk-update marginAllowed/discountAllowed on fees in a category). "
+                        + "/fees/bulk-margin (POST bulk-update marginAllowed/discountAllowed on ItemFee rows in a category; "
+                        + "fee-level only). "
+                        + "/items/bulk-discount-allowed (POST bulk-update Item-level discountAllowed for all non-retired "
+                        + "items in a category; body: categoryId, discountAllowed. Works generically on any Item subtype "
+                        + "by category, including InvestigationCategory — not just services). "
                         + "/fees/margin-disabled?categoryId=X (GET diagnostic list of fees with marginAllowed=false/null).",
                         "API Key",
                         "GET", "POST", "PUT", "PATCH", "DELETE"))

--- a/src/main/java/com/divudi/ws/service/ServiceApi.java
+++ b/src/main/java/com/divudi/ws/service/ServiceApi.java
@@ -511,6 +511,70 @@ public class ServiceApi {
     }
 
     /**
+     * Bulk-update discountAllowed at the item level (not fee level) for all
+     * non-retired items in a category. Item.discountAllowed is a separate flag
+     * from ItemFee.discountAllowed (see /fees/bulk-margin above) — the inward
+     * discount calculation requires both to be true, so this is typically used
+     * together with /fees/bulk-margin.
+     * POST /api/services/items/bulk-discount-allowed
+     * Body: {"categoryId": 1054, "discountAllowed": true}
+     */
+    @POST
+    @Path("/items/bulk-discount-allowed")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response bulkUpdateItemDiscountAllowed(String requestBody) {
+        try {
+            String key = requestContext.getHeader("Finance");
+            WebUser user = validateApiKey(key);
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            @SuppressWarnings("unchecked")
+            Map<String, Object> body;
+            try {
+                body = gson.fromJson(requestBody, Map.class);
+            } catch (JsonSyntaxException e) {
+                return errorResponse("Invalid JSON format: " + e.getMessage(), 400);
+            }
+
+            if (body == null) {
+                return errorResponse("Request body is required", 400);
+            }
+
+            Long categoryId = null;
+            if (body.get("categoryId") instanceof Number) {
+                Number n = (Number) body.get("categoryId");
+                if (n.doubleValue() != Math.floor(n.doubleValue()) || Double.isInfinite(n.doubleValue())) {
+                    return errorResponse("categoryId must be a whole number", 400);
+                }
+                categoryId = n.longValue();
+            }
+
+            Boolean discountAllowed = null;
+            if (body.get("discountAllowed") != null) {
+                if (body.get("discountAllowed") instanceof Boolean) {
+                    discountAllowed = (Boolean) body.get("discountAllowed");
+                } else {
+                    return errorResponse("discountAllowed must be a boolean", 400);
+                }
+            }
+
+            Map<String, Object> result = serviceApiService.bulkUpdateItemDiscountAllowed(
+                    categoryId, discountAllowed, user);
+            return successResponse(result);
+
+        } catch (Exception e) {
+            String msg = e.getMessage();
+            if (msg != null && (msg.contains("required") || msg.contains("Invalid") || msg.contains("must be"))) {
+                return errorResponse(msg, 400);
+            }
+            return errorResponse("An error occurred: " + (msg != null ? msg : "Unknown error"), 500);
+        }
+    }
+
+    /**
      * List fees with marginAllowed disabled (false or null) in a category.
      * GET /api/services/fees/margin-disabled?categoryId=X
      */


### PR DESCRIPTION
## Summary

Investigation of #23308 ("Added investigation can't add member discount") found two compounding, independent root causes preventing inward discounts from ever applying to investigations, while services already work:

- **`Item.discountAllowed` (default `false`) was never exposed by the Investigation API.** This flag gates the entire inward discount calculation in `InwardBeanController.applyInwardDiscountToBillFee`. The Service API already exposes it on `ServiceCreateRequestDTO`/`ServiceUpdateRequestDTO`/`ServiceResponseDTO`, but the parallel Investigation DTOs never had it — so there was no way, even via the UI's "Manage Investigation" checkbox one-at-a-time, to fix this at scale. Adds `discountAllowed` to `InvestigationCreateRequestDTO`/`UpdateRequestDTO`/`SearchResultDTO`, wires it through `InvestigationApiService`, and adds a new generic bulk endpoint `POST /api/services/items/bulk-discount-allowed` (scoped by `categoryId`, works on any `Item` subtype) so it can be turned on for a whole investigation category in one call instead of hundreds of individual edits.
- **Fixes #23237** — `PriceMatrixController.fetchInwardDiscountMatrixPercentCore` matched `department` as an exact value only, unlike `paymentMethod`/`admissionType` in the same query which already wildcard-match `IS NULL`. A discount-matrix row saved without a department (intended as "any department") never matched an investigation that has its own department set. This method has a live caller (`InwardBeanController.applyInwardDiscountToBillFee`), confirming #23237's open question — yes, it needs the same fix already shipped to the native-SQL path in #23220.

Verified locally against the `coop` dev DB: `PUT /api/investigations/{id}` and the new bulk endpoint both correctly read/write `Item.discountAllowed` (bulk call updated 1,280 investigations in one request), then reverted the test data back to `false`.

## Test plan
- [x] `mvn compile` clean
- [x] Local deploy + smoke test: `GET /api/investigations/search` returns `discountAllowed`; `PUT /api/investigations/{id}` sets it; `POST /api/services/items/bulk-discount-allowed` bulk-sets it by category and was reverted after testing
- [ ] After merge to `development` → `rh-local-staging` → CI/CD deploy to rhLocal: bulk-enable `discountAllowed` (item + fee level) for investigation categories, add the "Life" scheme wildcard discount-matrix row, and verify end-to-end against the exact BHT/scheme from #23308

Closes #23237

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring whether investigations allow discounts.
  * Exposed discount settings when creating, updating, and viewing investigations.
  * Added an endpoint to bulk-enable or disable item discounts for a category.
  * Improved discount matrix matching to support department-wide defaults.
* **Documentation**
  * Updated API documentation for investigation discount behavior and bulk service discount endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->