### PR TITLE
fix(pharmacy): disposal-issue BillItem.qty sign + Consumption by Category net-zero drop (#23448)

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
@@ -4191,7 +4191,19 @@ public class PharmacyController implements Serializable {
             String catName = dto.getCategoryName();
             if (deptName == null || deptName.trim().isEmpty()) continue;
             if (catName == null || catName.trim().isEmpty()) continue;
-            if (dto.getQty() == 0.0) continue;
+            // Skip only genuinely empty rows. A row whose quantities net to zero
+            // (e.g. an item issued and then fully returned within the period) still
+            // carries real value and MUST be shown here, otherwise this tab silently
+            // under-reports versus the Consumption Summary / By Bill Item tabs, which
+            // have no such filter. (Issue #23448: a 2025-05-28 sign regression on
+            // BillItem.qty made ~74 Operation-Theatre-style groups net to zero.)
+            if (dto.getQty() == 0.0
+                    && dto.getTotalPurchaseValue() == 0.0
+                    && dto.getTotalCostValue() == 0.0
+                    && dto.getTotalRetailValue() == 0.0
+                    && dto.getNetTotal() == 0.0) {
+                continue;
+            }
 
             // Category map: consumptionDept -> category -> items
             catMap.computeIfAbsent(deptName, k -> new TreeMap<>())
@@ -5181,6 +5193,10 @@ public class PharmacyController implements Serializable {
         return new ArrayList<>(aggregatedMap.values());
     }
 
+    private static boolean zeroOrNull(Double v) {
+        return v == null || v == 0.0;
+    }
+
     public void generateConsumptionReportTableAsCategoryWise(final List<DepartmentCategoryWiseItems> list) {
         totalSaleValue = 0.0;
         totalCostValue = 0.0;
@@ -5197,7 +5213,15 @@ public class PharmacyController implements Serializable {
             String departmentName = item.getConsumptionDepartment() != null ? item.getConsumptionDepartment().getName() : null;
             String categoryName = item.getCategory() != null ? item.getCategory().getName() : null;
 
-            if (item.getQty() == 0) {
+            // Skip only genuinely empty rows. A row whose quantities net to zero
+            // (e.g. an item issued and then fully returned within the period) still
+            // carries real value and MUST be shown here, otherwise this tab silently
+            // under-reports versus the Consumption Summary / By Bill Item tabs. (#23448)
+            if (item.getQty() == 0
+                    && zeroOrNull(item.getTotalPurchaseValue())
+                    && zeroOrNull(item.getTotalCostValue())
+                    && zeroOrNull(item.getTotalRetailValue())
+                    && zeroOrNull(item.getNetTotal())) {
                 continue;
             }
 

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyIssueController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyIssueController.java
@@ -902,10 +902,29 @@ public class PharmacyIssueController implements Serializable {
     @Inject
     private BillBeanController billBean;
 
+    /**
+     * A disposal issue always removes stock, so {@code BillItem.qty} must be
+     * persisted with the same negative sign that {@code PharmaceuticalBillItem.qty}
+     * already carries (it is set via {@code 0 - Math.abs(qty)} upstream). The
+     * editing UI deliberately works with a positive qty for its bounds checks
+     * ({@code qty > stock}, {@code qty <= 0}); this normaliser is applied at every
+     * persist point so the two quantities can never disagree in sign on a saved
+     * row. Historically both were negative; a regression left {@code BillItem.qty}
+     * positive from 2025-05-28, which silently broke the Consumption reports that
+     * group on {@code SUM(bi.qty)}.
+     */
+    private void normaliseDisposalIssueQtySign(BillItem tbi) {
+        if (tbi == null || tbi.getPharmaceuticalBillItem() == null) {
+            return;
+        }
+        tbi.setQty(0 - Math.abs(tbi.getQty()));
+    }
+
     private void savePreBillItemsFinally(List<BillItem> list) {
         for (BillItem tbi : list) {
             tbi.setInwardChargeType(InwardChargeType.Medicine);
             tbi.setBill(getPreBill());
+            normaliseDisposalIssueQtySign(tbi);
 
             if (tbi.getId() == null) {
                 tbi.setCreatedAt(Calendar.getInstance().getTime());
@@ -1100,6 +1119,7 @@ public class PharmacyIssueController implements Serializable {
                 tbi.setBill(getPreBill());
                 tbi.setCreatedAt(new Date());
                 tbi.setCreater(sessionController.getLoggedUser());
+                normaliseDisposalIssueQtySign(tbi);
                 getBillItemFacade().createAndFlush(tbi);
             }
             getPreBill().setBillItems(tmpBillItems);
@@ -1126,6 +1146,7 @@ public class PharmacyIssueController implements Serializable {
             for (BillItem tbi : getActiveBillItems()) {
                 tbi.setInwardChargeType(InwardChargeType.Medicine);
                 tbi.setBill(getPreBill());
+                normaliseDisposalIssueQtySign(tbi);
                 if (tbi.getId() == null) {
                     tbi.setCreatedAt(new Date());
                     tbi.setCreater(sessionController.getLoggedUser());


### PR DESCRIPTION
## What

1. **`PharmacyIssueController.normaliseDisposalIssueQtySign()`** — force `BillItem.qty` to `0 - Math.abs(qty)` at every disposal-issue persist point (`savePreBillItemsFinally` + both loops in `doSaveDisposalIssueDraft`), matching the sign `PharmaceuticalBillItem.qty` already carries.
2. **`PharmacyController`** — in `generateConsumptionSummaryAndCategoryDto()` and `generateConsumptionReportTableAsCategoryWise()`, skip a row only when the quantity **and** all four value fields are zero, not on net-zero quantity alone.

47 insertions, 2 deletions. No behaviour change outside disposal-issue save and the Consumption by Category report.

## Why

Since a deploy on **2025-05-28**, every Pharmacy Disposal Issue saved `BillItem.qty` positive while everything else (`PharmaceuticalBillItem.qty`, finance details, stock movement) stayed correctly negative. `updateFinancialsForIssue` negates `fd.*` but nothing normalised `BillItem.qty`, and `setQty()` rejects `<= 0`, so it lands positive.

The **Consumption by Category** report groups on `SUM(bi.qty)` and dropped any item whose net qty was exactly `0.0` — so an item issued both before and after the cut-over netted to zero and disappeared from that tab **with its value**. By Category then under-reported versus Summary / By Bill Item / COGS.

Reported by Ruhunu (2026-09-02): General Stores → Operation Theatre, May 2026 — By Category **330,851.85** vs Summary **864,490.25** (gap 533,638.40 = VARICOSE FIBRE 531,000 + URINE CONTAINERS 518.40 + TEEPOL ML 2,000 + PHOTO COPY A4 120).

Confined to May 2026 — the only month straddling the regression. June onward, all rows share the (wrong) positive sign so `SUM` is never 0 and nothing drops.

## Verification

- **Local** (restored Ruhunu prod backup): created a disposal issue via the UI → `bi.qty = -7`, consistent with `ph.qty` / `fd.quantity` / `fd.valueAtCostRate`. Re-ran By Category for Operation Theatre, May 2026 → **864,490.25**, matching Summary; all 4 previously-dropped items restored.
- **Live on `stg-migrated.carecode.org/rh`** (latest development + Ruhunu prod DB), after the data correction: By Category Operation Theatre May 2026 = **864,490.25**. VARICOSE FIBRE shows qty `-2.0` (was `0.0`) with its 531,000.00.
- `mvn clean package` green on this branch.

## Production data

Ruhunu prod DB rows for the affected period were corrected on 2026-09-03: `BillItem.qty` sign flipped to match `PharmaceuticalBillItem.qty`, scoped to `PHARMACY_DISPOSAL_ISSUE` + `qty > 0` + `ph.qty < 0` + `ABS(bi.qty) = ABS(ph.qty)` → 12,701 rows. Verified 0 positive rows remain, 0 sign mismatches. This code fix stops the regeneration of bad rows.

## Related

Hotfix for the Ruhunu migrated production branch: #23449 (→ `ruhunu-prod-migrated`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Consumption reports now include items with zero net quantity when they still have associated purchase, cost, retail, or total values.
  * Category-wise and summary consumption views now align with the corresponding consumption summary and bill-item views.
  * Disposal issue records now consistently treat issued quantities as negative values, improving quantity accuracy across disposal workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->