### PR TITLE
fix(inward): show all medicine issue/return rows on interim bill

### DIFF
--- a/src/main/webapp/inward/inward_bill_intrim_medicine_issue_table.xhtml
+++ b/src/main/webapp/inward/inward_bill_intrim_medicine_issue_table.xhtml
@@ -9,8 +9,6 @@
         value="#{issues}"
         var="iss"
         rowIndexVar="rowIndex"
-        scrollable="true"
-        scrollHeight="300"
         rowStyleClass="#{((iss.billClass eq 'class com.divudi.core.entity.PreBill')
                          or
                          (iss.billedBill ne null


### PR DESCRIPTION
## What changed

Fixes the "returns not shown" complaint on the Interim Bill's **Medicine and Consumable Charges** tab reported in #23511.

**Investigation found this was not a data/filtering bug.** The Pharmacy Medicine (and other department) charge-type totals were always correctly netting issues against returns, and every return/cancellation row (`RefundBill`) was already present in the underlying `issues` list and rendered in the table's DOM — the row-visibility predicate and `BhtSummeryController.getVisibleIssueTotal()` both work correctly.

The actual cause: `inward_bill_intrim_medicine_issue_table.xhtml`'s `p:dataTable` had a fixed `scrollable="true" scrollHeight="300"`. For admissions with more than ~4-5 medicine transactions, later rows — frequently the returns, since they tend to occur after the original issue — were scrolled out of view inside that small nested box. A user who didn't scroll *inside the mini-table* would never see them, which reads exactly like "returns aren't displayed."

**Fix:** removed `scrollable="true"`/`scrollHeight="300"` so the table renders every row in normal page flow. This template is shared by all 6 department tabs (ETU/Pharmacy/Inward/Theatre/Store/Inventory) via `ui:decorate`, so the fix applies uniformly. XHTML-only change — no Java, query, or entity changes.

## Verification

Reproduced and verified live against local Payara using BHT/57729 (Galle Co-Operative Hospital), an admission with 18 Pharmacy issues + 8 returns — a good stress case:

**Before** — badge says "26" but only 4 rows visible, no returns, even though the Total (32,116.62) already nets correctly:

![Before fix](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23511-medicine-issue-table-before-scroll-hides-returns.png)

**After** — all 18 issues and 8 returns (`View Returns`, negative amounts) visible without a nested scrollbar, footer Total unchanged:

![After fix](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23511-medicine-issue-table-after-all-rows-visible.png)

Also spot-checked the ETU tab (1 row) to confirm no visual regression for tables with few rows.

## Documentation

Updated the wiki: https://github.com/hmislk/hmis/wiki/Finance-Inpatient-Interim-Bills — new "Medicine and Consumable Charges — Issue and Return Detail" section explaining that issues and returns render together in one un-clipped list per department tab.

Closes #23511

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Changes**
  * The medicine issue table no longer uses a fixed-height scrollable body, allowing the table to display without the previous scrolling constraint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->