### PR TITLE
fix(finance): add create_bill_fee correction endpoint for orphaned BillItems (#23436)

### DIFF
--- a/developer_docs/api/using-apis/API_BILL_DATA_CORRECTION.md
+++ b/developer_docs/api/using-apis/API_BILL_DATA_CORRECTION.md
@@ -26,6 +26,7 @@ Then apply updates using:
 
 - `PATCH /api/bill_data_correction` — update existing BFD/bill/item fields
 - `POST /api/bill_data_correction/create_bill_item` — **create** a single missing `BillItem` on an already-saved bill
+- `POST /api/bill_data_correction/create_bill_fee` — **create** a single missing `BillFee` on an already-saved `BillItem`
 - `POST /api/pharmacy/backfill_bfd` — **create** missing BFDs for historical adjustment bills
 
 ## Creating a Missing Bill Item
@@ -79,6 +80,64 @@ the bill's existing `netTotal`/`total`.
     "auditComment": "...",
     "approvedBy": "Dr. Smith",
     "correctedAt": "2026-09-01 18:00:00",
+    "correctedByApiUser": "admin_user"
+  }
+}
+```
+
+As with `PATCH`, the correction is appended to the bill's `comments` for audit.
+
+## Creating a Missing Bill Fee
+
+Use this only to repair a `BillItem` that is missing a `BillFee` it should have — e.g. a refund item
+that was itself backfilled with `create_bill_item` above, but the corresponding fee was never
+recreated, so reports that join from `BillFee` (such as the QuickBooks Daily Return report) still
+don't see it. It does **not** recompute or touch the bill's totals, finance details, or payments.
+
+The `fee`, `department`, `institution`, and `patient` on the new row are copied from the
+`referenceBillFee` you supply — this mirrors what the normal refund code path
+(`BillReturnController`) does when it creates a refund `BillFee` by copying and inverting the
+original — so you only need to provide the (already-inverted) `feeValue`/`feeGrossValue`.
+
+- **Endpoint**: `POST /api/bill_data_correction/create_bill_fee`
+- **Auth Header**: `Finance: <API_KEY>`
+
+### Request Body
+
+```json
+{
+  "billItemId": 5251032,
+  "referenceBillFeeId": 5217123,
+  "feeValue": -1740.0,
+  "feeGrossValue": -1740.0,
+  "auditComment": "Backfill missing BillFee for refund bill RHDOM/R/26/60715 — BillItem 5251032 was recreated via create_bill_item after issue #23408, but its BillFee was never backfilled, leaving the QB Daily Return report (#23436) unable to see the refund",
+  "approvedBy": "Dr. Smith"
+}
+```
+
+- `billItemId` (required) — the `BillItem` the fee should be attached to.
+- `referenceBillFeeId` (required) — the original `BillFee` this one refunds/corrects. Its `fee`,
+  `department`, `institution`, and `patient` are copied onto the new row; the request is rejected
+  with `409` if the target bill item already has a non-retired fee referencing the same source fee
+  (prevents duplicate recreation).
+- `feeValue`, `feeGrossValue` — plain numeric fields copied onto the new `BillFee` as-is (already
+  inverted/signed as appropriate for a refund or cancellation).
+- `auditComment`, `approvedBy` — mandatory, as with `PATCH /api/bill_data_correction`.
+
+### Response (Success)
+
+```json
+{
+  "status": "success",
+  "code": 200,
+  "data": {
+    "targetType": "BILL_FEE_CREATE",
+    "billItemId": 5251032,
+    "createdBillFeeId": 5300001,
+    "newValues": {"billFeeId": 5300001, "billItemId": 5251032, "referenceBillFeeId": 5217123, "feeId": 123085, "feeValue": -1740.0, "feeGrossValue": -1740.0},
+    "auditComment": "...",
+    "approvedBy": "Dr. Smith",
+    "correctedAt": "2026-09-03 12:00:00",
     "correctedByApiUser": "admin_user"
   }
 }

--- a/src/main/java/com/divudi/service/BillDataCorrectionService.java
+++ b/src/main/java/com/divudi/service/BillDataCorrectionService.java
@@ -236,6 +236,107 @@ public class BillDataCorrectionService {
         return result;
     }
 
