### PR TITLE
fix(membership): navigate to review page before making all pharmacy items discountable

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyUpdateBulkController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyUpdateBulkController.java
@@ -139,15 +139,6 @@ public class PharmacyUpdateBulkController implements Serializable {
 
     }
 
-    public void makeAllPharmaceuticalsToAllowDiscount() {
-        amps = getAmpFacade().findAll();
-        for (Amp a : amps) {
-            a.setDiscountAllowed(Boolean.TRUE);
-            getAmpFacade().edit(a);
-        }
-        JsfUtil.addSuccessMessage("Updated...");
-    }
-
     public AmpFacade getAmpFacade() {
         return ampFacade;
     }

--- a/src/main/webapp/membership/admin/index.xhtml
+++ b/src/main/webapp/membership/admin/index.xhtml
@@ -65,9 +65,9 @@
                                     </p:tab>
                                     <p:tab title="Set Up" >
                                         <div class="d-grid gap-2">
-                                            <p:commandButton action="#{pharmacyUpdateBulkController.makeAllPharmaceuticalsToAllowDiscount()}" 
-                                                             value="Make All Pharmacy Items Discountable" onclick="if (!confirm('Are you sure?'))
-                                                                         return false"
+                                            <p:commandButton action="/membership/membership_pharmacy_items_discountable_bulk"
+                                                             actionListener="#{pharmacyUpdateBulkController.calerAll()}"
+                                                             value="Make All Pharmacy Items Discountable"
                                                              ajax="false" rendered="#{webUserController.hasPrivilege('MembershipSchemes')}"/>
 
                                         </div>

--- a/src/main/webapp/membership/membership_pharmacy_items_discountable_bulk.xhtml
+++ b/src/main/webapp/membership/membership_pharmacy_items_discountable_bulk.xhtml
@@ -1,0 +1,95 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/membership/admin/index.xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:p="http://primefaces.org/ui">
+
+
+    <ui:define name="subcontent">
+
+        <h:form>
+
+
+
+            <p:panel  >
+                <f:facet name="header" >
+                    <h:outputLabel value="Make All Pharmacy Items Discountable" ></h:outputLabel>
+                </f:facet>
+
+
+                <p:panel header="Items">
+                    <p:panel header="Pharmacy Items Not Currently Discountable" >
+
+                        <h:panelGrid columns="1" >
+                            <p:commandButton ajax="false" value="Process"
+                                            actionListener="#{pharmacyUpdateBulkController.fillPharmacyDiscountDisAllowedItems}" ></p:commandButton>
+                        </h:panelGrid>
+
+                        <h:panelGroup id="gpBillPreview"  styleClass="noBorder summeryBorder" style="min-width: 100%!important;">
+
+                            <p:dataTable id="tbl" rowIndexVar="ii"
+                                         value="#{pharmacyUpdateBulkController.amps}" var="i"
+                                         rows="50"
+                                         paginator="true"
+                                         paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                                         rowsPerPageTemplate="20, 50, 100">
+
+
+                                <p:column width="40px;" headerText="No" sortBy="#{ii}">
+                                    <h:outputLabel value="#{ii+1}" />
+                                </p:column>
+
+                                <p:column headerText="Code" width="50px;" sortBy="#{i.code}" filterBy="#{i.code}"
+                                          filterMatchMode="startsWith">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Code"/>
+                                    </f:facet>
+                                    <h:outputLabel value="#{i.code}" ></h:outputLabel>
+                                </p:column>
+
+                                <p:column headerText="Item" width="300px;" sortBy="#{i.name}" filterBy="#{i.name}"
+                                          filterMatchMode="contains">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Item"/>
+                                    </f:facet>
+                                    <h:outputLabel value="#{i.name}" ></h:outputLabel>
+                                </p:column>
+
+
+                                <p:column headerText="Discount Allowed" style="text-align: right;">
+                                    <f:facet name="header">
+                                        <h:outputLabel value="Discount Allowed"/>
+                                    </f:facet>
+                                    <h:outputLabel value="#{i.discountAllowed}"  >
+
+                                    </h:outputLabel>
+                                </p:column>
+
+
+
+                            </p:dataTable>
+                        </h:panelGroup>
+                    </p:panel>
+                </p:panel>
+                <p:panel header="Apply - Make All Discountable" >
+                    <p:panelGrid columns="1">
+                        <p:commandButton ajax="false" value="Update" onclick="if (!confirm('Are you sure you want to make all these items discountable ?'))
+                                    return false;" actionListener="#{pharmacyUpdateBulkController.updatePharmacyItemDiscountAllowed()}" ></p:commandButton>
+                    </p:panelGrid>
+                </p:panel>
+
+            </p:panel>
+
+
+
+
+        </h:form>
+
+
+
+    </ui:define>
+
+</ui:composition>

--- a/src/main/webapp/membership/membership_pharmacy_items_discountable_bulk.xhtml
+++ b/src/main/webapp/membership/membership_pharmacy_items_discountable_bulk.xhtml
@@ -16,7 +16,7 @@
 
             <p:panel  >
                 <f:facet name="header" >
-                    <h:outputLabel value="Make All Pharmacy Items Discountable" ></h:outputLabel>
+                    <h:outputText value="Make All Pharmacy Items Discountable" ></h:outputText>
                 </f:facet>
 
 
@@ -39,33 +39,33 @@
 
 
                                 <p:column width="40px;" headerText="No" sortBy="#{ii}">
