### PR TITLE
feat(inward,pharmacy): wire shared admission search into billing pages

### DIFF
--- a/src/main/java/com/divudi/bean/common/AdmissionSearchSupportController.java
+++ b/src/main/java/com/divudi/bean/common/AdmissionSearchSupportController.java
@@ -1,0 +1,40 @@
+/*
+ * Author : Dr. M H B Ariyaratne
+ *
+ * Consultant (Health Informatics)
+ * (94) 71 5812399
+ * Email : buddhika.ari@gmail.com
+ *
+ */
+package com.divudi.bean.common;
+
+import java.io.Serializable;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Named;
+
+/**
+ * Backing support for the shared {@code ezcomp/inpatient/admission_search.xhtml}
+ * composite, used across Inward/Pharmacy/Theater/Store admission-search pages
+ * (issue #23165).
+ *
+ * The composite's optional {@code itemSelectListener} attribute needs a
+ * default method to bind to when a calling page doesn't provide its own
+ * "on select" business logic - {@link #noop()} is that default. Stateless
+ * and side-effect free by design, so application scope is safe.
+ */
+@Named
+@ApplicationScoped
+public class AdmissionSearchSupportController implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Default {@code itemSelectListener} for {@code admcc:admission_search}.
+     * Intentionally does nothing - pages that need real logic to run when an
+     * admission is selected pass their own listener instead.
+     */
+    public void noop() {
+        // Intentionally empty.
+    }
+
+}

--- a/src/main/webapp/inward/inward_bill_deposit.xhtml
+++ b/src/main/webapp/inward/inward_bill_deposit.xhtml
@@ -9,14 +9,15 @@
                 xmlns:bill="http://xmlns.jcp.org/jsf/composite/inward/bill/payment"
                 xmlns:prints="http://xmlns.jcp.org/jsf/composite/ezcomp/prints"
                 xmlns:in="http://xmlns.jcp.org/jsf/composite/inward"
-                xmlns:pa="http://xmlns.jcp.org/jsf/composite/paymentMethod">
+                xmlns:pa="http://xmlns.jcp.org/jsf/composite/paymentMethod"
+                xmlns:admcc="http://xmlns.jcp.org/jsf/composite/ezcomp/inpatient">
 
 
 
     <ui:define name="content">
         <f:event type="preRenderView" listener="#{financialTransactionController.redirectIfShiftNotStarted()}"/>
         <h:panelGroup rendered="#{inwardDepositController.current.patientEncounter eq null}">
-            <h:form>
+            <h:form id="frmInwardDeposit">
                 <p:panel>
                     <f:facet name="header">
                         <h:outputText styleClass="fa-solid fa-address-card fa-lg" />
@@ -26,42 +27,15 @@
                     <div class="d-flex gap-4">
                         <h:outputLabel value="Type Patient Name or BHT : " class="mt-2"/>
 
-                        <p:autoComplete
+                        <admcc:admission_search
                             widgetVar="aPt"
-                            id="acPt"
-                            forceSelection="true"
+                            inputId="acPt"
                             value="#{inwardDepositController.current.patientEncounter}"
                             completeMethod="#{admissionController.completePatientAll}"
-                            var="myItem"
-                            size="60"
-                            maxResults="20"
-                            itemValue="#{myItem}"
-                            itemLabel="#{myItem.bhtNo}"
-                            style="width: 550px;"
-                            class="mx-2">
-
-                            <p:column headerText="BHT No" style="padding: 6px; width: 8em;">
-                                <h:outputLabel value="#{myItem.bhtNo}"/>
-                            </p:column>
-                            <p:column headerText="Patient" style="padding: 6px; width: 15em;">
-                                <h:outputLabel value="#{myItem.patient.person.nameWithTitle}"/>
-                            </p:column>
-                            <p:column headerText="Room" style="padding: 6px; width: 8em;">
-                                <h:outputLabel value="#{myItem.currentPatientRoom.roomFacilityCharge.name}"/>
-                            </p:column>
-                            <p:column headerText="Status" style="padding: 6px; width: 12em;">
-                                <div class="d-flex justify-content-center">
-                                    <span class="#{myItem.discharged ? 'discharged-badge' : 'not-discharged-badge'}">
-                                        #{myItem.discharged ? 'Discharged' : 'Not Discharged'}
-                                    </span>
-                                </div>
-                            </p:column>
-                            <p:column headerText="Payment" style="padding: 6px; width: 12em;">
-                                <h:outputLabel value="Payment Finalized"  rendered="#{myItem.paymentFinalized}"/>
-                            </p:column>
-                        </p:autoComplete>
+                            continueClientId="frmInwardDeposit:btnSelect" />
 
                         <p:commandButton
+                            id="btnSelect"
                             value="select"
                             ajax="false"
                             action="#{inwardDepositController.bhtListener}" >

--- a/src/main/webapp/inward/inward_bill_intrim_finalized.xhtml
+++ b/src/main/webapp/inward/inward_bill_intrim_finalized.xhtml
@@ -9,14 +9,15 @@
                 xmlns:p="http://primefaces.org/ui"
                 xmlns:bi="http://xmlns.jcp.org/jsf/composite/inward/bill"
 
