### PR TITLE
fix(pharmacy): show alternative-brand substitutes on Pharmacy BHT issue

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -2366,7 +2366,7 @@ and auto-advances; an exact query matching multiple admissions (e.g. several
 active admissions sharing one PHN) shows the dropdown and does not
 auto-advance.
 
-## 91. `ward/ward_pharmacy_bht_issue_request_bill.xhtml`'s "New Bill" button discards the current draft instead of saving it, and `ward_pharmacy_bht_issue.xhtml`'s "Issue to BHT" silently no-ops until a Porter/Staff is picked
+## 91. `ward/ward_pharmacy_bht_issue_request_bill.xhtml`'s "New Bill" button discards the current draft instead of saving it, and `ward_pharmacy_bht_issue.xhtml`'s "Issue to BHT" rejects (with a growl message, easy to miss in a scripted run) until a Porter/Staff is picked
 
 Found verifying issue #23470 (BHT substitute suggestions). On the ward-side
 request page, the toolbar has both **"New Bill"** and **"Settle Request"**
@@ -2379,14 +2379,19 @@ as a `REQUEST_MEDICINE_INWARD` bill.
 
 On the pharmacy-side issue page (`ward_pharmacy_bht_issue.xhtml`), the
 **"Issue to BHT"** button (`PharmacySaleBhtController.settlePharmacyBhtIssueAccept`)
-also fires a `confirm()`, but silently returns via `JsfUtil.addErrorMessage`
-if `getPreBill().getToStaff() == null` — i.e. the **"Porter / Staff Carrying
-Medicines to Ward"** autocomplete near the top of the page must be filled
-first. No exception is logged server-side and no new `BILL` row is created;
-the only symptom is that a DB check for a fresh `ISSUE_MEDICINE_ON_REQUEST_INWARD`
-row comes back empty after a seemingly-successful click-and-confirm. Always
-fill the Porter field (any active `STAFF` row works for local testing) before
-clicking "Issue to BHT", and verify success by querying `BILL` for a new row
+also fires a `confirm()`, but if `getPreBill().getToStaff() == null` it
+rejects the attempt with the growl message **"Please select the staff
+member (porter) who will carry the medicines to the ward."** and returns —
+i.e. the **"Porter / Staff Carrying Medicines to Ward"** autocomplete near
+the top of the page must be filled first. It's not a silent no-op (the
+message is real), but it's easy to miss when driving the page via
+Playwright without checking for growl text after every action, and no
+exception is logged server-side either way. A DB check for a fresh
+`ISSUE_MEDICINE_ON_REQUEST_INWARD` row is the reliable way to catch this in
+a script: it comes back empty after a seemingly-successful click-and-confirm
+if the Porter field was skipped. Always fill the Porter field (any active
+`STAFF` row works for local testing) before clicking "Issue to BHT", and
+verify success by querying `BILL` for a new row
 rather than trusting the confirm dialog alone.
 
 Also: that Porter/Staff autocomplete searches the `STAFF`/`PERSON` tables,

--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -2366,6 +2366,34 @@ and auto-advances; an exact query matching multiple admissions (e.g. several
 active admissions sharing one PHN) shows the dropdown and does not
 auto-advance.
 
