### PR TITLE
fix(inward): pass the Appointment ID, not the Reservation ID, to Admit

### DIFF
--- a/src/main/java/com/divudi/bean/common/AppointmentController.java
+++ b/src/main/java/com/divudi/bean/common/AppointmentController.java
@@ -490,7 +490,7 @@ public class AppointmentController implements Serializable, ControllerWithPatien
             if (res != null) {
                 // Room Reservation details (ROOM_ADMISSION)
                 dto = new ReservationDTO(
-                    res.getId(),
+                    apt.getId(), // ReservationDTO.id is always the Appointment ID - see ReservationDTO
                     res.getReservedFrom(),
                     res.getReservedTo(),
                     apt.getAppointmentNumber(),
@@ -508,7 +508,7 @@ public class AppointmentController implements Serializable, ControllerWithPatien
             } else {
                 // Non-room Appointment details (Procedure, Consultant, etc.)
                 dto = new ReservationDTO(
-                    apt.getId(), // Store Appointment ID since there is no Reservation ID
+                    apt.getId(), // ReservationDTO.id is always the Appointment ID - see ReservationDTO
                     combineDateAndTime(apt.getAppointmentDate(), apt.getAppointmentTimeFrom()), // Combined date and time
                     combineDateAndTime(apt.getAppointmentDate(), apt.getAppointmentTimeTo()), 
                     apt.getAppointmentNumber(),

--- a/src/main/java/com/divudi/core/data/dto/ReservationDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/ReservationDTO.java
@@ -9,6 +9,16 @@ import java.util.Date;
 public class ReservationDTO implements Serializable {
     private static final long serialVersionUID = 1L;
     
+    /**
+     * The Appointment ID - never the Reservation ID.
+     *
+     * Both consumers of this DTO (AppointmentController.navigatePatientAdmit and
+     * navigateToManageAppointment) resolve this value with appointmentFacade.find(),
+     * and they look the Reservation up themselves from the Appointment. Appointment
+     * and Reservation use independent IDENTITY sequences on different tables
+     * (patientencounter vs reservation), so putting a Reservation ID here makes the
+     * lookup fail ("No Appointment Found") or, on a colliding ID, load the wrong record.
+     */
     private Long id;
     private Date reservedFrom;
     private Date reservedTo;


### PR DESCRIPTION
Closes #23276

## Decisions made without approval

This ran unattended, so every judgment call is listed here first.

1. **Treated `ReservationDTO.id` as an Appointment ID and changed the producer, not the consumers.** The codebase gives a decisive signal rather than an ambiguous one: the DTO's other producer, `InwardReservationController.convertToReservationDTO()`, already passes `reloadAppointment.getId()`; both consumers declare the parameter as `Long appointmentId` and resolve it with `appointmentFacade.find()`; and `navigatePatientAdmit()` looks the `Reservation` up itself via `findReservationForAppointment(currentAppointment)`, so no consumer needs a Reservation ID at all. The room-reservation branch of `searchAppointments()` was the only place violating that. An inline comment in the other branch (`// Store Appointment ID since there is no Reservation ID`) suggests the original author intended the opposite contract, but no consumer was ever written for it.
2. **Did not rename the `id` field or add an `appointmentId` alias.** `id` is also the datatable `rowKey` and is read by the calendar pages (`inward_reservations_schedule_calendar.xhtml`, `theatre_schedule_calendar.xhtml`), so a rename or a synonym adds risk and confusion for no behavioural gain. Documented the contract on the field instead.
3. **Fixed the `Manage` button as a side effect rather than scoping to `Admit` only.** Both buttons on the page pass the same `r.id` into the same kind of lookup, so the one-line change repairs both. Splitting them would have left a known-broken button on the page under test. Confirmed pre-fix that `Manage` failed identically.
4. **Used a local-DB fixture for the reservation end date.** See *Verification* — noted because it deviates from the preferred generate-through-the-app route.
5. **Wiki: created a new page rather than editing existing prose.** No existing text was rewritten; nothing on the current wiki contradicted the code. See *Documentation*.

## Problem

On **Inward > Appointment > Manage Appointment**, clicking **Admit** on an appointment that has a room reservation reported **"No Appointment Found"**, so no patient could be admitted from an existing appointment.

## Root cause

`AppointmentController.searchAppointments()` built the row DTO with the **Reservation** primary key when the appointment had a room reservation:

```java
if (res != null) {
    dto = new ReservationDTO(
        res.getId(),          // <-- Reservation PK
        ...
```

`view_appointment.xhtml` passes that same `r.id` into `navigatePatientAdmit(Long appointmentId)` and `navigateToManageAppointment(Long appointmentId)`, both of which resolve it with `appointmentFacade.find(appointmentId)`.

`Appointment` and `Reservation` each use `@GeneratedValue(strategy = GenerationType.IDENTITY)` on **different tables** (`patientencounter` vs `reservation`), so their key spaces are unrelated. On the test database, reservation ids were `1`–`3` while appointment ids were around `13857336` — `find()` returned `null` every time.

Two consequences beyond the reported message:

- A room reservation is the *only* kind of appointment `Admit` accepts (`navigatePatientAdmit` rejects everything else with *"Admission is only applicable for Room Reservations."*), so the button was broken for every appointment it was ever offered on.
- Where a reservation id happens to collide with a real appointment id, the lookup would have silently opened **an unrelated patient's appointment** instead of failing — a correctness risk, not just a blocked workflow.

## Fix

- `AppointmentController.searchAppointments()` — pass `apt.getId()` in the room-reservation branch, matching the non-room branch and the calendar producer.
- `ReservationDTO` — documented that `id` is always the Appointment ID, and why, so the trap is not reintroduced.

No schema, privilege or query changes.

## Verification

Local Payara deployment, `coop` database, Inward department.

**Before** — with the change reverted, rebuilt and redeployed against the *same* appointment and a reservation covering today:

- **Admit** → `No Appointment Found` (read from the DOM; the growl fades faster than a screenshot)
- **Manage** → `No Appointment Found`

**After** — same appointment, fix applied:

- **Admit** → navigates to `inward_admission.xhtml` with the appointment's patient loaded and the appointment carried into the *Other > Appointment* tab
- **Manage** → opens `inward_appointment_edit.xhtml` showing the correct appointment (number, room, referring doctor, bill total), and **Update Appointment** saved a changed reservation window back to the database

Database check confirming the key spaces are disjoint, which is what made the old lookup fail:

```
reservation.id       : 1, 2, 3
patientencounter.id  : 13857336, 13857337, 13857339   (DTYPE = 'Appointment')
```

### Test-data note

The one pending room appointment in the local database had `reservedTo = NULL`, which fails the unrelated *"Reservation Expired"* guard. The preferred route — creating a fresh appointment through **Add Appointment** — could not be used: that form silently rejects the submit, because `settleBill()` returns via `JsfUtil.addErrorMessage(...)` but `inward_appointment.xhtml` renders no `p:messages`/growl outside the patient composite, so the reason is never shown to the user. That is a separate defect on a different page and is **not** addressed here.

The reservation window was therefore set through the app's own **Manage Appointment > Update Appointment** screen (which is itself one of the paths under test), after an initial `UPDATE` on the local `reservation` row. Local database only; no remote or production database was touched, and the local test data was left in place.

## Documentation

Added a new wiki page for the screen this issue is about, which had none: **[Manage Appointments](https://github.com/hmislk/hmis/wiki/Inward-Manage-Appointments)** — search filters, the Admit action with its room-reservation and expiry guards, and the Manage/edit action. Linked from the [Inward](https://github.com/hmislk/hmis/wiki/Inward) index and the Inpatient Module Overview.

No existing wiki prose was rewritten — nothing currently on the wiki contradicted the code or the verified behaviour. Only one screenshot was published: the appointment list, which carries no patient, doctor or institution name. The remaining screenshots from this run were withheld because they show a real referring doctor's name and the institution name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HxN1DVBseU2TkzkAoJ6ESw
