### PR TITLE
hotfix(finance): persist refund bill items explicitly in saveRefundBill()

### DIFF
--- a/developer_docs/api/using-apis/API_BILL_DATA_CORRECTION.md
+++ b/developer_docs/api/using-apis/API_BILL_DATA_CORRECTION.md
@@ -1,0 +1,217 @@
+# Bill Data Correction API
+
+## Overview
+
+This API provides a controlled way to correct already-saved bill-related financial data after human approval.
+
+- **Endpoint**: `PATCH /api/bill_data_correction`
+- **Auth Header**: `Finance: <API_KEY>`
+- **Purpose**: Correct historical data in bill records without direct database access.
+
+> **Important:** This endpoint can only **update** existing records. It **cannot create** a missing
+> `BillFinanceDetails` row. If you need to create missing BFDs for historical
+> `PHARMACY_STOCK_ADJUSTMENT` or `PHARMACY_RETAIL_RATE_ADJUSTMENT` bills, use
+> `POST /api/pharmacy/backfill_bfd` instead.
+
+## Current Related Endpoints
+
+Before applying corrections, use these read-only endpoints to identify the exact records:
+
+- `GET /api/pharmacy_f15_report`
+- `GET /api/costing_data/bills_by_type`
+- `GET /api/costing_data/by_bill_id/{billId}`
+
+Then apply updates using:
+
+- `PATCH /api/bill_data_correction` — update existing BFD/bill/item fields
+- `POST /api/bill_data_correction/create_bill_item` — **create** a single missing `BillItem` on an already-saved bill
+- `POST /api/pharmacy/backfill_bfd` — **create** missing BFDs for historical adjustment bills
+
+## Request Body
+
+```json
+{
+  "targetType": "BILL_FINANCE_DETAILS",
+  "targetId": 987654,
+  "fields": {
+    "totalRetailSaleValue": -62709.88,
+    "totalCostValue": 0.0
+  },
+  "auditComment": "F15 discrepancy correction — approved by Dr. Smith on 2026-02-20",
+  "approvedBy": "Dr. Smith"
+}
+```
+
+## Supported `targetType`
+
+| targetType | Entity | Editable fields |
+|---|---|---|
+| `BILL` | Bill | `netTotal`, `grossTotal`, `comments` |
+| `BILL_ITEM` | BillItem | `qty`, `rate`, `grossValue`, `netValue`, `discount` |
+| `BILL_FINANCE_DETAILS` | BillFinanceDetails | `totalRetailSaleValue`, `totalCostValue`, `totalPurchaseValue`, `netTotal`, `grossTotal`, `billExpensesConsideredForCosting`, `billExpensesNotConsideredForCosting`, `totalBillValue` |
+| `BILL_FEES` | BillFee | `feeValue`, `grossValue` |
+| `BILL_ITEM_FINANCE_DETAILS` | BillItemFinanceDetails | `valueAtRetailRate`, `valueAtCostRate`, `costRate`, `retailSaleRate` |
+| `PHARMACEUTICAL_BILL_ITEM` | PharmaceuticalBillItem | `qty`, `retailRate`, `costRate`, `retailValue`, `costValue` |
+
+## Validation Rules
+
+- `targetType`, `targetId`, and `fields` are mandatory.
+- `auditComment` is mandatory.
+- `approvedBy` is mandatory.
+- Unknown fields for the selected `targetType` are rejected with `400`.
+- API key must be valid and mapped to an active user.
+
+## Response (Success)
+
+```json
+{
+  "status": "success",
+  "code": 200,
+  "data": {
+    "targetType": "BILL_FINANCE_DETAILS",
+    "targetId": 987654,
+    "previousValues": {
+      "totalRetailSaleValue": -62422.21
+    },
+    "newValues": {
+      "totalRetailSaleValue": -62709.88
+    },
+    "auditComment": "F15 discrepancy correction — approved by Dr. Smith on 2026-02-20",
+    "approvedBy": "Dr. Smith",
+    "correctedAt": "2026-02-20 14:35:00",
+    "correctedByApiUser": "admin_user"
+  }
+}
+```
+
+## Error Responses
+
+The API layer maps `IllegalArgumentException` from missing entities (e.g., `targetId` not found)
+to `404 Not Found`, while true validation problems (unknown fields, empty payloads, etc.) remain
+`400 Bad Request` errors.
+
+### 400 – Validation Failure (Example)
+
+```json
+{
+  "status": "error",
+  "code": 400,
+  "message": "Field 'unknownField' is not allowed for BILL_FINANCE_DETAILS"
+}
+```
+
+### 401 – Invalid or Missing API Key
+
+```json
+{
+  "status": "error",
+  "code": 401,
+  "message": "Invalid or missing API key"
+}
+```
+
+### 404 – Target Entity Not Found
+
+```json
+{
+  "status": "error",
+  "code": 404,
+  "message": "Bill not found for id 123456"
+}
+```
+
+### 500 – Unexpected Server Error
+
+```json
+{
+  "status": "error",
+  "code": 500,
+  "message": "Internal server error"
+}
+```
+
+## Example cURL
+
+```bash
+curl -s -X PATCH "$BASE_URL/api/bill_data_correction" \
+  -H "Finance: $FINANCE_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "targetType": "BILL_FINANCE_DETAILS",
+    "targetId": 987654,
+    "fields": {
+      "totalRetailSaleValue": -62709.88
+    },
+    "auditComment": "F15 discrepancy correction - approved by Dr. Smith on 2026-02-20",
+    "approvedBy": "Dr. Smith"
+  }'
+```
+
+## Audit Trail
+
+Every correction is appended to the parent bill's `comments` including:
+
+- correction timestamp
+- target type and id
+- API user
+- approver
+- audit comment
+- previous values and new values
+
+## Creating a Missing Bill Item
+
+Use this only to repair a bill that is missing a `BillItem` it should have (e.g. a refund bill whose
+item never got persisted due to a bug in the saving code). It does **not** recompute or touch the
+bill's totals, finance details, or payments — the values you supply must already be consistent with
+the bill's existing `netTotal`/`total`.
+
+- **Endpoint**: `POST /api/bill_data_correction/create_bill_item`
+- **Auth Header**: `Finance: <API_KEY>`
+
+### Request Body
+
+```json
+{
+  "billId": 5214531,
+  "itemId": 61881,
+  "referenceBillItemId": 5232165,
+  "qty": -1.0,
+  "rate": 1740.0,
+  "netRate": 1740.0,
+  "grossValue": -1740.0,
+  "netValue": -1740.0,
+  "auditComment": "Refund bill item never persisted due to saveRefundBill() bug — recreated to match original bill item 5232165",
+  "approvedBy": "Dr. Smith"
+}
+```
+
+- `billId` (required) — the bill the item should belong to.
+- `itemId` (required) — the `Item` id (service/investigation/drug) for the new bill item.
+- `referenceBillItemId` (optional) — the original bill item this one refunds/corresponds to. When
+  given, `referenceBill` is set to that item's bill automatically, and the request is rejected with
+  `409` if the target bill already has a non-retired item referencing the same source item (prevents
+  duplicate recreation).
+- `qty`, `rate`, `netRate`, `grossValue`, `netValue` — plain numeric fields copied onto the new
+  `BillItem` as-is.
+- `auditComment`, `approvedBy` — mandatory, as with `PATCH /api/bill_data_correction`.
+
+### Response (Success)
+
+```json
+{
+  "status": "success",
+  "code": 200,
+  "data": {
+    "targetType": "BILL_ITEM_CREATE",
+    "billId": 5214531,
+    "createdBillItemId": 5240001,
+    "newValues": {"billItemId": 5240001, "itemId": 61881, "referenceBillItemId": 5232165, "qty": -1.0, "rate": 1740.0, "netRate": 1740.0, "grossValue": -1740.0, "netValue": -1740.0},
+    "auditComment": "...",
+    "approvedBy": "Dr. Smith",
+    "correctedAt": "2026-09-01 18:00:00",
+    "correctedByApiUser": "admin_user"
+  }
+}
+```
+
+As with `PATCH`, the correction is appended to the bill's `comments` for audit.