-                xmlns:credit="http://xmlns.jcp.org/jsf/composite/inward/creditCompany">
+                xmlns:credit="http://xmlns.jcp.org/jsf/composite/inward/creditCompany"
+                xmlns:admcc="http://xmlns.jcp.org/jsf/composite/ezcomp/inpatient">
 
 
 
     <ui:define name="subcontent">
 
         <h:panelGroup >
-            <h:form  >
+            <h:form id="frmIntrimFinalized">
                 <p:panel  >
                     <f:facet name="header">
                         <p:outputLabel value="Inward Payment Bill"/>
@@ -24,34 +25,15 @@
                         <p:commandButton ajax="false"  value="Clear" style="float:right;" action="#{bhtSummeryFinalizedController.makeNull()}"  />
                     </f:facet>
                     <h:panelGrid columns="3" style="min-width: 100%;">
-                        <p:panel header="BHT">
-                            <p:autoComplete  widgetVar="aPt" id="acPt" forceSelection="true"
-                                            value="#{bhtSummeryFinalizedController.patientEncounter}"
-                                            completeMethod="#{admissionController.completePatientAll}"
-                                            var="myItem" itemValue="#{myItem}"
-                                            itemLabel="#{myItem.bhtNo}"
-                                            size="30"  >
-                                <p:column>
-                                    #{myItem.bhtNo}
-                                </p:column>
-                                <p:column>
-                                    #{myItem.patient.person.nameWithTitle}
-                                </p:column>
-                                <p:column>
-                                    <h:outputLabel value="#{myItem.currentPatientRoom.roomFacilityCharge.name}"/>
-                                </p:column>
-                                <p:column>
-                                    <h:outputLabel value="Discharged"  rendered="#{myItem.discharged}"/>
-                                </p:column>
-                                <p:column>
-                                    <h:outputLabel value="Finalized"  rendered="#{myItem.paymentFinalized}"/>
-                                </p:column>
-                                <p:column>
-                                    <h:outputLabel  value="Cancelled"  rendered="#{myItem.retired}"/>
-                                </p:column>
-                            </p:autoComplete>
+                        <p:panel header="BHT" style="min-width: 350px;">
+                            <admcc:admission_search
+                                widgetVar="aPt"
+                                inputId="acPt"
+                                value="#{bhtSummeryFinalizedController.patientEncounter}"
+                                completeMethod="#{admissionController.completePatientAll}"
+                                continueClientId="frmIntrimFinalized:btnDisplay" />
 
-                            <p:commandButton ajax="false" value="Display" action="#{bhtSummeryFinalizedController.createTablesFinalized()}" >
+                            <p:commandButton id="btnDisplay" ajax="false" value="Display" action="#{bhtSummeryFinalizedController.createTablesFinalized()}" >
                             </p:commandButton>
 
                             <h:panelGroup id="panSearch2">

--- a/src/main/webapp/inward/inward_bill_intrim_finalized_error_correction.xhtml
+++ b/src/main/webapp/inward/inward_bill_intrim_finalized_error_correction.xhtml
@@ -8,8 +8,9 @@
                 xmlns:in="http://xmlns.jcp.org/jsf/composite/inward"
                 xmlns:p="http://primefaces.org/ui"
                 xmlns:bi="http://xmlns.jcp.org/jsf/composite/inward/bill"
-                
-                xmlns:credit="http://xmlns.jcp.org/jsf/composite/inward/creditCompany">
+
+                xmlns:credit="http://xmlns.jcp.org/jsf/composite/inward/creditCompany"
+                xmlns:admcc="http://xmlns.jcp.org/jsf/composite/ezcomp/inpatient">
 
 
 
@@ -19,38 +20,22 @@
             <h:form  >
                 <p:panel  >
                     <f:facet name="header">
-                        <p:inputText value="Inward Payment Bill"/>                                      
-                        <p:commandButton ajax="false"  value="Clear" style="float:right;" action="#{bhtSummeryFinalizedController.makeNull()}"  />                                                                        
+                        <p:inputText value="Inward Payment Bill"/>
+                        <p:commandButton ajax="false"  value="Clear" style="float:right;" action="#{bhtSummeryFinalizedController.makeNull()}"  />
                     </f:facet>
                     <h:panelGrid columns="2">
