### PR TITLE
feat(inward): wire shared admission search into room change pages

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -2339,6 +2339,33 @@ open a fresh tab, and navigate to
 into an inner page (bypassing a menu click) needs the `/faces/` segment
 regardless of which of the two symptoms it would otherwise hit.
 
+## 90. Simulating a barcode scan with `browser_type(..., submit: true)` on a `p:autoComplete` can submit the wrong button — use `slowly: true` and wait, don't press Enter
+
+Found while verifying issue #23165's barcode auto-select/auto-advance
+composite (`admcc:admission_search`) on `inward_room_change.xhtml`. Filling
+the autocomplete in one shot and pressing Enter immediately
+(`browser_type(..., submit: true)`, which does `fill()` then
+`press('Enter')`) fires the Enter keypress **before** PrimeFaces' debounced
+`query` AJAX call has completed, so the autocomplete's own suggestion list is
+still empty and doesn't intercept the key. The Enter falls through to the
+browser's native implicit-form-submission behavior, which submits via the
+**first** submit-type button in the form — not the intended "Continue"
+button, and not whatever the composite's own auto-advance JS would have
+clicked. On this page that meant landing on the unrelated "Nursing
+WorkBench" page instead of the admission's detail view, silently, with no
+error in `server.log` or the browser console.
+
+This is a test-methodology artifact, not evidence of a real bug — a real
+scanner still just types characters via keyboard events, and the auto-select
+JS runs off the `query` AJAX `oncomplete` callback, not off Enter. Simulate
+it correctly instead: `browser_type` with `slowly: true` (fires per-character
+keyup events, which is what triggers PrimeFaces' query debounce), no
+`submit`, then `browser_wait_for` a second or two before asserting on the
+result. Confirmed working this way: an exact single-match query auto-selects
+and auto-advances; an exact query matching multiple admissions (e.g. several
+active admissions sharing one PHN) shows the dropdown and does not
+auto-advance.
+
 ## Some PrimeFaces buttons need a jQuery-triggered click
 
 Most `p:commandButton`s submit fine with a normal Playwright click — including

--- a/src/main/webapp/inward/inward_room_change.xhtml
+++ b/src/main/webapp/inward/inward_room_change.xhtml
@@ -7,11 +7,12 @@
                 xmlns="http://www.w3.org/1999/xhtml"
                 xmlns:p="http://primefaces.org/ui"
                 xmlns:common="http://xmlns.jcp.org/jsf/composite/ezcomp/common"
-                xmlns:in="http://xmlns.jcp.org/jsf/composite/inward">
+                xmlns:in="http://xmlns.jcp.org/jsf/composite/inward"
+                xmlns:admcc="http://xmlns.jcp.org/jsf/composite/ezcomp/inpatient">
 
 
     <ui:define name="content">
-        <h:form>
+        <h:form id="frmRoomChange">
             <div class="alert alert-warning d-flex align-items-center gap-2 my-3" role="alert">
                 <i class="fa-solid fa-triangle-exclamation"></i>
                 <h:outputText value="This page is deprecated. Please use Patient Room Details (from the Interim Bill or Admission Profile page) for room management going forward. This page is kept only as a fallback and will be removed later." />
@@ -65,67 +66,25 @@
                                                            var="ins"
                                                            itemLabel="#{ins.name}"
                                                            itemValue="#{ins}" />
-                                            <p:ajax listener="#{roomChangeController.onInstitutionChange}" update="acPt pnlPatientPreview" />
+                                            <p:ajax listener="#{roomChangeController.onInstitutionChange}" update="admissionSearch pnlPatientPreview btnSelect" />
                                         </p:selectOneMenu>
                                     </div>
                                 </div>
 
                                 <div class="row mb-3">
                                     <div class="col-12">
-                                        <h:outputLabel for="acPt" styleClass="form-label fw-bold text-dark mb-2">
+                                        <h:outputLabel styleClass="form-label fw-bold text-dark mb-2">
                                             <i class="fa-solid fa-user me-2 text-primary"></i>
                                             Patient Search
                                         </h:outputLabel>
-                                        <p:autoComplete
+                                        <admcc:admission_search
+                                            id="admissionSearch"
                                             widgetVar="aPt"
-                                            id="acPt"
-                                            forceSelection="true"
+                                            inputId="acPt"
                                             value="#{roomChangeController.current}"
                                             completeMethod="#{roomChangeController.completePatientByInstitution}"
-                                            var="myItem"
-                                            itemValue="#{myItem}"
-                                            itemLabel="#{myItem.bhtNo}"
-                                            placeholder="Type patient name, BHT number, or PHN..."
-                                            minQueryLength="2"
-                                            style="width: 100%;"
-                                            inputStyleClass="form-control form-control-lg">
-                                            <p:ajax event="itemSelect" update="pnlPatientPreview" />
-                                            <p:column headerText="PHN" style="padding: 8px; min-width: 100px;">
-                                                <div class="d-flex align-items-center">
-                                                    <i class="fa-solid fa-id-card me-2 text-info"></i>
-                                                    <strong>#{myItem.patient.phn}</strong>
-                                                </div>
-                                            </p:column>
-                                            <p:column headerText="BHT No" style="padding: 8px; min-width: 120px;">
-                                                <div class="d-flex align-items-center">
-                                                    <i class="fa-solid fa-hospital me-2 text-warning"></i>
-                                                    <strong class="text-primary">#{myItem.bhtNo}</strong>
-                                                </div>
-                                            </p:column>
-                                            <p:column headerText="Patient Name" style="padding: 8px; min-width: 250px;">
-                                                <div class="d-flex align-items-center">
-                                                    <i class="fa-solid fa-user me-2 text-success"></i>
-                                                    <span class="fw-medium">#{myItem.patient.person.nameWithTitle}</span>
-                                                </div>
-                                            </p:column>
-                                            <p:column headerText="Room" style="padding: 8px; min-width: 150px;">
-                                                <h:panelGroup rendered="#{myItem.currentPatientRoom ne null}">
-                                                    <div class="d-flex align-items-center">
-                                                        <i class="fa-solid fa-bed me-2 text-secondary"></i>
-                                                        <span>#{myItem.currentPatientRoom.roomFacilityCharge.name}</span>
-                                                    </div>
-                                                </h:panelGroup>
-                                                <h:panelGroup rendered="#{myItem.currentPatientRoom eq null}">
-                                                    <span class="text-muted">
-                                                        <i class="fa-solid fa-question-circle me-1"></i>No room assigned
-                                                    </span>
-                                                </h:panelGroup>
-                                            </p:column>
-                                            <p:column headerText="Status" style="padding: 8px; min-width: 120px;">
-                                                <p:badge value="Discharged" styleClass="ui-badge-danger" rendered="#{myItem.discharged}" />
-                                                <p:badge value="Active" styleClass="ui-badge-success" rendered="#{!myItem.discharged}" />
-                                            </p:column>
-                                        </p:autoComplete>
+                                            continueClientId="frmRoomChange:btnSelect"
+                                            itemSelectUpdate=":frmRoomChange:pnlPatientPreview :frmRoomChange:btnSelect" />
                                     </div>
                                 </div>
 

--- a/src/main/webapp/inward/inward_room_change.xhtml
+++ b/src/main/webapp/inward/inward_room_change.xhtml
@@ -148,8 +148,10 @@
                     </div>
                 </div>
             </p:panel>
+        </h:form>
 
             <h:panelGroup rendered="#{roomChangeController.current ne null}">
+                <h:form id="frmRoomChangeDetail">
                 <p:panel>
                     <f:facet name="header" >
                         <div class="d-flex justify-content-between">
@@ -204,7 +206,6 @@
                         </div>
                     </f:facet>
 
-                    <h:form>
                         <div class="row w-100 ">
                             <div class="col-4">
                                 <p:panel>
@@ -455,11 +456,9 @@
 
                             </h:panelGrid>
                         </div>
-                    </h:form>
                 </p:panel>
+                </h:form>
             </h:panelGroup>
-
-        </h:form>
 
 
     </ui:define>

--- a/src/main/webapp/inward/inward_room_change_guardian.xhtml
+++ b/src/main/webapp/inward/inward_room_change_guardian.xhtml
@@ -6,12 +6,13 @@
                 xmlns:f="http://xmlns.jcp.org/jsf/core"
                 xmlns="http://www.w3.org/1999/xhtml"
                 xmlns:in="http://xmlns.jcp.org/jsf/composite/inward"
-                xmlns:p="http://primefaces.org/ui">
+                xmlns:p="http://primefaces.org/ui"
+                xmlns:admcc="http://xmlns.jcp.org/jsf/composite/ezcomp/inpatient">
 
 
     <ui:define name="content">
 
-        <h:form>
+        <h:form id="frmRoomChangeGuardian">
             <div class="alert alert-warning d-flex align-items-center gap-2 my-3" role="alert">
                 <i class="fa-solid fa-triangle-exclamation"></i>
                 <h:outputText value="This page is deprecated. Please use Patient Room Details (from the Interim Bill or Admission Profile page) for room management going forward. This page is kept only as a fallback and will be removed later." />
@@ -65,67 +66,25 @@
                                                            var="ins"
                                                            itemLabel="#{ins.name}"
                                                            itemValue="#{ins}" />
-                                            <p:ajax listener="#{roomChangeController.onInstitutionChange}" update="acPt pnlPatientPreview" />
+                                            <p:ajax listener="#{roomChangeController.onInstitutionChange}" update="admissionSearch pnlPatientPreview btnSelect" />
                                         </p:selectOneMenu>
                                     </div>
                                 </div>
 
                                 <div class="row mb-3">
                                     <div class="col-12">
-                                        <h:outputLabel for="acPt" styleClass="form-label fw-bold text-dark mb-2">
+                                        <h:outputLabel styleClass="form-label fw-bold text-dark mb-2">
                                             <i class="fa-solid fa-user me-2 text-primary"></i>
                                             Patient Search
                                         </h:outputLabel>
-                                        <p:autoComplete
+                                        <admcc:admission_search
+                                            id="admissionSearch"
                                             widgetVar="aPt"
-                                            id="acPt"
-                                            forceSelection="true"
+                                            inputId="acPt"
                                             value="#{roomChangeController.current}"
                                             completeMethod="#{roomChangeController.completePatientByInstitution}"
-                                            var="myItem"
-                                            itemValue="#{myItem}"
-                                            itemLabel="#{myItem.bhtNo}"
-                                            placeholder="Type patient name, BHT number, or PHN..."
-                                            minQueryLength="2"
-                                            style="width: 100%;"
-                                            inputStyleClass="form-control form-control-lg">
-                                            <p:ajax event="itemSelect" update="pnlPatientPreview" />
-                                            <p:column headerText="PHN" style="padding: 8px; min-width: 100px;">
-                                                <div class="d-flex align-items-center">
-                                                    <i class="fa-solid fa-id-card me-2 text-info"></i>
-                                                    <strong>#{myItem.patient.phn}</strong>
-                                                </div>
-                                            </p:column>
-                                            <p:column headerText="BHT No" style="padding: 8px; min-width: 120px;">
-                                                <div class="d-flex align-items-center">
-                                                    <i class="fa-solid fa-hospital me-2 text-warning"></i>
-                                                    <strong class="text-primary">#{myItem.bhtNo}</strong>
-                                                </div>
-                                            </p:column>
-                                            <p:column headerText="Patient Name" style="padding: 8px; min-width: 250px;">
-                                                <div class="d-flex align-items-center">
-                                                    <i class="fa-solid fa-user me-2 text-success"></i>
-                                                    <span class="fw-medium">#{myItem.patient.person.nameWithTitle}</span>
-                                                </div>
-                                            </p:column>
-                                            <p:column headerText="Room" style="padding: 8px; min-width: 150px;">
-                                                <h:panelGroup rendered="#{myItem.currentPatientRoom ne null}">
-                                                    <div class="d-flex align-items-center">
-                                                        <i class="fa-solid fa-bed me-2 text-secondary"></i>
-                                                        <span>#{myItem.currentPatientRoom.roomFacilityCharge.name}</span>
-                                                    </div>
-                                                </h:panelGroup>
-                                                <h:panelGroup rendered="#{myItem.currentPatientRoom eq null}">
-                                                    <span class="text-muted">
-                                                        <i class="fa-solid fa-question-circle me-1"></i>No room assigned
-                                                    </span>
-                                                </h:panelGroup>
-                                            </p:column>
-                                            <p:column headerText="Status" style="padding: 8px; min-width: 120px;">
-                                                <p:badge value="Discharged" styleClass="ui-badge-danger" rendered="#{myItem.discharged}" />
-                                                <p:badge value="Active" styleClass="ui-badge-success" rendered="#{!myItem.discharged}" />
-                                            </p:column>
-                                        </p:autoComplete>
+                                            continueClientId="frmRoomChangeGuardian:btnSelect"
+                                            itemSelectUpdate=":frmRoomChangeGuardian:pnlPatientPreview :frmRoomChangeGuardian:btnSelect" />
                                     </div>
                                 </div>
 
@@ -175,6 +134,7 @@
                                 <div class="row">
                                     <div class="col-12 text-center">
                                         <p:commandButton
+                                            id="btnSelect"
                                             ajax="false"
                                             value="Continue"
                                             icon="fa-solid fa-arrow-right"


### PR DESCRIPTION
## Summary

Continues the barcode-friendly admission search rollout tracked in #23165, following the pilot (PR #23176) and the subsequent batch of page migrations (PRs #23178–#23189).

Wires the shared `admcc:admission_search` composite into the next two checklist items:
- `inward/inward_room_change.xhtml`
- `inward/inward_room_change_guardian.xhtml`

Both pages share `RoomChangeController.completePatientByInstitution()`, which already delegates to `AdmissionController.completePatientNotFinalizedByInstitution()` — already MRN-searchable from the pilot PR, so **no JPQL changes were needed here**. Only the page markup changed: the hand-copied `p:autoComplete` block was replaced with the shared composite, matching the pattern used on every other already-migrated page.

Behavior: scanning an exact PHN/BHT/MRN match that resolves to exactly one admission now auto-selects and auto-advances (no click needed); a query matching more than one admission (e.g. a patient with several active admissions sharing one PHN) still shows the manual-pick dropdown. Free-text partial queries are unaffected. Existing query filter semantics (not-payment-finalized, optional institution filter) are untouched, per the issue's explicit "don't change which admissions each page's query returns" scope rule.

## Decisions made without approval

This ran via `dev-issue-unattended` — the user was unreachable, so these judgment calls were made and documented here for review rather than asked:

1. **Scope of this PR.** The issue's own remaining-work checklist (posted on the pilot PR's issue comment) lists ~4 groups still outstanding: `pharmacy_bill_issue_bht_old.xhtml` (a QA-only comparison link, not a real user workflow), the two room-change pages done here, and the larger "Family C" billing/report pages (explicitly flagged "lower priority" in that same comment). I picked the room-change pair because they're a closely-related duo sharing one controller/query method — letting one PR cover both cleanly — and left the QA-only page and the larger Family C batch for separate follow-up runs, to keep this PR small and reviewable.
2. **Value binding pattern.** Kept the original `value="#{roomChangeController.current}"` direct binding (matching the pre-existing markup on both pages, and the bhtEdit/pharmacy pilot pages) rather than `admit_room.xhtml`'s two-stage `selectedAdmission` staging-field pattern. `admit_room.xhtml` needs the staging field specifically to dodge a render-condition race (see its `RoomChangeController` field comment, issue #22911) — these two pages' Continue buttons don't have that same race, so the simpler direct binding matches existing (working) behavior exactly.
3. **Form IDs.** Both pages' outer `h:form` had no explicit `id` previously. Added `id="frmRoomChange"` / `id="frmRoomChangeGuardian"` so the composite's `continueClientId`/`itemSelectUpdate` attributes can use stable absolute client IDs — same as every other already-migrated page in this rollout.

