### PR TITLE
fix(pharmacy): reject negative return quantities in item return flows

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -2272,6 +2272,30 @@ Logging into `http://localhost:8080/rh` with the production app-login credential
 
 Found while verifying issue #22990.
 
+## 88. `pharmacy_search_pre_bill_for_return_item_only.xhtml`'s "Return Item Only" button can fail completely silently — no `p:messages`/growl update, plus `Bill` is L2-cached
+
+Two independent gotchas stack here, found while testing issue #23304 (reject negative return quantity):
+
+1. **Silent navigation failure.** `PreReturnController.navigateToReturnRetailSaleItemsOnly()` calls
+   `pharmacyRetailSaleReturnPolicyService.checkReturnAllowed(bill)` and returns `null` (staying on the
+   same page) when the sale bill is older than the "no approval" day limit (default 3 days) and has no
+   approved return request — see `PharmacyRetailSaleReturnPolicyService`. `pharmacy_search_pre_bill_for_return_item_only.xhtml`
+   has **no `p:messages`/`p:growl` component at all**, so `JsfUtil.addErrorMessage(...)` is added to the
+   `FacesContext` but never rendered — clicking "Return Item Only" just silently reloads the same search
+   page with zero visible feedback. Don't mistake this for the button/click not registering; check the
+   row's day-limit first (a "Request Approval" button appearing alongside "Return Item Only" is the tell
+   that the bill is past the no-approval window).
+2. **`Bill` is also L2-cached.** Same class of staleness as `feedback_cogs_report_testing_gotcha` and item
+   87's `WebUser` case: if you shift a `Bill.createdAt` via raw SQL to get a test bill inside the day-limit
+   window, and the app already loaded that `Bill` earlier in the same session (e.g. an earlier search hit
+   it), `checkReturnAllowed` keeps evaluating against the stale cached `createdAt` — the day-limit block
+   persists even though the DB row is correct. Use a bill your test session has never touched yet for the
+   `UPDATE`, or restart the domain, rather than assuming the fresh `UPDATE` took effect.
+
+Also: revert any `createdAt` shift back to the bill's real original value immediately after the test —
+day-based reports (Cost of Goods Sold, F15) key off it, and leaving it shifted taints those reports for
+both the original date and the shifted date.
+
 ## Some PrimeFaces buttons need a jQuery-triggered click
 
 Most `p:commandButton`s submit fine with a normal Playwright click — including