--- a/src/main/java/com/divudi/bean/common/BillSearch.java
+++ b/src/main/java/com/divudi/bean/common/BillSearch.java
@@ -2278,6 +2278,18 @@ public class BillSearch implements Serializable, ControllerWithMultiplePayments 
         billController.save(rb);
         currentRefundBill = rb;
 
+        // Explicitly persist the refund bill items and their fees. These are built
+        // in-memory by createBillItemsAndBillFeesForOpdRefund() and must not rely on
+        // JPA cascade alone — if the cascaded persist inside billController.save()
+        // above fails for any reason it is silently retried as a merge, which can
+        // leave the bill (and its later payment) saved with no bill items at all.
+        for (BillItem rbi : rb.getBillItems()) {
+            billItemController.save(rbi);
+            for (BillFee rbf : rbi.getBillFees()) {
+                billFeeController.save(rbf);
+            }
+        }
+
         // Update the original bill
         List<Bill> refundBills = new ArrayList<>(bill.getRefundBills());
         refundBills.add(rb);

--- a/src/main/java/com/divudi/service/BillDataCorrectionService.java
+++ b/src/main/java/com/divudi/service/BillDataCorrectionService.java
@@ -5,6 +5,7 @@ import com.divudi.core.entity.BillFee;
 import com.divudi.core.entity.BillFinanceDetails;
 import com.divudi.core.entity.BillItem;
 import com.divudi.core.entity.BillItemFinanceDetails;
