### PR TITLE
feat(inward,credit): wire shared admission search into remaining Family C report pages

### DIFF
--- a/src/main/webapp/credit/inward_patient_copay_payment.xhtml
+++ b/src/main/webapp/credit/inward_patient_copay_payment.xhtml
@@ -10,7 +10,8 @@
         xmlns:p="http://primefaces.org/ui"
         xmlns:in="http://xmlns.jcp.org/jsf/composite/inward"
         xmlns:pa="http://xmlns.jcp.org/jsf/composite/paymentMethod"
-        xmlns:bill="http://xmlns.jcp.org/jsf/composite/inward/bill/payment">
+        xmlns:bill="http://xmlns.jcp.org/jsf/composite/inward/bill/payment"
+        xmlns:admcc="http://xmlns.jcp.org/jsf/composite/ezcomp/inpatient">
 
     <ui:define name="admin">
         <f:event type="preRenderView" listener="#{financialTransactionController.redirectIfShiftNotStarted()}"/>
@@ -30,32 +31,16 @@
                                 <p:outputLabel value="Search by BHT / Patient Name" style="font-weight:bold;"/>
                             </div>
                             <div class="col-md-7">
-                                <p:autoComplete
+                                <admcc:admission_search
                                     widgetVar="aBht"
-                                    id="acBht"
-                                    forceSelection="true"
-                                    placeholder="Type BHT number or patient name"
+                                    inputId="acBht"
                                     value="#{inwardPaymentController.current.patientEncounter}"
                                     completeMethod="#{admissionController.completePatientAll}"
-                                    var="myItem"
-                                    itemValue="#{myItem}"
-                                    itemLabel="#{myItem.bhtNo}"
-                                    class="w-100"
-                                    inputStyleClass="w-100"
-                                    maxResults="20">
-                                    <p:column headerText="BHT No" style="width:8em;">
-                                        <h:outputLabel value="#{myItem.bhtNo}"/>
-                                    </p:column>
-                                    <p:column headerText="Patient" style="width:15em;">
-                                        <h:outputLabel value="#{myItem.patient.person.nameWithTitle}"/>
-                                    </p:column>
-                                    <p:column headerText="Payment" style="width:8em;">
-                                        <h:outputLabel value="#{myItem.paymentMethod}"/>
-                                    </p:column>
-                                </p:autoComplete>
+                                    continueClientId="copayForm:btnSelect" />
                             </div>
                             <div class="col-md-2">
                                 <p:commandButton
+                                    id="btnSelect"
                                     value="Select"
                                     icon="fa fa-check"
                                     class="ui-button-success w-100"

--- a/src/main/webapp/inward/bht_deposit_by_created_date_all.xhtml
+++ b/src/main/webapp/inward/bht_deposit_by_created_date_all.xhtml
@@ -5,6 +5,7 @@
       xmlns:p="http://primefaces.org/ui"
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:admcc="http://xmlns.jcp.org/jsf/composite/ezcomp/inpatient"
       >
 
     <h:body>
@@ -60,28 +61,14 @@
 
                                 <h:outputLabel value="B H T No :" ></h:outputLabel>
                                 <h:panelGrid columns="1">
-                                <p:autoComplete  widgetVar="aPt" id="acPt" forceSelection="true" 
-                                                value="#{mdInwardReportController.patientEncounter}"
-                                                completeMethod="#{admissionController.completePatientAll}" 
-                                                var="myItem" itemValue="#{myItem}" 
-                                                itemLabel="#{myItem.bhtNo}" 
-                                                size="30"  >/>
-                                    <p:column>
-                                        #{myItem.bhtNo}
-                                    </p:column>
-                                    <p:column>
-                                        #{myItem.patient.person.nameWithTitle}
-                                    </p:column>
-                                    <p:column>
-                                        <h:outputLabel value="#{myItem.currentPatientRoom.roomFacilityCharge.name}"/>
-                                    </p:column>
-                                    <p:column>
-                                        <h:outputLabel value="Discharged"  rendered="#{myItem.discharged}"/>
-                                    </p:column>
-                                    <p:column>
-                                        <h:outputLabel  value="Cancelled"  rendered="#{myItem.retired}"/>
-                                    </p:column>
-                                </p:autoComplete>   
+                                <!-- No continueClientId: BHT is one optional filter among several
+                                     here - selecting one must not auto-run Fill before the other
+                                     filters are set. -->
+                                <admcc:admission_search
+                                    widgetVar="aPt"
+                                    inputId="acPt"
+                                    value="#{mdInwardReportController.patientEncounter}"
+                                    completeMethod="#{admissionController.completePatientAll}" />
 
                             </h:panelGrid>
                         </h:panelGrid>

