### PR TITLE
fix(inward): keep returned/cancelled Service & Investigation rows on the Interim Bill

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -47,6 +47,16 @@ $env:JAVA_HOME="<path-to-jdk>"
   afterward.
 - Watch `<payara-install>\glassfish\domains\domain1\logs\server.log` for deployment errors
   before starting the browser flow.
+- **`--name` must match the actual deployed app name.** `asadmin list-applications`
+  first — on some machines it is `rh-3.0.0`, not `rh`. A `redeploy` with the
+  wrong `--name` fails with `Application with name [...] is not deployed`.
+- **Payara must run on JDK 11.** If Payara was started with JDK 21 on `PATH`,
+  deployment fails with `Unsupported class file major version 65` (65 = Java 21).
+  Fix: `asadmin stop-domain`, then set **both** `$env:JAVA_HOME` and
+  `$env:AS_JAVA` to the JDK 11 path before `start-domain`. A failed `deploy`
+  (as opposed to `redeploy`) also *removes* the app, so the next `redeploy`
+  then fails with "not deployed" — recover with a plain
+  `deploy --name rh-3.0.0 --contextroot rh <war>`.
 
 ---
 

--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -31,7 +31,11 @@ waste a session.
 
 If the change under test isn't deployed yet, rebuild and redeploy to the local
 Payara instance first (see [Local build tools](../../CLAUDE.md) for tool
-locations):
+locations). **This section is local dev only** — it is the `asadmin`
+build/deploy loop the `playwright-e2e` skill already mandates on a developer
+laptop. It does **not** apply to shared/staging/production Payara, where the
+"no manual/root deployment; everything through CI/CD" rule in `CLAUDE.md`
+still governs.
 
 ```powershell
 # Paths vary per machine — check C:\Credentials\Credentials.txt for your local values
@@ -56,7 +60,8 @@ $env:JAVA_HOME="<path-to-jdk>"
   `$env:AS_JAVA` to the JDK 11 path before `start-domain`. A failed `deploy`
   (as opposed to `redeploy`) also *removes* the app, so the next `redeploy`
   then fails with "not deployed" — recover with a plain
-  `deploy --name rh-3.0.0 --contextroot rh <war>`.
+  `deploy --name <name-from-list-applications> --contextroot <its-context-root> <war>`
+  (the name/context root you confirmed above, not a hardcoded guess).
 
 ---
 

--- a/src/main/java/com/divudi/bean/inward/InwardBeanController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardBeanController.java
@@ -2178,6 +2178,8 @@ public class InwardBeanController implements Serializable {
 
                 itm.setTransCheckedCount(calCheckedBillItemCount(itm, patientEncounter));
                 itm.setTransBillItemCount(billed - (cancelld + refund));
+                itm.setTransCancelledBillItemCount(cancelld);
+                itm.setTransRefundedBillItemCount(refund);
 
                 long itemTime = System.currentTimeMillis() - itemStartTime;
                 if (itemTime > 100) {
@@ -2263,6 +2265,8 @@ public class InwardBeanController implements Serializable {
 
                     itm.setTransCheckedCount(checked);
                     itm.setTransBillItemCount(billed - (cancelled + refund));
+                    itm.setTransCancelledBillItemCount(cancelled);
+                    itm.setTransRefundedBillItemCount(refund);
                     itm.setTransGrossValue(values[0]);
                     itm.setTransDiscount(values[1]);
                     itm.setTransMarginValue(values[2]);

--- a/src/main/java/com/divudi/core/entity/Item.java
+++ b/src/main/java/com/divudi/core/entity/Item.java
@@ -212,6 +212,10 @@ public class Item implements Serializable, Comparable<Item>, RetirableEntity {
     @Transient
     private double transBillItemCount;
     @Transient
+    private double transCancelledBillItemCount;
+    @Transient
+    private double transRefundedBillItemCount;
+    @Transient
     double transCheckedCount;
     @Transient
     private long transPendingCheckBillCount;
@@ -1039,6 +1043,22 @@ public class Item implements Serializable, Comparable<Item>, RetirableEntity {
 
     public void setTransBillItemCount(double transBillItemCount) {
         this.transBillItemCount = transBillItemCount;
+    }
+
+    public double getTransCancelledBillItemCount() {
+        return transCancelledBillItemCount;
+    }
+
+    public void setTransCancelledBillItemCount(double transCancelledBillItemCount) {
+        this.transCancelledBillItemCount = transCancelledBillItemCount;
+    }
+
+    public double getTransRefundedBillItemCount() {
+        return transRefundedBillItemCount;
+    }
+
+    public void setTransRefundedBillItemCount(double transRefundedBillItemCount) {
+        this.transRefundedBillItemCount = transRefundedBillItemCount;
     }
 
     public boolean isChargesVisibleForInward() {

--- a/src/main/webapp/inward/inward_bill_intrim.xhtml
+++ b/src/main/webapp/inward/inward_bill_intrim.xhtml
@@ -730,7 +730,25 @@
 
                                                 <p:column styleClass="text-end">
                                                     <f:facet name="header" >
-                                                        <h:outputLabel value="Count"/>
+                                                        <h:outputLabel value="Billed Count"/>
+                                                    </f:facet>
+                                                </p:column>
+
+                                                <p:column styleClass="text-end">
+                                                    <f:facet name="header" >
+                                                        <h:outputLabel value="Returned / Cancelled"/>
+                                                    </f:facet>
+                                                </p:column>
+
+                                                <p:column styleClass="text-end">
+                                                    <f:facet name="header" >
+                                                        <h:outputLabel value="Net Count"/>
+                                                    </f:facet>
+                                                </p:column>
+
+                                                <p:column >
+                                                    <f:facet name="header">
+                                                        <h:outputLabel value="Status"/>
                                                     </f:facet>
                                                 </p:column>
 
@@ -777,36 +795,70 @@
                                             <f:facet name="header">
                                                 <h:outputLabel value="#{dep.department.name}"/>
                                             </f:facet>
+                                            <!--
+                                                #23321 - keep returned/cancelled Service &amp; Investigation rows visible.
+                                                everBilled = the item was billed to this encounter at all, even if the
+                                                net (billed - cancelled - refund) is now zero. transBillItemCount keeps
+                                                its original "net active count" meaning for the other pages that read it.
+                                            -->
                                             <p:column styleClass="text-start">
-                                                <h:outputLabel value="#{ser.name}" rendered="#{ser.transBillItemCount ne 0}"/>
+                                                <h:outputLabel value="#{ser.name}" rendered="#{ser.transBillItemCount ne 0 or ser.transCancelledBillItemCount ne 0 or ser.transRefundedBillItemCount ne 0}"/>
                                             </p:column>
                                             <p:column styleClass="text-end" rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
-                                                <h:outputLabel value="#{ser.transGrossValue}" rendered="#{ser.transBillItemCount ne 0}">
+                                                <h:outputLabel value="#{ser.transGrossValue}" rendered="#{ser.transBillItemCount ne 0 or ser.transCancelledBillItemCount ne 0 or ser.transRefundedBillItemCount ne 0}">
                                                     <f:convertNumber pattern="#,##0.00"/>
                                                 </h:outputLabel>
                                             </p:column>
                                             <p:column styleClass="text-end" rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
-                                                <h:outputLabel value="#{ser.transDiscount}" rendered="#{ser.transBillItemCount ne 0}">
+                                                <h:outputLabel value="#{ser.transDiscount}" rendered="#{ser.transBillItemCount ne 0 or ser.transCancelledBillItemCount ne 0 or ser.transRefundedBillItemCount ne 0}">
                                                     <f:convertNumber pattern="#,##0.00"/>
                                                 </h:outputLabel>
                                             </p:column>
                                             <p:column styleClass="text-end" rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
-                                                <h:outputLabel value="#{ser.transMarginValue}" rendered="#{ser.transBillItemCount ne 0}">
+                                                <h:outputLabel value="#{ser.transMarginValue}" rendered="#{ser.transBillItemCount ne 0 or ser.transCancelledBillItemCount ne 0 or ser.transRefundedBillItemCount ne 0}">
                                                     <f:convertNumber pattern="#,##0.00"/>
                                                 </h:outputLabel>
                                             </p:column>
                                             <p:column styleClass="text-end" rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
-                                                <h:outputLabel value="#{ser.transNetValue}" rendered="#{ser.transBillItemCount ne 0}">
+                                                <h:outputLabel value="#{ser.transNetValue}" rendered="#{ser.transBillItemCount ne 0 or ser.transCancelledBillItemCount ne 0 or ser.transRefundedBillItemCount ne 0}">
                                                     <f:convertNumber pattern="#,##0.00"/>
                                                 </h:outputLabel>
                                             </p:column>
                                             <p:column styleClass="text-end" rendered="#{webUserController.hasPrivilege('ShowServiceCharges')}">
-                                                <h:outputLabel value="#{ser.transVat}" rendered="#{ser.transBillItemCount ne 0}">
+                                                <h:outputLabel value="#{ser.transVat}" rendered="#{ser.transBillItemCount ne 0 or ser.transCancelledBillItemCount ne 0 or ser.transRefundedBillItemCount ne 0}">
                                                     <f:convertNumber pattern="#,##0.00"/>
+                                                </h:outputLabel>
+                                            </p:column>
+                                            <!-- Billed Count = original billed qty (net + returned/cancelled) -->
+                                            <p:column styleClass="text-end">
+                                                <h:outputLabel value="#{ser.transBillItemCount + ser.transCancelledBillItemCount + ser.transRefundedBillItemCount}"
+                                                               rendered="#{ser.transBillItemCount ne 0 or ser.transCancelledBillItemCount ne 0 or ser.transRefundedBillItemCount ne 0}">
+                                                    <f:convertNumber pattern="#,##0.##"/>
                                                 </h:outputLabel>
                                             </p:column>
                                             <p:column styleClass="text-end">
-                                                <h:outputLabel value="#{ser.transBillItemCount}" rendered="#{ser.transBillItemCount ne 0}"/>
+                                                <h:outputLabel style="color: red;"
+                                                               value="#{ser.transCancelledBillItemCount + ser.transRefundedBillItemCount}"
+                                                               rendered="#{ser.transCancelledBillItemCount ne 0 or ser.transRefundedBillItemCount ne 0}">
+                                                    <f:convertNumber pattern="#,##0.##"/>
+                                                </h:outputLabel>
+                                            </p:column>
+                                            <p:column styleClass="text-end">
+                                                <h:outputLabel value="#{ser.transBillItemCount}"
+                                                               rendered="#{ser.transBillItemCount ne 0 or ser.transCancelledBillItemCount ne 0 or ser.transRefundedBillItemCount ne 0}">
+                                                    <f:convertNumber pattern="#,##0.##"/>
+                                                </h:outputLabel>
+                                            </p:column>
+                                            <p:column styleClass="text-start">
+                                                <h:outputLabel styleClass="badge bg-success"
+                                                               value="Active"
+                                                               rendered="#{ser.transBillItemCount ne 0 and ser.transCancelledBillItemCount eq 0 and ser.transRefundedBillItemCount eq 0}"/>
+                                                <h:outputLabel styleClass="badge bg-warning text-dark"
+                                                               value="Partially Returned / Cancelled"
+                                                               rendered="#{ser.transBillItemCount ne 0 and (ser.transCancelledBillItemCount ne 0 or ser.transRefundedBillItemCount ne 0)}"/>
+                                                <h:outputLabel styleClass="badge bg-danger"
+                                                               value="Fully Returned / Cancelled"
+                                                               rendered="#{ser.transBillItemCount eq 0 and (ser.transCancelledBillItemCount ne 0 or ser.transRefundedBillItemCount ne 0)}"/>
                                             </p:column>
                                             <p:column styleClass="text-end">
                                                 <h:outputLabel value="#{ser.transCheckedCount}" rendered="#{ser.transBillItemCount ne 0}"/>
@@ -817,7 +869,7 @@
                                                 </h:outputLabel>
                                             </p:column>
                                             <p:column styleClass="text-start">
-                                                <h:outputLabel value="#{ser.inwardChargeType}" rendered="#{ser.transBillItemCount ne 0}"/>
+                                                <h:outputLabel value="#{ser.inwardChargeType}" rendered="#{ser.transBillItemCount ne 0 or ser.transCancelledBillItemCount ne 0 or ser.transRefundedBillItemCount ne 0}"/>
                                             </p:column>
 
                                             <p:column styleClass="text-start">
@@ -830,9 +882,9 @@
                                             </p:column>
 
                                             <p:column styleClass="text-start">
-                                                <p:commandButton 
-                                                    ajax="false" 
-                                                    rendered="#{ser.transBillItemCount ne 0}"
+                                                <p:commandButton
+                                                    ajax="false"
+                                                    rendered="#{ser.transBillItemCount ne 0 or ser.transCancelledBillItemCount ne 0 or ser.transRefundedBillItemCount ne 0}"
                                                     action="inward_edit_bill_item_view?faces-redirect=true"
                                                     value="View Bill Items"  >
                                                     <f:setPropertyActionListener value="#{ser}" target="#{bhtSummeryController.item}"/>


### PR DESCRIPTION
Closes #23321

## Problem

On `inward/inward_bill_intrim.xhtml`, the **Service and Investigation Charges** tab aggregates bill items by `Item` and gated every cell on `rendered="#{ser.transBillItemCount ne 0}"`. `transBillItemCount` is `billed - (cancelled + refund)`, so once a Service/Investigation bill was **fully returned or cancelled** the count hit `0`, every cell rendered empty, and the row disappeared from the tab — no trace it had ever been billed.

## Decisions made without approval

This branch was run through `dev-issue-unattended`, so the approach was decided from code + git history rather than a Plan Mode pause. Points to double-check:

1. **New transient fields vs. changing `transBillItemCount`.** Added `Item.transCancelledBillItemCount` and `Item.transRefundedBillItemCount` (`@Transient`, following the existing `trans*` idiom). `transBillItemCount` keeps its exact current "net active count" meaning, so the **3 other pages** that read it are untouched: `inward_bill_intrim_estimate.xhtml`, `theater/patient_surgery.xhtml`, `theater/surgery_bill_summary.xhtml`. Rejected: changing `transBillItemCount`'s meaning (ripples to 2 controllers / 4 pages).
2. **Populated in both populators.** `createDepartmentBillItemsOptimized` (the one `BhtSummeryController` uses) and the non-optimized `createDepartmentBillItems` (used by `SurgeryBillController`) both already computed the cancelled and refund counts and discarded them — now they're stored. The theatre pages don't read the new fields, so no behaviour change there.
3. **XHTML gate + new columns, Interim Bill page only.** Visibility gate changed to "ever billed" (`net OR cancelled OR refunded != 0`). Added **Billed Count → Returned / Cancelled → Net Count** columns (in that order, per reviewer request during the run) plus a **Status** badge: `Active` / `Partially Returned / Cancelled` / `Fully Returned / Cancelled`. The Checked By / Checked At / Checked Count columns stay on the old net gate, so a fully-returned item shows no check data.
4. Rejected: filtering cancelled/refunded items out of `getToDepartmentItems` — the opposite of what the issue asks.

## Verification

Built (`BUILD SUCCESS`, 224 tests pass), deployed locally, exercised end-to-end with Playwright against the local `coop` DB, **BHT/56606**:

| Item | Billed | Returned/Cancelled | Net | Status |
| --- | --- | --- | --- | --- |
| A.P.T.T | 1 | 1 | 0 | Fully Returned / Cancelled |
| PROTHROMBIN TIME (PT) | 1 | 1 | 0 | Fully Returned / Cancelled |
| CREATININE & eGFR, FBC, HbA1c, RBS, APTT, PT & INR | 1 | – | 1 | Active |

Both fully-returned items — which previously vanished — now stay visible. DB counts (`SUM(ABS(qty))` grouped by bill class) confirmed to match the UI exactly.

![Service and Investigation Charges tab after the fix](https://github.com/hmislk/hmis.wiki/raw/master/images/23321-service-detail-returned-cancelled-visible.png)

## Documentation

- Wiki **[Intrim Bill](https://github.com/hmislk/hmis/wiki/Intrim-Bill)** — new section *"Returned / Cancelled Services and Investigations Stay Visible"* with the status-badge table and the screenshot above.
- `developer_docs/testing/playwright-e2e-workflow.md` §0a — added the JDK-11 (`Unsupported class file major version 65`), `--name rh-3.0.0`, and "a failed `deploy` removes the app" Payara redeploy gotchas hit during this run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inward billing now displays billed, cancelled/returned, and net item counts.
  * Added clear statuses for active, partially returned, and fully returned items.
  * Items with cancellations or refunds remain visible with their related financial details.

* **Bug Fixes**
  * Improved visibility of inward charge types and bill-view actions for cancelled or refunded items.

* **Documentation**
  * Added deployment troubleshooting and recovery guidance for Payara applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->