+import com.divudi.core.entity.Item;
 import com.divudi.core.entity.WebUser;
 import com.divudi.core.entity.pharmacy.PharmaceuticalBillItem;
 import com.divudi.core.facade.BillFacade;
@@ -12,6 +13,7 @@ import com.divudi.core.facade.BillFeeFacade;
 import com.divudi.core.facade.BillFinanceDetailsFacade;
 import com.divudi.core.facade.BillItemFacade;
 import com.divudi.core.facade.BillItemFinanceDetailsFacade;
+import com.divudi.core.facade.ItemFacade;
 import com.divudi.core.facade.PharmaceuticalBillItemFacade;
 import java.math.BigDecimal;
 import java.text.SimpleDateFormat;
@@ -44,6 +46,9 @@ public class BillDataCorrectionService {
 
     @EJB
     private PharmaceuticalBillItemFacade pharmaceuticalBillItemFacade;
+
+    @EJB
+    private ItemFacade itemFacade;
 
     private static final Set<String> BILL_FIELDS = new HashSet<>(Arrays.asList("netTotal", "grossTotal", "comments"));
     private static final Set<String> BILL_ITEM_FIELDS = new HashSet<>(Arrays.asList("qty", "rate", "grossValue", "netValue", "discount"));
@@ -111,6 +116,113 @@ public class BillDataCorrectionService {
         result.put("targetType", normalizedType);
         result.put("targetId", targetId);
         result.put("previousValues", previousValues);
+        result.put("newValues", newValues);
+        result.put("auditComment", auditComment);
+        result.put("approvedBy", approvedBy);
+        result.put("correctedAt", new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date()));
+        result.put("correctedByApiUser", correctedBy);
+        return result;
+    }
+
+    /**
+     * Creates a single BillItem that is missing from an already-saved bill (e.g. a refund
+     * bill whose item never got persisted because of a defect in the saving code). This is
+     * a narrow, audited data-repair action — it does not recompute or touch any bill totals,
+     * finance details, or payments; the caller is responsible for supplying values that are
+     * already consistent with the bill's existing netTotal/total.
+     */
+    public Map<String, Object> createMissingBillItem(Long billId,
+            Long itemId,
+            Long referenceBillItemId,
+            double qty,
+            double rate,
+            double netRate,
+            double grossValue,
+            double netValue,
+            String auditComment,
+            String approvedBy,
+            WebUser apiUser) {
+
+        if (billId == null) {
+            throw new IllegalArgumentException("billId is required");
+        }
+        if (itemId == null) {
+            throw new IllegalArgumentException("itemId is required");
+        }
+        if (auditComment == null || auditComment.trim().isEmpty()) {
+            throw new IllegalArgumentException("auditComment is required");
+        }
+        if (approvedBy == null || approvedBy.trim().isEmpty()) {
+            throw new IllegalArgumentException("approvedBy is required");
+        }
+
+        Bill bill = billFacade.find(billId);
+        if (bill == null) {
+            throw new IllegalArgumentException("Bill not found for id " + billId);
+        }
+
+        Item item = itemFacade.find(itemId);
+        if (item == null) {
+            throw new IllegalArgumentException("Item not found for id " + itemId);
+        }
+
+        BillItem referenceBillItem = null;
+        if (referenceBillItemId != null) {
+            referenceBillItem = billItemFacade.find(referenceBillItemId);
+            if (referenceBillItem == null) {
+                throw new IllegalArgumentException("Reference BillItem not found for id " + referenceBillItemId);
+            }
+
+            Map<String, Object> dupCheckParams = new java.util.HashMap<>();
+            dupCheckParams.put("ref", referenceBillItem);
+            dupCheckParams.put("b", bill);
+            long alreadyLinked = billItemFacade.findLongByJpql(
+                    "SELECT COUNT(bi) FROM BillItem bi WHERE bi.retired = false"
+                    + " AND bi.referanceBillItem = :ref AND bi.bill = :b",
+                    dupCheckParams);
+            if (alreadyLinked > 0) {
+                throw new IllegalStateException(
+                        "Bill " + billId + " already has an active BillItem referencing BillItem " + referenceBillItemId);
+            }
+        }
+
+        BillItem newItem = new BillItem();
+        newItem.setBill(bill);
+        newItem.setItem(item);
+        newItem.setReferanceBillItem(referenceBillItem);
+        if (referenceBillItem != null) {
+            newItem.setReferenceBill(referenceBillItem.getBill());
+        }
+        newItem.setQty(qty);
+        newItem.setRate(rate);
+        newItem.setNetRate(netRate);
+        newItem.setGrossValue(grossValue);
+        newItem.setNetValue(netValue);
+        newItem.setRetired(false);
+        newItem.setCreatedAt(new Date());
+        newItem.setCreater(apiUser);
+
+        billItemFacade.create(newItem);
+
+        Map<String, Object> newValues = new LinkedHashMap<>();
+        newValues.put("billItemId", newItem.getId());
+        newValues.put("itemId", itemId);
+        newValues.put("referenceBillItemId", referenceBillItemId);
+        newValues.put("qty", qty);
+        newValues.put("rate", rate);
+        newValues.put("netRate", netRate);
+        newValues.put("grossValue", grossValue);
+        newValues.put("netValue", netValue);
+
+        appendAuditLog(bill, "BILL_ITEM_CREATE", newItem.getId(), new LinkedHashMap<>(), newValues, auditComment, approvedBy, apiUser);
+        billFacade.edit(bill);
+
+        String correctedBy = apiUser != null ? apiUser.getName() : null;
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("targetType", "BILL_ITEM_CREATE");
+        result.put("billId", billId);
+        result.put("createdBillItemId", newItem.getId());
         result.put("newValues", newValues);
         result.put("auditComment", auditComment);
         result.put("approvedBy", approvedBy);

--- a/src/main/java/com/divudi/ws/finance/BillDataCorrectionApi.java
+++ b/src/main/java/com/divudi/ws/finance/BillDataCorrectionApi.java
@@ -15,6 +15,7 @@ import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
@@ -85,6 +86,59 @@ public class BillDataCorrectionApi {
         }
     }
 
