### PR TITLE
hotfix: OPD refund config options and print/navigation fixes (SLH)

### DIFF
--- a/src/main/java/com/divudi/bean/common/BillReturnController.java
+++ b/src/main/java/com/divudi/bean/common/BillReturnController.java
@@ -270,7 +270,6 @@ public class BillReturnController implements Serializable, ControllerWithMultipl
                         ewalletInstitution = institutionFacade.find(ewalletInstitution.getId());
                     }
 
-
                     // Get reference to ewallet once to avoid multiple getter calls creating new objects
                     ComponentDetail ewalletDetail = getPaymentMethodData().getEwallet();
                     ewalletDetail.setInstitution(ewalletInstitution);
@@ -690,7 +689,7 @@ public class BillReturnController implements Serializable, ControllerWithMultipl
 
                             if (currentPatientSample == null) {
                                 //can Refund Item
-                            }else if(configOptionApplicationController.getBooleanValueByKey("Can Refund Item in any Status", false)){
+                            } else if (configOptionApplicationController.getBooleanValueByKey("Can Refund Item in any Status", false)) {
                                 //can Refund Item
                             } else if (currentPatientSample.getStatus() == PatientInvestigationStatus.SAMPLE_SENT_TO_OUTLAB) {
                                 returningStarted.set(false);
@@ -1134,7 +1133,6 @@ public class BillReturnController implements Serializable, ControllerWithMultipl
         }
 
 // Print the original values
-
 // Convert all values to negative absolute amounts
         returningTotal = -Math.abs(returningTotal);
         returningNetTotal = -Math.abs(returningNetTotal);
@@ -1145,7 +1143,6 @@ public class BillReturnController implements Serializable, ControllerWithMultipl
 // Print the adjusted values
 
 // Print the adjusted values
-
 // Assign the adjusted values to newlyReturnedBill
         newlyReturnedBill.setGrantTotal(returningTotal);
         newlyReturnedBill.setNetTotal(returningNetTotal);
@@ -1157,7 +1154,6 @@ public class BillReturnController implements Serializable, ControllerWithMultipl
 // Print the values before setting
 
 // Print the values before setting
-
 // Assign the values
         newlyReturnedBill.setTotalHospitalFee(returningHospitalTotal);
         newlyReturnedBill.setTotalCenterFee(returningCCTotal);
