### PR TITLE
fix(inward): remove export-breaking footer facet on BHT Deposit and Credit Settlement Detail report

### DIFF
--- a/src/main/webapp/inward/inward_report_bht_payment_detail.xhtml
+++ b/src/main/webapp/inward/inward_report_bht_payment_detail.xhtml
@@ -512,30 +512,6 @@
                                 </f:facet>
                             </p:column>
 
-                            <f:facet name="footer">
-                                <div class="text-end">
-                                    <strong>Grand Total Deposits: </strong>
-                                    <h:outputText value="#{bhtPaymentSummaryReportController.grandTotalDeposits}">
-                                        <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
-                                    </h:outputText>
-                                    &#160;&#160;&#160;
-                                    <strong>Grand Total Payments: </strong>
-                                    <h:outputText value="#{bhtPaymentSummaryReportController.grandTotalPayments}">
-                                        <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
-                                    </h:outputText>
-                                    &#160;&#160;&#160;
-                                    <strong>Grand Total Post Payments: </strong>
-                                    <h:outputText value="#{bhtPaymentSummaryReportController.grandTotalPostFinalPayments}">
-                                        <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
-                                    </h:outputText>
-                                    &#160;&#160;&#160;
-                                    <strong>Grand Total Credit Settlements: </strong>
-                                    <h:outputText value="#{bhtPaymentSummaryReportController.grandTotalCreditSettlement}">
-                                        <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
-                                    </h:outputText>
-                                </div>
-                            </f:facet>
-
                         </p:dataTable>
 
                     </p:panel>


### PR DESCRIPTION
## Summary

- Removes a redundant table-level `<f:facet name="footer">` on `inward_report_bht_payment_detail.xhtml` ("BHT Deposit and Credit Settlement Detail" report) that duplicated totals already shown in the per-column footers (Total Deposits, Total Payments, Total Post Payments, Credit Settled) and broke the **Excel** and **PDF** exports — PrimeFaces' exporters can't cleanly render a mixed-content table-level facet, so they emitted it as an extra merged row holding a single bare, unconverted number after the real data (reported as an unlabeled `10000.0` in a merged A4:AA4 cell).
- No controller/Java changes — the underlying `grandTotalXxx` properties remain in use via the per-column footers.
- Also investigated #23260 (reported "Total Balance/Deposit Cash swapped" on this same report/controller) — confirmed it's already resolved by the earlier #23262 fix (PR #23362, merged 2026-08-31): `fetchDepositPayments()`/`fetchPayments()` query the correct `BillTypeAtomic`, and `BhtPaymentSummaryDTO.getTotalBalance()` already nets out Payments in its formula. No code change needed for #23260; commented on that issue with the evidence instead of duplicating it here.

Closes #23262
Closes #23260

## Test plan

Verified locally (Payara + `coop` DB, Inward department, admission-date range Aug 2026, BHT/56753–56760 + OPDCARD/43473, 9-row result set with non-zero Deposit and Payment values on several rows):

- [x] **Excel export**: downloaded `.xlsx`, unzipped and inspected `sheet1.xml` — dimension is exactly `A1:AA11` (1 header + 9 data rows + 1 totals row), no extra row. Totals row cell values (Deposit 4,272.00 / Payment 2,500.00 / Post Payment 600.00 / Grand Total 7,372.00 / Total Bill Value 15,000.00 / Total Balance −6,678.00) match the on-screen column footers exactly.
- [x] **PDF export**: rendered to PNG and visually confirmed the last data row is followed directly by the bold totals row, no stray row in between.
- [x] On-screen column footers still show all four previously-duplicated totals (Deposits/Payments/Post Payments/Credit Settled) — no information lost by removing the table-level facet.

![PDF export: no wreckage row after the fix](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23262-pdf-export-no-wreckage-row.png)

## Documentation

Updated: https://github.com/hmislk/hmis/wiki/Inward-BHT-Deposit-and-Credit-Settlement-Detail-Report — added a retest note explaining the removed summary line and why, corrected the "totals shown below the table" text (now inaccurate), and added the export evidence screenshot above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the redundant combined summary row from the BHT payment details report.
  * Individual totals for deposits, payments, post-payments, and credit settlements remain available in their respective columns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->