-                        <p:panel header="BHT">
-                            <p:autoComplete  widgetVar="aPt" id="acPt" forceSelection="true" 
-                                            value="#{bhtSummeryFinalizedController.patientEncounter}"
-                                            completeMethod="#{admissionController.completePatientAll}" 
-                                            var="myItem" itemValue="#{myItem}" 
-                                            itemLabel="#{myItem.bhtNo}" 
-                                            size="30"  >
-                                <p:ajax event="itemSelect" 
-                                        process="@this" 
-                                        update="@all" 
-                                        listener="#{bhtSummeryFinalizedController.createTablesFinalized()}"/>
-                                <p:column>
-                                    <p:outputLabel value="#{myItem.bhtNo}" />
-                                </p:column>
-                                <p:column>
-                                    <p:outputLabel value="#{myItem.patient.person.nameWithTitle}" />
-
-                                </p:column>
-                                <p:column>
-                                    <h:outputLabel value="#{myItem.currentPatientRoom.roomFacilityCharge.name}"/>
-                                </p:column>
-                                <p:column>
-                                    <h:outputLabel value="Discharged"  rendered="#{myItem.discharged}"/>
-                                </p:column>
-                                <p:column>
-                                    <h:outputLabel  value="Cancelled"  rendered="#{myItem.retired}"/>
-                                </p:column>
-                            </p:autoComplete>   
+                        <p:panel header="BHT" style="min-width: 350px;">
+                            <!-- No continueClientId: this page has no separate "Display"/"Continue"
+                                 button - selecting a BHT must load its finalized bill tables
+                                 immediately (itemSelectListener), same as the original itemSelect
+                                 listener this replaces. -->
+                            <admcc:admission_search
+                                widgetVar="aPt"
+                                inputId="acPt"
+                                value="#{bhtSummeryFinalizedController.patientEncounter}"
+                                completeMethod="#{admissionController.completePatientAll}"
+                                itemSelectListener="#{bhtSummeryFinalizedController.createTablesFinalized}"
+                                itemSelectUpdate="@all" />
 
                         </p:panel>
                         <in:finalTable bill="#{bhtSummeryFinalizedController.patientEncounter.finalBill}"/>

--- a/src/main/webapp/inward/inward_bill_payment.xhtml
+++ b/src/main/webapp/inward/inward_bill_payment.xhtml
@@ -9,61 +9,35 @@
                 xmlns:bill="http://xmlns.jcp.org/jsf/composite/inward/bill/payment"
                 xmlns:prints="http://xmlns.jcp.org/jsf/composite/ezcomp/prints"
                 xmlns:in="http://xmlns.jcp.org/jsf/composite/inward"
-                xmlns:pa="http://xmlns.jcp.org/jsf/composite/paymentMethod">
+                xmlns:pa="http://xmlns.jcp.org/jsf/composite/paymentMethod"
+                xmlns:admcc="http://xmlns.jcp.org/jsf/composite/ezcomp/inpatient">
 
 
 
     <ui:define name="content">
         <f:event type="preRenderView" listener="#{financialTransactionController.redirectIfShiftNotStarted()}"/>
         <h:panelGroup rendered="#{inwardPaymentController.current.patientEncounter eq null}">
-            <h:form>
+            <h:form id="frmInwardPayment">
                 <p:panel>
                     <f:facet name="header">
-                        <h:outputText styleClass="fa-solid fa-address-card fa-lg" /> 
+                        <h:outputText styleClass="fa-solid fa-address-card fa-lg" />
                         <p:outputLabel value="Patient Details" class="m-2"/>
                     </f:facet>
 
                     <div class="d-flex gap-4">
                         <h:outputLabel value="Type Patient Name or BHT : " class="mt-2"/>
 
-                        <p:autoComplete  
-                            widgetVar="aPt" 
-                            id="acPt" 
-                            forceSelection="true" 
+                        <admcc:admission_search
+                            widgetVar="aPt"
+                            inputId="acPt"
                             value="#{inwardPaymentController.current.patientEncounter}"
-                            completeMethod="#{admissionController.completePatientAll}" 
-                            var="myItem" 
-                            size="60"
-                            maxResults="20"
-                            itemValue="#{myItem}" 
-                            itemLabel="#{myItem.bhtNo}"
-                            style="width: 550px;"
-                            class="mx-2">
+                            completeMethod="#{admissionController.completePatientAll}"
+                            continueClientId="frmInwardPayment:btnSelect" />
 
-                            <p:column headerText="BHT No" style="padding: 6px; width: 8em;">
-                                <h:outputLabel value="#{myItem.bhtNo}"/>
-                            </p:column>
-                            <p:column headerText="Patient" style="padding: 6px; width: 15em;">
-                                <h:outputLabel value="#{myItem.patient.person.nameWithTitle}"/>
-                            </p:column>
-                            <p:column headerText="Room" style="padding: 6px; width: 8em;">
-                                <h:outputLabel value="#{myItem.currentPatientRoom.roomFacilityCharge.name}"/>
-                            </p:column>
-                            <p:column headerText="Status" style="padding: 6px; width: 12em;">
-                                <div class="d-flex justify-content-center">
-                                    <span class="#{myItem.discharged ? 'discharged-badge' : 'not-discharged-badge'}">
-                                        #{myItem.discharged ? 'Discharged' : 'Not Discharged'}
-                                    </span>
-                                </div>
-                            </p:column>
-                            <p:column headerText="Payment" style="padding: 6px; width: 12em;">
-                                <h:outputLabel value="Payment Finalized"  rendered="#{myItem.paymentFinalized}"/>
-                            </p:column>
-                        </p:autoComplete>
-
-                        <p:commandButton 
-                            value="select" 
-                            ajax="false" 
+                        <p:commandButton
+                            id="btnSelect"
+                            value="select"
+                            ajax="false"
                             action="#{inwardPaymentController.bhtListener}" >
                         </p:commandButton>
 