-                                    <h:outputLabel value="#{ii+1}" />
+                                    <h:outputText value="#{ii+1}" />
                                 </p:column>
 
                                 <p:column headerText="Code" width="50px;" sortBy="#{i.code}" filterBy="#{i.code}"
                                           filterMatchMode="startsWith">
                                     <f:facet name="header">
-                                        <h:outputLabel value="Code"/>
+                                        <h:outputText value="Code"/>
                                     </f:facet>
-                                    <h:outputLabel value="#{i.code}" ></h:outputLabel>
+                                    <h:outputText value="#{i.code}" ></h:outputText>
                                 </p:column>
 
                                 <p:column headerText="Item" width="300px;" sortBy="#{i.name}" filterBy="#{i.name}"
                                           filterMatchMode="contains">
                                     <f:facet name="header">
-                                        <h:outputLabel value="Item"/>
+                                        <h:outputText value="Item"/>
                                     </f:facet>
-                                    <h:outputLabel value="#{i.name}" ></h:outputLabel>
+                                    <h:outputText value="#{i.name}" ></h:outputText>
                                 </p:column>
 
 
                                 <p:column headerText="Discount Allowed" style="text-align: right;">
                                     <f:facet name="header">
-                                        <h:outputLabel value="Discount Allowed"/>
+                                        <h:outputText value="Discount Allowed"/>
                                     </f:facet>
-                                    <h:outputLabel value="#{i.discountAllowed}"  >
+                                    <h:outputText value="#{i.discountAllowed}"  >
 
-                                    </h:outputLabel>
+                                    </h:outputText>
                                 </p:column>
 
 


### PR DESCRIPTION
## Decisions made without approval

This PR was developed unattended via `dev-issue-unattended`. Judgment calls made along the way:

- **Chosen fix shape**: built a dedicated review-then-confirm page rather than just removing the raw `confirm()` popup, per the issue's explicit 5-step "Expected behavior" (navigate → show affected items → explicit apply action → confirm on that page).
- **Modeled the new page directly on an existing, already-shipped precedent in the same controller**: the "Update Bulk Categery" button (`pharmacy/admin/index.xhtml`) + `pharmacy_update_categery_bulk.xhtml` page use the exact `action="/..."` (navigation outcome) + `actionListener="calerAll()"` pattern this fix now applies to the discountable-items button.
- **Wired in two pre-existing, unused bean methods** (`fillPharmacyDiscountDisAllowedItems()`, `updatePharmacyItemDiscountAllowed()`) instead of writing new ones — they already implemented exactly this review-then-apply flow but were never referenced from any XHTML, strongly suggesting this was the originally intended (but unfinished) design.
- **Removed `makeAllPharmaceuticalsToAllowDiscount()`** from `PharmacyUpdateBulkController` since it becomes dead code after the fix (confirmed via repo-wide grep: zero other callers).
- **Kept the raw `onclick="confirm(...)"` style** on the new page's "Update" button rather than switching to `p:confirmDialog`, to match the existing convention on the model page and elsewhere in this controller.

## Problem

The "Make All Pharmacy Items Discountable" button in **Administration → Membership Administration → Set Up** fired the bulk discount-allowed update immediately (guarded only by a raw JS `confirm()`) instead of navigating to a dedicated page first, unlike every other bulk-action button in this app's admin panels.

## Fix

- `membership/admin/index.xhtml`: the Set Up tab's button now navigates via `action="/membership/membership_pharmacy_items_discountable_bulk"` + `actionListener="#{pharmacyUpdateBulkController.calerAll()}"`, with no more inline confirm.
- New page `membership/membership_pharmacy_items_discountable_bulk.xhtml`: shows a "Process" button that loads all non-retired, non-Store-department pharmacy items currently *not* discountable into a paginated table, then an "Update" button (with the confirm prompt) that applies the change.
- `PharmacyUpdateBulkController.java`: removed the now-dead `makeAllPharmaceuticalsToAllowDiscount()` method.

## Testing

Verified end-to-end locally via Playwright against `coop` (local dev DB):
1. Logged in, selected department, navigated to Administration → Membership Administration → Set Up.
2. Clicked "Make All Pharmacy Items Discountable" — navigated straight to the new page with **no dialog**, matching the issue's expected behavior.
3. Clicked "Process" — loaded 101 items (3 pages) all showing `discountAllowed=false`.
4. Clicked "Update" — confirm dialog appeared ("Are you sure you want to make all these items discountable ?"), accepted it, saw the "Updated..." success message and the table's "Discount Allowed" column flip to `true` for all rows.
5. Confirmed directly against the DB: `DISCOUNTALLOWED=0` count for non-retired `Amp` items went from 101 → 0 (3697 → 3798 discountable), matching exactly what the UI showed.

No exceptions in `server.log` from deploy or from exercising the new page/flow.

## Documentation

Updated the wiki page [Admin-Membership-Administration](https://github.com/hmislk/hmis/wiki/Admin-Membership-Administration) with a new "Set Up — Make All Pharmacy Items Discountable" section describing the review-then-confirm workflow, with two screenshots from this run's Playwright verification.

Closes #23075

🤖 Generated with unattended `dev-issue-unattended` — review the "Decisions made without approval" section above before merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an administration page for reviewing and managing pharmacy item discount eligibility.
  - View pharmacy items with codes, names, and discount status, with filtering, sorting, and pagination.
  - Added actions to load items that are not discountable and update the displayed items to allow discounts.
  - Added confirmation before applying bulk discount-eligibility updates.

- **Updates**
  - The existing pharmacy discount setup command now opens the dedicated management page for review before updates are applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->