### PR TITLE
fix(inward): block removing/editing a timed service on a validated surgery

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -2454,6 +2454,68 @@ them before the first Save attempt. Note that a `required` `p:autoComplete`
 exact label and leaving it is an empty model value as far as JSF is
 concerned, even though the textbox looks filled.
 
+## 93. Privileges are scoped per-department — a rendered button check can fail under the "wrong" department even though the user genuinely has the privilege
+
+Seen verifying issue #23510 (Surgery Dashboard "Remove" a validated timed
+service). `theater/surgery_bill_summary.xhtml`'s **Validate Surgery** button
+is gated by `webUserController.hasPrivilege('InwardSurgeryValidate')`. The
+test user held that privilege (`WEBUSERPRIVILEGE` row, `PRIVILEGE =
+'InwardSurgeryValidate'`) — but the row's `DEPARTMENT_ID` pointed at "Inward",
+not the "THEATRE" department selected at login. Under THEATRE the button
+simply didn't render (no error, no disabled state — just absent), which looks
+identical to "user lacks the privilege" from the UI alone.
+
+**Diagnose it this way**: don't stop at confirming a `WEBUSERPRIVILEGE` row
+exists for the user — check its `DEPARTMENT_ID` against the department
+actually selected for the session:
+
+```sql
+SELECT ID, PRIVILEGE, DEPARTMENT_ID FROM WEBUSERPRIVILEGE
+WHERE WEBUSER_ID = <id> AND PRIVILEGE = '<PrivilegeName>';
+```
+
+If the department differs from the one under test, log out and reselect the
+department that matches the privilege row — per §1 there is no in-session
+department switch. Never grant a new `WEBUSERPRIVILEGE` row yourself to route
+around this; that is a privilege/access-control change, out of bounds for
+verifying a fix.
+
+## 94. PrimeFaces `p:datePicker` popups don't always close on their own — the previous field's panel can intercept clicks meant for the next field
+
+Seen adding a timed service on
+`theater/inward_timed_service_consume_surgery.xhtml` (Start Time / End Time,
+both `p:datePicker` with `showTime="true"`). Clicking the End Time input right
+after picking a Start Time did not open a new calendar — it silently reused
+the Start Time picker that was still open underneath, so time-spinner clicks
+kept editing the wrong field. A later click on the real End Time input then
+timed out with `<div class="ui-datepicker-header">... intercepts pointer
+events` because the stale panel from the previous field was still on top.
+
+**Fix**: click a neutral, non-input element on the page (e.g. a panel header)
+to dismiss the open picker before clicking the next date field — `Escape`
+alone was not reliable here. Re-`browser_snapshot` after opening a picker to
+confirm which field's `_panel` id is actually active before interacting with
+its spinners.
+
+## 95. Theatre's "+ Add New Surgery" briefly lands on a generic, blank-looking `admission_profile.xhtml` — the surgery Bill is already created; go through "Surgeries for BHT" to reach it
+
+Seen creating test data for issue #23510. Clicking **+ Add New Surgery** on
+`theater/patient_surgery.xhtml` navigates to `inward/admission_profile.xhtml`
+showing empty Name/Gender/DOB fields and a *different*, just-now Date of
+Admission — which looks like the action failed or created a stray blank
+encounter. It did not: the surgery `Bill` (`BILLTYPE = 'SurgeryBill'`) was
+created against the *original* BHT encounter, and a second, child
+`PatientEncounter` (the "procedure" record, `PARENTENCOUNTER_ID` = the BHT's
+id) was also created — `admission_profile.xhtml` is just rendering that new,
+still-mostly-empty child encounter, which is a separate, likely
+pre-existing display gap and not something this fix touched.
+
+**To get back to the surgery you just created**, don't fight that page —
+navigate to `theater/inward_bill_surgery_list.xhtml` ("Surgeries for BHT"),
+which lists every `SurgeryBill` for the current `patientEncounter` and has a
+**Surgery Dashboard** button per row that loads it into
+`surgeryBillController.surgeryBill` correctly.
+
 ## Some PrimeFaces buttons need a jQuery-triggered click
 
 Most `p:commandButton`s submit fine with a normal Playwright click — including