--- a/src/main/webapp/inward/bht_deposit_by_created_date_discharged.xhtml
+++ b/src/main/webapp/inward/bht_deposit_by_created_date_discharged.xhtml
@@ -5,6 +5,7 @@
       xmlns:p="http://primefaces.org/ui"
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:admcc="http://xmlns.jcp.org/jsf/composite/ezcomp/inpatient"
       >
 
     <h:body>
@@ -60,32 +61,18 @@
 
                             <h:outputLabel value="B H T No :" ></h:outputLabel>
                             <h:panelGrid columns="1">
-                                <p:autoComplete  widgetVar="aPt" id="acPt" forceSelection="true"
-                                                value="#{mdInwardReportController.patientEncounter}"
-                                                completeMethod="#{admissionController.completePatientAll}"
-                                                var="myItem" itemValue="#{myItem}"
-                                                itemLabel="#{myItem.bhtNo}"
-                                                size="30"  >
-                                    <p:ajax event="itemSelect"
-                                            process="@this"
-                                            update="@all"
-                                            listener="#{bhtSummeryFinalizedController.selectLitener}"/>
-                                    <p:column>
-                                        #{myItem.bhtNo}
-                                    </p:column>
-                                    <p:column>
-                                        #{myItem.patient.person.nameWithTitle}
-                                    </p:column>
-                                    <p:column>
-                                        <h:outputLabel value="#{myItem.currentPatientRoom.roomFacilityCharge.name}"/>
-                                    </p:column>
-                                    <p:column>
-                                        <h:outputLabel value="Discharged"  rendered="#{myItem.discharged}"/>
-                                    </p:column>
-                                    <p:column>
-                                        <h:outputLabel  value="Cancelled"  rendered="#{myItem.retired}"/>
-                                    </p:column>
-                                </p:autoComplete>   
+                                <!-- No continueClientId: BHT is one optional filter among several
+                                     here - selecting one must not auto-run Fill before the other
+                                     filters are set. itemSelectListener preserved as-is from the
+                                     original itemSelect handler (bhtSummeryFinalizedController,
+                                     not the mdInwardReportController this field is bound to). -->
+                                <admcc:admission_search
+                                    widgetVar="aPt"
+                                    inputId="acPt"
+                                    value="#{mdInwardReportController.patientEncounter}"
+                                    completeMethod="#{admissionController.completePatientAll}"
+                                    itemSelectListener="#{bhtSummeryFinalizedController.selectLitener}"
+                                    itemSelectUpdate="@all" />
 
                             </h:panelGrid>
                         </h:panelGrid>

--- a/src/main/webapp/inward/bht_deposit_by_created_date_discharged_above.xhtml
+++ b/src/main/webapp/inward/bht_deposit_by_created_date_discharged_above.xhtml
@@ -5,6 +5,7 @@
       xmlns:p="http://primefaces.org/ui"
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:admcc="http://xmlns.jcp.org/jsf/composite/ezcomp/inpatient"
       >
 
     <h:body>
@@ -46,32 +47,18 @@
                             </p:selectOneMenu>
                             <h:outputLabel value="B H T No :" ></h:outputLabel>
                             <h:panelGrid columns="1">
