### PR TITLE
fix(pharmacy): scope VTM duplicate-name checks to the department type

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -593,6 +593,22 @@ cached per session at login and won't pick up a new row otherwise. This came up 
 `BhtSummeryController.settle()` (`InwardSettleFinalBill`), where the local `buddhika`
 user had the privilege for `Store`/`Main Pharmacy` departments but not `Inward`.
 
+**Before inserting a row, check whether some *other* department already has it** — picking
+that department on the login screen needs no DB write at all and is the faster route:
+
+```sql
+SELECT PRIVILEGE, DEPARTMENT_ID FROM webuserprivilege
+WHERE WEBUSER_ID = <id> AND RETIRED = 0 AND PRIVILEGE = 'SomePrivilege';
+```
+
+Testing issue #23484's pharmacy-admin pages, `PharmacyItemNameEdit` existed for `Inward`
+only, so every **Add New**/**Edit** button on `vtm_dto.xhtml`, `store_vtm.xhtml` and
+`lab_vtm.xhtml` rendered `disabled` under the default `Main Pharmacy` department — nothing
+to do with those pages, and no privilege row needed. Logging out and reselecting `Inward`
+enabled all of them. A `disabled` (rather than absent) admin button is the tell: per this
+project's convention, privilege-gated controls are disabled, not hidden, so a greyed-out
+button means "wrong department", not "broken page".
+
 **`WebUser.department` is not a fixed "home department" — `SessionController.selectDepartment()`
 overwrites and persists it (`loggedUser.setDepartment(department); getFacede().edit(loggedUser)`)
 every time the department-selection screen is submitted, which is why it pre-fills with
@@ -2366,6 +2382,45 @@ and auto-advances; an exact query matching multiple admissions (e.g. several
 active admissions sharing one PHN) shows the dropdown and does not
 auto-advance.
 
+## 91. A `p:commandButton` save that does nothing — no growl, no error, no DB row, a clean `server.log` — is usually a required field whose message went to a `<p:messages>` you never looked at
+
+Seen on `pharmacy/admin/lab_amp.xhtml` and `store_amp.xhtml` while verifying
+issue #23484. Clicking **Save** with Name, Code and VMP filled produced: no
+growl, nothing under `.ui-message*`, no new `Amp` row, and not a single new
+line in `server.log`. The form still held every value, so it looked like the
+action method had run and silently returned.
+
+It had not run at all. Both pages mark **Dosage Form** (`selDosageForm`) and
+**Category** (`ampCat`) `required="true"`, and the Save button uses
+`process="@form"` with `update="form:msg ..."` — so JSF failed validation in
+the Process Validations phase, never invoked `labAmpController.save()`, and
+routed both `requiredMessage`s into the `form:msg` `<p:messages>` component.
+That component contributes no accessible name when its own re-render is what
+populated it, so it does not show up in `browser_snapshot`, in
+`browser_find` for `/error|required/i`, or in a `.ui-growl-item` query.
+
+**Diagnose it this way** — the three symptoms together (form still populated
++ DB unchanged + `server.log` clean) mean the action method never fired, which
+narrows it to client-side or validation-phase rejection, not business logic:
+
+```js
+// enumerate every required input in the form and which ones are still empty
+() => Array.from(document.querySelectorAll('#form [aria-required="true"], #form .ui-state-error'))
+        .map(e => ({ id: e.id, cls: e.className, val: e.value }))
+```
+
+and read the message panel by id rather than by class:
+
+```js
+() => document.querySelector('#form\:msg')?.textContent.trim()
+```
+
+Cheaper still: `grep -n 'required="true"' <page>.xhtml` and fill every one of
+them before the first Save attempt. Note that a `required` `p:autoComplete`
+(Category here) is only satisfied by **clicking a suggestion** — typing the
+exact label and leaving it is an empty model value as far as JSF is
+concerned, even though the textbox looks filled.
+
 ## Some PrimeFaces buttons need a jQuery-triggered click
 
 Most `p:commandButton`s submit fine with a normal Playwright click — including
@@ -2494,4 +2549,6 @@ Verified while testing issue #23377.
 - [ ] If test data is unavailable, **generated it through the app** (create purchase → return → etc.) rather than falling back to code-only checks.
 - [ ] Asserted the outcome of every click (URL/destination element); for icon-only datatable row buttons that silently no-op, fell back to `$(el).trigger('click')`.
 - [ ] Resolved any local "Unknown column" 500 via the app's own `/faces/mf.xhtml` migration page, not hand-written DDL.
+- [ ] Treated a greyed-out admin **Add New**/**Edit** as "wrong department for that privilege row" (§20) before assuming the page is broken.
+- [ ] When a Save did nothing with a clean `server.log` and an unchanged DB, read the form's `<p:messages>` **by id** and grepped the page for `required="true"` (§91) before hunting the controller.
 - [ ] For a guard fix: asserted the **action actually executed** (expected message in the response) before treating unchanged DB state as proof — a JSF-disabled button skips its action entirely — and ran the negative test (clean record still succeeds), reverting it through the app.