--- a/src/main/webapp/inward/inward_bill_payment_1.xhtml
+++ b/src/main/webapp/inward/inward_bill_payment_1.xhtml
@@ -8,7 +8,8 @@
                 xmlns:p="http://primefaces.org/ui"
                 xmlns:bill="http://xmlns.jcp.org/jsf/composite/inward/bill"
                 xmlns:in="http://xmlns.jcp.org/jsf/composite/inward"
-                xmlns:pa="http://xmlns.jcp.org/jsf/composite/paymentMethod">
+                xmlns:pa="http://xmlns.jcp.org/jsf/composite/paymentMethod"
+                xmlns:admcc="http://xmlns.jcp.org/jsf/composite/ezcomp/inpatient">
 
 
 
@@ -18,30 +19,17 @@
             <h:form  >
                 <p:panel header="Inward Payment Bill" rendered="#{!inwardPaymentController.printPreview}">
                     <h:panelGrid columns="2">
-                        <p:panel header="BHT">
-                            <p:autoComplete  widgetVar="aPt" id="acPt" forceSelection="true" 
-                                            value="#{inwardPaymentController.current.patientEncounter}"
-                                            completeMethod="#{admissionController.completePatientAll}" 
-                                            var="myItem" itemValue="#{myItem}" 
-                                            itemLabel="#{myItem.bhtNo}" 
-                                            size="30"  style="width: 400px;">
-                                <p:ajax event="itemSelect" process="@this" update="@all" listener="#{inwardPaymentController.bhtListener}"/>
-                                <p:column>
-                                    <h:outputLabel value="#{myItem.bhtNo}"/>
-                                </p:column>
-                                <p:column>
-                                    <h:outputLabel value="#{myItem.patient.person.nameWithTitle}"/>
-                                </p:column>
-                                <p:column>
-                                    <h:outputLabel value="#{myItem.currentPatientRoom.roomFacilityCharge.name}"/>
-                                </p:column>
-                                <p:column>
-                                    <h:outputLabel value="Discharged"  rendered="#{myItem.discharged}"/>
-                                </p:column>
-                                <p:column>
-                                    <h:outputLabel value="Payment Finalized"  rendered="#{myItem.paymentFinalized}"/>
-                                </p:column>
-                            </p:autoComplete>   
+                        <p:panel header="BHT" style="min-width: 350px;">
+                            <!-- No continueClientId: selecting a BHT here must NOT auto-click
+                                 "Pay" - it only populates the due amount (itemSelectListener)
+                                 so staff can review/adjust before actually submitting payment. -->
+                            <admcc:admission_search
+                                widgetVar="aPt"
+                                inputId="acPt"
+                                value="#{inwardPaymentController.current.patientEncounter}"
+                                completeMethod="#{admissionController.completePatientAll}"
+                                itemSelectListener="#{inwardPaymentController.bhtListener}"
+                                itemSelectUpdate="@all" />
                             <h:panelGroup id="panSearch2">
                                 <in:bhtDetail admission="#{inwardPaymentController.current.patientEncounter}"/>
                             </h:panelGroup>

--- a/src/main/webapp/inward/inward_bill_post_final_payment.xhtml
+++ b/src/main/webapp/inward/inward_bill_post_final_payment.xhtml
@@ -9,14 +9,15 @@
                 xmlns:bill="http://xmlns.jcp.org/jsf/composite/inward/bill/payment"
                 xmlns:in="http://xmlns.jcp.org/jsf/composite/inward"
                 xmlns:pa="http://xmlns.jcp.org/jsf/composite/paymentMethod"
-                xmlns:prints="http://xmlns.jcp.org/jsf/composite/ezcomp/prints">
+                xmlns:prints="http://xmlns.jcp.org/jsf/composite/ezcomp/prints"
+                xmlns:admcc="http://xmlns.jcp.org/jsf/composite/ezcomp/inpatient">
 
 
 
     <ui:define name="content">
         <f:event type="preRenderView" listener="#{financialTransactionController.redirectIfShiftNotStarted()}"/>
         <h:panelGroup rendered="#{postFinalBillInwardPaymentController.current.patientEncounter eq null}">
-            <h:form>
+            <h:form id="frmPostFinalPayment">
                 <p:panel>
                     <f:facet name="header">
                         <h:outputText styleClass="fa-solid fa-address-card fa-lg" />
@@ -26,42 +27,15 @@
                     <div class="d-flex gap-4">
                         <h:outputLabel value="Type Patient Name or BHT : " class="mt-2"/>
 
-                        <p:autoComplete
+                        <admcc:admission_search
                             widgetVar="aPt"
-                            id="acPt"
-                            forceSelection="true"
+                            inputId="acPt"
                             value="#{postFinalBillInwardPaymentController.current.patientEncounter}"
                             completeMethod="#{admissionController.completePatientAll}"