-                                <p:autoComplete  widgetVar="aPt" id="acPt" forceSelection="true" 
-                                                value="#{mdInwardReportController.patientEncounter}"
-                                                completeMethod="#{admissionController.completePatientAll}" 
-                                                var="myItem" itemValue="#{myItem}" 
-                                                itemLabel="#{myItem.bhtNo}" 
-                                                size="30"  >
-                                    <p:ajax event="itemSelect" 
-                                            process="@this" 
-                                            update="@all" 
-                                            listener="#{bhtSummeryFinalizedController.selectLitener}"/>
-                                    <p:column>
-                                        #{myItem.bhtNo}
-                                    </p:column>
-                                    <p:column>
-                                        #{myItem.patient.person.nameWithTitle}
-                                    </p:column>
-                                    <p:column>
-                                        <h:outputLabel value="#{myItem.currentPatientRoom.roomFacilityCharge.name}"/>
-                                    </p:column>
-                                    <p:column>
-                                        <h:outputLabel value="Discharged"  rendered="#{myItem.discharged}"/>
-                                    </p:column>
-                                    <p:column>
-                                        <h:outputLabel  value="Cancelled"  rendered="#{myItem.retired}"/>
-                                    </p:column>
-                                </p:autoComplete>   
+                                <!-- No continueClientId: BHT is one optional filter among several
+                                     here - selecting one must not auto-run Fill before the other
+                                     filters are set. itemSelectListener preserved as-is from the
+                                     original itemSelect handler (bhtSummeryFinalizedController,
+                                     not the mdInwardReportController this field is bound to). -->
+                                <admcc:admission_search
+                                    widgetVar="aPt"
+                                    inputId="acPt"
+                                    value="#{mdInwardReportController.patientEncounter}"
+                                    completeMethod="#{admissionController.completePatientAll}"
+                                    itemSelectListener="#{bhtSummeryFinalizedController.selectLitener}"
+                                    itemSelectUpdate="@all" />
 
                             </h:panelGrid>
                         </h:panelGrid>

--- a/src/main/webapp/inward/bht_deposit_by_created_date_discharged_all.xhtml
+++ b/src/main/webapp/inward/bht_deposit_by_created_date_discharged_all.xhtml
@@ -5,6 +5,7 @@
       xmlns:p="http://primefaces.org/ui"
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:admcc="http://xmlns.jcp.org/jsf/composite/ezcomp/inpatient"
       >
 
     <h:body>
@@ -60,28 +61,14 @@
 
                             <h:outputLabel value="B H T No :" ></h:outputLabel>
                             <h:panelGrid columns="1">
-                                <p:autoComplete  widgetVar="aPt" id="acPt" forceSelection="true"
-                                                value="#{mdInwardReportController.patientEncounter}"
-                                                completeMethod="#{admissionController.completePatientAll}"
-                                                var="myItem" itemValue="#{myItem}"
-                                                itemLabel="#{myItem.bhtNo}"
-                                                size="30"  >
-                                    <p:column>
-                                        #{myItem.bhtNo}
-                                    </p:column>
-                                    <p:column>
-                                        #{myItem.patient.person.nameWithTitle}
-                                    </p:column>
-                                    <p:column>
-                                        <h:outputLabel value="#{myItem.currentPatientRoom.roomFacilityCharge.name}"/>
-                                    </p:column>
-                                    <p:column>
-                                        <h:outputLabel value="Discharged"  rendered="#{myItem.discharged}"/>
-                                    </p:column>
-                                    <p:column>
-                                        <h:outputLabel  value="Cancelled"  rendered="#{myItem.retired}"/>
-                                    </p:column>
-                                </p:autoComplete>   
+                                <!-- No continueClientId: BHT is one optional filter among several
+                                     here - selecting one must not auto-run Fill before the other
+                                     filters are set. -->
+                                <admcc:admission_search
+                                    widgetVar="aPt"
+                                    inputId="acPt"
+                                    value="#{mdInwardReportController.patientEncounter}"
+                                    completeMethod="#{admissionController.completePatientAll}" />
 
                             </h:panelGrid>
                         </h:panelGrid>

--- a/src/main/webapp/inward/bht_deposit_by_created_date_not_discharge.xhtml
+++ b/src/main/webapp/inward/bht_deposit_by_created_date_not_discharge.xhtml
@@ -5,6 +5,7 @@
       xmlns:p="http://primefaces.org/ui"
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:admcc="http://xmlns.jcp.org/jsf/composite/ezcomp/inpatient"
       >
 
     <h:body>
@@ -62,32 +63,18 @@
 
                             <h:outputLabel value="B H T No :" ></h:outputLabel>
 
