### PR TITLE
fix(inward): allow adding/settling services for room-less baby admissions

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -2625,6 +2625,28 @@ brand new login/HTTP session is used. A plain redeploy is not enough; use
 
 Verified while testing issue #23377.
 
+## A `p:calendar` bound to Date of Birth can ignore real keystrokes — use the widget's `setDate()` API
+
+On `inward_admission_child.xhtml`'s "Admit a Baby" form, the DOB field (`dpDob`, a `p:calendar`
+with `timeInput="true"`) rejected even a real slow-typed keystroke sequence
+(`click` → `Control+a` → `pressSequentially('05/09/2026 00:00:00 am')` → `Escape`): the input
+stayed visually blank and the server still reported "Patient Age is Required" (the DOB-backed
+check) on submit. This is a step further than §3's "JS-set values are silently discarded" note —
+that one only warns about `page.evaluate`/`fill()`, but here the *keyboard* path documented
+elsewhere in this guide as the fix for datepickers also silently failed to commit.
+
+**Fix:** call the widget's own API directly instead of trying to type into it:
+
+```js
+() => { PrimeFaces.widgets['widget_<formId>_<fieldId>_dpDob'].setDate(new Date()); }
+```
+
+Find the exact widget variable name first with
+`Object.keys(PrimeFaces.widgets).filter(k => k.toLowerCase().includes('dob'))` — it's generated
+from the component's full client id, not the plain `id` attribute, so don't guess it. Confirm the
+commit by reading `document.getElementById('<formId>:<fieldId>:dpDob_input').value` before
+submitting. Verified while testing issue #23509 (baby admission with no NIC/phone).
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.

--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -2214,7 +2214,11 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
                     return true;
                 }
             }