@@ -1323,15 +1319,15 @@ public class BillReturnController implements Serializable, ControllerWithMultipl
     public void setPaymentMethodData(PaymentMethodData paymentMethodData) {
         if (paymentMethodData != null) {
             if (paymentMethodData.getPaymentMethod() != null) {
-                if(paymentMethodData.getPaymentMethod()==PaymentMethod.ewallet){
-                    if(paymentMethodData.getEwallet()!=null){
+                if (paymentMethodData.getPaymentMethod() == PaymentMethod.ewallet) {
+                    if (paymentMethodData.getEwallet() != null) {
                     }
                 }
             }
         }
         // Allow setting payment method data for form binding
         // This is needed for JSF to properly bind form values during submission
-        
+
         this.paymentMethodData = paymentMethodData;
     }
 
@@ -1448,7 +1444,6 @@ public class BillReturnController implements Serializable, ControllerWithMultipl
         try {
             // Save the updated bill
             billFacade.edit(batchBill);
-
 
         } catch (Exception e) {
             JsfUtil.addErrorMessage("Error updating batch bill balance: " + e.getMessage());

--- a/src/main/java/com/divudi/bean/common/BillReturnController.java
+++ b/src/main/java/com/divudi/bean/common/BillReturnController.java
@@ -689,7 +689,7 @@ public class BillReturnController implements Serializable, ControllerWithMultipl
 
                             if (currentPatientSample == null) {
                                 //can Refund Item
-                            } else if (configOptionApplicationController.getBooleanValueByKey("Can Refund Item in any Status", false)) {
+                            } else if (configOptionApplicationController.getBooleanValueByKey("OPD Refund - Can Refund Item in any Status", false)) {
                                 //can Refund Item
                             } else if (currentPatientSample.getStatus() == PatientInvestigationStatus.SAMPLE_SENT_TO_OUTLAB) {
                                 returningStarted.set(false);

--- a/src/main/java/com/divudi/bean/common/BillReturnController.java
+++ b/src/main/java/com/divudi/bean/common/BillReturnController.java
@@ -690,6 +690,8 @@ public class BillReturnController implements Serializable, ControllerWithMultipl
 
                             if (currentPatientSample == null) {
                                 //can Refund Item
+                            }else if(configOptionApplicationController.getBooleanValueByKey("Can Refund Item in any Status", false)){
+                                //can Refund Item
                             } else if (currentPatientSample.getStatus() == PatientInvestigationStatus.SAMPLE_SENT_TO_OUTLAB) {
                                 returningStarted.set(false);
                                 JsfUtil.addErrorMessage("This item can't be refunded. This investigation sample has been sent to an external lab.");

--- a/src/main/java/com/divudi/bean/common/BillReturnController.java
+++ b/src/main/java/com/divudi/bean/common/BillReturnController.java
@@ -712,12 +712,15 @@ public class BillReturnController implements Serializable, ControllerWithMultipl
 
         calculateRefundingAmount();
 
-        Drawer loggedUserDraver = drawerController.getUsersDrawer(sessionController.getLoggedUser());
+        if (!configOptionApplicationController.getBooleanValueByKey("OPD Refund - Bypass the Drawer to Refund", false)) {
 
-        if (!drawerService.hasSufficientDrawerBalance(loggedUserDraver, paymentMethod, refundingTotalAmount)) {
-            JsfUtil.addErrorMessage("Your Draver does not have enough Money");
-            returningStarted.set(false);
-            return null;
+            Drawer loggedUserDraver = drawerController.getUsersDrawer(sessionController.getLoggedUser());
+
+            if (!drawerService.hasSufficientDrawerBalance(loggedUserDraver, paymentMethod, refundingTotalAmount)) {
+                JsfUtil.addErrorMessage("Your Draver does not have enough Money");
+                returningStarted.set(false);
+                return null;
+            }
         }
 
         originalBillToReturn = billFacade.findWithoutCache(originalBillToReturn.getId());

--- a/src/main/java/com/divudi/bean/common/BillSearch.java
+++ b/src/main/java/com/divudi/bean/common/BillSearch.java
@@ -4472,7 +4472,9 @@ public class BillSearch implements Serializable, ControllerWithMultiplePayments 
             JsfUtil.addErrorMessage("No Bill to Dsiplay");
             return "";
         }
-        return "/opd/view/opd_refund_bill_admin?faces-redirect=true";
+        billReturnController.setNewlyReturnedBill(viewingBill);
+        
+        return "/opd/bill_return_print?faces-redirect=true";
     }
 
     public String navigateToAdminOpdRefundBill() {

--- a/src/main/webapp/opd/bill_return.xhtml
+++ b/src/main/webapp/opd/bill_return.xhtml
@@ -309,10 +309,6 @@
                             </div>
                         </div>
 
-
-
-
-
                     </p:panel>
                 </h:form>
             </ui:define>

--- a/src/main/webapp/opd/bill_return_print.xhtml
+++ b/src/main/webapp/opd/bill_return_print.xhtml
@@ -32,6 +32,7 @@
                                     <f:selectItems value="#{enumController.paperTypes}" />
                                 </p:selectOneMenu>
                                 <p:commandButton ajax="false" icon="fa fa-sync-alt" class="ui-button m-1 " title="Redraw Bill"></p:commandButton>
+                                
                             </div>
 
                             <p:commandButton 
@@ -39,7 +40,6 @@
                                 class="ui-button-info m-1"
                                 icon="fa fa-print"
                                 style="float: right"
-                                rendered="#{billSearch.bill.refunded}"
                                 ajax="false">
                                 <p:printer target="refundPrint" />
                             </p:commandButton>


### PR DESCRIPTION
## Summary
- Add config option "OPD Refund - Can Refund Item in any Status" to allow refunding an investigation item regardless of its lab sample status.
- Add config option "OPD Refund - Bypass the Drawer to Refund" to skip the drawer-balance check on refund.
- Fix the refund print button on `bill_return_print.xhtml` being hidden unless the bill was already refunded.
- Fix `BillSearch.navigateToAdminOpdRefundBillView` to route to `bill_return_print` with the return bill wired into `BillReturnController`, instead of the removed `opd_refund_bill_admin` view.
- Whitespace/formatting cleanup in `BillReturnController` and `bill_return.xhtml`.

Closes #23437

## Test plan
- [ ] Confirm refund of an item whose sample is SAMPLE_SENT_TO_OUTLAB/INTERNAL_LAB/ACCEPTED is blocked by default and allowed once "OPD Refund - Can Refund Item in any Status" is enabled.
- [ ] Confirm refund is blocked on insufficient drawer balance by default and allowed once "OPD Refund - Bypass the Drawer to Refund" is enabled.
- [ ] Confirm the refund print button always renders on `bill_return_print.xhtml`.
- [ ] Confirm admin refund bill navigation lands on the refund print page with the correct bill loaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KvVpQ5RbycFjEY3xQ9U9Cw