-                            <p:autoComplete  widgetVar="aPt" id="acPt" forceSelection="true" 
-                                            value="#{mdInwardReportController.patientEncounter}"
-                                            completeMethod="#{admissionController.completePatientAll}" 
-                                            var="myItem" itemValue="#{myItem}" 
-                                            itemLabel="#{myItem.bhtNo}" 
-                                            size="30"  >
-                                <p:ajax event="itemSelect" 
-                                        process="@this" 
-                                        update="@all" 
-                                        listener="#{bhtSummeryFinalizedController.selectLitener}"/>
-                                <p:column>
-                                    #{myItem.bhtNo}
-                                </p:column>
-                                <p:column>
-                                    #{myItem.patient.person.nameWithTitle}
-                                </p:column>
-                                <p:column>
-                                    <h:outputLabel value="#{myItem.currentPatientRoom.roomFacilityCharge.name}"/>
-                                </p:column>
-                                <p:column>
-                                    <h:outputLabel value="Discharged"  rendered="#{myItem.discharged}"/>
-                                </p:column>
-                                <p:column>
-                                    <h:outputLabel  value="Cancelled"  rendered="#{myItem.retired}"/>
-                                </p:column>
-                            </p:autoComplete>   
+                            <!-- No continueClientId: BHT is one optional filter among several
+                                 here - selecting one must not auto-run Fill before the other
+                                 filters are set. itemSelectListener preserved as-is from the
+                                 original itemSelect handler (bhtSummeryFinalizedController,
+                                 not the mdInwardReportController this field is bound to). -->
+                            <admcc:admission_search
+                                widgetVar="aPt"
+                                inputId="acPt"
+                                value="#{mdInwardReportController.patientEncounter}"
+                                completeMethod="#{admissionController.completePatientAll}"
+                                itemSelectListener="#{bhtSummeryFinalizedController.selectLitener}"
+                                itemSelectUpdate="@all" />
 
                             <p:panelGrid columns="3">
                             <p:commandButton ajax="false" value="Fill" action="#{mdInwardReportController.createDepositByCreatedDateNotDischarged()}"  ></p:commandButton>

--- a/src/main/webapp/inward/inward_report_bht_bil.xhtml
+++ b/src/main/webapp/inward/inward_report_bht_bil.xhtml
@@ -6,6 +6,7 @@
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:f="http://xmlns.jcp.org/jsf/core"
       xmlns:bi="http://xmlns.jcp.org/jsf/composite/inward/bill"
+      xmlns:admcc="http://xmlns.jcp.org/jsf/composite/ezcomp/inpatient"
       >
 
     <h:body>
@@ -16,32 +17,16 @@
                 <h:form>
                     <p:panel header="Reprint" styleClass="alignTop" >
                         <h:panelGrid columns="1">
-                            <p:autoComplete  widgetVar="aPt" id="acPt" forceSelection="true" 
-                                            value="#{bhtSummeryFinalizedController.patientEncounter}"
-                                            completeMethod="#{admissionController.completePatientAll}" 
-                                            var="myItem" itemValue="#{myItem}" 
-                                            itemLabel="#{myItem.bhtNo}" 
-                                            size="30"  >
-                                <p:ajax event="itemSelect" 
-                                        process="@this" 
-                                        update="@all" 
-                                        listener="#{bhtSummeryFinalizedController.selectLitener}"/>
-                                <p:column>
-                                    #{myItem.bhtNo}
-                                </p:column>
-                                <p:column>
-                                    #{myItem.patient.person.nameWithTitle}
-                                </p:column>
-                                <p:column>
-                                    <h:outputLabel value="#{myItem.currentPatientRoom.roomFacilityCharge.name}"/>
-                                </p:column>
-                                <p:column>
-                                    <h:outputLabel value="Discharged"  rendered="#{myItem.discharged}"/>
-                                </p:column>
-                                <p:column>
-                                    <h:outputLabel  value="Cancelled"  rendered="#{myItem.retired}"/>
-                                </p:column>
-                            </p:autoComplete>   
+                            <!-- No separate Continue button on this page - selecting a BHT must
+                                 load its bill items immediately (itemSelectListener), matching
+                                 the original itemSelect handler. -->
+                            <admcc:admission_search
+                                widgetVar="aPt"
+                                inputId="acPt"
+                                value="#{bhtSummeryFinalizedController.patientEncounter}"
+                                completeMethod="#{admissionController.completePatientAll}"
+                                itemSelectListener="#{bhtSummeryFinalizedController.selectLitener}"
+                                itemSelectUpdate="@all" />
 
                         </h:panelGrid>
                       

