### PR TITLE
feat(api): add duplicate-by-name check to pharmaceutical_items create

### DIFF
--- a/developer_docs/api/using-apis/API_PHARMACEUTICAL_MANAGEMENT.md
+++ b/developer_docs/api/using-apis/API_PHARMACEUTICAL_MANAGEMENT.md
@@ -211,6 +211,23 @@ curl -X POST "http://localhost:8080/api/pharmaceutical_items/vtm" \
   -d '{"name": "Paracetamol", "descreption": "Analgesic", "departmentType": "Pharmacy"}'
 ```
 
+**Duplicate-by-name detection:** create checks for an existing, non-retired
+row of the same type whose `name` matches case-insensitively before creating
+a new one. If a match is found, no row is created — the endpoint returns
+`409 Conflict` with the existing row instead:
+```json
+{
+  "status": "already_exists",
+  "code": 409,
+  "id": 123,
+  "data": { "id": 123, "name": "Paracetamol", "code": "paracetamol", "retired": false, "inactive": false }
+}
+```
+This applies to all six types (VTM, ATM, VMP, AMP, VMPP, AMPP) and matches
+the same convention used by `ClinicalMetadataApi` and `InvestigationApi`. A
+retired row with the same name does **not** block a new create — the name is
+only unique among non-retired rows of that type.
+
 ### 4. Update Item
 
 **PUT** `/api/pharmaceutical_items/{type}/{id}`
@@ -360,7 +377,7 @@ All responses follow this standard format:
 | 400 | Bad request (validation error, invalid type, missing required field) |
 | 401 | Unauthorized (invalid or missing API key) |
 | 404 | Not found |
-| 409 | Conflict (already retired / not retired) |
+| 409 | Conflict (already retired / not retired / duplicate name on create) |
 | 500 | Internal server error |
 
 ## Response DTO Fields by Type

--- a/src/main/java/com/divudi/service/pharmacy/DuplicateItemException.java
+++ b/src/main/java/com/divudi/service/pharmacy/DuplicateItemException.java
@@ -1,0 +1,42 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.service.pharmacy;
+
+/**
+ * Raised by {@link PharmaceuticalItemApiService} when a create request matches an
+ * existing, non-retired row by name (case-insensitive). Carries the already-loaded
+ * existing entity's ID and response DTO directly, rather than just an ID for the
+ * caller to re-fetch: a re-fetch call reopens a window where a concurrent retire
+ * of that same row would turn the intended 409 already_exists into a confusing
+ * 500 "not found" (findItemById excludes retired rows).
+ *
+ * <p>This is a checked (non-RuntimeException) exception on purpose: the service is a
+ * {@code @Stateless} EJB, and unchecked exceptions escaping a business method are
+ * wrapped by the container into {@code javax.ejb.EJBException} before the caller
+ * sees them, which silently defeats a {@code catch} on the original type. A checked
+ * exception is not wrapped and reaches {@link PharmaceuticalItemApi} intact.
+ *
+ * @author Buddhika
+ */
+public class DuplicateItemException extends Exception {
+
+    private final Long existingId;
+    private final Object existingDto;
+
+    public DuplicateItemException(Long existingId, Object existingDto) {
+        super("Duplicate item, ID: " + existingId);
+        this.existingId = existingId;
+        this.existingDto = existingDto;
+    }
+
+    public Long getExistingId() {
+        return existingId;
+    }
+
+    public Object getExistingDto() {
+        return existingDto;
+    }
+}

--- a/src/main/java/com/divudi/service/pharmacy/PharmaceuticalItemApiService.java
+++ b/src/main/java/com/divudi/service/pharmacy/PharmaceuticalItemApiService.java
@@ -31,6 +31,7 @@ import com.divudi.core.entity.pharmacy.PharmaceuticalItemCategory;
 import com.divudi.core.entity.pharmacy.Vmp;
 import com.divudi.core.entity.pharmacy.Vmpp;
 import com.divudi.core.entity.pharmacy.Vtm;
+import com.divudi.core.facade.AbstractFacade;
 import com.divudi.core.facade.AmpFacade;
 import com.divudi.core.facade.AmppFacade;
 import com.divudi.core.facade.AtmFacade;
@@ -396,10 +397,13 @@ public class PharmaceuticalItemApiService implements Serializable {
         Vtm item = new Vtm();
         applyBaseFields(item, request);
         item.setInstructions(request.getInstructions());
+        Vtm duplicate = findDuplicateByName(vtmFacade, "Vtm", item.getName());
+        if (duplicate != null) {
+            throw new DuplicateItemException(duplicate.getId(), buildVtmDto(duplicate));
+        }
         setAuditFieldsForCreate(item, user);
         vtmFacade.createAndFlush(item);
-        return new VtmDto(item.getId(), item.getName(), item.getCode(),
-                item.getDescreption(), item.getInstructions(), item.isRetired(), item.isInactive());
+        return buildVtmDto(item);
     }
 
     private AtmDto createAtm(AtmRequestDTO request, WebUser user) throws Exception {
@@ -413,10 +417,13 @@ public class PharmaceuticalItemApiService implements Serializable {
             }
             item.setVtm(vtm);
         }
+        Atm duplicate = findDuplicateByName(atmFacade, "Atm", item.getName());
+        if (duplicate != null) {
+            throw new DuplicateItemException(duplicate.getId(), buildAtmDto(duplicate));
+        }
         setAuditFieldsForCreate(item, user);
         atmFacade.createAndFlush(item);
-        return new AtmDto(item.getId(), item.getName(), item.getCode(),
-                item.getDescreption(), item.isRetired(), item.isInactive());
+        return buildAtmDto(item);
     }
 
     private VmpDto createVmp(VmpRequestDTO request, WebUser user) throws Exception {
@@ -438,6 +445,10 @@ public class PharmaceuticalItemApiService implements Serializable {
             item.setDosageForm(dosageForm);
         }
         applyVmpUnitFields(item, request);
+        Vmp duplicate = findDuplicateByName(vmpFacade, "Vmp", item.getName());
+        if (duplicate != null) {
+            throw new DuplicateItemException(duplicate.getId(), buildVmpDto(duplicate));
+        }
         setAuditFieldsForCreate(item, user);
         vmpFacade.createAndFlush(item);
         return buildVmpDto(item);
@@ -448,6 +459,10 @@ public class PharmaceuticalItemApiService implements Serializable {
         Amp item = new Amp();
         applyBaseFields(item, request);
         applyAmpSpecificFields(item, request);
+        Amp duplicate = findDuplicateByName(ampFacade, "Amp", item.getName());
+        if (duplicate != null) {
+            throw new DuplicateItemException(duplicate.getId(), buildAmpDto(duplicate));
+        }
         setAuditFieldsForCreate(item, user);
         ampFacade.createAndFlush(item);
         return buildAmpDto(item);
@@ -458,12 +473,13 @@ public class PharmaceuticalItemApiService implements Serializable {
         Vmpp item = new Vmpp();
         applyBaseFields(item, request);
         applyPackFields(item, request.getVmpId(), request.getDblValue(), request.getPackUnitId(), "VMP");
+        Vmpp duplicate = findDuplicateByName(vmppFacade, "Vmpp", item.getName());
+        if (duplicate != null) {
+            throw new DuplicateItemException(duplicate.getId(), buildVmppDto(duplicate));
+        }
         setAuditFieldsForCreate(item, user);
         vmppFacade.createAndFlush(item);
-        Long vmpId = item.getVmp() != null ? item.getVmp().getId() : null;
-        String vmpName = item.getVmp() != null ? item.getVmp().getName() : null;
-        return new VmppDto(item.getId(), item.getName(), item.getCode(),
-                item.isRetired(), item.isInactive(), vmpId, vmpName);
+        return buildVmppDto(item);
     }
 
     private AmppDto createAmpp(AmppRequestDTO request, WebUser user) throws Exception {
@@ -487,14 +503,13 @@ public class PharmaceuticalItemApiService implements Serializable {
             }
             item.setPackUnit(packUnit);
         }
+        Ampp duplicate = findDuplicateByName(amppFacade, "Ampp", item.getName());
+        if (duplicate != null) {
+            throw new DuplicateItemException(duplicate.getId(), buildAmppDto(duplicate));
+        }
         setAuditFieldsForCreate(item, user);
         amppFacade.createAndFlush(item);
-        Long ampId = item.getAmp() != null ? item.getAmp().getId() : null;
-        String ampName = item.getAmp() != null ? item.getAmp().getName() : null;
-        String packUnitName = item.getPackUnit() != null ? item.getPackUnit().getName() : null;
-        return new AmppDto(item.getId(), item.getName(), item.getCode(),
-                item.isRetired(), item.isInactive(),
-                item.getDblValue(), packUnitName, ampId, ampName);
+        return buildAmppDto(item);
     }
 
     // ==================== UPDATE ====================
@@ -814,6 +829,30 @@ public class PharmaceuticalItemApiService implements Serializable {
 
     // ==================== HELPER METHODS ====================
 
+    /**
+     * Looks up an existing, non-retired row with the same name (case-insensitive),
+     * matching the "already_exists" dedup pattern already used by
+     * ClinicalMetadataApi / InvestigationApi. Called after all other create-time
+     * validation (parent-reference lookups etc.) has already passed, so a request
+     * with both a bad reference and a duplicate name still surfaces the reference
+     * error first -- the duplicate is the last thing checked before persisting.
+     *
+     * <p>Returns the matched entity itself (not just its ID) so the caller can build
+     * its already_exists response DTO directly from data already in hand, instead of
+     * re-fetching by ID afterwards -- a re-fetch would reopen a window where a
+     * concurrent retire of that same row turns the intended 409 into a confusing
+     * 500 "not found" (findItemById excludes retired rows).
+     */
+    private <T extends Item> T findDuplicateByName(AbstractFacade<T> facade, String entityName, String name) {
+        if (name == null || name.trim().isEmpty()) {
+            return null;
+        }
+        Map<String, Object> params = new HashMap<>();
+        params.put("n", name.trim().toUpperCase());
+        return facade.findFirstByJpql(
+                "select i from " + entityName + " i where i.retired=false and upper(i.name)=:n", params);
+    }
+
     private void validateBaseRequest(PharmaceuticalItemBaseRequestDTO request) throws Exception {
         if (request == null) {
             throw new Exception("Request body is required");
@@ -994,6 +1033,32 @@ public class PharmaceuticalItemApiService implements Serializable {
             dto.setStrengthUnitName(item.getStrengthUnit().getName());
         }
         return dto;
+    }
+
+    private VtmDto buildVtmDto(Vtm item) {
+        return new VtmDto(item.getId(), item.getName(), item.getCode(),
+                item.getDescreption(), item.getInstructions(), item.isRetired(), item.isInactive());
+    }
+
+    private AtmDto buildAtmDto(Atm item) {
+        return new AtmDto(item.getId(), item.getName(), item.getCode(),
+                item.getDescreption(), item.isRetired(), item.isInactive());
+    }
+
+    private VmppDto buildVmppDto(Vmpp item) {
+        Long vmpId = item.getVmp() != null ? item.getVmp().getId() : null;
+        String vmpName = item.getVmp() != null ? item.getVmp().getName() : null;
+        return new VmppDto(item.getId(), item.getName(), item.getCode(),
+                item.isRetired(), item.isInactive(), vmpId, vmpName);
+    }
+
+    private AmppDto buildAmppDto(Ampp item) {
+        Long ampId = item.getAmp() != null ? item.getAmp().getId() : null;
+        String ampName = item.getAmp() != null ? item.getAmp().getName() : null;
+        String packUnitName = item.getPackUnit() != null ? item.getPackUnit().getName() : null;
+        return new AmppDto(item.getId(), item.getName(), item.getCode(),
+                item.isRetired(), item.isInactive(),
+                item.getDblValue(), packUnitName, ampId, ampName);
     }
 
     private void applyPackFields(Item item, Long parentVmpId, Double dblValue, Long packUnitId, String parentType) throws Exception {

--- a/src/main/java/com/divudi/ws/pharmacy/PharmaceuticalItemApi.java
+++ b/src/main/java/com/divudi/ws/pharmacy/PharmaceuticalItemApi.java
@@ -8,6 +8,7 @@ package com.divudi.ws.pharmacy;
 import com.divudi.bean.common.ApiKeyController;
 import com.divudi.core.entity.ApiKey;
 import com.divudi.core.entity.WebUser;
+import com.divudi.service.pharmacy.DuplicateItemException;
 import com.divudi.service.pharmacy.PharmaceuticalItemApiService;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -165,6 +166,8 @@ public class PharmaceuticalItemApi {
 
         } catch (JsonSyntaxException e) {
             return errorResponse("Invalid JSON format: " + e.getMessage(), 400);
+        } catch (DuplicateItemException e) {
+            return alreadyExistsResponse(e.getExistingId(), e.getExistingDto());
         } catch (Exception e) {
             String msg = e.getMessage();
             if (msg != null && (msg.contains("not found") || msg.contains("is required") || msg.contains("Invalid"))) {
@@ -172,6 +175,22 @@ public class PharmaceuticalItemApi {
             }
             return errorResponse("An error occurred: " + (msg != null ? msg : "Unknown error"), 500);
         }
+    }
+
+    /**
+     * Builds the already_exists/409 response for a duplicate-by-name create,
+     * same convention as ClinicalMetadataApi / InvestigationApi. Built directly
+     * from the DTO the service already loaded (see DuplicateItemException) rather
+     * than re-fetching by ID, so a concurrent retire of that row in between can't
+     * turn this into a spurious 500.
+     */
+    private Response alreadyExistsResponse(Long existingId, Object existingDto) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("status", "already_exists");
+        response.put("code", 409);
+        response.put("id", existingId);
+        response.put("data", existingDto);
+        return Response.status(409).entity(gson.toJson(response)).build();
     }
 
     /**


### PR DESCRIPTION
## Decisions made without approval

Run via `dev-issue-unattended`, no user present. Every judgment call below is
also in the commit body; summarized here for quick review:

1. **Duplicate signal uses a new checked `DuplicateItemException`, not the
   `IllegalStateException` convention `InvestigationApiService` uses.** Live
   testing showed that convention is actually broken: `PharmaceuticalItemApiService`
   is a `@Stateless` EJB, and an *unchecked* exception escaping a business method
   gets wrapped by the container into `javax.ejb.EJBException` before the caller
   sees it — so `catch (IllegalStateException ...)` at the API layer never matches,
   and the request falls through to a bare `500`. I reproduced the identical failure
   live against the existing `POST /api/investigations` endpoint (which uses that
   exact pattern), confirming this is a **pre-existing bug in the reference
   implementation**, not something introduced here. Filed separately as
   **#23497** rather than fixed in this PR (out of this issue's scope). A checked
   exception (not a `RuntimeException`) is not wrapped by the EJB container, so it
   reaches the REST layer intact.
2. **`DuplicateItemException` carries the existing entity's ID *and* pre-built
   response DTO**, rather than just an ID for the API layer to re-fetch. My own
   `/code-review medium` self-review pass (step 8a) flagged that a re-fetch-by-ID
   reopens a race: a concurrent retire of that same row between the duplicate
   check and the re-fetch would turn the intended `409` into a confusing `500 not
   found` (`findItemById` excludes retired rows). Fixed by carrying the DTO
   directly instead.
3. **Duplicate-name check moved to run *after* all other create-time validation**
   (parent-reference/unit lookups), not first. Same self-review pass found the
   original ordering meant a request with both a duplicate name and a bad parent
   reference (e.g. a typo'd `vtmId`) returned `409` first, masking the reference
   error until the caller fixed the name and resubmitted. Verified live: a bad
   `vtmId` + duplicate name now correctly returns `400 VTM not found` first.
4. **Two other self-review findings judged out of scope, filed as #23498 instead
   of fixed here:**
   - The check-then-insert isn't atomic — none of the 6 entity types has a unique
     DB constraint on `name`, so two near-simultaneous creates with the same name
     could both pass the check before either commits. Closing this needs a schema
     change, which is outside this automation run's hard limits.
   - The same "find by case-insensitive name, build already_exists" pattern is
     now independently re-implemented across ~7 create endpoints
     (`PharmaceuticalItemApiService`, `ClinicalMetadataApi` ×2, `InvestigationApiService`,
     `ChannelSpecialityApi`) with visible drift between copies (checked vs.
     unchecked exception, `findFirstByJpql` vs. `findByJpql`+`isEmpty()`, `409`
     vs. `200` status).
5. **Left unfixed and unfiled** (low-confidence/stylistic): each `create*` method
   passes the JPQL entity-name as a hand-typed string literal (e.g. `"Vtm"`) that
   must stay in sync with the facade argument — a real design smell, but low risk
   given this file supports a fixed set of 6 types today. Noted here for a human
   to weigh rather than acted on.

## What changed

`POST /api/pharmaceutical_items/{type}` for all six types (`vtm`, `atm`, `vmp`,
`amp`, `vmpp`, `ampp`) now checks for an existing, non-retired row with the same
name (case-insensitive) before creating. On a match, no row is created and the
endpoint returns `409 Conflict`:

```json
{
  "status": "already_exists",
  "code": 409,
  "id": 123,
  "data": { "id": 123, "name": "...", "code": "...", "retired": false, "inactive": false }
}
```

Matches the existing convention in `ClinicalMetadataApi` / `InvestigationApi`.
A retired row with the same name does not block a new create — the name is
only unique among non-retired rows of that type.

## Verification

Built, deployed to local Payara against the local `coop` DB, and exercised live
via `curl` with a real API key for all 6 types:

- First create of a new name → `200`, row created.
- Repeat create with the identical name (and again with different
  case/whitespace) → `409 already_exists` with the original row's `id`/`data`;
  confirmed via direct DB query that exactly **one** row exists per test name
  (no duplicate created).
- A genuinely different name still creates normally.
- A request combining a duplicate name **and** a bad parent reference
  (`vtmId`) now correctly returns `400 VTM not found` (the reference error),
  not `409` — confirms the reordering fix from decision #3 above.

Also ran a `/code-review medium` self-review pass on the diff before this push
(see decisions 1–5 above for the full triage).

## Documentation

Updated `developer_docs/api/using-apis/API_PHARMACEUTICAL_MANAGEMENT.md`:
documented the new duplicate-by-name behavior under "3. Create Item" with a
sample `409` response, and updated the HTTP status code table. No `hmis.wiki`
page update — this is API/developer reference for programmatic integrators,
not end-user (pharmacy/nurse/doctor) documentation.

## Follow-ups filed

- #23497 — `POST /api/investigations` returns `500` instead of `409
  already_exists` on duplicate name (the `IllegalStateException`/EJB-wrapping
  bug described in decision #1).
- #23498 — duplicate-by-name dedup checks across 4 APIs are check-then-insert
  races and independently duplicated (decision #4).

Closes #23494

🤖 Generated with [Claude Code](https://claude.com/claude-code)