-                            var="myItem"
-                            size="60"
-                            maxResults="20"
-                            itemValue="#{myItem}"
-                            itemLabel="#{myItem.bhtNo}"
-                            style="width: 550px;"
-                            class="mx-2">
-
-                            <p:column headerText="BHT No" style="padding: 6px; width: 8em;">
-                                <h:outputLabel value="#{myItem.bhtNo}"/>
-                            </p:column>
-                            <p:column headerText="Patient" style="padding: 6px; width: 15em;">
-                                <h:outputLabel value="#{myItem.patient.person.nameWithTitle}"/>
-                            </p:column>
-                            <p:column headerText="Room" style="padding: 6px; width: 8em;">
-                                <h:outputLabel value="#{myItem.currentPatientRoom.roomFacilityCharge.name}"/>
-                            </p:column>
-                            <p:column headerText="Status" style="padding: 6px; width: 12em;">
-                                <div class="d-flex justify-content-center">
-                                    <span class="#{myItem.discharged ? 'discharged-badge' : 'not-discharged-badge'}">
-                                        #{myItem.discharged ? 'Discharged' : 'Not Discharged'}
-                                    </span>
-                                </div>
-                            </p:column>
-                            <p:column headerText="Payment" style="padding: 6px; width: 12em;">
-                                <h:outputLabel value="Payment Finalized"  rendered="#{myItem.paymentFinalized}"/>
-                            </p:column>
-                        </p:autoComplete>
+                            continueClientId="frmPostFinalPayment:btnSelect" />
 
                         <p:commandButton
+                            id="btnSelect"
                             value="select"
                             ajax="false"
                             action="#{postFinalBillInwardPaymentController.bhtListener}" >

--- a/src/main/webapp/inward/inward_bill_post_final_payment_refund.xhtml
+++ b/src/main/webapp/inward/inward_bill_post_final_payment_refund.xhtml
@@ -8,13 +8,14 @@
                 xmlns:p="http://primefaces.org/ui"
                 xmlns:in="http://xmlns.jcp.org/jsf/composite/inward"
                 xmlns:pa="http://xmlns.jcp.org/jsf/composite/paymentMethod"
-                xmlns:bill="http://xmlns.jcp.org/jsf/composite/inward/bill">
+                xmlns:bill="http://xmlns.jcp.org/jsf/composite/inward/bill"
+                xmlns:admcc="http://xmlns.jcp.org/jsf/composite/ezcomp/inpatient">
 
 
     <ui:define name="content">
 
         <h:panelGroup >
-            <h:form  >
+            <h:form id="frmPostFinalPaymentRefund">
                 <h:panelGroup  class="row" rendered="#{postFinalBillInwardPaymentController.refundCurrent.patientEncounter.bhtNo eq null}">
                     <div class="col-12">
                         <h:panelGroup>
@@ -25,29 +26,14 @@
                                 </f:facet>
                                 <h:outputLabel value="Type Patient Name or BHT : "/>
 
-                                <p:autoComplete widgetVar="aPt" id="acPt" forceSelection="true"
-                                                required="true" requiredMessage="Please select a patient"
-                                                value="#{postFinalBillInwardPaymentController.refundCurrent.patientEncounter}"
-                                                completeMethod="#{admissionController.completePatientAll}"
-                                                var="myItem" itemValue="#{myItem}"
-                                                itemLabel="#{myItem.bhtNo}"
-                                                class="mx-2" size="30">
-                                    <p:column>
-                                        <h:outputLabel value="#{myItem.bhtNo}"/>
-                                    </p:column>
-                                    <p:column>
-                                        <h:outputLabel value="#{myItem.patient.person.nameWithTitle}"/>
-                                    </p:column>
-                                    <p:column>
-                                        <h:outputLabel value="#{myItem.currentPatientRoom.roomFacilityCharge.name}"/>
-                                    </p:column>
-                                    <p:column>
-                                        <h:outputLabel value="Discharged"  rendered="#{myItem.discharged}"/>
-                                    </p:column>
-                                    <p:column>
-                                        <h:outputLabel value="Payment Finalized"  rendered="#{myItem.paymentFinalized}"/>
-                                    </p:column>
-                                </p:autoComplete>
+                                <admcc:admission_search
+                                    widgetVar="aPt"
+                                    inputId="acPt"
+                                    value="#{postFinalBillInwardPaymentController.refundCurrent.patientEncounter}"
+                                    completeMethod="#{admissionController.completePatientAll}"
+                                    continueClientId="frmPostFinalPaymentRefund:btnSelect"
+                                    required="true"
+                                    requiredMessage="Please select a patient" />
 
                                 <p:commandButton
                                     id="btnSelect"

--- a/src/main/webapp/inward/inward_bill_refund.xhtml
+++ b/src/main/webapp/inward/inward_bill_refund.xhtml
@@ -8,14 +8,15 @@
                 xmlns:p="http://primefaces.org/ui"
                 xmlns:in="http://xmlns.jcp.org/jsf/composite/inward"
                 xmlns:pa="http://xmlns.jcp.org/jsf/composite/paymentMethod"