+    @POST
+    @Path("/create_bill_item")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response createMissingBillItem(String requestBody) {
+        try {
+            String key = requestContext.getHeader("Finance");
+            WebUser user = validateApiKey(key);
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            CreateBillItemRequest request;
+            try {
+                request = gson.fromJson(requestBody, CreateBillItemRequest.class);
+            } catch (JsonSyntaxException ex) {
+                return errorResponse("Invalid JSON format: " + ex.getMessage(), 400);
+            }
+
+            if (request == null) {
+                return errorResponse("Request body is required", 400);
+            }
+            if (request.getAuditComment() == null || request.getAuditComment().trim().isEmpty()) {
+                return errorResponse("auditComment is required", 400);
+            }
+            if (request.getApprovedBy() == null || request.getApprovedBy().trim().isEmpty()) {
+                return errorResponse("approvedBy is required", 400);
+            }
+
+            Map<String, Object> result = correctionService.createMissingBillItem(
+                    request.getBillId(),
+                    request.getItemId(),
+                    request.getReferenceBillItemId(),
+                    request.getQty(),
+                    request.getRate(),
+                    request.getNetRate(),
+                    request.getGrossValue(),
+                    request.getNetValue(),
+                    request.getAuditComment().trim(),
+                    request.getApprovedBy().trim(),
+                    user
+            );
+
+            return successResponse(result);
+        } catch (IllegalArgumentException ex) {
+            return errorResponse(ex.getMessage(), 400);
+        } catch (IllegalStateException ex) {
+            return errorResponse(ex.getMessage(), 409);
+        } catch (Exception ex) {
+            return errorResponse("An error occurred: " + ex.getMessage(), 500);
+        }
+    }
+
     private WebUser validateApiKey(String key) {
         if (key == null || key.trim().isEmpty()) {
             return null;
@@ -149,6 +203,100 @@ public class BillDataCorrectionApi {
 
         public void setFields(Map<String, Object> fields) {
             this.fields = fields;
+        }
+
+        public String getAuditComment() {
+            return auditComment;
+        }
+
+        public void setAuditComment(String auditComment) {
+            this.auditComment = auditComment;
+        }
+
+        public String getApprovedBy() {
+            return approvedBy;
+        }
+
+        public void setApprovedBy(String approvedBy) {
+            this.approvedBy = approvedBy;
+        }
+    }
+
+    public static class CreateBillItemRequest {
+
+        private Long billId;
+        private Long itemId;
+        private Long referenceBillItemId;
+        private double qty;
+        private double rate;
+        private double netRate;
+        private double grossValue;
+        private double netValue;
+        private String auditComment;
+        private String approvedBy;
+
+        public Long getBillId() {
+            return billId;
+        }
+
+        public void setBillId(Long billId) {
+            this.billId = billId;
+        }
+
+        public Long getItemId() {
+            return itemId;
+        }
+
+        public void setItemId(Long itemId) {
+            this.itemId = itemId;
+        }
+
+        public Long getReferenceBillItemId() {
+            return referenceBillItemId;
+        }
+
+        public void setReferenceBillItemId(Long referenceBillItemId) {
+            this.referenceBillItemId = referenceBillItemId;
+        }
+
+        public double getQty() {
+            return qty;
+        }
+
+        public void setQty(double qty) {
+            this.qty = qty;
+        }
+
+        public double getRate() {
+            return rate;
+        }
+
+        public void setRate(double rate) {
+            this.rate = rate;
+        }
+
+        public double getNetRate() {
+            return netRate;
+        }
+
+        public void setNetRate(double netRate) {
+            this.netRate = netRate;
+        }
+
+        public double getGrossValue() {
+            return grossValue;
+        }
+
+        public void setGrossValue(double grossValue) {
+            this.grossValue = grossValue;
+        }
+
+        public double getNetValue() {
+            return netValue;
+        }
+
+        public void setNetValue(double netValue) {
+            this.netValue = netValue;
         }
 
         public String getAuditComment() {


### PR DESCRIPTION
## Summary
Hotfix for Ruhunu production: refunding a single item from an OPD bill (`BillSearch.refundOpdBill()`) saved the Refund Bill and its Payment correctly, but never persisted the refunded `BillItem`/`BillFee` — `saveRefundBill()` relied solely on JPA cascade via `billController.save(rb)`, and `BillController.save()` silently swallows any exception from the cascaded persist and falls back to `merge()`, which can drop the child rows.

- `saveRefundBill()` now explicitly persists each refund bill item and its fees via `billItemController.save()` / `billFeeController.save()`, matching the already-correct pattern in `BillReturnController.returnOpdBill()`.
- Added `POST /api/bill_data_correction/create_bill_item` (audited, `Finance` API key) to repair bills already missing an item because of this bug, without direct DB access. See `developer_docs/api/using-apis/API_BILL_DATA_CORRECTION.md`.

Closes #23408

## Verified in production before this fix
`GET /api/costing_data/bill?number=RHDOM/R/26/60715` showed a correct `Payment` row but zero `BillItem` rows for a real refund bill — confirming the bug in production.

## Test plan
- [x] `mvn -q -o compile` passes on this branch
- [ ] Refund a single item from an OPD bill via the bill search screen on Ruhunu; confirm the refund bill's item appears on print/view
- [ ] Call `POST /api/bill_data_correction/create_bill_item` against `RHDOM/R/26/60715` to repair the already-affected bill