## Verified

End-to-end with Playwright against local Payara + MySQL (`coop` dev DB):
- **Exact single-match auto-advance**: scanning `BHT/56758` (unique admission, no PHN/MRN) on `inward_room_change.xhtml` auto-selected and auto-advanced straight to the Admitted Patient Room screen with no click.
- **Ambiguous match → manual pick**: scanning PHN `PGCH4K0` (3 different active admissions share this PHN in local test data) on `inward_room_change_guardian.xhtml` showed the dropdown and did **not** auto-advance.
- **Manual selection still works**: picking a row from that dropdown and clicking Continue correctly advanced to the Guardian Room Change screen for the selected admission.
- No new errors in `server.log` or the browser console during any of the above.

Screenshots (patient identifiers redacted — name/BHT/room/NIC/phone/mobile/email/address all blacked out):

**Ambiguous match** — dropdown shown, no auto-advance:
![Multiple matches listed for manual selection](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23165-06-guardian-multiple-matches.png)

**After manual selection** — Guardian Room Change screen for the picked admission:
![Guardian Room Change screen after a patient is selected](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23165-07-guardian-manual-select.png)

## Documentation

Updated the existing wiki page [Inpatient — Room Change and Guardian Room Change](https://github.com/hmislk/hmis/wiki/Inpatient-Room-Change-and-Guardian-Room-Change):
- Step 1 now describes PHN/BHT/MRN scan auto-select/auto-advance, and mentions manual selection as a fallback for ambiguous matches.
- Added a note that both pages now show a deprecated/fallback banner (directly observed on both pages — verified, not inferred).
- Added the two screenshots above under Guardian Room Change.

## Self-review (step 8a)

Ran `/code-review` at `medium` effort against the working diff before the first push. No findings — the reviewer confirmed the composite wiring (form IDs, absolute search expressions for `continueClientId`/`itemSelectUpdate`, no leftover references to the old `acPt`/label-`for` wiring) is consistent with the ~14 other already-migrated pages, and the shared composite itself is unmodified.

## CodeRabbit review pass

Two findings:
1. **Nested `h:form`** on `inward_room_change.xhtml` — real, and 100% pre-existing (this diff originally only added an `id` to the already-nested outer form). Playwright verification confirmed the Continue button and detail-page postbacks worked correctly despite the nesting even before a fix, but the user asked for it to be settled properly rather than deferred. **Fixed in commit `67a9fba5`**: split the outer form so it now closes right after the Patient Selection panel, and added a new `frmRoomChangeDetail` form wrapping the entire "Admitted Patient Room" panel (including its header facet, so the Patient Lookup/Patient Profile/Inpatient Dashboard/Nursing WorkBench buttons stay inside a form — a plain one-line "close the form earlier" fix would have stranded them outside any form). Re-verified end-to-end with Playwright: barcode auto-advance into the detail page, the header-facet buttons, and the Change-room action's own postback (via its validation message) all still work correctly, no new server/console errors. Originally filed as follow-up #23428; now closed as resolved by this commit. `inward_room_change_guardian.xhtml` never had this problem — it was always a single, non-nested form.
2. **`h:outputLabel` vs `h:outputText`** for the "Patient Search" label — dismissed as a false positive relative to established rollout convention: this exact pattern is copied from the pilot page (`inward_edit_bht.xhtml`, PR #23176) and most other already-migrated pages. One sibling page does use `h:outputText`, so the rollout isn't itself fully consistent either way — standardizing that is a separate, broader cleanup, not a piecemeal fix in just these two files.

Codex hit its usage limit and did not review this PR.

## Follow-up (not in this PR)

Per the issue's own remaining-work checklist, still outstanding after this PR:
- `inward/pharmacy_bill_issue_bht_old.xhtml` (QA-only comparison link)
- The Family C billing/report pages (`inward_bill_payment.xhtml` and siblings, `inward_report_*` pages) — explicitly lower priority per the issue's own tracking comment

Closes nothing on its own — tracked as part of #23165, which stays open until the remaining checklist items are done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated patient searches on room-change pages with a consistent admission search experience.
  - Search results now support streamlined selection and continuation, including clearer handling when multiple matches are found.
  - Institution changes refresh the patient search and selection preview automatically.

- **Documentation**
  - Added guidance for reliably testing barcode scans and understanding single-match versus multi-match search behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