--- a/src/main/java/com/divudi/bean/pharmacy/PreReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PreReturnController.java
@@ -265,6 +265,11 @@ public class PreReturnController implements Serializable {
     public void onEdit(BillItem tmp) {
         //    PharmaceuticalBillItem tmp = (PharmaceuticalBillItem) event.getObject();
 
+        if (tmp.getQty() < 0) {
+            tmp.setQty(0.0);
+            JsfUtil.addErrorMessage("Returning quantity cannot be negative. The returning quantity was set to 0.");
+        }
+
         if (tmp.getQty() > getPharmacyRecieveBean().calQty3(tmp.getReferanceBillItem())) {
             tmp.setQty(0.0);
             JsfUtil.addErrorMessage("You cant return over than ballanced Qty ");
@@ -415,6 +420,14 @@ public class PreReturnController implements Serializable {
         for (BillItem bi : getBillItems()) {
             if (bi.getQty() > 0 && bi.getItem() != null && !bi.getItem().isRefundsAllowed()) {
                 JsfUtil.addErrorMessage("Item '" + bi.getItem().getName() + "' is not allowed to be returned. Refunds are not permitted for this item.");
+                return;
+            }
+        }
+
+        // Reject negative returning quantities
+        for (BillItem bi : getBillItems()) {
+            if (bi.getQty() < 0) {
+                JsfUtil.addErrorMessage("Returning quantity cannot be negative.");
                 return;
             }
         }

--- a/src/main/java/com/divudi/bean/pharmacy/PreReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PreReturnController.java
@@ -393,6 +393,15 @@ public class PreReturnController implements Serializable {
     StaffService staffBean;
 
     public void settle() {
+        // Reject negative returning quantities before any other check, so a
+        // negative-qty row can never be masked by a coincidental zero total
+        for (BillItem bi : getBillItems()) {
+            if (bi.getQty() < 0) {
+                JsfUtil.addErrorMessage("Returning quantity cannot be negative.");
+                return;
+            }
+        }
+
         String returnBlockReason = pharmacyRetailSaleReturnPolicyService.checkReturnAllowed(bill);
         if (returnBlockReason != null) {
             JsfUtil.addErrorMessage(returnBlockReason);
@@ -420,14 +429,6 @@ public class PreReturnController implements Serializable {
         for (BillItem bi : getBillItems()) {
             if (bi.getQty() > 0 && bi.getItem() != null && !bi.getItem().isRefundsAllowed()) {
                 JsfUtil.addErrorMessage("Item '" + bi.getItem().getName() + "' is not allowed to be returned. Refunds are not permitted for this item.");
-                return;
-            }
-        }
-
-        // Reject negative returning quantities
-        for (BillItem bi : getBillItems()) {
-            if (bi.getQty() < 0) {
-                JsfUtil.addErrorMessage("Returning quantity cannot be negative.");
                 return;
             }
         }

--- a/src/main/java/com/divudi/bean/pharmacy/SaleReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/SaleReturnController.java
@@ -768,6 +768,15 @@ public class SaleReturnController implements Serializable, com.divudi.bean.commo
     }
 
     public void settle() {
+        // Reject negative returning quantities before any other check, so a
+        // negative-qty row can never be masked by a coincidental zero total
+        for (BillItem bi : getBillItems()) {
+            if (bi.getQty() < 0) {
+                JsfUtil.addErrorMessage("Returning quantity cannot be negative.");
+                return;
+            }
+        }
+
         String returnBlockReason = pharmacyRetailSaleReturnPolicyService.checkReturnAllowed(bill);
         if (returnBlockReason != null) {
             JsfUtil.addErrorMessage(returnBlockReason);
@@ -788,14 +797,6 @@ public class SaleReturnController implements Serializable, com.divudi.bean.commo
         for (BillItem bi : getBillItems()) {
             if (bi.getQty() > 0 && bi.getItem() != null && !bi.getItem().isRefundsAllowed()) {
                 JsfUtil.addErrorMessage("Item '" + bi.getItem().getName() + "' is not allowed to be returned. Refunds are not permitted for this item.");
-                return;
-            }
-        }
-
-        // Reject negative returning quantities
-        for (BillItem bi : getBillItems()) {
-            if (bi.getQty() < 0) {
-                JsfUtil.addErrorMessage("Returning quantity cannot be negative.");
                 return;
             }
         }

--- a/src/main/java/com/divudi/bean/pharmacy/SaleReturnController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/SaleReturnController.java
@@ -343,6 +343,11 @@ public class SaleReturnController implements Serializable, com.divudi.bean.commo
 
     public void onEdit(BillItem tmp) {
         //    PharmaceuticalBillItem tmp = (PharmaceuticalBillItem) event.getObject();
+        if (tmp.getQty() < 0) {
+            tmp.setQty(0.0);
+            JsfUtil.addErrorMessage("Returning quantity cannot be negative. The returning quantity was set to 0.");
+        }
+
         double remainingQty = getPharmacyRecieveBean().calQty3(tmp.getReferanceBillItem());
         if (tmp.getQty() > remainingQty) {
             tmp.setQty(0.0);
@@ -783,6 +788,14 @@ public class SaleReturnController implements Serializable, com.divudi.bean.commo
         for (BillItem bi : getBillItems()) {
             if (bi.getQty() > 0 && bi.getItem() != null && !bi.getItem().isRefundsAllowed()) {
                 JsfUtil.addErrorMessage("Item '" + bi.getItem().getName() + "' is not allowed to be returned. Refunds are not permitted for this item.");
+                return;
+            }
+        }
+
+        // Reject negative returning quantities
+        for (BillItem bi : getBillItems()) {
+            if (bi.getQty() < 0) {
+                JsfUtil.addErrorMessage("Returning quantity cannot be negative.");
                 return;
             }
         }


### PR DESCRIPTION
## Decisions made without approval

This was run via `dev-issue-unattended` (issue #23304), so these judgment calls were made without a human checkpoint — flagging them here for review:

- Applied the fix using the exact same guard pattern the codebase already uses for the "over remaining balance" check (reset qty to `0.0` + `JsfUtil.addErrorMessage`), in both `onEdit()` (immediate blur feedback) and `settle()` (final gate before persisting), in **both** `PreReturnController` (Return Item Only) and `SaleReturnController` (Return Item and Payment) — not an ambiguous choice, since both controllers already shared this exact validation shape for the existing check.
- To reproduce with realistic data under the local 3-day no-approval return window, I temporarily shifted `createdAt` on 3 real local test bills via direct SQL, then reverted them to their original values immediately after testing (see Testing below).
- Confirmed there's no COGS/F15 report variance risk from this change: it only adds a validation gate that runs *before* any stock/costing code executes, and no test return was actually submitted end-to-end during verification (only the field-level `onEdit` validation was exercised), so no stock/bill-item/history rows were created.

## Problem

In both the "Return Item Only" and "Return Item and Payment" screens (`pharmacy_bill_return_pre.xhtml` / `pharmacy_bill_return_retail.xhtml`), the Returning Qty field's `onEdit` validation only checked that the entered quantity didn't exceed the remaining returnable balance — it never rejected a negative value. A user could enter `-1` and complete the return, which would reverse the sign of the refund and add stock back on what should have been a return.

## Root cause

`PreReturnController.onEdit()` (`src/main/java/com/divudi/bean/pharmacy/PreReturnController.java`) and `SaleReturnController.onEdit()` (`src/main/java/com/divudi/bean/pharmacy/SaleReturnController.java`) each only guarded the upper bound (`qty > remainingQty`). Neither `onEdit()` nor the final `settle()` gate rejected `qty < 0`.

## Fix

- Added a `qty < 0` check in both controllers' `onEdit()`, resetting to `0.0` with an error message — mirroring the existing over-balance check.
- Added a defense-in-depth loop in both controllers' `settle()` that rejects the whole submission if any bill item still has a negative quantity, in case `onEdit` was bypassed (e.g. programmatic AJAX call without a blur event).

## Testing

Verified end-to-end against a local Payara/MySQL instance with a real pharmacy retail sale bill (`MP/SALE/140893`, item "Paracetol 500mg"):

- Entering `-1` in the Returning Qty field on `pharmacy_bill_return_retail.xhtml` (the exact page named in the issue) now shows **"Returning quantity cannot be negative. The returning quantity was set to 0."** and resets the field to `0.0`.
- A valid quantity (`1`, within the remaining balance of `2`) is still accepted normally, and the Receivable Amount correctly recalculates to `3.49` — no regression.
- Re-entering `99` (over the remaining balance) still shows the existing **"You cant return over than the remaining quanty to return..."** message and resets to `0` — no regression.
- No actual return was submitted during testing (only the qty field's blur-triggered validation was exercised), and I confirmed via direct DB query that zero new `BILLITEM`/`STOCKHISTORY` rows were created — so there's no COGS/F15 report impact from this verification.
- To get a fresh, in-window test bill for the day-limit policy (`PharmacyRetailSaleReturnPolicyService`), I temporarily shifted `createdAt` on 3 local test bills (`MP/SALE/140893`, `140894`, `140895`) via direct SQL, then reverted all three to their original values immediately after — confirmed via a follow-up `SELECT`.

Screenshot: ![Negative return quantity rejected](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23304-negative-return-qty-rejected.png)

## Documentation

Updated both wiki pages that document these flows, since neither previously mentioned quantity validation:
- [Pharmacy ‐ Return Items and Payments](https://github.com/hmislk/hmis/wiki/Pharmacy-%E2%80%90-Return-Items-and-Payments) — added a note + the screenshot above.
- [Pharmacy Return ‐ Items Only](https://github.com/hmislk/hmis/wiki/Pharmacy-Return-%E2%80%90-Items-Only) — added the same note (shares the same validation shape, verified in `PreReturnController`).

Also recorded a new Playwright testing gotcha in `developer_docs/testing/playwright-e2e-workflow.md` (#88): the "Return Item Only" search page has no `p:messages`/growl component so a day-limit block fails completely silently, and `Bill` is L2-cached the same way `ConfigOption`/`WebUser` are (items #26/#87), so a raw-SQL `createdAt` shift can appear to have no effect if the bill was already loaded this session.

Closes #23304