-            if (configOptionApplicationController.getBooleanValueByKey("Patient Phone Number is Required in Patient Admission", false)) {
+            // Baby admissions typically have no phone number of their own yet either
+            // (staff use the "Copy Address & Phone to Baby" button when one is needed),
+            // so this admission-specific phone-required check is skipped for them too,
+            // matching the NIC exemption above. (Issue #23509)
+            if (!isBabyAdmission() && configOptionApplicationController.getBooleanValueByKey("Patient Phone Number is Required in Patient Admission", false)) {
                 if (getCurrent().getPatient().getPerson().getPhone() == null || getCurrent().getPatient().getPerson().getPhone().trim().isEmpty()) {
                     JsfUtil.addErrorMessage("Patient Phone Number is Required");
                     return true;

--- a/src/main/java/com/divudi/bean/inward/BillBhtController.java
+++ b/src/main/java/com/divudi/bean/inward/BillBhtController.java
@@ -1358,8 +1358,11 @@ public class BillBhtController implements Serializable {
         }
 
         // Room is optional for baby admissions (they stay in the mother's room), so
-        // skip the room-required check entirely for a room-less baby. (Issue #23509)
-        if ((!isBabyAdmission() || getPatientEncounter().getCurrentPatientRoom() != null) && errorCheckForPatientRoomDepartment()) {
+        // skip the room-required check entirely for a room-less baby — same gate as
+        // addToBill()/settleBill()/errorCheck() use. (Issue #23509)
+        if (((getPatientEncounter().getAdmissionType().isRoomChargesAllowed() && !isBabyAdmission())
+                || getPatientEncounter().getCurrentPatientRoom() != null)
+                && errorCheckForPatientRoomDepartment()) {
             return;
         }
 

--- a/src/main/java/com/divudi/bean/inward/BillBhtController.java
+++ b/src/main/java/com/divudi/bean/inward/BillBhtController.java
@@ -846,9 +846,11 @@ public class BillBhtController implements Serializable {
             return;
         }
         paymentMethod = null;
-        if (getPatientEncounter().getAdmissionType().isRoomChargesAllowed() || getPatientEncounter().getCurrentPatientRoom() != null) {
+        if ((getPatientEncounter().getAdmissionType().isRoomChargesAllowed() && !isBabyAdmission()) || getPatientEncounter().getCurrentPatientRoom() != null) {
             settleBill(getPatientEncounter().getCurrentPatientRoom().getRoomFacilityCharge().getDepartment(), getPatientEncounter().getPaymentMethod());
         } else {
+            // Baby admissions may have no room of their own (they stay in the
+            // mother's room), so fall back to the encounter's department. (Issue #23509)
             settleBill(getPatientEncounter().getDepartment(), getPatientEncounter().getPaymentMethod());
         }
     }
@@ -981,6 +983,11 @@ public class BillBhtController implements Serializable {
     }
 
     public void logicalDischage() {
+        // A room-less baby admission has nothing to discharge from. (Issue #23509)
+        if (getPatientEncounter().getCurrentPatientRoom() == null) {
+            JsfUtil.addSuccessMessage("No room assigned to discharge");
+            return;
+        }
         getPatientEncounter().getCurrentPatientRoom().setDischarged(true);
         getPatientEncounter().getCurrentPatientRoom().setDischargedBy(getSessionController().getLoggedUser());
         JsfUtil.addSuccessMessage("Logically Dischaged Success");
@@ -1016,7 +1023,9 @@ public class BillBhtController implements Serializable {
             return true;
         }
 
-        if (getPatientEncounter().getAdmissionType().isRoomChargesAllowed() || getPatientEncounter().getCurrentPatientRoom() != null) {
+        // Room is optional for baby admissions (they stay in the mother's room), so
+        // this gate only fires for babies when a room was actually assigned. (Issue #23509)
+        if ((getPatientEncounter().getAdmissionType().isRoomChargesAllowed() && !isBabyAdmission()) || getPatientEncounter().getCurrentPatientRoom() != null) {
             if (getPatientEncounter().getCurrentPatientRoom() == null) {
                 return true;
             }
@@ -1051,6 +1060,16 @@ public class BillBhtController implements Serializable {
         }
 
         return false;
+    }
+
+    /**
+     * @return {@code true} when the current encounter is a baby admission
+     * (i.e. it has a parent encounter). Babies stay in the mother's room, so
+     * room selection is optional for them, mirroring AdmissionController's
+     * isBabyAdmission(). (Issue #23509)
+     */
+    private boolean isBabyAdmission() {
+        return getPatientEncounter() != null && getPatientEncounter().getParentEncounter() != null;
     }
 
     private boolean errorCheckForPatientRoomDepartment() {
@@ -1124,7 +1143,8 @@ public class BillBhtController implements Serializable {
             return;
         }
 
-        if (patientEncounter.getAdmissionType().isRoomChargesAllowed() || patientEncounter.getCurrentPatientRoom() != null) {
+        // Room is optional for baby admissions (they stay in the mother's room). (Issue #23509)
+        if ((patientEncounter.getAdmissionType().isRoomChargesAllowed() && !isBabyAdmission()) || patientEncounter.getCurrentPatientRoom() != null) {
             if (errorCheckForPatientRoomDepartment()) {
                 return;
             }
@@ -1174,9 +1194,10 @@ public class BillBhtController implements Serializable {
         }
         addingEntry.setBillItem(bItem);
         addingEntry.setLstBillComponents(getBillBean().billComponentsFromBillItem(bItem));
-        if (patientEncounter.getAdmissionType().isRoomChargesAllowed() || getPatientEncounter().getCurrentPatientRoom() != null) {
+        if ((patientEncounter.getAdmissionType().isRoomChargesAllowed() && !isBabyAdmission()) || getPatientEncounter().getCurrentPatientRoom() != null) {
             addingEntry.setLstBillFees(billFeeFromBillItemWithMatrix(bItem, getPatientEncounter(), getPatientEncounter().getCurrentPatientRoom().getRoomFacilityCharge().getDepartment(), getPatientEncounter().getPaymentMethod()));
         } else {
+            // Room-less baby admissions fall back to the encounter's department. (Issue #23509)
             addingEntry.setLstBillFees(billFeeFromBillItemWithMatrix(bItem, getPatientEncounter(), getPatientEncounter().getDepartment(), getPatientEncounter().getPaymentMethod()));
         }
         addingEntry.setLstBillSessions(getBillBean().billSessionsfromBillItem(bItem));
@@ -1336,7 +1357,9 @@ public class BillBhtController implements Serializable {
             return;
         }
 
-        if (errorCheckForPatientRoomDepartment()) {
+        // Room is optional for baby admissions (they stay in the mother's room), so
+        // skip the room-required check entirely for a room-less baby. (Issue #23509)
+        if ((!isBabyAdmission() || getPatientEncounter().getCurrentPatientRoom() != null) && errorCheckForPatientRoomDepartment()) {
             return;
         }
 
@@ -1349,9 +1372,15 @@ public class BillBhtController implements Serializable {
                 ? bf.getBillItem().getQty() : 1.0;
         bf.setFeeUnitGrossValue(bf.getFeeGrossValue() / qty);
 
-        PriceMatrix priceMatrix = getPriceMatrixController().fetchInwardMargin(bf.getBillItem(), bf.getFeeUnitGrossValue(), getPatientEncounter().getCurrentPatientRoom().getRoomFacilityCharge().getDepartment(), getPatientEncounter().getPaymentMethod(), null, getPatientEncounter().getAdmissionType(), resolveCurrentRoomCategory(getPatientEncounter()));
+        // Room-less baby admissions fall back to the encounter's department for the
+        // matrix/margin lookups, matching addToBill()'s pattern. (Issue #23509)
+        Department feeDepartment = ((getPatientEncounter().getAdmissionType().isRoomChargesAllowed() && !isBabyAdmission()) || getPatientEncounter().getCurrentPatientRoom() != null)
+                ? getPatientEncounter().getCurrentPatientRoom().getRoomFacilityCharge().getDepartment()
+                : getPatientEncounter().getDepartment();
 
-        getInwardBean().updateBillItemMargin(bf, bf.getFeeGrossValue(), getPatientEncounter(), getPatientEncounter().getCurrentPatientRoom().getRoomFacilityCharge().getDepartment(), priceMatrix);
+        PriceMatrix priceMatrix = getPriceMatrixController().fetchInwardMargin(bf.getBillItem(), bf.getFeeUnitGrossValue(), feeDepartment, getPatientEncounter().getPaymentMethod(), null, getPatientEncounter().getAdmissionType(), resolveCurrentRoomCategory(getPatientEncounter()));
+
+        getInwardBean().updateBillItemMargin(bf, bf.getFeeGrossValue(), getPatientEncounter(), feeDepartment, priceMatrix);
 
         recalculateFeeVat(bf);
 


### PR DESCRIPTION
## What

Fixes #23509 — adding a service to a baby admission with no room failed with "Please Set Room or Bed For This Patient".

**Root cause**: not a classic regression. Room became optional for baby admissions in a prior feature (refs #9900), but that fix only updated the admission-creation validation in `AdmissionController` — the sibling room-required checks in `BillBhtController` (used by `inward_bill_service.xhtml`'s Add Services flow) were never updated to match.

## Changes

- **`BillBhtController.java`**: added `isBabyAdmission()` mirroring `AdmissionController`'s existing helper, and gated every `isRoomChargesAllowed()`-driven room check on it: `errorCheck()`, `addToBill()` (both the validation gate and the fee-matrix department lookup), `settleBill()`, and `feeChanged()` (previously an *unconditional* room check). Each now falls back to the encounter's own department when no room is assigned, matching the pattern `addToBill()` already used. Also guarded `logicalDischage()` against a null room (dead code today — no UI caller — but same bug class).
- **`AdmissionController.java`**: brought the "Patient Phone Number is Required in Patient Admission" check in line with the existing NIC exemption for baby admissions (issue #22998) — same gap, same fix, so a baby admission isn't blocked on a phone number it doesn't have yet.
- **`developer_docs/testing/playwright-e2e-workflow.md`**: documented a new Playwright gotcha found while testing — a `p:calendar` bound to Date of Birth can silently ignore real keystrokes; the widget's `setDate()` API is the reliable fix.

## Verification

Rebuilt and redeployed locally, then end-to-end on a fresh baby admission (BHT/57815, off mother BHT/57814, no room):

![Service added to a room-less baby admission with no error](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23509-baby-service-added-no-room.png)

*X RAY added successfully — previously blocked.*

![Settled bill for a room-less baby admission](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23509-baby-bill-settled.png)

*Bill settled (Inward//26/000552, net 1,510.00), correctly billed to the encounter's RADIOLOGY department instead of a room. DB-verified: `BILL.PATIENTENCOUNTER_ID` points at the baby's encounter, `BILLFEE` rows resolve to the RADIOLOGY department, and totals reconcile (760 + 750 = 1,510).*

Also verified the phone-number exemption: with "Patient Phone Number is Required in Patient Admission" turned on, a second baby admission (BHT/57816) with no phone succeeded:

![Printed baby admission confirmation with Room and Mobile No left blank](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23509-baby-admission-no-phone-required.png)

...while a **normal (non-baby) admission** with no room was still correctly blocked with "Select Room" — confirming the exemption is baby-specific and doesn't loosen validation for regular patients. Config was reverted to its original value afterward.

## Documentation

Updated [Inpatient — Baby Admission](https://github.com/hmislk/hmis/wiki/Inpatient-Baby-Admission): corrected the outdated "may be the same physical room" wording (room is now explicitly optional), documented the NIC/Phone exemption, and added a new section on billing services for a room-less baby.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Baby admissions no longer require a dedicated phone number during admission.
  - Room assignments are optional for baby admissions throughout inward service billing and discharge workflows.
  - Room-less baby admissions use the encounter’s department for applicable billing calculations.

- **Documentation**
  - Added Playwright guidance for reliably setting date-of-birth fields through the calendar widget and verifying the value before submission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->