### PR TITLE
Hotfix: disposal-issue BillItem.qty sign + Consumption by Category net-zero drop (#23448)

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
@@ -4115,7 +4115,19 @@ public class PharmacyController implements Serializable {
             String catName = dto.getCategoryName();
             if (deptName == null || deptName.trim().isEmpty()) continue;
             if (catName == null || catName.trim().isEmpty()) continue;
-            if (dto.getQty() == 0.0) continue;
+            // Skip only genuinely empty rows. A row whose quantities net to zero
+            // (e.g. an item issued and then fully returned within the period) still
+            // carries real value and MUST be shown here, otherwise this tab silently
+            // under-reports versus the Consumption Summary / By Bill Item tabs, which
+            // have no such filter. (Issue #23448: a 2025-05-28 sign regression on
+            // BillItem.qty made ~74 Operation-Theatre-style groups net to zero.)
+            if (dto.getQty() == 0.0
+                    && dto.getTotalPurchaseValue() == 0.0
+                    && dto.getTotalCostValue() == 0.0
+                    && dto.getTotalRetailValue() == 0.0
+                    && dto.getNetTotal() == 0.0) {
+                continue;
+            }
 
             // Category map: consumptionDept -> category -> items
             catMap.computeIfAbsent(deptName, k -> new TreeMap<>())
@@ -5105,6 +5117,10 @@ public class PharmacyController implements Serializable {
         return new ArrayList<>(aggregatedMap.values());
     }
 
+    private static boolean zeroOrNull(Double v) {
+        return v == null || v == 0.0;
+    }
+
     public void generateConsumptionReportTableAsCategoryWise(final List<DepartmentCategoryWiseItems> list) {
         totalSaleValue = 0.0;
         totalCostValue = 0.0;
@@ -5121,7 +5137,15 @@ public class PharmacyController implements Serializable {
             String departmentName = item.getConsumptionDepartment() != null ? item.getConsumptionDepartment().getName() : null;
             String categoryName = item.getCategory() != null ? item.getCategory().getName() : null;
 
-            if (item.getQty() == 0) {
+            // Skip only genuinely empty rows. A row whose quantities net to zero
+            // (e.g. an item issued and then fully returned within the period) still
+            // carries real value and MUST be shown here, otherwise this tab silently
+            // under-reports versus the Consumption Summary / By Bill Item tabs. (#23448)
+            if (item.getQty() == 0
+                    && zeroOrNull(item.getTotalPurchaseValue())
+                    && zeroOrNull(item.getTotalCostValue())
+                    && zeroOrNull(item.getTotalRetailValue())
+                    && zeroOrNull(item.getNetTotal())) {
                 continue;
             }
 

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyIssueController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyIssueController.java
@@ -878,10 +878,29 @@ public class PharmacyIssueController implements Serializable {
     @Inject
     private BillBeanController billBean;
 
+    /**
+     * A disposal issue always removes stock, so {@code BillItem.qty} must be
+     * persisted with the same negative sign that {@code PharmaceuticalBillItem.qty}
+     * already carries (it is set via {@code 0 - Math.abs(qty)} upstream). The
+     * editing UI deliberately works with a positive qty for its bounds checks
+     * ({@code qty > stock}, {@code qty <= 0}); normalise here, at the persist
+     * point, so the two quantities can never disagree in sign on a saved row.
+     * Historically both were negative; a regression left {@code BillItem.qty}
+     * positive from 2025-05-28, which silently broke the Consumption reports that
+     * group on {@code SUM(bi.qty)} (issue #23448).
+     */
+    private void normaliseDisposalIssueQtySign(BillItem tbi) {
+        if (tbi == null || tbi.getPharmaceuticalBillItem() == null) {
+            return;
+        }
+        tbi.setQty(0 - Math.abs(tbi.getQty()));
+    }
+
     private void savePreBillItemsFinally(List<BillItem> list) {
         for (BillItem tbi : list) {
             tbi.setInwardChargeType(InwardChargeType.Medicine);
             tbi.setBill(getPreBill());
+            normaliseDisposalIssueQtySign(tbi);
 
             if (tbi.getId() == null) {
                 tbi.setCreatedAt(Calendar.getInstance().getTime());


### PR DESCRIPTION
## What

Two targeted changes for **#23448**:

1. **`PharmacyIssueController.normaliseDisposalIssueQtySign()`** — force `BillItem.qty` to `0 - Math.abs(qty)` in `savePreBillItemsFinally()`, matching the sign `PharmaceuticalBillItem.qty` already carries. Stops new disposal issues from saving a positive `BillItem.qty`.
2. **`PharmacyController`** — in `generateConsumptionSummaryAndCategoryDto()` and `generateConsumptionReportTableAsCategoryWise()`, skip a row only when the quantity **and** all four value fields are zero, not on net-zero quantity alone.

45 insertions, 2 deletions. No behaviour change outside disposal-issue save and the Consumption by Category report.

## Why

Since a deploy on **2025-05-28**, every Pharmacy Disposal Issue saved `BillItem.qty` positive while everything else (`PharmaceuticalBillItem.qty`, finance details, stock movement) stayed correctly negative. The **Consumption by Category** report groups on `SUM(bi.qty)` and dropped any item whose net qty was exactly `0.0` — so an item issued both before and after the cut-over netted to zero and disappeared from that tab **with its value**. Result: By Category under-reported versus Summary / By Bill Item / COGS.

Reported by Ruhunu (2026-09-02): General Stores → Operation Theatre, May 2026 — By Category **330,851.85** vs Summary **864,490.25** (gap 533,638.40).

## Verification

- **Local** (restored prod backup): new disposal issue saves `bi.qty = -7` consistent with `ph.qty`; By Category for Operation Theatre May 2026 = **864,490.25**, all 4 previously-dropped items restored.
- **Live on `stg-migrated.carecode.org/rh`** (this same prod DB), after the data correction: By Category Operation Theatre May 2026 = **864,490.25**, reconciles with Summary. VARICOSE FIBRE now shows qty `-2.0` (was `0.0`) with its full 531,000.00.
- Build: `mvn clean package` green on this branch.

## Production data

The affected rows on the Ruhunu prod DB were corrected separately on 2026-09-03: `BillItem.qty` sign flipped to match `PharmaceuticalBillItem.qty`, scoped to `PHARMACY_DISPOSAL_ISSUE` + `qty > 0` + `ph.qty < 0` + `ABS(bi.qty) = ABS(ph.qty)` → 12,701 rows. Verified 0 positive rows remain, 0 sign mismatches. This code fix stops the regeneration of bad rows.

## Also going to

`development` (PR to follow) and `ruhunu-prod` (matching `-hotfix` branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)