### PR TITLE
fix(lab): correct invalid panelGrid column count on reporting search page

### DIFF
--- a/src/main/webapp/lab/search_for_reporting.xhtml
+++ b/src/main/webapp/lab/search_for_reporting.xhtml
@@ -13,7 +13,7 @@
                     <p:panel header="Search Bills" >
                         <h:panelGrid columns="1" >
                             <h:panelGroup >
-                                <p:panelGrid columns="7" >
+                                <p:panelGrid columns="6" >
                                     <p:commandButton ajax="false" value="List All" actionListener="#{institutionLabSumeryController.listAllPatientInvestigations}"   ></p:commandButton>
                                     
                                     <h:inputText autocomplete="off"  style="width: 600px;" id="txtSearch" value="#{institutionLabSumeryController.txtSearch}"  >


### PR DESCRIPTION
Closes #23477

## Problem

`lab/search_for_reporting.xhtml` returns **HTTP 500** on render and is completely unusable:

```
Error Message: PanelGrid "j_idt532:j_idt536" columns must be a number that factors into 12.
               For example: 1,2,3,4,6,12
```

## Cause

Line 16 declared `<p:panelGrid columns="7">`. In PrimeFaces 14.0.6, `PanelGridBase.getLayout()` defaults to `"grid"` (verified against the shipped jar), so the grid CSS renderer applies and rejects any column count that does not divide 12.

The grid actually holds **6** children — the "List All" button, the search input, and the From Date and To Date labels with their calendars — so `columns="7"` was wrong regardless of the rendering restriction.

## Change

One attribute: `columns="7"` -> `columns="6"`. Valid grid width, and the true child count.

JSF-only change, so no compilation or test run required per the project guidelines.

## Related

Found while investigating the Suwani lab report layout problem (#23475), but unrelated to it.

Ten other pages carry the same defect class — a `p:panelGrid` with a column count that does not divide 12 and no `layout="tabular"` to bypass the grid renderer. They are filed separately rather than swept into this PR, since each needs its own column-count judgement and they span pharmacy, HR, credit and inward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the “Search Bills” filter panel to use a six-column layout for improved presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->