--- a/src/main/webapp/inward/inward_report_bht_room_detail.xhtml
+++ b/src/main/webapp/inward/inward_report_bht_room_detail.xhtml
@@ -6,6 +6,7 @@
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:f="http://xmlns.jcp.org/jsf/core"
       xmlns:bi="http://xmlns.jcp.org/jsf/composite/inward/bill"
+      xmlns:admcc="http://xmlns.jcp.org/jsf/composite/ezcomp/inpatient"
       >
 
     <h:body>
@@ -52,31 +53,14 @@
                                             var="dept" itemLabel="#{dept.name}" itemValue="#{dept}"
                                             forceSelection="true" value="#{inwardReportControllerBht.department}" />
                             <h:outputLabel value="BHT No  " ></h:outputLabel>
-                            <p:autoComplete  widgetVar="aPt" id="acPt" forceSelection="true" 
-                                            value="#{inwardReportControllerBht.reportKeyWord.patientEncounter}"
-                                            completeMethod="#{admissionController.completePatientAll}" 
-                                            var="myItem" itemValue="#{myItem}" 
-                                            itemLabel="#{myItem.bhtNo}" 
-                                            size="30"  >
-                                <p:column>
-                                    #{myItem.bhtNo}
-                                </p:column>
-                                <p:column>
-                                    #{myItem.patient.person.nameWithTitle}
-                                </p:column>
-                                <p:column>
-                                    <h:outputLabel value="#{myItem.currentPatientRoom.roomFacilityCharge.name}"/>
-                                </p:column>
-                                <p:column>
-                                    <h:outputLabel value="Discharged"  rendered="#{myItem.discharged}"/>
-                                </p:column>
-                                <p:column>
-                                    <h:outputLabel value="Finalized"  rendered="#{myItem.paymentFinalized}"/>
-                                </p:column>
-                                <p:column>
-                                    <h:outputLabel  value="Cancelled"  rendered="#{myItem.retired}"/>
-                                </p:column>
-                            </p:autoComplete>   
+                            <!-- No continueClientId: BHT is one optional filter among several here
+                                 (date range, admission type, institution, etc.) - selecting one
+                                 must not auto-run Search before the other filters are set. -->
+                            <admcc:admission_search
+                                widgetVar="aPt"
+                                inputId="acPt"
+                                value="#{inwardReportControllerBht.reportKeyWord.patientEncounter}"
+                                completeMethod="#{admissionController.completePatientAll}" />
                         </h:panelGrid>
 
                         <h:panelGrid columns="3">

--- a/src/main/webapp/inward/inward_report_discount.xhtml
+++ b/src/main/webapp/inward/inward_report_discount.xhtml
@@ -5,6 +5,7 @@
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:p="http://primefaces.org/ui"
       xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:admcc="http://xmlns.jcp.org/jsf/composite/ezcomp/inpatient"
       >
 
     <h:body>
@@ -39,31 +40,14 @@
                                                 itemValue="#{ccc}" itemLabel="#{ccc.name}"></f:selectItems>
                             </p:selectOneMenu>
                             <h:outputLabel value="BHT No : " ></h:outputLabel>
