### PR TITLE
fix(store,ward): guard p:defaultCommand targets against not-yet-rendered buttons

### DIFF
--- a/src/main/webapp/store/store_retail_sale_bht.xhtml
+++ b/src/main/webapp/store/store_retail_sale_bht.xhtml
@@ -20,7 +20,13 @@
                 <h:form id="bill" >
 
                     <p:commandButton id="nullButton2" value="No Action" action="#" style="display: none;" ></p:commandButton>
-                    <p:defaultCommand  target="btnAdd" />  
+                    <!-- btnAdd only renders once a patient/bill is selected AND the bill hasn't been
+                         settled yet (the whole h:panelGrid below is hidden once billPreview is true,
+                         since settleStoreBhtIssue() sets billPreview=true without clearing
+                         patientEncounter). Fall back to the always-rendered no-op button in every
+                         other state so PrimeFaces' client-side defaultCommand init doesn't throw on a
+                         not-yet-rendered target (issue #23490). -->
+                    <p:defaultCommand  target="#{storeSaleBhtController.billPreview or storeSaleBhtController.patientEncounter eq null ? 'nullButton2' : 'btnAdd'}" />
 
                     <h:panelGrid id="sale" columns="1" class="alignTop w-100" >
                         <p:panel rendered="#{!storeSaleBhtController.billPreview}" >

--- a/src/main/webapp/ward/ward_pharmacy_bht_issue_request_bill.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_bht_issue_request_bill.xhtml
@@ -18,7 +18,17 @@
             <ui:define name="content">
 
                 <h:form id="bill" >
-                    <p:defaultCommand target="#{configOptionApplicationController.getBooleanValueByKey('Enable Prescription Details for Pharmacy Requests', true) ? 'btnCalcAdd' : 'btnAddNoRx'}" />
+                    <!-- btnCalcAdd/btnAddNoRx/btnProceed all live inside the h:panelGroup below,
+                         which is hidden entirely once billPreview is true (settle/save actions set
+                         billPreview=true without clearing patientEncounter/department - see
+                         clearBill()/clearBillItem() in the controller). Within that panelGroup,
+                         btnCalcAdd/btnAddNoRx only render once patient+department are both selected
+                         (the "sale" panel); before that only the search panel (with btnProceed) is
+                         rendered. Fall back to nullButtonBill in every state where none of those
+                         targets exist, so PrimeFaces' client-side defaultCommand init doesn't throw
+                         on a not-yet-rendered target (issue #23490). -->
+                    <p:commandButton id="nullButtonBill" value="No Action" action="#" style="display: none;" ></p:commandButton>
+                    <p:defaultCommand target="#{pharmacyRequestForBhtController.billPreview ? 'nullButtonBill' : (pharmacyRequestForBhtController.patientEncounter ne null and pharmacyRequestForBhtController.department ne null ? (configOptionApplicationController.getBooleanValueByKey('Enable Prescription Details for Pharmacy Requests', true) ? 'btnCalcAdd' : 'btnAddNoRx') : 'btnProceed')}" />
                     <h:panelGroup
                         rendered="#{!pharmacyRequestForBhtController.billPreview}"
                         style="width: fit-content;" >


### PR DESCRIPTION
## Summary

Fixes #23490 — two `p:defaultCommand target="..."` declarations referenced
a button id that only exists once the page has progressed past its initial
search/selection panel. PrimeFaces' client-side `defaultCommand` init then
throws immediately on page load:

```
TypeError: Cannot read properties of undefined (reading 'hasAttribute')
    at d.init (components.js?ln=primefaces&v=14.0.6:571:401)
```

Both instances predate the #23165 admission-search rollout (`git show`
against the pre-rollout commit shows identical lines) — this was found as
an unrelated, pre-existing bug during that rollout's QA pass.

## Decisions made without approval

- **`store_retail_sale_bht.xhtml`**: the file already had an unused hidden
  "no action" button (`nullButton2`) sitting right next to the
  `defaultCommand` declaration, unreferenced. Repurposed it as the fallback
  target rather than adding a new element, matching the same
  dummy-button-as-fallback idiom already used on ~15 other pages in this
  codebase (`grep -rn 'No Action'`).
- **Extended the fix beyond the literal repro in the issue**: while
  self-reviewing, traced `settleStoreBhtIssue()` /
  `PharmacyRequestForBhtController`'s settle/save paths and found both set
  `billPreview = true` without clearing `patientEncounter`/`department`
  (`clearBill()`/`clearBillItem()` only null out the bill/item, not the
  encounter). That means the *same* not-yet-rendered-target bug can also
  fire after settling, since the whole panel containing the "real" target
  is hidden by `billPreview` regardless of `patientEncounter`. Folded this
  into the same fix (same file, same root cause) rather than filing a
  separate issue.
- **`ward_pharmacy_bht_issue_request_bill.xhtml`** needed a nested EL
  ternary (search-panel `btnProceed` → sale-panel `btnCalcAdd`/`btnAddNoRx`
  depending on a ConfigOption → a new `nullButtonBill` once `billPreview`),
  since three different buttons can be the "current" target depending on
  page state. Verified the nesting is syntactically the same pattern the
  file's original code already used for the config-driven half of the
  ternary.

## Scope note (carried from the issue)

`grep -rn 'p:defaultCommand target=' src/main/webapp --include='*.xhtml' | wc -l`
returns 413 matches project-wide; only the two in this PR were confirmed to
exhibit the failure. A full audit is out of scope here.

## Verification

Local Payara, Playwright-driven, redeployed after each change:

- `store_retail_sale_bht.xhtml`: 0 console errors on load (pre-selection),
  0 console errors after searching + selecting an admission (post-selection,
  add-items panel with `btnAdd` visible). Confirmed via `browser_console_messages`
  before and after.
- `ward_pharmacy_bht_issue_request_bill.xhtml`: 0 console errors on load
  (pre-selection, `btnProceed` visible), 0 console errors after selecting a
  department + admission and the AJAX `itemSelect` re-render that swaps in
  the "sale" panel (`btnCalcAdd`/`btnAddNoRx` visible).
- The `billPreview=true` fallback (`nullButton2` / `nullButtonBill`) was
  verified by code-level trace of the controllers' settle/save paths rather
  than a full live settle (assembling a stock-batch → add-item → settle
  chain for this specific store item didn't have readily available test
  stock locally); the logic mirrors the already-Playwright-verified
  pre-selection fallback exactly (same ternary shape, same no-op button
  pattern), just gated on a different boolean read from the same managed
  bean.
- Server log checked for SEVERE/Exception entries after each redeploy and
  after each test round — clean throughout.

## Documentation

No wiki update needed — this is an internal client-side JS error fix with
no user-visible behavior change (the buttons' actions are unchanged; only
which button responds to Enter/defaultCommand in intermediate states).

Closes #23490


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved default keyboard-command behavior on retail sales and pharmacy billing screens.
  * Prevented unintended actions during bill preview and when required patient or department details are unavailable.
  * Ensured the appropriate billing action is selected based on the available prescription details and current form state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->