--- a/src/main/java/com/divudi/bean/lab/LabVtmController.java
+++ b/src/main/java/com/divudi/bean/lab/LabVtmController.java
@@ -117,6 +117,13 @@ public class LabVtmController implements Serializable {
             return;
         }
 
+        // A new record must carry this page's department type before the duplicate
+        // check runs - the check is scoped by it, and relying on prepareAdd() alone
+        // leaves it null on any other entry path (issue #23484).
+        if (current.getId() == null && current.getDepartmentType() == null) {
+            current.setDepartmentType(DepartmentType.Lab);
+        }
+
         if (!validateVtm()) {
             return;
         }
@@ -612,13 +619,15 @@ public class LabVtmController implements Serializable {
         }
 
         if (checkVtmName(current.getName(), current)) {
-            JsfUtil.addErrorMessage("A VTM with this name already exists");
+            JsfUtil.addErrorMessage("A VTM with this name already exists in the "
+                    + scopeDepartmentTypeOf(current) + " department");
             return false;
         }
 
         if (current.getCode() != null && !current.getCode().trim().isEmpty()) {
             if (checkVtmCode(current.getCode(), current)) {
-                JsfUtil.addErrorMessage("A VTM with this code already exists");
+                JsfUtil.addErrorMessage("A VTM with this code already exists in the "
+                        + scopeDepartmentTypeOf(current) + " department");
                 return false;
             }
         }
@@ -626,17 +635,50 @@ public class LabVtmController implements Serializable {
         return true;
     }
 