-                            <p:autoComplete  widgetVar="aPt" id="acPt" forceSelection="true" 
-                                            value="#{inwardReportController1.patientEncounter}"
-                                            completeMethod="#{admissionController.completePatientAll}" 
-                                            var="myItem" itemValue="#{myItem}" 
-                                            itemLabel="#{myItem.bhtNo}" 
-                                            size="30"  >
-                                <p:column>
-                                    #{myItem.bhtNo}
-                                </p:column>
-                                <p:column>
-                                    #{myItem.patient.person.nameWithTitle}
-                                </p:column>
-                                <p:column>
-                                    <h:outputLabel value="#{myItem.currentPatientRoom.roomFacilityCharge.name}"/>
-                                </p:column>
-                                <p:column>
-                                    <h:outputLabel value="Discharged"  rendered="#{myItem.discharged}"/>
-                                </p:column>
-                                <p:column>
-                                    <h:outputLabel value="Finalized"  rendered="#{myItem.paymentFinalized}"/>
-                                </p:column>
-                                <p:column>
-                                    <h:outputLabel  value="Cancelled"  rendered="#{myItem.retired}"/>
-                                </p:column>
-                            </p:autoComplete> 
+                            <!-- No continueClientId: BHT is one optional filter among several here
+                                 (date range, admission type, credit company, etc.) - selecting one
+                                 must not auto-run Process before the other filters are set. -->
+                            <admcc:admission_search
+                                widgetVar="aPt"
+                                inputId="acPt"
+                                value="#{inwardReportController1.patientEncounter}"
+                                completeMethod="#{admissionController.completePatientAll}" />
                                                     </h:panelGrid>
 
                         <p:panelGrid columns="3">

--- a/src/main/webapp/inward/inward_report_professional_payment_due.xhtml
+++ b/src/main/webapp/inward/inward_report_professional_payment_due.xhtml
@@ -5,6 +5,7 @@
       xmlns:p="http://primefaces.org/ui"
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:admcc="http://xmlns.jcp.org/jsf/composite/ezcomp/inpatient"
       >
 
     <h:body>
@@ -73,28 +74,14 @@
 
 
                             <h:outputLabel value="BHT No"/>
-                            <p:autoComplete class="mx-4 w-100" inputStyleClass="w-100" widgetVar="aPt" id="acPt" forceSelection="true" 
-                                            value="#{searchController.searchKeyword.patientEncounter}"
-                                            completeMethod="#{admissionController.completePatientAll}" 
-                                            var="myItem" itemValue="#{myItem}" 
-                                            itemLabel="#{myItem.bhtNo}" 
-                                            size="30"  >
-                                <p:column>
-                                    #{myItem.bhtNo}
-                                </p:column>
-                                <p:column>
-                                    #{myItem.patient.person.nameWithTitle}
-                                </p:column>
-                                <p:column>
-                                    <h:outputLabel value="#{myItem.currentPatientRoom.roomFacilityCharge.name}"/>
-                                </p:column>
-                                <p:column>
-                                    <h:outputLabel value="Discharged"  rendered="#{myItem.discharged}"/>
-                                </p:column>
-                                <p:column>
-                                    <h:outputLabel  value="Cancelled"  rendered="#{myItem.retired}"/>
-                                </p:column>
-                            </p:autoComplete>
+                            <!-- No continueClientId: BHT is one optional filter among several here
+                                 (date range, speciality, doctor, admission type, etc.) - selecting
+                                 one must not auto-run Search before the other filters are set. -->
+                            <admcc:admission_search
+                                widgetVar="aPt"
+                                inputId="acPt"
+                                value="#{searchController.searchKeyword.patientEncounter}"
+                                completeMethod="#{admissionController.completePatientAll}" />
 
 
 


### PR DESCRIPTION
## ⚠️ Merge order: requires PR #23433 merged first

4 pages in this PR (`inward_report_bht_bil.xhtml` + 3 `bht_deposit_by_created_date_*` pages) use the composite's new `itemSelectListener` attribute, added in **PR #23433** (not yet merged). `development` doesn't have that attribute yet, so **this PR must not be merged before #23433** — doing so would leave those 4 pages calling an attribute the composite doesn't declare. Everything in this PR was built and verified locally on top of #23433's branch together; CodeRabbit correctly flagged this as a diff-against-`development` gap, not a code bug (see the review-thread reply on the relevant comment).

## Summary

Continues #23165's barcode-friendly admission search rollout, following PR #23433 (the other Family C billing pages).

Migrates the remaining 10 Family C pages that have a genuine BHT search field:

- `credit/inward_patient_copay_payment.xhtml` — wizard pattern (search → select → advance to the co-payment screen)
- `inward_report_bht_bil.xhtml` — `itemSelectListener` pattern (loads bill items immediately on pick, no separate Continue button)
- `inward_report_bht_room_detail.xhtml`, `inward_report_discount.xhtml`, `inward_report_professional_payment_due.xhtml` — filter-report pattern (BHT is one optional filter among several; auto-select only, no auto-run)
- `bht_deposit_by_created_date_discharged.xhtml`, `_not_discharge.xhtml`, `_discharged_above.xhtml`, `_all.xhtml`, `_discharged_all.xhtml` — filter-report pattern (3 of the 5 preserve a pre-existing itemSelect listener from the original markup)

All search methods (`completePatientAll`) were already MRN-searchable from the pilot PR — no JPQL changes needed.

**Two pages intentionally excluded**: `bht_deposit_by_discharge_date.xhtml` and `bht_deposit_by_discharge_date_and_created_date.xhtml` have **no BHT search field at all** — they're pure date/credit-company filtered aggregate reports with no single-admission-selection step, so this issue's pattern genuinely doesn't apply to them.

## Decisions made without approval

1. **Wizard vs. filter-report classification per page**, based on actually reading each page's markup and controller methods, not assumption:
   - Wizard pages (safe to auto-advance): the BHT box is gated behind a `rendered="...eq null"` panel that switches to a different screen once selected.
   - Filter-report pages: the BHT box is one field among several (date range, admission type, institution, etc.) alongside a separate Search/Fill/Process button — auto-advancing on scan would be premature since the user may still need to set other filters. These get auto-select only, no `continueClientId`.
   - Verified every action wired to auto-advance is read-only report/setup logic (checked `selectLitener()`, `selectBhtListenerForRefund()`, `createDepositByCreatedDate*()`, etc.) before enabling it — none mutate persisted data.
2. **Preserved 3 pre-existing itemSelect listeners** on `bhtSummeryFinalizedController` from the original `bht_deposit_by_*` markup, even though they read a *different* controller's field (`mdInwardReportController`) than the one the page's BHT box is actually bound to — looks like a copy-paste artifact predating this change. Kept the exact existing (if slightly odd) behavior rather than silently dropping or "fixing" it, since that's outside this issue's scope.

## A bug I caught and fixed before committing

Initially missed carrying over `itemSelectUpdate="@all"` (the original itemSelect ajax's `update` target) onto 4 of the `itemSelectListener` pages. Without it, the listener still ran correctly server-side, but the DOM was never told to refresh — so scanning a BHT looked like nothing happened. Caught this by actually checking the resulting page state (not just watching for errors), fixed all 4 (`inward_report_bht_bil.xhtml` + 3 `bht_deposit_by_*` pages), and reverified each end-to-end before this PR.

## Verified

End-to-end with Playwright against local Payara + MySQL (`coop` dev DB):
- **`credit/inward_patient_copay_payment.xhtml`**: exact BHT scan auto-selects and auto-advances to the co-payment screen, correctly showing the "final bill not finalized" validation message for the test admission.
- **`inward_report_bht_bil.xhtml`**: exact BHT scan auto-selects and immediately loads Patient Detail + Bill Items with real data (Ward 105/V wom, Credit BHT Type) — confirmed this wasn't stale/empty state after the `itemSelectUpdate` fix.
- **`inward_report_bht_room_detail.xhtml`**: exact BHT scan auto-selects into the BHT No filter but does **not** auto-click Search — the other filters (date range, admission type, institution, etc.) stay available to set first.
- The remaining 7 pages visually confirmed rendering correctly with the composite wired in (full-width search box, no layout regressions).
- No new errors in `server.log` or the browser console across the whole verification pass.

## Follow-up (not in this PR)

`bht_deposit_by_discharge_date.xhtml` and `bht_deposit_by_discharge_date_and_created_date.xhtml` — flagged for the issue owner to confirm they're genuinely out of scope (no BHT search step exists to migrate) rather than silently skipped.

With this PR, the Family C batch from the issue's original checklist is complete except for those two out-of-pattern report pages.

Closes nothing on its own — tracked as part of #23165.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a standardized admission search component across inpatient co-payment, deposit, billing, room charge, discount, and payment-due pages.
  * Admission searches now provide a consistent selection experience while retaining the relevant patient, encounter, and report filtering behavior.
  * Selecting an admission updates dependent information where appropriate, while report pages wait for the remaining filters before running searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