-                xmlns:bill="http://xmlns.jcp.org/jsf/composite/inward/bill">
+                xmlns:bill="http://xmlns.jcp.org/jsf/composite/inward/bill"
+                xmlns:admcc="http://xmlns.jcp.org/jsf/composite/ezcomp/inpatient">
 
 
     <ui:define name="content">
 
         <h:panelGroup >
-            <h:form  >
-                <h:panelGroup  class="row" rendered="#{inwardRefundController.current.patientEncounter.bhtNo eq null}"> 
+            <h:form id="frmInwardRefund">
+                <h:panelGroup  class="row" rendered="#{inwardRefundController.current.patientEncounter.bhtNo eq null}">
                     <div class="col-12">
                         <h:panelGroup>
                             <p:panel >
@@ -25,29 +26,14 @@
                                 </f:facet>
                                 <h:outputLabel value="Type Patient Name or BHT : "/>
 
-                                <p:autoComplete widgetVar="aPt" id="acPt" forceSelection="true" 
-                                                required="true" requiredMessage="Please select a patient"
-                                                value="#{inwardRefundController.current.patientEncounter}"
-                                                completeMethod="#{admissionController.completePatientAll}" 
-                                                var="myItem" itemValue="#{myItem}" 
-                                                itemLabel="#{myItem.bhtNo}" 
-                                                class="mx-2" size="30">
-                                    <p:column>
-                                        <h:outputLabel value="#{myItem.bhtNo}"/>
-                                    </p:column>
-                                    <p:column>
-                                        <h:outputLabel value="#{myItem.patient.person.nameWithTitle}"/>
-                                    </p:column>
-                                    <p:column>
-                                        <h:outputLabel value="#{myItem.currentPatientRoom.roomFacilityCharge.name}"/>
-                                    </p:column>
-                                    <p:column>
-                                        <h:outputLabel value="Discharged"  rendered="#{myItem.discharged}"/>
-                                    </p:column>
-                                    <p:column>
-                                        <h:outputLabel value="Payment Finalized"  rendered="#{myItem.paymentFinalized}"/>
-                                    </p:column>
-                                </p:autoComplete> 
+                                <admcc:admission_search
+                                    widgetVar="aPt"
+                                    inputId="acPt"
+                                    value="#{inwardRefundController.current.patientEncounter}"
+                                    completeMethod="#{admissionController.completePatientAll}"
+                                    continueClientId="frmInwardRefund:btnSelect"
+                                    required="true"
+                                    requiredMessage="Please select a patient" />
 
                                 <p:commandButton
                                     id="btnSelect"

--- a/src/main/webapp/inward/pharmacy_bill_issue_bht_old.xhtml
+++ b/src/main/webapp/inward/pharmacy_bill_issue_bht_old.xhtml
@@ -8,7 +8,8 @@
                 xmlns:bil="http://xmlns.jcp.org/jsf/composite/bill"
                 xmlns:phe="http://xmlns.jcp.org/jsf/composite/pharmacy/inward"
                 xmlns:phi="http://xmlns.jcp.org/jsf/composite/pharmacy"
-                xmlns:bill="http://xmlns.jcp.org/jsf/composite/inward">
+                xmlns:bill="http://xmlns.jcp.org/jsf/composite/inward"
+                xmlns:admcc="http://xmlns.jcp.org/jsf/composite/ezcomp/inpatient">
 
     <ui:define name="content">
         <h:form id="bill" >
@@ -57,7 +58,7 @@
                                         <div class="text-center mb-4">
                                             <i class="fa-solid fa-search fa-3x text-info mb-3"></i>
                                             <h5 class="text-dark mb-2">Find Inpatient</h5>
-                                            <p class="text-muted">Search by patient name, BHT number, or PHN to continue with medicine issuing</p>
+                                            <p class="text-muted">Search by patient name, BHT number, MRN, or PHN to continue with medicine issuing</p>
                                         </div>
 
                                         <div class="row align-items-end">
@@ -66,55 +67,12 @@
                                                     <i class="fa-solid fa-user me-2 text-primary"></i>
                                                     Patient Search
                                                 </label>
-                                                <p:autoComplete
+                                                <admcc:admission_search
                                                     widgetVar="aPt2"
-                                                    id="acPt2"
-                                                    forceSelection="true"
+                                                    inputId="acPt2"
                                                     value="#{pharmacySaleBhtController.patientEncounter}"
                                                     completeMethod="#{admissionController.completePatient}"