+    /**
+     * The department type whose namespace a VTM's name/code must be unique within.
+     * Taken from the record being saved rather than hardcoded to this page's own type:
+     * the legacy `vtm.xhtml` screen exposes a free `DepartmentType` dropdown, so a record
+     * edited here can legitimately carry another type, and scoping the check to
+     * Lab would then miss a real duplicate in that other type's namespace.
+     * A null type is a legacy row, which the whole codebase treats as Pharmacy.
+     */
+    private DepartmentType scopeDepartmentTypeOf(Vtm savingVtm) {
+        DepartmentType dt = savingVtm == null ? null : savingVtm.getDepartmentType();
+        return dt != null ? dt : DepartmentType.Pharmacy;
+    }
+
+    /**
+     * Legacy VTMs carry a null department type and are listed as Pharmacy VTMs, so the
+     * Pharmacy namespace has to include them - otherwise a name already visible in the
+     * Pharmacy list could be saved a second time. Every other type matches strictly.
+     */
+    private String departmentTypeScopePredicate(DepartmentType dep) {
+        return dep == DepartmentType.Pharmacy
+                ? "(c.departmentType IS NULL OR c.departmentType=:dep)"
+                : "c.departmentType=:dep";
+    }
+
+    /**
+     * VTM names are unique per department type, not globally - the same name may
+     * legitimately exist as a Lab VTM and as a VTM of another department type
+     * (issue #23484), so the duplicate check is scoped to one department type's
+     * namespace instead of searching every VTM in the system.
+     */
     public boolean checkVtmName(String name, Vtm savingVtm) {
         if (savingVtm == null || name == null || name.trim().isEmpty()) {
             return false;
         }
+        DepartmentType dep = scopeDepartmentTypeOf(savingVtm);
         Map<String, Object> params = new HashMap<>();
-        String jpql = "SELECT c FROM Vtm c WHERE c.retired=:retired AND UPPER(c.name)=:name";
+        String jpql = "SELECT c FROM Vtm c WHERE c.retired=:retired AND UPPER(c.name)=:name "
+                + "AND " + departmentTypeScopePredicate(dep);
         if (savingVtm.getId() != null) {
             jpql += " AND c.id <> :id";
             params.put("id", savingVtm.getId());
         }
         params.put("retired", false);
+        params.put("dep", dep);
         params.put("name", name.toUpperCase().trim());
         Vtm vtm = getFacade().findFirstByJpql(jpql, params);
         return vtm != null;
@@ -646,13 +688,16 @@ public class LabVtmController implements Serializable {
         if (savingVtm == null || code == null || code.trim().isEmpty()) {
             return false;
         }
+        DepartmentType dep = scopeDepartmentTypeOf(savingVtm);
         Map<String, Object> params = new HashMap<>();
-        String jpql = "SELECT c FROM Vtm c WHERE c.retired=:retired AND UPPER(c.code)=:code";
+        String jpql = "SELECT c FROM Vtm c WHERE c.retired=:retired AND UPPER(c.code)=:code "
+                + "AND " + departmentTypeScopePredicate(dep);
         if (savingVtm.getId() != null) {
             jpql += " AND c.id <> :id";
             params.put("id", savingVtm.getId());
         }
         params.put("retired", false);
+        params.put("dep", dep);
         params.put("code", code.toUpperCase().trim());
         Vtm vtm = getFacade().findFirstByJpql(jpql, params);
         return vtm != null;

--- a/src/main/java/com/divudi/bean/lab/LabVtmController.java
+++ b/src/main/java/com/divudi/bean/lab/LabVtmController.java
@@ -117,10 +117,12 @@ public class LabVtmController implements Serializable {
             return;
         }
 
-        // A new record must carry this page's department type before the duplicate
-        // check runs - the check is scoped by it, and relying on prepareAdd() alone
-        // leaves it null on any other entry path (issue #23484).
-        if (current.getId() == null && current.getDepartmentType() == null) {
+        // A new record must carry this page's department type before the duplicate check
+        // runs - the check is scoped by it, and relying on prepareAdd() alone leaves the
+        // field unset on any other entry path. Set unconditionally: a getter-based null
+        // check cannot work here, because Item.getDepartmentType() reports a null field as
+        // Pharmacy on any PharmaceuticalItem (issue #23484).
+        if (current.getId() == null) {
             current.setDepartmentType(DepartmentType.Lab);
         }
 
@@ -641,7 +643,9 @@ public class LabVtmController implements Serializable {
      * the legacy `vtm.xhtml` screen exposes a free `DepartmentType` dropdown, so a record
      * edited here can legitimately carry another type, and scoping the check to
      * Lab would then miss a real duplicate in that other type's namespace.
-     * A null type is a legacy row, which the whole codebase treats as Pharmacy.
+     * A legacy row with a null type scopes to Pharmacy: Item.getDepartmentType() already
+     * substitutes Pharmacy for a null field on any PharmaceuticalItem, so the explicit
+     * fallback below only covers a null argument.
      */
     private DepartmentType scopeDepartmentTypeOf(Vtm savingVtm) {
         DepartmentType dt = savingVtm == null ? null : savingVtm.getDepartmentType();

--- a/src/main/java/com/divudi/bean/pharmacy/VtmController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/VtmController.java
@@ -174,6 +174,14 @@ public class VtmController implements Serializable {
         return vtmList;
     }
 
+    /**
+     * Pharmacy-scoped: the only callers are the pharmacy-side Excel imports on this
+     * controller (DataUploadController.uploadVtms, and the ATM/VMP imports), so an
+     * imported row must resolve against - and be created in - the Pharmacy namespace.
+     * Without the scope an import could silently reuse a Lab or Store VTM of the same
+     * name, and without the explicit type it would create the null-departmentType rows
+     * that the strict pharmacy queries then refuse to load (issue #23484).
+     */
     public Vtm findAndSaveVtmByNameAndCode(Vtm vtm) {
         String jpql;
         Map m = new HashMap();
@@ -184,11 +192,13 @@ public class VtmController implements Serializable {
             m.put("retired", false);
             m.put("name", vtm.getName());
             m.put("code", vtm.getCode());
+            m.put("dep", DepartmentType.Pharmacy);
             jpql = "select c "
                     + " from Vtm c "
                     + " where c.retired=:retired "
                     + " and c.name=:name"
-                    + " and c.code=:code";
+                    + " and c.code=:code"
+                    + " and " + departmentTypeScopePredicate(DepartmentType.Pharmacy);
             List<Vtm> vtms = getFacade().findByJpql(jpql, m);
             if (vtms != null) {
                 if (!vtms.isEmpty()) {
@@ -200,6 +210,10 @@ public class VtmController implements Serializable {
             return nvtm;
         }
         if (vtm.getId() == null) {
+            // Set unconditionally: Item.getDepartmentType() substitutes Pharmacy for a null
+            // field on any PharmaceuticalItem, so a getter-based null check never fires and
+            // the row would be persisted with departmentType still NULL.
+            vtm.setDepartmentType(DepartmentType.Pharmacy);
             getFacade().create(vtm);
         }
         return vtm;
@@ -214,16 +228,19 @@ public class VtmController implements Serializable {
         } else {
             m.put("ret", false);
             m.put("name", name);
+            m.put("dep", DepartmentType.Pharmacy);
             jpql = "select c "
                     + " from Vtm c "
                     + " where c.retired=:ret "
-                    + " and c.name=:name";
+                    + " and c.name=:name"
+                    + " and " + departmentTypeScopePredicate(DepartmentType.Pharmacy);
             nvtm = getFacade().findFirstByJpql(jpql, m);
         }
         if (nvtm == null) {
             nvtm = new Vtm();
             nvtm.setName(name);
             nvtm.setCode(CommonFunctions.nameToCode("vtm_" + name));
+            nvtm.setDepartmentType(DepartmentType.Pharmacy);
             getFacade().create(nvtm);
         }
         return nvtm;
@@ -408,13 +425,9 @@ public class VtmController implements Serializable {
             return;
         }
 
-        // A new record must carry this page's department type before the duplicate
-        // check runs - the check is scoped by it, and relying on prepareAdd() alone
-        // leaves it null on any other entry path (issue #23484).
-        if (current.getId() == null && current.getDepartmentType() == null) {
-            current.setDepartmentType(DepartmentType.Pharmacy);
-        }
-
+        // No department-type defaulting here on purpose: vtm.xhtml lets the user choose
+        // the Type, prepareAdd() sets Pharmacy for new records, and Item.getDepartmentType()
+        // already reports a null field as Pharmacy for scoping (issue #23484).
         // Validate before saving
         if (!validateVtm()) {
             return;
@@ -1010,7 +1023,9 @@ public class VtmController implements Serializable {
      * the legacy `vtm.xhtml` screen exposes a free `DepartmentType` dropdown, so a record
      * edited here can legitimately carry another type, and scoping the check to
      * Pharmacy would then miss a real duplicate in that other type's namespace.
-     * A null type is a legacy row, which the whole codebase treats as Pharmacy.
+     * A legacy row with a null type scopes to Pharmacy: Item.getDepartmentType() already
+     * substitutes Pharmacy for a null field on any PharmaceuticalItem, so the explicit
+     * fallback below only covers a null argument.
      */
     private DepartmentType scopeDepartmentTypeOf(Vtm savingVtm) {
         DepartmentType dt = savingVtm == null ? null : savingVtm.getDepartmentType();

--- a/src/main/java/com/divudi/bean/pharmacy/VtmController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/VtmController.java
@@ -408,6 +408,13 @@ public class VtmController implements Serializable {
             return;
         }
 
+        // A new record must carry this page's department type before the duplicate
+        // check runs - the check is scoped by it, and relying on prepareAdd() alone
+        // leaves it null on any other entry path (issue #23484).
+        if (current.getId() == null && current.getDepartmentType() == null) {
+            current.setDepartmentType(DepartmentType.Pharmacy);
+        }
+
         // Validate before saving
         if (!validateVtm()) {
             return;
@@ -997,17 +1004,50 @@ public class VtmController implements Serializable {
         return auditData;
     }
 
+    /**
+     * The department type whose namespace a VTM's name/code must be unique within.
+     * Taken from the record being saved rather than hardcoded to this page's own type:
+     * the legacy `vtm.xhtml` screen exposes a free `DepartmentType` dropdown, so a record
+     * edited here can legitimately carry another type, and scoping the check to
+     * Pharmacy would then miss a real duplicate in that other type's namespace.
+     * A null type is a legacy row, which the whole codebase treats as Pharmacy.
+     */
+    private DepartmentType scopeDepartmentTypeOf(Vtm savingVtm) {
+        DepartmentType dt = savingVtm == null ? null : savingVtm.getDepartmentType();
+        return dt != null ? dt : DepartmentType.Pharmacy;
+    }
+
+    /**
+     * Legacy VTMs carry a null department type and are listed as Pharmacy VTMs, so the
+     * Pharmacy namespace has to include them - otherwise a name already visible in the
+     * Pharmacy list could be saved a second time. Every other type matches strictly.
+     */
+    private String departmentTypeScopePredicate(DepartmentType dep) {
+        return dep == DepartmentType.Pharmacy
+                ? "(c.departmentType IS NULL OR c.departmentType=:dep)"
+                : "c.departmentType=:dep";
+    }
+
+    /**
+     * VTM names are unique per department type, not globally - the same name may
+     * legitimately exist as a Pharmacy VTM and as a VTM of another department type
+     * (issue #23484), so the duplicate check is scoped to one department type's
+     * namespace instead of searching every VTM in the system.
+     */
     public boolean checkVtmName(String name, Vtm savingVtm) {
         if (savingVtm == null || name == null || name.trim().isEmpty()) {
             return false;
         }
+        DepartmentType dep = scopeDepartmentTypeOf(savingVtm);
         Map<String, Object> params = new HashMap<>();
-        String jpql = "SELECT c FROM Vtm c WHERE c.retired=:retired AND UPPER(c.name)=:name";
+        String jpql = "SELECT c FROM Vtm c WHERE c.retired=:retired AND UPPER(c.name)=:name "
+                + "AND " + departmentTypeScopePredicate(dep);
         if (savingVtm.getId() != null) {
             jpql += " AND c.id <> :id";
             params.put("id", savingVtm.getId());
         }
         params.put("retired", false);
+        params.put("dep", dep);
         params.put("name", name.toUpperCase().trim());
         Vtm vtm = getFacade().findFirstByJpql(jpql, params);
         return vtm != null;
@@ -1017,13 +1057,16 @@ public class VtmController implements Serializable {
         if (savingVtm == null || code == null || code.trim().isEmpty()) {
             return false;
         }
+        DepartmentType dep = scopeDepartmentTypeOf(savingVtm);
         Map<String, Object> params = new HashMap<>();
-        String jpql = "SELECT c FROM Vtm c WHERE c.retired=:retired AND UPPER(c.code)=:code";
+        String jpql = "SELECT c FROM Vtm c WHERE c.retired=:retired AND UPPER(c.code)=:code "
+                + "AND " + departmentTypeScopePredicate(dep);
         if (savingVtm.getId() != null) {
             jpql += " AND c.id <> :id";
             params.put("id", savingVtm.getId());
         }
         params.put("retired", false);
+        params.put("dep", dep);
         params.put("code", code.toUpperCase().trim());
         Vtm vtm = getFacade().findFirstByJpql(jpql, params);
         return vtm != null;
@@ -1043,14 +1086,16 @@ public class VtmController implements Serializable {
 
         // Check name uniqueness
         if (checkVtmName(current.getName(), current)) {
-            JsfUtil.addErrorMessage("A VTM with this name already exists");
+            JsfUtil.addErrorMessage("A VTM with this name already exists in the "
+                    + scopeDepartmentTypeOf(current) + " department");
             return false;
         }
 
         // Check code uniqueness if provided
         if (current.getCode() != null && !current.getCode().trim().isEmpty()) {
             if (checkVtmCode(current.getCode(), current)) {
-                JsfUtil.addErrorMessage("A VTM with this code already exists");
+                JsfUtil.addErrorMessage("A VTM with this code already exists in the "
+                        + scopeDepartmentTypeOf(current) + " department");
                 return false;
             }
         }

--- a/src/main/java/com/divudi/bean/store/StoreVtmController.java
+++ b/src/main/java/com/divudi/bean/store/StoreVtmController.java
@@ -117,6 +117,13 @@ public class StoreVtmController implements Serializable {
             return;
         }
 
+        // A new record must carry this page's department type before the duplicate
+        // check runs - the check is scoped by it, and relying on prepareAdd() alone
+        // leaves it null on any other entry path (issue #23484).
+        if (current.getId() == null && current.getDepartmentType() == null) {
+            current.setDepartmentType(DepartmentType.Store);
+        }
+
         if (!validateVtm()) {
             return;
         }
@@ -612,13 +619,15 @@ public class StoreVtmController implements Serializable {
         }
 
         if (checkVtmName(current.getName(), current)) {
-            JsfUtil.addErrorMessage("A VTM with this name already exists");
+            JsfUtil.addErrorMessage("A VTM with this name already exists in the "
+                    + scopeDepartmentTypeOf(current) + " department");
             return false;
         }
 
         if (current.getCode() != null && !current.getCode().trim().isEmpty()) {
             if (checkVtmCode(current.getCode(), current)) {
-                JsfUtil.addErrorMessage("A VTM with this code already exists");
+                JsfUtil.addErrorMessage("A VTM with this code already exists in the "
+                        + scopeDepartmentTypeOf(current) + " department");
                 return false;
             }
         }
@@ -626,17 +635,50 @@ public class StoreVtmController implements Serializable {
         return true;
     }
 
+    /**
+     * The department type whose namespace a VTM's name/code must be unique within.
+     * Taken from the record being saved rather than hardcoded to this page's own type:
+     * the legacy `vtm.xhtml` screen exposes a free `DepartmentType` dropdown, so a record
+     * edited here can legitimately carry another type, and scoping the check to
+     * Store would then miss a real duplicate in that other type's namespace.
+     * A null type is a legacy row, which the whole codebase treats as Pharmacy.
+     */
+    private DepartmentType scopeDepartmentTypeOf(Vtm savingVtm) {
+        DepartmentType dt = savingVtm == null ? null : savingVtm.getDepartmentType();
+        return dt != null ? dt : DepartmentType.Pharmacy;
+    }
+
+    /**
+     * Legacy VTMs carry a null department type and are listed as Pharmacy VTMs, so the
+     * Pharmacy namespace has to include them - otherwise a name already visible in the
+     * Pharmacy list could be saved a second time. Every other type matches strictly.
+     */
+    private String departmentTypeScopePredicate(DepartmentType dep) {
+        return dep == DepartmentType.Pharmacy
+                ? "(c.departmentType IS NULL OR c.departmentType=:dep)"
+                : "c.departmentType=:dep";
+    }
+
+    /**
+     * VTM names are unique per department type, not globally - the same name may
+     * legitimately exist as a Store VTM and as a VTM of another department type
+     * (issue #23484), so the duplicate check is scoped to one department type's
+     * namespace instead of searching every VTM in the system.
+     */
     public boolean checkVtmName(String name, Vtm savingVtm) {
         if (savingVtm == null || name == null || name.trim().isEmpty()) {
             return false;
         }
+        DepartmentType dep = scopeDepartmentTypeOf(savingVtm);
         Map<String, Object> params = new HashMap<>();
-        String jpql = "SELECT c FROM Vtm c WHERE c.retired=:retired AND UPPER(c.name)=:name";
+        String jpql = "SELECT c FROM Vtm c WHERE c.retired=:retired AND UPPER(c.name)=:name "
+                + "AND " + departmentTypeScopePredicate(dep);
         if (savingVtm.getId() != null) {
             jpql += " AND c.id <> :id";
             params.put("id", savingVtm.getId());
         }
         params.put("retired", false);
+        params.put("dep", dep);
         params.put("name", name.toUpperCase().trim());
         Vtm vtm = getFacade().findFirstByJpql(jpql, params);
         return vtm != null;
@@ -646,13 +688,16 @@ public class StoreVtmController implements Serializable {
         if (savingVtm == null || code == null || code.trim().isEmpty()) {
             return false;
         }
+        DepartmentType dep = scopeDepartmentTypeOf(savingVtm);
         Map<String, Object> params = new HashMap<>();
-        String jpql = "SELECT c FROM Vtm c WHERE c.retired=:retired AND UPPER(c.code)=:code";
+        String jpql = "SELECT c FROM Vtm c WHERE c.retired=:retired AND UPPER(c.code)=:code "
+                + "AND " + departmentTypeScopePredicate(dep);
         if (savingVtm.getId() != null) {
             jpql += " AND c.id <> :id";
             params.put("id", savingVtm.getId());
         }
         params.put("retired", false);
+        params.put("dep", dep);
         params.put("code", code.toUpperCase().trim());
         Vtm vtm = getFacade().findFirstByJpql(jpql, params);
         return vtm != null;

--- a/src/main/java/com/divudi/bean/store/StoreVtmController.java
+++ b/src/main/java/com/divudi/bean/store/StoreVtmController.java
@@ -117,10 +117,12 @@ public class StoreVtmController implements Serializable {
             return;
         }
 
-        // A new record must carry this page's department type before the duplicate
-        // check runs - the check is scoped by it, and relying on prepareAdd() alone
-        // leaves it null on any other entry path (issue #23484).
-        if (current.getId() == null && current.getDepartmentType() == null) {
+        // A new record must carry this page's department type before the duplicate check
+        // runs - the check is scoped by it, and relying on prepareAdd() alone leaves the
+        // field unset on any other entry path. Set unconditionally: a getter-based null
+        // check cannot work here, because Item.getDepartmentType() reports a null field as
+        // Pharmacy on any PharmaceuticalItem (issue #23484).
+        if (current.getId() == null) {
             current.setDepartmentType(DepartmentType.Store);
         }
 
@@ -641,7 +643,9 @@ public class StoreVtmController implements Serializable {
      * the legacy `vtm.xhtml` screen exposes a free `DepartmentType` dropdown, so a record
      * edited here can legitimately carry another type, and scoping the check to
      * Store would then miss a real duplicate in that other type's namespace.
-     * A null type is a legacy row, which the whole codebase treats as Pharmacy.
+     * A legacy row with a null type scopes to Pharmacy: Item.getDepartmentType() already
+     * substitutes Pharmacy for a null field on any PharmaceuticalItem, so the explicit
+     * fallback below only covers a null argument.
      */
     private DepartmentType scopeDepartmentTypeOf(Vtm savingVtm) {
         DepartmentType dt = savingVtm == null ? null : savingVtm.getDepartmentType();


### PR DESCRIPTION
Closes #23484

## Decisions made without approval

This ran unattended, so every judgment call is listed here first.

1. **Scope the check by department type rather than relax it.** The issue asks for the same name in two department types. Git archaeology settled the shape: `StoreVtmController` and `LabVtmController` were copied from `VtmController` in 3b364ed8 ("Add Store VTM and Lab VTM management pages"), and every other query in all three controllers already scopes by `departmentType` — the uniqueness checks were the only ones that did not. Scoping them restores the intent the rest of each controller expresses; removing the check entirely would have gone further than the issue asked.

2. **Derive the scope from the record, not from the page.** Initially I hardcoded each controller's own type. The pre-push review caught that `vtm.xhtml` binds a free `DepartmentType` dropdown to `current.departmentType` (line 122, fed by `enumController.departmentType` = all values), so a record saved from the Pharmacy page can carry Type = Lab — and a hardcoded Pharmacy scope would search the wrong namespace and create the exact Lab duplicate the Lab page rejects. The scope now comes from `savingVtm.getDepartmentType()`. Verified live, both directions (see Verification, case 4).

3. **Treat a null department type as Pharmacy.** Legacy VTMs carry `departmentType = null`. The Pharmacy list and DTO queries are already null-tolerant, so those rows *appear* in the Pharmacy list; the duplicate check has to include them or a name visible in that list could be saved twice. Store and Lab match strictly, exactly as their list queries do.

4. **Set the page's department type on new records before validating.** `save()` previously relied on `prepareAdd()` having set it. Any other entry path left it unset, which after decision 2 would have scoped the check off a default. The Store and Lab pages now set it explicitly for new records; `VtmController` deliberately does not, so `vtm.xhtml`'s Type dropdown stays authoritative. *(My first attempt at this guarded on `getDepartmentType() == null` and was a no-op — see the CodeRabbit section below for why, and the fix.)*

5. **Scope the `code` check too, not just `name`.** The issue only quotes the name message, but a user re-entering the same item in a second department will typically type the same code and would just hit "A VTM with this code already exists" instead — a half-fix. `Vtm.code` has no consumer anywhere in the codebase outside these three checks (verified by grep), so scoping it is safe.

6. **No change for VMP.** No VMP controller has ever had a name or code uniqueness check. Verified live: created "Mirror Panel 23484" as a Lab VMP and again as a Store VMP, both saved.

7. **No change for AMP, and AMP code uniqueness deliberately left global.** No AMP controller checks names either — the coop data already contains same-name AMPs across department types ("Mupifen (mupirocin) ointment" and "Valsure 200" each exist as Pharmacy and Store), and 20 name groups are duplicated *within* one department type. Verified live too (Lab + Store "Mirror Kit 23484"). AMP **code** is a different matter and stays system-wide unique on purpose: `Item.code` is a global lookup key used by `SapInventorySyncService.findItemByField`, `PharmacyItemExcelManager`, `DataUploadController`, `MiscellaneousStaffFeeController` and the code/barcode search in `ItemController`. Making codes per-department would make those lookups ambiguous. Flagging this in case the reporter actually wanted AMP codes relaxed as well — that would need its own discussion.

8. **Message now names the scope.** "A VTM with this name already exists" became "... already exists in the Lab department", derived from the same value the query used. Cosmetic, but the reporter's confusion was precisely not knowing which list the clash was in.

9. **Wiki prose left alone where I could not verify it.** See Documentation below.

## Root cause

`checkVtmName` / `checkVtmCode` in all three VTM controllers queried every VTM in the system:

```java
"SELECT c FROM Vtm c WHERE c.retired=:retired AND UPPER(c.name)=:name"
```

No `departmentType` predicate, while `getItems`, `getVtmDtos`, `getSelectedItems`, `fillItems`, the autocompletes and the audit query in the same classes all scope by it.

## Pre-push self-review (`/code-review high`)

Run against the working diff before the first commit, at `high` because the diff touches pharmacy code.

**Fixed in this PR:**
- Hardcoded scope let the legacy page create a cross-department duplicate → decision 2 above.
- Javadoc claimed the predicate "mirrors the one every other query in this controller uses"; that is true in the Store/Lab controllers but false in `VtmController`, where four queries use strict equality. Reworded.

**Filed as separate issues (real, but outside this issue's files/screens):**
- #23485 — the VMP autocomplete on the AMP admin pages is not scoped to the page's department type. `LabAmpController` and `StoreAmpController` apply no filter at all; `AmpController` uses an inverted `departmentType != Store`. Surfaced directly in this run: the Lab AMP page's VMP picker listed both the Lab and the Store "Mirror Panel 23484".
- #23486 — `PharmacyBean.getVtmByName` / `StoreBean.getVtmByName` resolve by name with no department and no `retired` filter, then `setRetired(false)`. Used by the Excel importers. This PR makes cross-department same-name VTMs an intended state, so the ambiguity these have always carried is now reachable in normal use.
- #23487 — `StoreVtmController` / `LabVtmController` resolve client-submitted ids via `getFacade().find(id)` with no scope check, the hole #23062 closed for `VtmController` only. Decision 2 reduces its blast radius (an out-of-scope record is at least checked against its real namespace) but does not close it.

**Noted, no action:**
- A legacy null-`departmentType` VTM is listed on the Pharmacy page but rejected by the strict `isInPharmacyScope`, so it cannot be edited or deleted — and now cannot be replaced either, since the duplicate check (correctly) sees it. The dead end is pre-existing, introduced by #23062's guard; the local coop DB has zero null-type VTM rows so I could not reproduce it, and the right fix is on the strict side, outside this diff. Raised here rather than filed on an unverified premise.
- Pre-existing and untouched: the check compares `UPPER(c.name)` against a trimmed value while `save()` persists `current.getName()` untrimmed, so a name stored with surrounding whitespace evades it next time.

## CodeRabbit review (cycle 1) — one finding, fixed

`findAndSaveVtmByNameAndCode()` / `findAndSaveVtmByName()` in `VtmController` looked VTMs up by name (and code) with no `departmentType` predicate and created new ones with the type unset. Their only callers are the pharmacy-side Excel imports on this same controller — `DataUploadController.uploadVtms()` plus the ATM and VMP imports — so an import could bind to a Lab or Store VTM of the same name, and every VTM it created landed with `departmentType` NULL. Valid, and in a file this PR already touches, so fixed here rather than deferred (commit 79ade63).

**That fix exposed a real bug in my own first commit.** `Item.getDepartmentType()` substitutes `Pharmacy` for a null field on any `PharmaceuticalItem`:

```java
public DepartmentType getDepartmentType() {
    if (departmentType == null && this instanceof PharmaceuticalItem) {
        return DepartmentType.Pharmacy;
    }
    return departmentType;
}
```

So a `getDepartmentType() == null` guard can never fire on a `Vtm`. The first attempt at the import fix used one and still wrote a NULL-typed row — caught by checking the database rather than trusting the code. The two `save()` guards added in the first commit (decision 4) had the same defect and were silently no-ops. Now:

- the import helpers set the type unconditionally when creating;
- `StoreVtmController` / `LabVtmController.save()` set the page's type unconditionally for a new record;
- `VtmController.save()` sets nothing on purpose — `vtm.xhtml`'s Type dropdown must stay authoritative, `prepareAdd()` covers new records, and the getter already reports a null field as Pharmacy for scoping.

The JPQL `departmentType IS NULL OR = :dep` predicate is unaffected and still required: JPQL reads the column, not the getter, so it is what actually catches legacy rows.

## Verification

Local Payara + local `coop` DB, driven through the UI with Playwright, every result confirmed in the database. All four cases re-run against the post-review build.

1. **The reported scenario** — "Mirror" as a Lab VTM, then "Mirror" with the same code as a Store VTM. Both saved (ids 13839403 / 13839404). Added again as a Pharmacy VTM (13839405): all three department types, one name, one code.
2. **The rule still holds within a department** — a second Store "Mirror" rejected with "A VTM with this name already exists in the Store department"; a second Pharmacy "Mirror" likewise. No row created either time.
3. **Post-review re-run** — "Scalpel Handle 23484" + code `SCH23484` saved as Store (13839412) and Lab (13839413); a second Lab record of that name rejected, naming the Lab department.
4. **The bug the review caught** — on `vtm.xhtml` with Type = **Lab**, "Scalpel Handle 23484" is now rejected ("... in the Lab department"); before the fix it would have been checked against Pharmacy, found nothing, and created a duplicate Lab VTM. The same form with Type switched to **Pharmacy** saved successfully (13839414) — proving the scope is genuinely derived and not just tightened.
5. **VMP** — "Mirror Panel 23484" saved as both a Lab and a Store VMP (13839406 / 13839407), unchanged behaviour.
6. **AMP** — "Mirror Kit 23484" saved as both a Lab and a Store AMP (13839408 / 13839409), unchanged behaviour.
7. **The VTM Excel import** (after the CodeRabbit fix) — created a Lab VTM "Import Probe 23484" carrying the exact code the importer derives (`vtm_import_probe_23484`), so a pre-fix import would have matched and reused it. Uploading that row through `upload_vtms.xhtml` now creates a **separate Pharmacy VTM** (13839417) instead. Re-uploading the same file is idempotent — it matches the Pharmacy row and creates nothing. A new Store VTM of the same name still saves as Store (13839418). `SELECT COUNT(*) FROM item WHERE DTYPE='Vtm' AND DEPARTMENTTYPE IS NULL AND retired=0` returns 0.

## Documentation

Wiki page updated: **[Managing Virtual Therapeutic Moieties (VTM)](https://github.com/hmislk/hmis/wiki/Managing-Virtual-Therapeutic-Moieties-(VTM))** — new "VTMs Are Scoped by Department Type" and "Duplicate Names and Codes" sections, with three screenshots (Lab list, Store list, and the rejected same-department save). Screenshots cropped to the content area so no user or institution name is published.

Only verified prose was added. The page's existing navigation instructions ("Menu > Administration > Pharmaceutical Management", a "Medicine Component Management" tab) and its "Deleting a VTM" section describe an older single-page workflow that does not match the current three-tab Pharmacy Administration layout I navigated in this run — but I reached the pages by direct URL and via the admin index tabs, not via that menu path, so I did not verify the menu path is wrong and left that prose untouched. **Worth a human pass**: that page appears to predate the Pharmacy/Store/Lab split.

Also recorded in `developer_docs/testing/playwright-e2e-workflow.md`: a new §91 (a Save that does nothing with a clean `server.log` is usually a required field whose message went to a `<p:messages>` you never read — hit on the AMP pages here) and an addition to §20 (check whether another department already holds a privilege row before inserting one — `PharmacyItemNameEdit` existed only for one department, which is why every Add/Edit button rendered disabled).

## Not done

Nothing in the issue's scope was left out. The three follow-up issues above are genuinely separate fixes, not deferred parts of this one.
