### PR TITLE
docs(skills): add mandatory Claude self-review before first push to dev-issue-unattended

### DIFF
--- a/.claude/skills/dev-issue-unattended/SKILL.md
+++ b/.claude/skills/dev-issue-unattended/SKILL.md
@@ -335,6 +335,46 @@ If 3+ fix attempts don't converge, that's the systematic-debugging
 architecture-question trigger, not a reason to keep guessing: stop, post
 findings, end the run.
 
+## 8a. Claude self-review before first push
+
+The only review this skill otherwise gets is step 14's CodeRabbit/Codex loop
+— and both bots can be unavailable at once (rate-limited, usage-exhausted)
+with no fallback, leaving a PR that ships with zero substantive review. This
+step adds an earlier, Claude-driven pass so a caught bug becomes part of the
+initial push instead of a second commit reacting to a bot (or a human) after
+the fact. It runs once step 8's Iterate loop passes end-to-end, before
+step 9/11.
+
+1. **Pick an effort level.** Default `medium`. Bump to `high` if the diff
+   touches billing, pharmacy, API (`ws/`), or security/privilege code — the
+   same shared/core risk areas `merge-gate` already flags ("touches
+   shared/core code (API, billing, pharmacy) where a regression could
+   silently break unrelated functions"), extended here to security/privilege
+   code given this skill's existing hard limit against writing such changes
+   at all.
+2. **Run `/code-review`** at that effort level against the working diff —
+   the uncommitted changes on the branch, before the first commit/push, not
+   against an already-open PR.
+3. **Triage each finding into one of three buckets:**
+   - **In-scope, confirmed bug** → fix it, rebuild/redeploy, re-run the
+     relevant Playwright/DB verification from step 7, and fold the fix into
+     the same commit as the original change.
+   - **Valid but outside the issue's named files/screens** → leave this PR's
+     diff alone; file a separate GitHub issue describing the pattern (same
+     shape as issue #23385, filed from this exact gap), and reference it in
+     this PR's description under a short "Follow-up" note. This is filing an
+     issue, which step 0's blanket authorization already covers — no
+     separate confirmation needed.
+   - **Low-confidence / stylistic / reuse-nitpick** → no fix, no new issue;
+     note it under the PR's "Decisions made without approval" section (step
+     13) so a human can look later.
+4. **Document the pass** in that same PR section — which findings came up,
+   which bucket each landed in, and why — the same judgment-call-logging
+   convention already used for steps 3 and 13.
+
+Step 14's CodeRabbit/Codex loop is unchanged by this step — this is an
+earlier, additional layer, not a replacement.
+
 ## 9. Record learnings
 
 Same as `dev-issue` step 9 — append new Playwright/dev gotchas to


### PR DESCRIPTION
## Background

While running `dev-issue-unattended` end-to-end on #23304 (PR #23383), CodeRabbit and Codex were both rate-limited/exhausted at review time. Step 14 of the skill has no fallback for this — its only review mechanism is the bot-driven loop, so the PR would have shipped with zero substantive review.

At the user's request, `/code-review 23383 high` was run manually against the already-open PR instead. It found:
1. A real bug in the fix itself (the new `settle()` negative-qty guard could be masked by an earlier "Total is Zero" early-return) — required a second commit after the PR was already open.
2. The identical validation gap in 5 sibling controllers outside the two screens #23304 named — filed separately as #23385.

Both findings would have been available *before* the first push if this ran as part of the skill itself.

## Change

Adds step 8a to `.claude/skills/dev-issue-unattended/SKILL.md`, between the existing step 8 ("Iterate") and step 9/11 ("Record learnings" / "Pre-push check"):

- Run `/code-review` on the working diff before the first commit/push (not against an already-open PR).
- Effort level adaptive by risk area: `medium` default, `high` for billing/pharmacy/API/security code — reusing `merge-gate`'s existing risk-area list, extended to security/privilege given this skill's existing hard limit there.
- 3-bucket triage: in-scope confirmed bug → fix and fold into the same commit; valid-but-out-of-scope pattern → file a separate follow-up issue (same shape as #23385) rather than expanding the PR; low-confidence/stylistic → note in "Decisions made without approval," no fix, no new issue.
- Step 14's existing CodeRabbit/Codex loop is unchanged — this is an earlier, additional layer, not a replacement.

Scoped to `dev-issue-unattended` only (not the base `dev-issue` skill) — decided during discussion, since `dev-issue` already has a human present at its own discussion gates who can trigger `/code-review` manually.

Documentation-only change (a `.claude/skills/*.md` file) — no compilation or app testing applies.

Closes #23386

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the development workflow to include an additional review checkpoint before changes are committed and published.
  * Review findings are now categorized, tracked, or documented consistently.
  * No direct changes to product functionality or the end-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->