-                                                    var="apt2"
-                                                    itemLabel="#{apt2.bhtNo}"
-                                                    itemValue="#{apt2}"
-                                                    placeholder="Type patient name, BHT number, or PHN..."
-                                                    minQueryLength="2"
-                                                    style="width: 100%;"
-                                                    inputStyleClass="form-control form-control-lg">
-                                                    <p:column headerText="PHN" style="padding: 8px; min-width: 100px;">
-                                                        <div class="d-flex align-items-center">
-                                                            <i class="fa-solid fa-id-card me-2 text-info"></i>
-                                                            <strong>#{apt2.patient.phn}</strong>
-                                                        </div>
-                                                    </p:column>
-                                                    <p:column headerText="BHT No" style="padding: 8px; min-width: 120px;">
-                                                        <div class="d-flex align-items-center">
-                                                            <i class="fa-solid fa-hospital me-2 text-warning"></i>
-                                                            <strong class="text-primary">#{apt2.bhtNo}</strong>
-                                                        </div>
-                                                    </p:column>
-                                                    <p:column headerText="Patient Name" style="padding: 8px; min-width: 250px;">
-                                                        <div class="d-flex align-items-center">
-                                                            <i class="fa-solid fa-user me-2 text-success"></i>
-                                                            <span class="fw-medium">#{apt2.patient.person.nameWithTitle}</span>
-                                                        </div>
-                                                    </p:column>
-                                                    <p:column headerText="Room" style="padding: 8px; min-width: 150px;">
-                                                        <h:panelGroup rendered="#{apt2.currentPatientRoom ne null}">
-                                                            <div class="d-flex align-items-center">
-                                                                <i class="fa-solid fa-bed me-2 text-secondary"></i>
-                                                                <span>#{apt2.currentPatientRoom.roomFacilityCharge.name}</span>
-                                                            </div>
-                                                        </h:panelGroup>
-                                                        <h:panelGroup rendered="#{apt2.currentPatientRoom eq null}">
-                                                            <span class="text-muted">
-                                                                <i class="fa-solid fa-question-circle me-1"></i>No room assigned
-                                                            </span>
-                                                        </h:panelGroup>
-                                                    </p:column>
-                                                    <p:column headerText="Status" style="padding: 8px; min-width: 120px;">
-                                                        <p:badge value="Discharged" styleClass="ui-badge-danger" rendered="#{apt2.discharged}" />
-                                                        <p:badge value="Active" styleClass="ui-badge-success" rendered="#{!apt2.discharged}" />
-                                                    </p:column>
-                                                </p:autoComplete>
+                                                    continueClientId="bill:btnSelect" />
                                             </div>
                                             <div class="col-12 col-md-3">
                                                 <p:commandButton
@@ -137,7 +95,7 @@
                                                             <h6 class="alert-heading mb-2">Quick Tips:</h6>
                                                             <ul class="mb-0 ps-3">
                                                                 <li>Start typing at least 2 characters to search for patients</li>
-                                                                <li>You can search by patient name, BHT number, or PHN</li>
+                                                                <li>You can search by patient name, BHT number, MRN, or PHN</li>
                                                                 <li>Only active inpatients are available for medicine issuing</li>
                                                                 <li>Discharged patients are shown with a "Discharged" status</li>
                                                             </ul>

--- a/src/main/webapp/resources/ezcomp/inpatient/admission_search.xhtml
+++ b/src/main/webapp/resources/ezcomp/inpatient/admission_search.xhtml
@@ -24,6 +24,14 @@
              update components OUTSIDE the composite, it must pass ABSOLUTE search expressions
              (leading ':', e.g. ":frmBhtEdit:pnlPatientPreview :frmBhtEdit:btnSelect"). -->
         <cc:attribute name="itemSelectUpdate" type="java.lang.String" default="" />
+        <!-- Optional business logic to run when an admission is selected (by click or by the
+             barcode auto-select below) - e.g. a page that must populate a due amount or load
+             related tables the moment a BHT is picked, not only when its own Continue button is
+             clicked. Defaults to a no-op so pages that don't need one (the majority) are
+             unaffected. Runs before itemSelectUpdate's components are re-rendered, same as any
+             p:ajax listener. -->
+        <cc:attribute name="itemSelectListener" method-signature="void listener()"
+                      default="#{admissionSearchSupportController.noop}" />
         <cc:attribute name="placeholder" type="java.lang.String"
                       default="Type patient name, BHT number, MRN, or PHN..." />
         <cc:attribute name="required" type="java.lang.Boolean" default="false" />
@@ -51,7 +59,7 @@
             style="width: 100%;"
             inputStyleClass="form-control form-control-lg">
             <p:ajax event="query" oncomplete="HmisAdmissionSearch.onQueryComplete('#{cc.attrs.widgetVar}', '#{cc.attrs.continueClientId}')" />
-            <p:ajax event="itemSelect" update="#{cc.attrs.itemSelectUpdate}" oncomplete="HmisAdmissionSearch.onItemSelectComplete('#{cc.attrs.continueClientId}')" />
+            <p:ajax event="itemSelect" listener="#{cc.attrs.itemSelectListener}" update="#{cc.attrs.itemSelectUpdate}" oncomplete="HmisAdmissionSearch.onItemSelectComplete('#{cc.attrs.continueClientId}')" />
             <p:column headerText="PHN" style="padding: 8px; min-width: 100px;">
                 <div class="d-flex align-items-center">
                     <i class="fa-solid fa-id-card me-2 text-info"></i>


### PR DESCRIPTION
## Summary

Continues #23165's barcode-friendly admission search rollout, following PR #23426 (room change pages).