+## 91. `ward/ward_pharmacy_bht_issue_request_bill.xhtml`'s "New Bill" button discards the current draft instead of saving it, and `ward_pharmacy_bht_issue.xhtml`'s "Issue to BHT" silently no-ops until a Porter/Staff is picked
+
+Found verifying issue #23470 (BHT substitute suggestions). On the ward-side
+request page, the toolbar has both **"New Bill"** and **"Settle Request"**
+next to each other. "New Bill" looks like a generic submit/save action but
+it actually **discards the in-progress request and resets the form** to a
+blank "Start Pharmacy Request for Inpatients" screen — no `BILL` row is
+written, no error is shown. Only **"Settle Request"** (which fires a native
+`confirm()` — handle it with `browser_handle_dialog`) persists the request
+as a `REQUEST_MEDICINE_INWARD` bill.
+
+On the pharmacy-side issue page (`ward_pharmacy_bht_issue.xhtml`), the
+**"Issue to BHT"** button (`PharmacySaleBhtController.settlePharmacyBhtIssueAccept`)
+also fires a `confirm()`, but silently returns via `JsfUtil.addErrorMessage`
+if `getPreBill().getToStaff() == null` — i.e. the **"Porter / Staff Carrying
+Medicines to Ward"** autocomplete near the top of the page must be filled
+first. No exception is logged server-side and no new `BILL` row is created;
+the only symptom is that a DB check for a fresh `ISSUE_MEDICINE_ON_REQUEST_INWARD`
+row comes back empty after a seemingly-successful click-and-confirm. Always
+fill the Porter field (any active `STAFF` row works for local testing) before
+clicking "Issue to BHT", and verify success by querying `BILL` for a new row
+rather than trusting the confirm dialog alone.
+
+Also: that Porter/Staff autocomplete searches the `STAFF`/`PERSON` tables,
+not `WEBUSER` — a logged-in user's own username (e.g. "Lawan") will not
+resolve; search by an actual staff member's name from `STAFF` joined to
+`PERSON`.
+
 ## Some PrimeFaces buttons need a jQuery-triggered click
 
 Most `p:commandButton`s submit fine with a normal Playwright click — including

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
@@ -2121,9 +2121,12 @@ public class PharmacySaleBhtController implements Serializable {
      * into the minimal {@link StockDTO} that
      * {@link com.divudi.service.pharmacy.PharmacySubstituteService#swapStockIntoBillItem}
      * actually reads: {@code stockId} (to reload the managed {@link Stock})
-     * and {@code costRate} (read raw here rather than persisted, matching
-     * that method's contract of never mutating the {@link com.divudi.core.entity.pharmacy.ItemBatch}
-     * via its mutating {@code getCostRate()} getter). Issue #23470.
+     * and {@code costRate}. The cost rate is read via a scalar JPQL query
+     * rather than {@code ItemBatch.getCostRate()} — that getter derives and
+     * ASSIGNS {@code costRate = purcahseRate} when the stored cost is null,
+     * which would both dirty the managed {@link com.divudi.core.entity.pharmacy.ItemBatch}
+     * and hide the null from {@code swapStockIntoBillItem}'s own
+     * null-as-zero handling. Issue #23470.
      */
     private StockDTO toSubstituteStockDto(Stock stock) {
         if (stock == null || stock.getId() == null) {
@@ -2131,8 +2134,12 @@ public class PharmacySaleBhtController implements Serializable {
         }
         StockDTO dto = new StockDTO();
         dto.setStockId(stock.getId());
-        if (stock.getItemBatch() != null) {
-            dto.setCostRate(stock.getItemBatch().getCostRate());
+        if (stock.getItemBatch() != null && stock.getItemBatch().getId() != null) {
+            Map<String, Object> params = new HashMap<>();
+            params.put("id", stock.getItemBatch().getId());
+            Double rawCostRate = itemBatchFacade.findSingleResultByJpql(
+                    "SELECT ib.costRate FROM ItemBatch ib WHERE ib.id = :id", params, TemporalType.DATE);
+            dto.setCostRate(rawCostRate);
         }
         return dto;
     }

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
@@ -2017,8 +2017,8 @@ public class PharmacySaleBhtController implements Serializable {
     }
     
     private BillItem itemForSubstitution;
-    private Stock selectedSubstituteStock;
-    private List<Stock> substituteStocks;
+    private StockDTO selectedSubstituteStock;
+    private List<StockDTO> substituteStocks;
     // Per-row selection state for the "Issuing Bill Item" autocomplete on each BHT Issue
     // row, keyed by BillItem instance identity. A single shared field doesn't work here —
     // every row's p:autoComplete is bound to the same @SessionScoped controller instance,
@@ -2041,7 +2041,9 @@ public class PharmacySaleBhtController implements Serializable {
     VmpController vmpController;
     @EJB
     PharmacyCostingService pharmacyCostingService;
-    
+    @EJB
+    private com.divudi.service.pharmacy.PharmacySubstituteService pharmacySubstituteService;
+
     public void prepareSubstitute(BillItem bi) {
         itemForSubstitution = bi;
         selectedSubstituteStock = null;
@@ -2049,74 +2051,22 @@ public class PharmacySaleBhtController implements Serializable {
         if (bi == null || bi.getItem() == null) {
             return;
         }
-        List<Amp> amps = pharmacyBean.resolveAmps(bi.getItem());
-        Date currentDate = new Date();
-        for (Amp substituteAmp : amps) {
-            List<Stock> stocks = pharmacyBean.getStockByQty(substituteAmp, sessionController.getDepartment());
-            if (stocks != null) {
-                for (Stock stock : stocks) {
-                    if (stock.getStock() > 0
-                            && stock.getItemBatch() != null
-                            && stock.getItemBatch().getDateOfExpire() != null
-                            && stock.getItemBatch().getDateOfExpire().after(currentDate)) {
-                        substituteStocks.add(stock);
-                    }
-                }
-            }
-        }
+        double requiredQty = bi.getQty() == null ? 0d : bi.getQty();
+        substituteStocks = pharmacySubstituteService.findSubstituteStocks(bi.getItem(), sessionController.getDepartment(), requiredQty);
     }
-    
+
     public void replaceSelectedSubstitute() {
         if (itemForSubstitution == null || selectedSubstituteStock == null) {
             JsfUtil.addErrorMessage("Please select a substitute stock.");
             return;
         }
-
-        // Update the bill item with selected stock details
-        itemForSubstitution.setItem(selectedSubstituteStock.getItemBatch().getItem());
-
-        PharmaceuticalBillItem phItem = itemForSubstitution.getPharmaceuticalBillItem();
-        if (phItem == null) {
-            phItem = new PharmaceuticalBillItem();
-            phItem.setBillItem(itemForSubstitution);
-            itemForSubstitution.setPharmaceuticalBillItem(phItem);
+        if (pharmacySubstituteService.swapStockIntoBillItem(itemForSubstitution, selectedSubstituteStock)) {
+            calculateRates(itemForSubstitution);
+            calCurrentBillItemTotal(getBillItems());
+            JsfUtil.addSuccessMessage("Stock replaced successfully.");
+        } else {
+            JsfUtil.addErrorMessage("Could not replace the stock — the selected substitute may no longer be available. Please try again.");
         }
-
-        // Set stock and batch details
-        phItem.setStock(selectedSubstituteStock);
-        phItem.setItemBatch(selectedSubstituteStock.getItemBatch());
-        phItem.setDoe(selectedSubstituteStock.getItemBatch().getDateOfExpire());
-        phItem.setPurchaseRate(selectedSubstituteStock.getItemBatch().getPurcahseRate());
-        phItem.setRetailRateInUnit(selectedSubstituteStock.getItemBatch().getRetailsaleRate());
-
-        // Update rates in pharmaceutical bill item
-        phItem.setPurchaseRatePack(selectedSubstituteStock.getItemBatch().getPurcahseRate());
-        phItem.setRetailRatePack(selectedSubstituteStock.getItemBatch().getRetailsaleRate());
-        phItem.setCostRate(selectedSubstituteStock.getItemBatch().getCostRate());
-        phItem.setCostRatePack(selectedSubstituteStock.getItemBatch().getCostRate());
-
-        // Update financials
-        BillItemFinanceDetails financeDetails = itemForSubstitution.getBillItemFinanceDetails();
-        if (financeDetails != null) {
-            BigDecimal transferRate = determineTransferRate(selectedSubstituteStock.getItemBatch());
-            financeDetails.setLineGrossRate(transferRate);
-            financeDetails.setLineNetRate(transferRate);
-
-            // Update cost and retail rates
-            financeDetails.setLineCostRate(BigDecimal.valueOf(selectedSubstituteStock.getItemBatch().getCostRate()));
-            financeDetails.setRetailSaleRate(BigDecimal.valueOf(selectedSubstituteStock.getItemBatch().getRetailsaleRate()));
-
-            // Update values at different rates
-            BigDecimal qty = financeDetails.getQuantity() != null ? financeDetails.getQuantity() : BigDecimal.ONE;
-            financeDetails.setValueAtCostRate(BigDecimal.valueOf(selectedSubstituteStock.getItemBatch().getCostRate()).multiply(qty));
-            financeDetails.setValueAtPurchaseRate(BigDecimal.valueOf(selectedSubstituteStock.getItemBatch().getPurcahseRate()).multiply(qty));
-            financeDetails.setValueAtRetailRate(BigDecimal.valueOf(selectedSubstituteStock.getItemBatch().getRetailsaleRate()).multiply(qty));
-        }
-
-        calculateRates(itemForSubstitution);
-        calCurrentBillItemTotal(getBillItems());
-
-        JsfUtil.addSuccessMessage("Stock replaced successfully.");
     }
 
     /**
@@ -2158,10 +2108,33 @@ public class PharmacySaleBhtController implements Serializable {
             return;
         }
         itemForSubstitution = bi;
-        selectedSubstituteStock = issuingSelections.get(bi);
+        selectedSubstituteStock = toSubstituteStockDto(issuingSelections.get(bi));
         replaceSelectedSubstitute();
         // Leave the map entry as-is (don't null it out) so the row keeps showing what
         // was just picked instead of reverting to blank on the next render.
+    }
+
+    /**
+     * Adapts a {@link Stock} entity (as picked by the "Issuing Bill Item"
+     * autocomplete, which searches {@link Stock} directly rather than going
+     * through {@link com.divudi.service.pharmacy.PharmacySubstituteService})
+     * into the minimal {@link StockDTO} that
+     * {@link com.divudi.service.pharmacy.PharmacySubstituteService#swapStockIntoBillItem}
+     * actually reads: {@code stockId} (to reload the managed {@link Stock})
+     * and {@code costRate} (read raw here rather than persisted, matching
+     * that method's contract of never mutating the {@link com.divudi.core.entity.pharmacy.ItemBatch}
+     * via its mutating {@code getCostRate()} getter). Issue #23470.
+     */
+    private StockDTO toSubstituteStockDto(Stock stock) {
+        if (stock == null || stock.getId() == null) {
+            return null;
+        }
+        StockDTO dto = new StockDTO();
+        dto.setStockId(stock.getId());
+        if (stock.getItemBatch() != null) {
+            dto.setCostRate(stock.getItemBatch().getCostRate());
+        }
+        return dto;
     }
 
     /**
@@ -2262,25 +2235,6 @@ public class PharmacySaleBhtController implements Serializable {
         return true;
     }
 
-
-    private BigDecimal determineTransferRate(ItemBatch itemBatch) {
-        if (itemBatch == null) {
-            return BigDecimal.ZERO;
-        }
-
-        boolean pharmacyTransferIsByPurchaseRate = configOptionApplicationController.getBooleanValueByKey("Pharmacy Transfer is by Purchase Rate", false);
-        boolean pharmacyTransferIsByCostRate = configOptionApplicationController.getBooleanValueByKey("Pharmacy Transfer is by Cost Rate", false);
-        boolean pharmacyTransferIsByRetailRate = configOptionApplicationController.getBooleanValueByKey("Pharmacy Transfer is by Retail Rate", true);
-
-        if (pharmacyTransferIsByPurchaseRate) {
-            return BigDecimal.valueOf(itemBatch.getPurcahseRate());
-        } else if (pharmacyTransferIsByCostRate) {
-            return BigDecimal.valueOf(itemBatch.getCostRate());
-        } else {
-            return BigDecimal.valueOf(itemBatch.getRetailsaleRate());
-        }
-    }
-    
     private boolean settleBhtIssueRequestAccept(BillType btp, BillTypeAtomic bta, Department matrixDepartment, BillNumberSuffix billNumberSuffix) {
 
         if (matrixDepartment == null) {
@@ -4161,19 +4115,19 @@ public class PharmacySaleBhtController implements Serializable {
         this.itemForSubstitution = itemForSubstitution;
     }
 
-    public Stock getSelectedSubstituteStock() {
+    public StockDTO getSelectedSubstituteStock() {
         return selectedSubstituteStock;
     }
 
-    public void setSelectedSubstituteStock(Stock selectedSubstituteStock) {
+    public void setSelectedSubstituteStock(StockDTO selectedSubstituteStock) {
         this.selectedSubstituteStock = selectedSubstituteStock;
     }
 
-    public List<Stock> getSubstituteStocks() {
+    public List<StockDTO> getSubstituteStocks() {
         return substituteStocks;
     }
 
-    public void setSubstituteStocks(List<Stock> substituteStocks) {
+    public void setSubstituteStocks(List<StockDTO> substituteStocks) {
         this.substituteStocks = substituteStocks;
     }
 

--- a/src/main/webapp/ward/ward_pharmacy_bht_issue.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_bht_issue.xhtml
@@ -580,33 +580,33 @@
                             styleClass="table-striped">
 
                             <p:column headerText="Item Name">
-                                <h:outputText value="#{sStock.itemBatch.item.name}"/>
+                                <h:outputText value="#{sStock.itemName}"/>
                             </p:column>
 
                             <p:column headerText="Batch No">
-                                <h:outputText value="#{sStock.itemBatch.batchNo}"/>
+                                <h:outputText value="#{sStock.batchNo}"/>
                             </p:column>
 
                             <p:column headerText="Expiry Date">
-                                <h:outputText value="#{sStock.itemBatch.dateOfExpire}">
+                                <h:outputText value="#{sStock.dateOfExpire}">
                                     <f:convertDateTime pattern="MM/yyyy"/>
                                 </h:outputText>
                             </p:column>
 
                             <p:column headerText="Available Qty">
-                                <h:outputText value="#{sStock.stock}">
+                                <h:outputText value="#{sStock.stockQty}">
                                     <f:convertNumber pattern="#,###.#"/>
                                 </h:outputText>
                             </p:column>
 
                             <p:column headerText="Purchase Rate" rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}">
-                                <h:outputText value="#{sStock.itemBatch.purcahseRate}">
+                                <h:outputText value="#{sStock.purchaseRate}">
                                     <f:convertNumber pattern="#,##0.00"/>
                                 </h:outputText>
                             </p:column>
 
                             <p:column headerText="Retail Rate" rendered="#{configOptionApplicationController.getBooleanValueByKey('Nursing IP Billing - Show Rate and Value', false) and webUserController.hasPrivilege('NursingIPBillingViewRates')}">
-                                <h:outputText value="#{sStock.itemBatch.retailsaleRate}">
+                                <h:outputText value="#{sStock.retailRate}">
                                     <f:convertNumber pattern="#,##0.00"/>
                                 </h:outputText>
                             </p:column>


### PR DESCRIPTION
## Summary

- `PharmacySaleBhtController.prepareSubstitute()` (the Pharmacy BHT-issue page, `ward/ward_pharmacy_bht_issue.xhtml`) resolved alternatives with `PharmacyBean.resolveAmps(item)`, which stays **brand-exact** — for the normal case (an `Amp` item) it returns only that same Amp, so the "Select a Substitute" popup only ever showed the requested item's own batches, never other brands. This was inconsistent with the Ward request page and the Direct Issue to BHT page, which both already use the correct shared substitute logic.
- Switched `PharmacySaleBhtController` to the shared `PharmacySubstituteService` (`findSubstituteStocks` / `swapStockIntoBillItem`) already used by Direct Issue to BHT and Retail Sale — this resolves true VMP-sibling alternative brands via `PharmacyBean.resolveSubstituteAmps()`, deleting the old duplicated (and brand-exact) substitute logic in the process.
- Rebound the substitute dialog's `p:dataTable` columns in `ward_pharmacy_bht_issue.xhtml` from `Stock`/`ItemBatch` entity paths to the shared `StockDTO` fields to match the new backing type.
- Removed `determineTransferRate()`, which became dead code once the shared service's swap logic replaced the old hand-rolled one (it was already the only writer of `BillItemFinanceDetails.lineGrossRate/lineNetRate` for this controller, and nothing in the BHT-issue path reads those fields back — confirmed via grep across the codebase).

## Test plan

Verified end to end on local Payara with Playwright + DB checks (details and screenshots posted to [issue #23470](https://github.com/hmislk/hmis/issues/23470#issuecomment-5546954138)):

- [x] Created a BHT medicine request as a Ward user for "Leflox 500mg tablet" (2 configured alternative brands sharing the same VMP: "Levo 500" and "Levocil 500mg Tablet")
- [x] Opened the request for issuing as a Pharmacy user — "Select a Substitute" now lists both alternative brands, not just the requested item's own batches
- [x] Selected "Levocil 500mg Tablet" as a substitute — the issuing row updates correctly (item, batch, expiry, qty)
- [x] Settled the bill ("Issue to BHT") and confirmed in the DB: the issued `BILLITEM` is the substitute item (109780, "Levocil 500mg Tablet"), correctly linked back to the request via `REFERANCEBILLITEM_ID`, with correct batch/rates on `PHARMACEUTICALBILLITEM`, and the substitute's stock correctly decremented (141 → 131 for qty 10) while the original item's stock was untouched
- [x] `mvn clean package -DskipTests` builds clean; local Payara redeploy successful, no errors in `server.log`

## Documentation

Updated [Inward BHT Issue Against Request](https://github.com/hmislk/hmis/wiki/Inward-BHT-Issue-Against-Request) to describe and show the alternative-brand substitutes in the Select a Substitute dialog.

Closes #23470

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved substitute-stock selection and replacement during BHT medicine issuing.
  - Substitute-stock details now display item, batch, expiry, quantity, and pricing information more consistently.
  - Existing formatting, rate visibility controls, and replacement behavior remain unchanged.

- **Documentation**
  - Expanded Playwright workflow guidance for draft handling, required porter/staff selection, autocomplete behavior, and required-field validation messages.
  - Added guidance to check for existing department privilege records before creating new ones.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->