### PR TITLE
fix(inward): bridge admissionController.current on Room Change's Patient Profile button

### DIFF
--- a/src/main/webapp/inward/inward_room_change.xhtml
+++ b/src/main/webapp/inward/inward_room_change.xhtml
@@ -174,11 +174,20 @@
                                             ajax="false"
                                             icon="fa fa-user"
                                             value="Patient Profile"
-                                            class="ui-button-success" 
-                                            action="#{patientController.navigateToOpdPatientProfile()}" 
+                                            class="ui-button-success"
+                                            action="#{patientController.navigateToOpdPatientProfile()}"
                                             >
-                                            <f:setPropertyActionListener 
-                                                value="#{admissionController.current.patient}" 
+                                            <!-- This page's own search/selection flow only ever populates
+                                                 roomChangeController.current (bound directly on the
+                                                 admission_search composite) - bridge it into
+                                                 admissionController.current first, same as the
+                                                 "Inpatient Dashboard" button below, so the read of
+                                                 admissionController.current.patient isn't null/stale
+                                                 (issue #23491). Listener order matters: the bridge must
+                                                 run before the read. -->
+                                            <f:setPropertyActionListener value="#{roomChangeController.current}" target="#{admissionController.current}" />
+                                            <f:setPropertyActionListener
+                                                value="#{admissionController.current.patient}"
                                                 target="#{patientController.current}" ></f:setPropertyActionListener>
                                         </p:commandButton>
                                         <p:commandButton


### PR DESCRIPTION
## Summary

Fixes #23491 — on the deprecated Room Change page, the **"Patient Profile"**
header button silently did nothing when clicked (no navigation, no error).
The sibling **"Inpatient Dashboard"** button on the same page worked
correctly.

## Root cause

This page's own search/selection flow only ever populates
`roomChangeController.current` (bound directly on the `admission_search`
composite). The **Inpatient Dashboard** button already bridges this into
`admissionController.current` via its own `f:setPropertyActionListener`
before its own action runs. The **Patient Profile** button had no such
bridge — it read `admissionController.current.patient` directly, but
`admissionController.current` was never set by this page's own flow, so the
value read was null (or stale from an unrelated earlier page in the
session). `patientController.current` then got set to null, and
`navigateToOpdPatientProfile()` had nothing to navigate to.

Confirmed pre-existing via `git show` against the commit immediately before
#23426's form-split changes touched this file — unrelated to that rollout,
found during its QA pass.

## Fix

Added the same bridging `f:setPropertyActionListener` the Inpatient
Dashboard button already has, ordered **before** the existing listener that
reads `admissionController.current.patient` — listener order matters, the
bridge has to run first.

## Decisions made without approval

None beyond the literal fix suggested in the issue — this was a single,
unambiguous root cause with an existing working sibling button as the exact
pattern to copy.

## Verification

Local Payara, Playwright-driven, redeployed after the change:

- Navigated to Room Change (Deprecated), searched and selected a real
  admission (BHT/55366).
- Clicked **Patient Profile** — now navigates to `opd/patient.xhtml` and
  correctly shows that patient's profile (previously did nothing).
- Re-clicked into the same admission and clicked **Inpatient Dashboard** —
  confirmed it still works correctly, unaffected by this change
  (non-regression check on the sibling button).
- Zero browser console errors on both navigations
  (`browser_console_messages`); server log checked for SEVERE/Exception
  entries after redeploy and after each test round — clean throughout.

## Documentation

No wiki update needed — this is a bug fix restoring existing documented
button behavior (matching its working sibling), not a new feature or a
behavior change.

Closes #23491


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed the Patient Profile action in room-change details so it opens the correct patient record.
  - Ensured the current admission information is refreshed before navigating to the patient profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->