Two commits:
1. **Composite enhancement** — adds an optional `itemSelectListener` attribute to the shared `admcc:admission_search` composite, defaulting to a safe no-op. Needed because two of the billing pages below attach real business logic (not just the model value) directly to the autocomplete's own selection event.
2. **9 pages migrated**: `pharmacy_bill_issue_bht_old.xhtml` (the QA-only comparison page left over from #23165's own scope) plus 8 of the "Family C" billing pages that have a genuine "search for a BHT" step:
   - `inward_bill_payment.xhtml`, `inward_bill_payment_1.xhtml`, `inward_bill_refund.xhtml`
   - `inward_bill_post_final_payment.xhtml`, `inward_bill_post_final_payment_refund.xhtml`
   - `inward_bill_deposit.xhtml`
   - `inward_bill_intrim_finalized.xhtml`, `inward_bill_intrim_finalized_error_correction.xhtml`

All these pages' search methods (`admissionController.completePatient` / `completePatientAll`) were already MRN-searchable from the original pilot PR — no JPQL changes needed here.

## Decisions made without approval / judgment calls

1. **Scope narrowed from the full "Family C" list.** The issue's own tracking comment lists ~20 billing/report pages as "Family C — lower priority." Investigating them, two shapes emerged:
   - Pages with a genuine "find and select one BHT, then act" step — these 8, migrated here.
   - Pages where the BHT box is one optional filter among several on a report with no single-admission-selection step (e.g. `bht_deposit_by_discharge_date.xhtml` and its `_and_created_date` sibling have **no BHT search field at all** — pure date/credit-company filtered aggregate reports) — these are a different UX shape than what this issue's acceptance criteria describe, and are left for a separate follow-up rather than forced into this pattern.
2. **Composite extended with `itemSelectListener`** rather than leaving `inward_bill_payment_1.xhtml` and `inward_bill_intrim_finalized_error_correction.xhtml` unmigrated. Confirmed via a regression check against the pilot page (`inward_edit_bht.xhtml`) that the new default no-op doesn't affect any of the ~15 already-migrated pages.
3. **`continueClientId` deliberately omitted on `inward_bill_payment_1.xhtml`.** Its "Pay" button submits a real payment; auto-clicking it on a barcode scan would fire a financial transaction without staff review. Used `itemSelectListener` instead so scanning still auto-populates the due amount and patient details, but the actual payment stays a deliberate click. Same reasoning applies to why `inward_bill_intrim_finalized_error_correction.xhtml` uses `itemSelectListener` alone (loading a read-only report, not a mutation) rather than `continueClientId` (it has no separate Continue button to click anyway).
4. **Verified each "select" action is read-only setup before wiring auto-advance** on the other 6 pages (`bhtListener`, `selectBhtListener`, `selectBhtListenerForRefund`, `createTablesFinalized`) — all just load/compute display state, none mutate persisted data.
5. **Fixed a layout regression**, not just the search UX: the composite's `width:100%` collapses to a tiny box inside an `h:panelGrid`'s auto-sized column on 3 of these pages (they don't use a Bootstrap `col-*` div wrapper like the other migrated pages). Added an explicit `min-width: 350px` on each affected page's BHT panel.

## Verified

End-to-end with Playwright against local Payara + MySQL (`coop` dev DB):
- **`inward_bill_payment.xhtml`**: exact BHT scan auto-selects and auto-advances to Payment Details; the due-amount panel correctly reflects `bhtListener()`'s output ("Payment Details Are Not Finalized").
- **`inward_bill_intrim_finalized.xhtml`**: exact BHT scan auto-selects and auto-clicks Display; Room Detail tab shows real charge data (e.g. Room Charge 11,600) for the scanned BHT, not stale/default data.
- **`inward_bill_payment_1.xhtml`**: scanning a BHT updates the due amount and patient-detail panel but does **not** auto-click Pay — confirmed by scanning a second, different BHT and observing the panel update in place with no navigation.
- **`inward_bill_intrim_finalized_error_correction.xhtml`**: scanning a BHT loads its finalized bill tables immediately (matching the page's original itemSelect behavior), search box renders at the corrected width.
- The 5 remaining Bootstrap-layout pages (refund, post-final-payment, post-final-payment-refund, deposit, old pharmacy) visually confirmed rendering correctly at full width with the shared composite.
- No new errors in `server.log` or the browser console across the whole verification pass.

## Follow-up (not in this PR)

Still outstanding from the issue's original checklist:
- The remaining Family C **report** pages (`inward_bill_payment.xhtml`'s siblings' report-only counterparts, `inward_report_*` pages, `bht_deposit_by_*` variants) — need per-page investigation to classify wizard-vs-filter shape, same as this PR did.
- `bht_deposit_by_discharge_date.xhtml` and `bht_deposit_by_discharge_date_and_created_date.xhtml` specifically have no BHT search field at all and don't fit this issue's pattern — flagged for the issue owner to confirm they're genuinely out of scope rather than silently skipped.

Closes nothing on its own — tracked as part of #23165.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
