### PR TITLE
fix(inward): set currentPatientRoom on admission-handover transfer accept

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -2332,6 +2332,45 @@ otherwise you have not distinguished "correctly blocks" from "blocks everything"
 negative test creates through the app's own Cancel action, never with an `UPDATE`.
 Verified while testing issue #23222.
 
+## A department/room created by direct SQL needs more than the FK columns
+
+When a test scenario needs a *new* Department or RoomFacilityCharge that doesn't already exist
+locally (e.g. to simulate a patient's room belonging to a different department than the one they
+were admitted from), inserting just the obvious FK columns produces a department that silently
+breaks large parts of the UI instead of erroring:
+
+- **`DEPARTMENT.DTYPE` must be set** (`'Department'`, matching the existing rows) — `Department` is
+  `@Inheritance`-annotated, so a `NULL` discriminator isn't just "unmapped for this row", it makes
+  the **entire polymorphic query return an empty list** (e.g. `SessionController.listLoggableDepts`
+  during login), not just exclude the bad row. Symptom: login fails with "This user has no privilage
+  to login to any Department" even though the WebUserDepartment row is correct.
+- **`DEPARTMENT.DEPARTMENTTYPE` is compared case-sensitively** against the literal used elsewhere in
+  the codebase (`'Inward'`, not `'INWARD'`). A mismatch doesn't error — the department loads and the
+  header renders, but the entire top menu bar and all page-level toolbars silently disappear because
+  their `rendered` conditions never match.
+- **`DEPARTMENT.SITE_ID` should be copied from a real department of the same kind** — leaving it
+  `NULL` is a further contributor to missing toolbar/menu regions on some pages.
+- **Privileges (`WEBUSERPRIVILEGE`) are scoped by `DEPARTMENT_ID`**, and
+  `SessionController.getUserPrivileges()` looks them up against `loggedUser.getDepartment()` (the
+  session's *currently selected* department after login), not just the user. A brand-new department
+  has zero privilege rows for any user, so every `hasPrivilege(...)`-gated button vanishes even
+  though the same user has full privileges in their usual department. Fix: copy the relevant
+  `WEBUSERPRIVILEGE` rows, changing only `DEPARTMENT_ID`, to the new department.
+- **`ROOMFACILITYCHARGE.COMPANY_ID` must be set** when the scenario will exercise an
+  institute-scoped search/filter (e.g. "Logged Institute"/"Logged Department" scope buttons) — those
+  queries `AND` on `roomFacilityCharge.company = :loggedInstitution`, and a `NULL` company silently
+  drops the row from every institute-scoped result with no error, while institute-unscoped ("Any
+  Institute") searches still find it fine. This made a genuine fix look like it wasn't working until
+  the room's `COMPANY_ID` was backfilled to match the test institution.
+
+Each of the above requires a **Payara restart** to take effect if the row (or a row referencing it)
+was already read once in the current server process — EclipseLink's shared L2 cache can otherwise
+keep serving the pre-fix version of the entity even though the DB row is already corrected and a
+brand new login/HTTP session is used. A plain redeploy is not enough; use
+`asadmin stop-domain && asadmin start-domain`.
+
+Verified while testing issue #23377.
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.

--- a/src/main/java/com/divudi/bean/inward/PatientTransferController.java
+++ b/src/main/java/com/divudi/bean/inward/PatientTransferController.java
@@ -348,20 +348,33 @@ public class PatientTransferController implements Serializable {
     }
 
     public void acceptTransfer(PatientTransferRequest req) {
-        if (req == null) {
+        if (req == null || req.getId() == null) {
             return;
         }
-        if (req.getTheatreTransferType() == TheatreTransferType.SEND_TO_THEATRE) {
+        // Re-fetch and atomically claim PENDING to prevent a double-accept (double-click,
+        // two sessions) from both creating a PatientRoom for the same request — mirrors
+        // the reload-by-ID pattern already used in cancelPendingAndReopen()/acceptInTheatre().
+        PatientTransferRequest persisted = patientTransferRequestFacade.find(req.getId());
+        if (persisted == null || persisted.getStatus() != TransferRequestStatus.PENDING) {
+            loadPendingForDepartment();
+            JsfUtil.addErrorMessage("This transfer request is no longer pending and cannot be accepted.");
+            return;
+        }
+        if (persisted.getTheatreTransferType() == TheatreTransferType.SEND_TO_THEATRE) {
             JsfUtil.addErrorMessage("This is a theatre transfer request. Use \"Accept Theatre Patient\" instead.");
             loadPendingForDepartment();
             return;
         }
 
-        java.util.Map<String, Object> beforeAccept = transferAuditMap(req);
-        Date effectiveAt = req.getAcceptedAt() != null ? req.getAcceptedAt() : new Date();
-        req.setAcceptedAt(effectiveAt);
+        java.util.Map<String, Object> beforeAccept = transferAuditMap(persisted);
+        Date effectiveAt = persisted.getAcceptedAt() != null ? persisted.getAcceptedAt() : new Date();
+        persisted.setAcceptedAt(effectiveAt);
+        // Claim PENDING immediately so a concurrent accept sees ACCEPTED and bails out above.
+        persisted.setStatus(TransferRequestStatus.ACCEPTED);
+        persisted.setAcceptedBy(sessionController.getLoggedUser());
+        patientTransferRequestFacade.edit(persisted);
 
-        if (req.getFromPatientRoom() == null) {
+        if (persisted.getFromPatientRoom() == null) {
             // Admission handover. When the admission-time room selection already
             // created and set this same room as current (Issue #23145), there is
             // nothing to do here beyond confirming roomAdmitted — this request only
@@ -370,9 +383,9 @@ public class PatientTransferController implements Serializable {
             // no PatientRoom has ever been created for this admission, so
             // currentPatientRoom must be set here or it stays null forever and the
             // "Current Department" search (#22382) can never find the patient. (#23377)
-            Admission admission = req.getAdmission();
+            Admission admission = persisted.getAdmission();
             PatientRoom existingCurrentRoom = admission.getCurrentPatientRoom();
-            RoomFacilityCharge targetRoomFacilityCharge = req.getToRoomFacilityCharge();
+            RoomFacilityCharge targetRoomFacilityCharge = persisted.getToRoomFacilityCharge();
             boolean alreadyInTargetRoom = existingCurrentRoom != null
                     && existingCurrentRoom.getRoomFacilityCharge() != null
                     && targetRoomFacilityCharge != null
@@ -392,7 +405,7 @@ public class PatientTransferController implements Serializable {
             admissionFacade.edit(admission);
         } else {
             // Ward-to-ward transfer
-            PatientRoom fromPatientRoom = req.getFromPatientRoom();
+            PatientRoom fromPatientRoom = persisted.getFromPatientRoom();
             fromPatientRoom.setDischarged(true);
             fromPatientRoom.setDischargedAt(effectiveAt);
             fromPatientRoom.setDischargedBy(sessionController.getLoggedUser());
@@ -402,22 +415,19 @@ public class PatientTransferController implements Serializable {
             newPatientRoom = inwardBean.savePatientRoom(
                     newPatientRoom,
                     fromPatientRoom,
-                    req.getToRoomFacilityCharge(),
-                    req.getAdmission(),
+                    persisted.getToRoomFacilityCharge(),
+                    persisted.getAdmission(),
                     effectiveAt,
                     sessionController.getLoggedUser());
 
             fromPatientRoom.setNextRoom(newPatientRoom);
             patientRoomFacade.edit(fromPatientRoom);
 
-            req.getAdmission().setCurrentPatientRoom(newPatientRoom);
-            admissionFacade.edit(req.getAdmission());
+            persisted.getAdmission().setCurrentPatientRoom(newPatientRoom);
+            admissionFacade.edit(persisted.getAdmission());
         }
 
-        req.setStatus(TransferRequestStatus.ACCEPTED);
-        req.setAcceptedBy(sessionController.getLoggedUser());
-        patientTransferRequestFacade.edit(req);
-        auditTransfer(req, "Transfer Accepted", beforeAccept);
+        auditTransfer(persisted, "Transfer Accepted", beforeAccept);
 
         loadPendingForDepartment();
         JsfUtil.addSuccessMessage("Patient accepted successfully.");

--- a/src/main/java/com/divudi/bean/inward/PatientTransferController.java
+++ b/src/main/java/com/divudi/bean/inward/PatientTransferController.java
@@ -362,9 +362,34 @@ public class PatientTransferController implements Serializable {
         req.setAcceptedAt(effectiveAt);
 
         if (req.getFromPatientRoom() == null) {
-            // Admission handover — mark room as admitted
-            req.getAdmission().setRoomAdmitted(true);
-            admissionFacade.edit(req.getAdmission());
+            // Admission handover. When the admission-time room selection already
+            // created and set this same room as current (Issue #23145), there is
+            // nothing to do here beyond confirming roomAdmitted — this request only
+            // exists as a nursing acknowledgement. Otherwise (e.g. the room was
+            // assigned later via a manually initiated transfer with no prior room),
+            // no PatientRoom has ever been created for this admission, so
+            // currentPatientRoom must be set here or it stays null forever and the
+            // "Current Department" search (#22382) can never find the patient. (#23377)
+            Admission admission = req.getAdmission();
+            PatientRoom existingCurrentRoom = admission.getCurrentPatientRoom();
+            RoomFacilityCharge targetRoomFacilityCharge = req.getToRoomFacilityCharge();
+            boolean alreadyInTargetRoom = existingCurrentRoom != null
+                    && existingCurrentRoom.getRoomFacilityCharge() != null
+                    && targetRoomFacilityCharge != null
+                    && existingCurrentRoom.getRoomFacilityCharge().getId() != null
+                    && existingCurrentRoom.getRoomFacilityCharge().getId().equals(targetRoomFacilityCharge.getId());
+            if (!alreadyInTargetRoom && targetRoomFacilityCharge != null) {
+                PatientRoom newPatientRoom = new PatientRoom();
+                newPatientRoom = inwardBean.savePatientRoom(
+                        newPatientRoom,
+                        targetRoomFacilityCharge,
+                        admission,
+                        effectiveAt,
+                        sessionController.getLoggedUser());
+                admission.setCurrentPatientRoom(newPatientRoom);
+            }
+            admission.setRoomAdmitted(true);
+            admissionFacade.edit(admission);
         } else {
             // Ward-to-ward transfer
             PatientRoom fromPatientRoom = req.getFromPatientRoom();


### PR DESCRIPTION
## Decisions made without approval

This branch was developed unattended via `/dev-issue-unattended`; the judgment calls below were made autonomously and should be double-checked first.

- **Root cause identification**: traced to `PatientTransferController.acceptTransfer()`'s `fromPatientRoom == null` branch (the "admission handover" case) never setting `Admission.currentPatientRoom`, based on reading the search JPQL added in #22382 plus git history/comments around #23145 (which documents that admission-time room selection *does* set `currentPatientRoom` immediately, unconditionally). This ruled out the admission-time path as the bug and pointed at the manual Initiate-Transfer-then-Accept path (no prior room) as the actual broken one.
- **Fix shape**: chose to create the `PatientRoom` and set `currentPatientRoom` only when the admission doesn't already have a current room matching the transfer's target `RoomFacilityCharge` — this guard avoids creating a duplicate `PatientRoom` for the pre-existing "simultaneous processes = false" flow from #23145, where a `PatientRoom` is already created at admission time and the handover request that later gets accepted is purely a nursing acknowledgement.
- **Test data**: local `coop` DB has no multi-floor ward department hierarchy, so I created a disposable test department + room (`Second Floor Ward Test23377`) via direct SQL to reproduce a room belonging to a different department than the admission. Existing local admission `BHT/56756` (already roomless) was reused rather than creating a new one. Local DB only — not applied anywhere else.
- **Wiki**: `Inpatient-Admissions-Search` had no documentation at all for the "Search By Admitted/Current Department" buttons (added in #22382, undocumented since). Added a short section with a verified, redacted screenshot rather than leaving the gap — this is filling a pre-existing omission, not correcting existing (wrong) prose, so flagging it here per the "leave it and flag" guidance for anything beyond straightforward verified-behavior documentation.

## Problem

The "Search By Current Department → Logged Department" button (#22382) is meant to find a patient by the department of their *current* room, not their admission department. It never worked for a patient whose current room was assigned after admission via a manually initiated transfer (Initiate Transfer → Accept), because accepting that transfer never actually set `Admission.currentPatientRoom` — only the `roomAdmitted` flag.

## Root cause

`PatientTransferController.acceptTransfer()` branches on whether the transfer request has a `fromPatientRoom`:

- **Ward-to-ward transfer** (`fromPatientRoom != null`): correctly creates a new `PatientRoom` and sets `Admission.currentPatientRoom`.
- **Admission handover** (`fromPatientRoom == null`): only set `Admission.roomAdmitted = true`. If the admission never had a room before (e.g. admitted without a room, then later manually transferred into one via Initiate Transfer), no `PatientRoom` was ever created and `currentPatientRoom` stayed `null` forever — the "Current Department" search filters on `currentPatientRoom.roomFacilityCharge.department`, so it could never match.

This is distinct from the admission-time "room selected inline on the admission form" path (#23145), which already sets `currentPatientRoom` immediately and unconditionally — that path was already working correctly.

## Fix

In the `fromPatientRoom == null` branch, create the `PatientRoom` for the transfer's target `RoomFacilityCharge` and set it as `Admission.currentPatientRoom`, mirroring the existing ward-to-ward branch and the pattern used in `RoomChangeController.addNewRoom()`. A guard skips creating a duplicate room when the admission is already in the target room (the #23145 nursing-acknowledgement case).

## Testing

Verified end-to-end against local Payara + `coop` DB:
1. Created a disposable test department + room via SQL (local dataset has no multi-floor ward hierarchy to reproduce "room belongs to a different department").
2. Created a PENDING `PatientTransferRequest` (`fromPatientRoom = null`) targeting that room, for an existing roomless local admission (`BHT/56756`).
3. Logged into the target department, accepted the request via the real "Accept Patients" UI.
4. Confirmed in DB: `Admission.currentPatientRoom` now points to a new `PatientRoom` referencing the correct `RoomFacilityCharge`/department (previously stayed `NULL`).
5. Confirmed in UI: "Search By Current Department → Logged Department" now finds the patient, showing "Current Room: Room 102 Test23377" — screenshot in the wiki page below.

## Documentation

Updated the [Inpatient — Admissions Search](https://github.com/hmislk/hmis/wiki/Inpatient-Admissions-Search) wiki page with a new section documenting the "Search By Admitted/Current Department" scope buttons (previously undocumented), including a verified screenshot of the fixed behavior.

Closes #23377

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved patient transfer processing by preventing missing, already accepted, or duplicate transfer requests from being processed.
  * Fixed concurrent transfer handling to ensure admission and ward updates use the correct transfer request.
  * Preserved correct room assignment behavior for admissions and ward-to-ward transfers.

* **Documentation**
  * Added guidance for setting up test departments and room facility charges.
  * Documented troubleshooting steps for silent UI failures and cached configuration changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->