+    /**
+     * Creates a single BillFee that is missing for an already-saved BillItem (e.g. a refund
+     * bill item whose fee never got persisted because of a defect in the saving code, or was
+     * left behind after {@link #createMissingBillItem} backfilled only the BillItem). This is
+     * a narrow, audited data-repair action — it does not recompute or touch any bill totals,
+     * finance details, or payments. The fee/department/institution/patient are copied from the
+     * supplied referenceBillFee (the fee this one corrects/mirrors) so the new row lines up with
+     * how the normal refund code path (BillReturnController) builds a BillFee; the caller is
+     * responsible for supplying a feeValue/feeGrossValue already consistent with the bill's
+     * existing netTotal.
+     */
+    public Map<String, Object> createMissingBillFee(Long billItemId,
+            Long referenceBillFeeId,
+            double feeValue,
+            double feeGrossValue,
+            String auditComment,
+            String approvedBy,
+            WebUser apiUser) {
+
+        if (billItemId == null) {
+            throw new IllegalArgumentException("billItemId is required");
+        }
+        if (referenceBillFeeId == null) {
+            throw new IllegalArgumentException("referenceBillFeeId is required");
+        }
+        if (auditComment == null || auditComment.trim().isEmpty()) {
+            throw new IllegalArgumentException("auditComment is required");
+        }
+        if (approvedBy == null || approvedBy.trim().isEmpty()) {
+            throw new IllegalArgumentException("approvedBy is required");
+        }
+
+        BillItem billItem = billItemFacade.find(billItemId);
+        if (billItem == null) {
+            throw new IllegalArgumentException("BillItem not found for id " + billItemId);
+        }
+
+        Bill bill = billItem.getBill();
+        if (bill == null) {
+            throw new IllegalStateException("BillItem " + billItemId + " has no parent bill");
+        }
+
+        BillFee referenceBillFee = billFeeFacade.find(referenceBillFeeId);
+        if (referenceBillFee == null) {
+            throw new IllegalArgumentException("Reference BillFee not found for id " + referenceBillFeeId);
+        }
+
+        Map<String, Object> dupCheckParams = new java.util.HashMap<>();
+        dupCheckParams.put("ref", referenceBillFee);
+        dupCheckParams.put("bi", billItem);
+        long alreadyLinked = billFeeFacade.findLongByJpql(
+                "SELECT COUNT(bf) FROM BillFee bf WHERE bf.retired = false"
+                + " AND bf.referenceBillFee = :ref AND bf.billItem = :bi",
+                dupCheckParams);
+        if (alreadyLinked > 0) {
+            throw new IllegalStateException(
+                    "BillItem " + billItemId + " already has an active BillFee referencing BillFee " + referenceBillFeeId);
+        }
+
+        BillFee newFee = new BillFee();
+        newFee.setBill(bill);
+        newFee.setBillItem(billItem);
+        newFee.setFee(referenceBillFee.getFee());
+        newFee.setDepartment(referenceBillFee.getDepartment());
+        newFee.setInstitution(referenceBillFee.getInstitution());
+        newFee.setPatient(referenceBillFee.getPatient());
+        newFee.setReferenceBillFee(referenceBillFee);
+        newFee.setReferenceBillItem(referenceBillFee.getBillItem());
+        newFee.setFeeValue(feeValue);
+        newFee.setFeeGrossValue(feeGrossValue);
+        newFee.setRetired(false);
+        newFee.setCreatedAt(new Date());
+        newFee.setCreater(apiUser);
+
+        billFeeFacade.create(newFee);
+
+        Map<String, Object> newValues = new LinkedHashMap<>();
+        newValues.put("billFeeId", newFee.getId());
+        newValues.put("billItemId", billItemId);
+        newValues.put("referenceBillFeeId", referenceBillFeeId);
+        newValues.put("feeId", referenceBillFee.getFee() != null ? referenceBillFee.getFee().getId() : null);
+        newValues.put("feeValue", feeValue);
+        newValues.put("feeGrossValue", feeGrossValue);
+
+        appendAuditLog(bill, "BILL_FEE_CREATE", newFee.getId(), new LinkedHashMap<>(), newValues, auditComment, approvedBy, apiUser);
+        billFacade.edit(bill);
+
+        String correctedBy = apiUser != null ? apiUser.getName() : null;
+
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("targetType", "BILL_FEE_CREATE");
+        result.put("billItemId", billItemId);
+        result.put("createdBillFeeId", newFee.getId());
+        result.put("newValues", newValues);
+        result.put("auditComment", auditComment);
+        result.put("approvedBy", approvedBy);
+        result.put("correctedAt", new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(new Date()));
+        result.put("correctedByApiUser", correctedBy);
+        return result;
+    }
+
     private Bill updateBill(Long id, Map<String, Object> fields, Map<String, Object> previousValues, Map<String, Object> newValues, WebUser apiUser) {
         Bill entity = billFacade.find(id);
         if (entity == null) {

--- a/src/main/java/com/divudi/ws/finance/BillDataCorrectionApi.java
+++ b/src/main/java/com/divudi/ws/finance/BillDataCorrectionApi.java
@@ -167,6 +167,12 @@ public class BillDataCorrectionApi {
             if (request.getApprovedBy() == null || request.getApprovedBy().trim().isEmpty()) {
                 return errorResponse("approvedBy is required", 400);
             }
+            if (request.getFeeValue() == null) {
+                return errorResponse("feeValue is required", 400);
+            }
+            if (request.getFeeGrossValue() == null) {
+                return errorResponse("feeGrossValue is required", 400);
+            }
 
             Map<String, Object> result = correctionService.createMissingBillFee(
                     request.getBillItemId(),
@@ -369,8 +375,8 @@ public class BillDataCorrectionApi {
 
         private Long billItemId;
         private Long referenceBillFeeId;
-        private double feeValue;
-        private double feeGrossValue;
+        private Double feeValue;
+        private Double feeGrossValue;
         private String auditComment;
         private String approvedBy;
 
@@ -390,19 +396,19 @@ public class BillDataCorrectionApi {
             this.referenceBillFeeId = referenceBillFeeId;
         }
 
-        public double getFeeValue() {
+        public Double getFeeValue() {
             return feeValue;
         }
 
-        public void setFeeValue(double feeValue) {
+        public void setFeeValue(Double feeValue) {
             this.feeValue = feeValue;
         }
 
-        public double getFeeGrossValue() {
+        public Double getFeeGrossValue() {
             return feeGrossValue;
         }
 
-        public void setFeeGrossValue(double feeGrossValue) {
+        public void setFeeGrossValue(Double feeGrossValue) {
             this.feeGrossValue = feeGrossValue;
         }
 

--- a/src/main/java/com/divudi/ws/finance/BillDataCorrectionApi.java
+++ b/src/main/java/com/divudi/ws/finance/BillDataCorrectionApi.java
@@ -139,6 +139,55 @@ public class BillDataCorrectionApi {
         }
     }
 
+    @POST
+    @Path("/create_bill_fee")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response createMissingBillFee(String requestBody) {
+        try {
+            String key = requestContext.getHeader("Finance");
+            WebUser user = validateApiKey(key);
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            CreateBillFeeRequest request;
+            try {
+                request = gson.fromJson(requestBody, CreateBillFeeRequest.class);
+            } catch (JsonSyntaxException ex) {
+                return errorResponse("Invalid JSON format: " + ex.getMessage(), 400);
+            }
+
+            if (request == null) {
+                return errorResponse("Request body is required", 400);
+            }
+            if (request.getAuditComment() == null || request.getAuditComment().trim().isEmpty()) {
+                return errorResponse("auditComment is required", 400);
+            }
+            if (request.getApprovedBy() == null || request.getApprovedBy().trim().isEmpty()) {
+                return errorResponse("approvedBy is required", 400);
+            }
+
+            Map<String, Object> result = correctionService.createMissingBillFee(
+                    request.getBillItemId(),
+                    request.getReferenceBillFeeId(),
+                    request.getFeeValue(),
+                    request.getFeeGrossValue(),
+                    request.getAuditComment().trim(),
+                    request.getApprovedBy().trim(),
+                    user
+            );
+
+            return successResponse(result);
+        } catch (IllegalArgumentException ex) {
+            return errorResponse(ex.getMessage(), 400);
+        } catch (IllegalStateException ex) {
+            return errorResponse(ex.getMessage(), 409);
+        } catch (Exception ex) {
+            return errorResponse("An error occurred: " + ex.getMessage(), 500);
+        }
+    }
+
     private WebUser validateApiKey(String key) {
         if (key == null || key.trim().isEmpty()) {
             return null;
@@ -297,6 +346,64 @@ public class BillDataCorrectionApi {
 
         public void setNetValue(double netValue) {
             this.netValue = netValue;
+        }
+
+        public String getAuditComment() {
+            return auditComment;
+        }
+
+        public void setAuditComment(String auditComment) {
+            this.auditComment = auditComment;
+        }
+
+        public String getApprovedBy() {
+            return approvedBy;
+        }
+
+        public void setApprovedBy(String approvedBy) {
+            this.approvedBy = approvedBy;
+        }
+    }
+
+    public static class CreateBillFeeRequest {
+
+        private Long billItemId;
+        private Long referenceBillFeeId;
+        private double feeValue;
+        private double feeGrossValue;
+        private String auditComment;
+        private String approvedBy;
+
+        public Long getBillItemId() {
+            return billItemId;
+        }
+
+        public void setBillItemId(Long billItemId) {
+            this.billItemId = billItemId;
+        }
+
+        public Long getReferenceBillFeeId() {
+            return referenceBillFeeId;
+        }
+
+        public void setReferenceBillFeeId(Long referenceBillFeeId) {
+            this.referenceBillFeeId = referenceBillFeeId;
+        }
+
+        public double getFeeValue() {
+            return feeValue;
+        }
+
+        public void setFeeValue(double feeValue) {
+            this.feeValue = feeValue;
+        }
+
+        public double getFeeGrossValue() {
+            return feeGrossValue;
+        }
+
+        public void setFeeGrossValue(double feeGrossValue) {
+            this.feeGrossValue = feeGrossValue;
         }
 
         public String getAuditComment() {


### PR DESCRIPTION
## Summary
- Investigated #23436 (QB Daily Return report not reflecting the Aug 25 refund of Urine Sodium on bill RHDOM/OBB/26/56731/01).
- Root cause: refund bill RHDOM/R/26/60715's BillItem was never persisted due to issue #23408 (`BillSearch.saveRefundBill()` relying on cascade-only save), fixed in PR #23409. The missing BillItem was backfilled via the existing `create_bill_item` correction endpoint on 2026-09-01, which fixed the Daily Return Report — but the corresponding BillFee was never recreated, so the QB report (which inner-joins from BillFee) still can't see the refund.
- Scanned all active OPD refund bills in the Ruhunu production DB: only this one is missing a BillFee (out of 17), and it's the only bill ever touched by the Bill Data Correction tool — this is an isolated leftover, not an ongoing systemic gap.
- Adds `POST /api/bill_data_correction/create_bill_fee`, mirroring the existing `create_bill_item` endpoint: given a `billItemId` and `referenceBillFeeId`, copies fee/department/institution/patient from the reference fee (matching how `BillReturnController` normally builds a refund BillFee) and persists the row with the caller-supplied `feeValue`/`feeGrossValue`, under the same audit-comment/approved-by trail as other corrections.

## Test plan
- [x] `mvn -o compile` succeeds
- [ ] After merge/deploy, call `POST /api/bill_data_correction/create_bill_fee` against Ruhunu production with `billItemId=5251032`, `referenceBillFeeId=5217123`, `feeValue=-1740.0`, `feeGrossValue=-1740.0` to backfill the missing BillFee, then confirm the Aug 25 refund now appears on the QB Daily Return report for Ruhunu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Finance API endpoint for recreating missing bill-fee records on existing bill items.
  * Supports fee values, reference-fee details, approver information, and audit comments.
  * Prevents duplicate fee creation and returns clear success or error responses.

* **Documentation**
  * Documented the new endpoint, request fields, response behavior, duplicate protection, and audit logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->