### PR TITLE
fix(ui): gate login page migration warning banner by config option

### DIFF
--- a/src/main/webapp/resources/ezcomp/footer.xhtml
+++ b/src/main/webapp/resources/ezcomp/footer.xhtml
@@ -18,7 +18,7 @@
             <p:outputLabel rendered="false" value="#{sessionController.userPreference.id}" ></p:outputLabel>
         </div>-->
 
-        <h:panelGroup rendered="#{applicationController.databaseMigrationPending}">
+<h:panelGroup rendered="#{applicationController.databaseMigrationPending and configOptionApplicationController.getBooleanValueByKey('Display pending Database Migration warning on the login page',true)}">
             <div style="position: fixed; bottom: 0; left: 0; width: 100%; z-index: 9999;
                         background-color: #dc3545; color: #fff; text-align: center;
                         padding: 10px 15px; font-size: 14px; font-weight: bold;"


### PR DESCRIPTION
## Description
The pending database-migration warning banner on the login page footer (`footer.xhtml`) is shown purely based on `applicationController.databaseMigrationPending`, with no way for an admin to hide it. This forces the warning to display for all users any time a migration is pending, even when it is not actionable/relevant to them.

## Fix
Gate the `<h:panelGroup>` rendering the warning in `src/main/webapp/resources/ezcomp/footer.xhtml` with an additional `configOptionApplicationController.getBooleanValueByKey('Display pending Database Migration warning on the login page', true)` check. Defaults to `true` to preserve current behavior.

## Scope
JSF/XHTML-only change (`footer.xhtml`).

Same fix as #23468 (merged into `ruhunu-prod-migrated`), forward-ported to `development`.

Fixes #23467

🤖 Generated with [Claude Code](https://claude.com/claude-code)