--- a/src/main/java/com/divudi/bean/inward/InwardTimedItemController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardTimedItemController.java
@@ -327,6 +327,10 @@ public class InwardTimedItemController implements Serializable {
     }
 
     public void updateTimedService(BillFee bf) {
+        if (batchBill != null && surgeryBillController.isSurgeryLockedForAdditions(batchBill)) {
+            JsfUtil.addErrorMessage("This surgery has been validated and is locked. Revert validation to make changes.");
+            return;
+        }
         if (generalChecking()) {
             return;
         }
@@ -353,6 +357,10 @@ public class InwardTimedItemController implements Serializable {
     }
 
     public void removeTimedEncFromDbase(EncounterComponent encounterComponent) {
+        if (batchBill != null && surgeryBillController.isSurgeryLockedForAdditions(batchBill)) {
+            JsfUtil.addErrorMessage("This surgery has been validated and is locked. Revert validation to make changes.");
+            return;
+        }
         if (generalChecking()) {
             return;
         }

--- a/src/main/java/com/divudi/bean/inward/SurgeryBillController.java
+++ b/src/main/java/com/divudi/bean/inward/SurgeryBillController.java
@@ -390,13 +390,42 @@ public class SurgeryBillController implements Serializable {
     }
 
     public void removeTimeService(PatientItem patientItem) {
-        if (patientItem != null) {
-            patientItem.setRetirer(getSessionController().getLoggedUser());
-            patientItem.setRetiredAt(new Date());
-            patientItem.setRetired(true);
-            getPatientItemFacade().edit(patientItem);
-            refreshTimedEncounterComponents();
+        if (patientItem == null) {
+            return;
         }
+        Bill surgeryBill = findSurgeryBillForTimedServicePatientItem(patientItem);
+        if (isSurgeryLockedForAdditions(surgeryBill)) {
+            JsfUtil.addErrorMessage("This surgery has been validated and is locked. Revert validation to make changes.");
+            return;
+        }
+        patientItem.setRetirer(getSessionController().getLoggedUser());
+        patientItem.setRetiredAt(new Date());
+        patientItem.setRetired(true);
+        getPatientItemFacade().edit(patientItem);
+        refreshTimedEncounterComponents();
+    }
+
+    /**
+     * A timed service added from the Surgery Dashboard never gets its own
+     * {@code PatientItem.bill} set (see
+     * {@code InwardTimedItemController#savePatientItem}) — only the BillFee
+     * that wraps it does, and that BillFee's own Bill (the per-surgery
+     * "TimedService" sub-bill) points back to the surgery Bill via
+     * {@code forwardReferenceBill}. Timed services added through the
+     * general, non-surgery inward flow have no such BillFee and this simply
+     * returns null, which is correct — they aren't locked by surgery
+     * validation.
+     */
+    private Bill findSurgeryBillForTimedServicePatientItem(PatientItem patientItem) {
+        // BillFee.patientItem carries no DB uniqueness constraint; order by
+        // most-recently-created so a lock check against a hypothetical
+        // duplicate link can't silently land on the wrong surgery.
+        String jpql = "SELECT bf.bill.forwardReferenceBill FROM BillFee bf "
+                + "WHERE bf.patientItem = :pi AND bf.retired = false "
+                + "ORDER BY bf.createdAt DESC";
+        Map<String, Object> params = new HashMap<>();
+        params.put("pi", patientItem);
+        return getBillFacade().findFirstByJpql(jpql, params);
     }
 
     public void removeProEncFromList(EncounterComponent encounterComponent) {

--- a/src/main/webapp/theater/inward_timed_service_consume_surgery.xhtml
+++ b/src/main/webapp/theater/inward_timed_service_consume_surgery.xhtml
@@ -305,7 +305,7 @@
                                         icon="fa fa-pencil"
                                         ajax="false"
                                         action="#{inwardTimedItemController.updateTimedService(ti.billFee)}"
-                                        disabled="#{ti.billFee.id eq null or ti.billFee.retired or inwardTimedItemController.batchBill.patientEncounter.paymentFinalized}"/>
+                                        disabled="#{ti.billFee.id eq null or ti.billFee.retired or inwardTimedItemController.batchBill.patientEncounter.paymentFinalized or inwardTimedItemController.batchBill.completed}"/>
                                     <p:commandButton
                                         id="btnRemoveFromList"
                                         icon="fa-solid fa-trash"
@@ -314,7 +314,7 @@
                                         value="Remove"
                                         rendered="#{ti.billFee.id eq null}"
                                         action="#{inwardTimedItemController.removeTimedEncFromList(ti)}"
-                                        disabled="#{inwardTimedItemController.batchBill.patientEncounter.paymentFinalized}"/>
+                                        disabled="#{inwardTimedItemController.batchBill.patientEncounter.paymentFinalized or inwardTimedItemController.batchBill.completed}"/>
                                     <p:commandButton
                                         id="btnRemoveFromDbase"
                                         icon="fa-solid fa-trash"
@@ -323,7 +323,7 @@
                                         value="Remove"
                                         rendered="#{ti.billFee.id ne null and not ti.billFee.retired}"
                                         action="#{inwardTimedItemController.removeTimedEncFromDbase(ti)}"
-                                        disabled="#{inwardTimedItemController.batchBill.patientEncounter.paymentFinalized}"/>
+                                        disabled="#{inwardTimedItemController.batchBill.patientEncounter.paymentFinalized or inwardTimedItemController.batchBill.completed}"/>
                                 </div>
                             </p:column>
                         </p:dataTable>

--- a/src/main/webapp/theater/patient_surgery.xhtml
+++ b/src/main/webapp/theater/patient_surgery.xhtml
@@ -545,7 +545,7 @@
                                             <p:column headerText="Action">
                                                 <p:commandButton ajax="false" value="Remove"
                                                                  action="#{surgeryBillController.removeTimeService(ti.billFee.patientItem)}"
-                                                                 disabled="#{ti.billFee.patientItem.retired eq true}"/>
+                                                                 disabled="#{ti.billFee.patientItem.retired eq true or ti.billFee.bill.forwardReferenceBill.completed eq true}"/>
                                             </p:column>
                                         </p:dataTable>
                                     </p:tab>


### PR DESCRIPTION
## Decisions made without approval

- **Guard location & data path**: `PatientItem.bill` is never set for a timed service added from the Surgery Dashboard (only the general, non-surgery inward flow sets it — see `InwardTimedItemController#savePatientItem` vs `#createBillForTimedService`). Rather than relying on that field, the fix resolves the owning surgery via the timed service's `BillFee.bill.forwardReferenceBill` (the same path `SurgeryBillController#getSurgeryTimedServiceBill` already uses), verified empirically against the local DB after reproducing the bug.
- **Shared method, no signature change**: `removeTimeService(PatientItem)` is called from both `theater/patient_surgery.xhtml` (Surgery Dashboard, in scope) and `inward/inward_bill_intrim.xhtml` (a general interim-bill page, out of scope for this issue). The guard resolves the surgery bill by JPQL lookup rather than changing the method's parameter, so the fix protects the shared method without touching the second, unrelated call site's markup.
- **No admin UI found for creating a `TimedItem` locally**: local `coop` DB had zero `TimedItem` rows. A minimal one (`QA Timed Service 23510`) was inserted directly into the local `ITEM` table (master/config data, not a schema or business-transaction change) to generate real test data through the Surgery Workbench, per the skill's local-DB test-data allowance.
- **Wiki update**: added a short note + one new screenishot to `Theatre-Surgery-Bill-Validation.md`'s "What Gets Locked" list and to `Theatre-Timed-Services.md`'s existing "Removal is only possible while..." note — both pages described the finalize/admission lock but never mentioned the surgery-validation lock at all, which this fix makes real. Pushed directly to the `hmis.wiki` repo (already merged, see below).

## Problem

On `theater/patient_surgery.xhtml` (Surgery Dashboard), once a surgery is
validated (`Bill.completed = true`), all "Add ..." actions are correctly
disabled — but the **Remove** button on the Timed Services tab was not
guarded at all: `SurgeryBillController#removeTimeService` unconditionally
retired the `PatientItem`, both from the client (button was never disabled)
and the server (no check).

## Root cause

`removeTimeService` was a bare retire-and-save, with none of the
`generalChecking()`/`isSurgeryLockedForAdditions()` guard other add/remove
actions on this controller already use.

## Fix

- `SurgeryBillController#removeTimeService`: resolve the timed service's
  owning surgery Bill via `BillFee.bill.forwardReferenceBill` and reject the
  removal with the same "validated and locked" message used elsewhere if
  that surgery is `completed`.
- `patient_surgery.xhtml`: disable the **Remove** button under the same
  condition, for immediate UI feedback (defense in depth — the server check
  above is what actually matters).

## Verification

Local Payara + `coop` DB, THEATRE/Inward departments, BHT/57814 (synthetic
"Unidentified Patient" test admission):

1. Created a surgery (`theatre/SURG/1`, Functional Endoscopic Sinus Surgery),
   added a timed service (`QA Timed Service 23510`) — confirmed **Remove**
   enabled and the DB shows `PATIENTITEM.RETIRED=0`.
2. Checked the timed-service sub-bill and validated the surgery via
   **Surgery Bill Summary / Validate** — confirmed `BILL.COMPLETED=1` in the
   DB.
3. Reloaded the Surgery Dashboard: **Remove** now renders disabled.
4. Forced the button back on via a DOM edit (simulating a stale
   page/bypassed client check) and clicked it anyway: the page reloaded with
   no change — `PATIENTITEM.RETIRED` is still `0`, proving the block is
   server-side, not just a disabled attribute.

Screenshots and full narrative in the issue comment.

## Documentation

- [Theatre — Surgery Bill Summary / Validate](https://github.com/hmislk/hmis/wiki/Theatre-Surgery-Bill-Validation) — added removing a Timed Service to "What Gets Locked"
- [Theatre — Timed Services in Surgery](https://github.com/hmislk/hmis/wiki/Theatre-Timed-Services) — cross-referenced the validation lock next to the existing admission-finalised note

Closes #23510

🤖 Generated with [Claude Code](https://claude.com/claude-code)
