### PR TITLE
fix(lab): make report format css-to-ri migration complete and re-runnable

### DIFF
--- a/src/main/java/com/divudi/bean/lab/InvestigationItemController.java
+++ b/src/main/java/com/divudi/bean/lab/InvestigationItemController.java
@@ -892,55 +892,117 @@ public class InvestigationItemController implements Serializable {
         this.file = file;
     }
 
+    /**
+     * Migrates report items from the legacy String css* layout fields to the
+     * numeric ri* fields the current report rendering reads.
+     *
+     * Safe to re-run: a row that already carries new format coordinates keeps
+     * them, so a partially converted database is not overwritten.
+     */
     public void convertCssValuesToRiValues() {
         String j = "select ri from ReportItem ri";
         List<ReportItem> ris = riFacade.findByJpql(j);
+        int layoutMigrated = 0;
+        int textMigrated = 0;
+        int alreadyConverted = 0;
+        int failed = 0;
+
         for (ReportItem ri : ris) {
-
             try {
+                boolean changed = false;
 
-                ri.setCssTop(ri.getCssTop().replace("%", ""));
-                ri.setCssLeft(ri.getCssLeft().replace("%", ""));
-                ri.setCssHeight(ri.getCssHeight().replace("%", ""));
-                ri.setCssWidth(ri.getCssWidth().replace("%", ""));
+                // getRiTop() and getRiLeft() return the stored value as is. Do not use
+                // getRiWidth(), getRiHeight() or getRiFontSize() for this test - they
+                // apply a lazy default and write it back to the entity when read.
+                if (ri.getRiTop() == 0 && ri.getRiLeft() == 0) {
+                    Double top = parseLegacyCssLength(ri.getCssTop());
+                    Double left = parseLegacyCssLength(ri.getCssLeft());
+                    Double width = parseLegacyCssLength(ri.getCssWidth());
+                    Double height = parseLegacyCssLength(ri.getCssHeight());
 
-                try {
-                    ri.setRiTop(Double.parseDouble(ri.getCssTop()));
-                } catch (Exception e) {
-                    ri.setRiTop(11.11);
-                }
-
-                try {
-                    ri.setRiLeft(Double.parseDouble(ri.getCssLeft()));
-                } catch (Exception e) {
-                    ri.setRiTop(22.22);
-                }
-
-                try {
-                    ri.setRiHeight(Double.parseDouble(ri.getCssHeight()));
-                } catch (Exception e) {
-                    ri.setRiHeight(2);
-                }
-
-                try {
-                    ri.setRiWidth(Double.parseDouble(ri.getCssWidth()));
-                    if (ri.getRiWidth() < 20) {
-                        ri.setRiWidth(20);
+                    if (top != null) {
+                        ri.setRiTop(top);
+                        changed = true;
                     }
-                } catch (Exception e) {
-                    ri.setRiWidth(40);
+                    if (left != null) {
+                        ri.setRiLeft(left);
+                        changed = true;
+                    }
+                    if (width != null) {
+                        ri.setRiWidth(width);
+                        changed = true;
+                    }
+                    if (height != null) {
+                        ri.setRiHeight(height);
+                        changed = true;
+                    }
+                    if (changed) {
+                        layoutMigrated++;
+                    }
+                } else {
+                    alreadyConverted++;
                 }
 
-                if (ri.getHtmltext() == null || ri.getHtmltext().trim().equals("")) {
-                    ri.setHtmltext(ri.getName());
+                // The new format renders label content from htmltext. This is migrated
+                // independently of the layout - a row with no usable legacy coordinates
+                // still needs its text, or it renders blank.
+                // Image items are skipped: for those htmltext holds the image URL, not
+                // display text, so seeding it from the name would produce a broken src.
+                if (!isImageItem(ri)
+                        && (ri.getHtmltext() == null || ri.getHtmltext().trim().equals(""))) {
+                    if (ri.getName() != null && !ri.getName().trim().equals("")) {
+                        ri.setHtmltext(ri.getName());
+                        textMigrated++;
+                        changed = true;
+                    }
                 }
 
-                riFacade.edit(ri);
+                if (changed) {
+                    riFacade.edit(ri);
+                }
 
             } catch (Exception e) {
+                failed++;
             }
         }
 
+        JsfUtil.addSuccessMessage("Report items checked: " + ris.size()
+                + ". Layout migrated: " + layoutMigrated
+                + ". Text migrated: " + textMigrated
+                + ". Already in new format: " + alreadyConverted
+                + ". Failed: " + failed + ".");
+    }
+
+    /**
+     * Image items hold the image URL in htmltext rather than display text.
+     */
+    private boolean isImageItem(ReportItem ri) {
+        return ri.getIxItemType() == InvestigationItemType.ExternalImage
+                || ri.getIxItemType() == InvestigationItemType.Image
+                || ri.getIxItemType() == InvestigationItemType.ReportImage;
+    }
+
+    /**
+     * Parses a legacy css length such as "47", "10%" or " 30 " into the plain
+     * number the ri* fields hold.
+     *
+     * Returns null when there is nothing usable to migrate - null, blank, or a
+     * unit this percentage based layout never supported such as "25px" - so the
+     * caller leaves the field untouched instead of inventing a position.
+     */
+    private Double parseLegacyCssLength(String cssValue) {
+        if (cssValue == null) {
+            return null;
+        }
+        String cleaned = cssValue.replace("%", "").trim();
+        if (cleaned.isEmpty()) {
+            return null;
+        }
+        try {
+            return Double.valueOf(cleaned);
+        } catch (NumberFormatException e) {
+            return null;
+        }
     }
 
     public String uploadJsonToCreateAnInvestigation() {

--- a/src/main/java/com/divudi/bean/lab/InvestigationItemController.java
+++ b/src/main/java/com/divudi/bean/lab/InvestigationItemController.java
@@ -994,12 +994,25 @@ public class InvestigationItemController implements Serializable {
         if (cssValue == null) {
             return null;
         }
-        String cleaned = cssValue.replace("%", "").trim();
+        String cleaned = cssValue.trim();
+        if (cleaned.endsWith("%")) {
+            cleaned = cleaned.substring(0, cleaned.length() - 1).trim();
+        }
+        // Anything with a percent sign left in it is malformed, such as "10%%".
+        if (cleaned.contains("%")) {
+            return null;
+        }
         if (cleaned.isEmpty()) {
             return null;
         }
         try {
-            return Double.valueOf(cleaned);
+            // Double.valueOf accepts "NaN" and "Infinity". Those cannot be stored in
+            // the double ri* columns, so treat them as nothing usable to migrate.
+            Double value = Double.valueOf(cleaned);
+            if (value.isNaN() || value.isInfinite()) {
+                return null;
+            }
+            return value;
         } catch (NumberFormatException e) {
             return null;
         }


### PR DESCRIPTION
Closes #23475

## Context

Found while investigating Suwani, which was upgraded from a very old build. Its lab report data entry preview and printing rendered every report item stacked on top of each other with blank labels.

Root cause: the new rendering reads the numeric `ri*` fields, but all 7250 `reportitem` rows were still on the legacy String `css*` fields, because `convertCssValuesToRiValues()` had never been run there. Running it as written would only have converted about half the rows and corrupted some.

## Changes

`InvestigationItemController.convertCssValuesToRiValues()`:

- **Null-safe parsing.** `getCssTop()` and friends return the raw nullable field, so the old `.replace("%","")` threw NPE inside one broad `catch` and abandoned the entire row *before* `htmltext` was set. On Suwani that skipped 3715 of 7250 rows, including all 581 `WorksheetItem` rows.
- **Fixed `setRiTop` / `setRiLeft` mix-up.** The `cssLeft` fallback called `setRiTop(22.22)`, leaving `riLeft` at 0 and clobbering the `riTop` computed one line above.
- **Removed the magic numbers.** `11.11` / `22.22` appear zero times across two already-migrated production databases, and the `riWidth < 20 -> 20` clamp corrupts legitimate small widths (migrated data contains 4, 13, 18). A field with nothing usable to migrate is now left untouched rather than given an invented position.
- **`htmltext` migrated independently of layout**, so a row with no usable coordinates still gets its text instead of rendering blank.
- **Image types skipped when seeding `htmltext`** — for `ExternalImage` / `Image` / `ReportImage` that field holds the image URL, so seeding it from `name` produces a broken `src`.
- **Re-runnable.** Layout is migrated only for rows still on the legacy format, so running this on a partially converted database no longer overwrites good coordinates.
- **Legacy `css*` columns left untouched**, so they remain available as a rollback source.
- **Reports a summary** instead of failing silently.

`cssFontSize` is deliberately not migrated — legacy values are px-scale (`18px`, `22px`) while `riFontSize` renders as `pt`, and migrated databases sit at the 12pt default for the large majority of rows. Copying the number across would enlarge every report by a third.

## Note on `ReportItem` getters

`getRiWidth()`, `getRiHeight()` and `getRiFontSize()` apply a lazy default **and write it back to the entity when read**, so they cannot be used to test whether a value was ever set. `getRiTop()` and `getRiLeft()` have no default and are safe. The new code relies on that distinction and there is a comment marking it.

## Verification

Applied the equivalent migration to the Suwani production database (backed up first, in a transaction) and bounced the app to clear the EclipseLink shared cache:

| | Before | After |
|---|---|---|
| Report items with `top` in rendered style | 0 / 100 | 100 / 100 |
| Distinct rendered positions | 1 | 100 |
| `riTop` populated | 0 / 7250 | 6289 |
| `htmltext` populated | 0 / 7250 | 6954 |
| Magic `11.11` / `22.22` values | — | 0 |
| Rows where `riTop` disagrees with legacy `cssTop` | — | 0 |

Reports now render as correct lab reports. Compilation verified with `mvn compile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Legacy investigation item layout conversion can now be safely rerun without modifying already-converted records.
  * Unsupported, malformed, incomplete, or non-finite CSS values remain unchanged instead of being replaced with fallback values.
  * Image-based items are no longer assigned text content during conversion.
  * Conversion results now report layout migrations, text migrations, already-converted records, and failures for improved visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->