### PR TITLE
feat(inward-reports): configurable column selection on 3 Inward reports

### DIFF
--- a/.claude/skills/dev-issue/SKILL.md
+++ b/.claude/skills/dev-issue/SKILL.md
@@ -15,7 +15,8 @@ argument-hint: "<issue-number>"
 
 Invoking this skill is the explicit authorization for every commit/push/PR
 step below — do not re-ask before each one. Discussion gates (steps 2a
-non-repro case, 3, 4, 14) are the points where you pause for the user.
+non-repro case, 3, 4's environment choice only, 14) are the points where you
+pause for the user.
 
 This authorization also covers `superpowers:writing-plans`' Execution
 Handoff question, if that chain gets invoked anywhere in this flow (e.g.
@@ -80,18 +81,27 @@ Exit Plan Mode only once the user approves or adjusts the plan.
 
 ## 4. Gather test context
 
-Before writing code, ask the user (via `AskUserQuestion`):
-- **Department** to use for Playwright testing (must match a real department
-  in the local DB the feature touches — e.g. Pharmacy, Inward, OPD)
+Local Payara / local DB is a testing environment — pick department and
+records yourself rather than gating on the user for them:
+- **Department**: query the local DB for one that's real and relevant to the
+  feature (e.g. Pharmacy, Inward, OPD), and say which one you picked before
+  testing.
 - **Specific records** to exercise (e.g. an admission ID, bill number, item
-  code) — pick something that exists in the local DB and is relevant to the
-  feature
+  code): query the local DB for existing records that fit the feature and
+  use those — report exactly which ones you used (BHT no, bill no, etc.) in
+  the PR/issue evidence. Only ask the user if the local DB has no suitable
+  record at all (e.g. the feature needs a state nothing local is in) — that
+  is a real blocker, not a preference question.
 - **Environment**: local Payara (default) unless the issue specifically
-  requires testing against a remote env, in which case confirm which one.
-  Credentials live outside the repo in `C:\Credentials\` — never inlined
+  requires testing against a remote env, in which case confirm which one
+  with the user (this one *is* a real decision — remote envs carry real
+  data/credentials risk that local doesn't). Credentials live outside the
+  repo in `C:\Credentials\` — never inlined.
 
-Don't guess these — wrong department/record selection wastes the whole
-Playwright pass later.
+Only the environment choice is a discussion gate here. Department/record
+selection against local test data is not — deciding it yourself and moving
+straight to step 5 keeps this step from wasting a round-trip on a question
+that has no wrong answer in a disposable local DB.
 
 ## 5. Develop
 

--- a/src/main/java/com/divudi/bean/common/UserSettingsController.java
+++ b/src/main/java/com/divudi/bean/common/UserSettingsController.java
@@ -3025,4 +3025,637 @@ public class UserSettingsController implements Serializable {
         settings.setColumnVisible("onlineSettlement", visible);
         saveColumnVisibility("all_drawers", settings);
     }
+
+    // Page: inward_invoice_journal (Issue #23515)
+    // Note: Discount/Service Charge/Gross Total columns stay gated by the
+    // existing admin ConfigOption "Inpatient Reports - Show Gross Value,
+    // Discount and Service Charge" (not user-toggleable here), and the
+    // dynamic per-InwardChargeType columns keep their existing
+    // auto-hide-when-zero behavior - neither is part of this panel.
+
+    public boolean isInwardInvoiceJournalBhtNoVisible() {
+        return isColumnVisible("inward_invoice_journal", "bhtNo");
+    }
+
+    public void setInwardInvoiceJournalBhtNoVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_invoice_journal");
+        settings.setColumnVisible("bhtNo", visible);
+        saveColumnVisibility("inward_invoice_journal", settings);
+    }
+
+    public boolean isInwardInvoiceJournalPatientNameVisible() {
+        return isColumnVisible("inward_invoice_journal", "patientName");
+    }
+
+    public void setInwardInvoiceJournalPatientNameVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_invoice_journal");
+        settings.setColumnVisible("patientName", visible);
+        saveColumnVisibility("inward_invoice_journal", settings);
+    }
+
+    public boolean isInwardInvoiceJournalAdmittedVisible() {
+        return isColumnVisible("inward_invoice_journal", "admitted");
+    }
+
+    public void setInwardInvoiceJournalAdmittedVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_invoice_journal");
+        settings.setColumnVisible("admitted", visible);
+        saveColumnVisibility("inward_invoice_journal", settings);
+    }
+
+    public boolean isInwardInvoiceJournalDischargedVisible() {
+        return isColumnVisible("inward_invoice_journal", "discharged");
+    }
+
+    public void setInwardInvoiceJournalDischargedVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_invoice_journal");
+        settings.setColumnVisible("discharged", visible);
+        saveColumnVisibility("inward_invoice_journal", settings);
+    }
+
+    public boolean isInwardInvoiceJournalFinalBillNoVisible() {
+        return isColumnVisible("inward_invoice_journal", "finalBillNo");
+    }
+
+    public void setInwardInvoiceJournalFinalBillNoVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_invoice_journal");
+        settings.setColumnVisible("finalBillNo", visible);
+        saveColumnVisibility("inward_invoice_journal", settings);
+    }
+
+    public boolean isInwardInvoiceJournalAdmissionTypeVisible() {
+        return isColumnVisible("inward_invoice_journal", "admissionType");
+    }
+
+    public void setInwardInvoiceJournalAdmissionTypeVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_invoice_journal");
+        settings.setColumnVisible("admissionType", visible);
+        saveColumnVisibility("inward_invoice_journal", settings);
+    }
+
+    public boolean isInwardInvoiceJournalTotalFinalPaymentVisible() {
+        return isColumnVisible("inward_invoice_journal", "totalFinalPayment");
+    }
+
+    public void setInwardInvoiceJournalTotalFinalPaymentVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_invoice_journal");
+        settings.setColumnVisible("totalFinalPayment", visible);
+        saveColumnVisibility("inward_invoice_journal", settings);
+    }
+
+    public boolean isInwardInvoiceJournalTotalDepositVisible() {
+        return isColumnVisible("inward_invoice_journal", "totalDeposit");
+    }
+
+    public void setInwardInvoiceJournalTotalDepositVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_invoice_journal");
+        settings.setColumnVisible("totalDeposit", visible);
+        saveColumnVisibility("inward_invoice_journal", settings);
+    }
+
+    public boolean isInwardInvoiceJournalCreditSettlementVisible() {
+        return isColumnVisible("inward_invoice_journal", "creditSettlement");
+    }
+
+    public void setInwardInvoiceJournalCreditSettlementVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_invoice_journal");
+        settings.setColumnVisible("creditSettlement", visible);
+        saveColumnVisibility("inward_invoice_journal", settings);
+    }
+
+    public boolean isInwardInvoiceJournalCreditCompanyDueVisible() {
+        return isColumnVisible("inward_invoice_journal", "creditCompanyDue");
+    }
+
+    public void setInwardInvoiceJournalCreditCompanyDueVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_invoice_journal");
+        settings.setColumnVisible("creditCompanyDue", visible);
+        saveColumnVisibility("inward_invoice_journal", settings);
+    }
+
+    public boolean isInwardInvoiceJournalCreditCompanyNameVisible() {
+        return isColumnVisible("inward_invoice_journal", "creditCompanyName");
+    }
+
+    public void setInwardInvoiceJournalCreditCompanyNameVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_invoice_journal");
+        settings.setColumnVisible("creditCompanyName", visible);
+        saveColumnVisibility("inward_invoice_journal", settings);
+    }
+
+    // Page: inward_bht_payment_detail (Issue #23515)
+    // Backs inward_report_bht_payment_detail.xhtml (bhtPaymentSummaryReportController - see #23258).
+
+    public boolean isInwardBhtPaymentDetailBhtNoVisible() {
+        return isColumnVisible("inward_bht_payment_detail", "bhtNo");
+    }
+
+    public void setInwardBhtPaymentDetailBhtNoVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_bht_payment_detail");
+        settings.setColumnVisible("bhtNo", visible);
+        saveColumnVisibility("inward_bht_payment_detail", settings);
+    }
+
+    public boolean isInwardBhtPaymentDetailPatientNameVisible() {
+        return isColumnVisible("inward_bht_payment_detail", "patientName");
+    }
+
+    public void setInwardBhtPaymentDetailPatientNameVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_bht_payment_detail");
+        settings.setColumnVisible("patientName", visible);
+        saveColumnVisibility("inward_bht_payment_detail", settings);
+    }
+
+    public boolean isInwardBhtPaymentDetailAdmissionTypeVisible() {
+        return isColumnVisible("inward_bht_payment_detail", "admissionType");
+    }
+
+    public void setInwardBhtPaymentDetailAdmissionTypeVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_bht_payment_detail");
+        settings.setColumnVisible("admissionType", visible);
+        saveColumnVisibility("inward_bht_payment_detail", settings);
+    }
+
+    public boolean isInwardBhtPaymentDetailAdmittedVisible() {
+        return isColumnVisible("inward_bht_payment_detail", "admitted");
+    }
+
+    public void setInwardBhtPaymentDetailAdmittedVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_bht_payment_detail");
+        settings.setColumnVisible("admitted", visible);
+        saveColumnVisibility("inward_bht_payment_detail", settings);
+    }
+
+    public boolean isInwardBhtPaymentDetailDischargedVisible() {
+        return isColumnVisible("inward_bht_payment_detail", "discharged");
+    }
+
+    public void setInwardBhtPaymentDetailDischargedVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_bht_payment_detail");
+        settings.setColumnVisible("discharged", visible);
+        saveColumnVisibility("inward_bht_payment_detail", settings);
+    }
+
+    public boolean isInwardBhtPaymentDetailDepositCashVisible() {
+        return isColumnVisible("inward_bht_payment_detail", "depositCash");
+    }
+
+    public void setInwardBhtPaymentDetailDepositCashVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_bht_payment_detail");
+        settings.setColumnVisible("depositCash", visible);
+        saveColumnVisibility("inward_bht_payment_detail", settings);
+    }
+
+    public boolean isInwardBhtPaymentDetailDepositCardVisible() {
+        return isColumnVisible("inward_bht_payment_detail", "depositCard");
+    }
+
+    public void setInwardBhtPaymentDetailDepositCardVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_bht_payment_detail");
+        settings.setColumnVisible("depositCard", visible);
+        saveColumnVisibility("inward_bht_payment_detail", settings);
+    }
+
+    public boolean isInwardBhtPaymentDetailDepositOtherVisible() {
+        return isColumnVisible("inward_bht_payment_detail", "depositOther");
+    }
+
+    public void setInwardBhtPaymentDetailDepositOtherVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_bht_payment_detail");
+        settings.setColumnVisible("depositOther", visible);
+        saveColumnVisibility("inward_bht_payment_detail", settings);
+    }
+
+    public boolean isInwardBhtPaymentDetailTotalDepositsVisible() {
+        return isColumnVisible("inward_bht_payment_detail", "totalDeposits");
+    }
+
+    public void setInwardBhtPaymentDetailTotalDepositsVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_bht_payment_detail");
+        settings.setColumnVisible("totalDeposits", visible);
+        saveColumnVisibility("inward_bht_payment_detail", settings);
+    }
+
+    public boolean isInwardBhtPaymentDetailPaymentCashVisible() {
+        return isColumnVisible("inward_bht_payment_detail", "paymentCash");
+    }
+
+    public void setInwardBhtPaymentDetailPaymentCashVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_bht_payment_detail");
+        settings.setColumnVisible("paymentCash", visible);
+        saveColumnVisibility("inward_bht_payment_detail", settings);
+    }
+
+    public boolean isInwardBhtPaymentDetailPaymentCardVisible() {
+        return isColumnVisible("inward_bht_payment_detail", "paymentCard");
+    }
+
+    public void setInwardBhtPaymentDetailPaymentCardVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_bht_payment_detail");
+        settings.setColumnVisible("paymentCard", visible);
+        saveColumnVisibility("inward_bht_payment_detail", settings);
+    }
+
+    public boolean isInwardBhtPaymentDetailPaymentCreditVisible() {
+        return isColumnVisible("inward_bht_payment_detail", "paymentCredit");
+    }
+
+    public void setInwardBhtPaymentDetailPaymentCreditVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_bht_payment_detail");
+        settings.setColumnVisible("paymentCredit", visible);
+        saveColumnVisibility("inward_bht_payment_detail", settings);
+    }
+
+    public boolean isInwardBhtPaymentDetailPaymentOtherVisible() {
+        return isColumnVisible("inward_bht_payment_detail", "paymentOther");
+    }
+
+    public void setInwardBhtPaymentDetailPaymentOtherVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_bht_payment_detail");
+        settings.setColumnVisible("paymentOther", visible);
+        saveColumnVisibility("inward_bht_payment_detail", settings);
+    }
+
+    public boolean isInwardBhtPaymentDetailTotalPaymentsVisible() {
+        return isColumnVisible("inward_bht_payment_detail", "totalPayments");
+    }
+
+    public void setInwardBhtPaymentDetailTotalPaymentsVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_bht_payment_detail");
+        settings.setColumnVisible("totalPayments", visible);
+        saveColumnVisibility("inward_bht_payment_detail", settings);
+    }
+
+    public boolean isInwardBhtPaymentDetailPostPaymentCashVisible() {
+        return isColumnVisible("inward_bht_payment_detail", "postPaymentCash");
+    }
+
+    public void setInwardBhtPaymentDetailPostPaymentCashVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_bht_payment_detail");
+        settings.setColumnVisible("postPaymentCash", visible);
+        saveColumnVisibility("inward_bht_payment_detail", settings);
+    }
+
+    public boolean isInwardBhtPaymentDetailPostPaymentCardVisible() {
+        return isColumnVisible("inward_bht_payment_detail", "postPaymentCard");
+    }
+
+    public void setInwardBhtPaymentDetailPostPaymentCardVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_bht_payment_detail");
+        settings.setColumnVisible("postPaymentCard", visible);
+        saveColumnVisibility("inward_bht_payment_detail", settings);
+    }
+
+    public boolean isInwardBhtPaymentDetailPostPaymentCreditVisible() {
+        return isColumnVisible("inward_bht_payment_detail", "postPaymentCredit");
+    }
+
+    public void setInwardBhtPaymentDetailPostPaymentCreditVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_bht_payment_detail");
+        settings.setColumnVisible("postPaymentCredit", visible);
+        saveColumnVisibility("inward_bht_payment_detail", settings);
+    }
+
+    public boolean isInwardBhtPaymentDetailPostPaymentOtherVisible() {
+        return isColumnVisible("inward_bht_payment_detail", "postPaymentOther");
+    }
+
+    public void setInwardBhtPaymentDetailPostPaymentOtherVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_bht_payment_detail");
+        settings.setColumnVisible("postPaymentOther", visible);
+        saveColumnVisibility("inward_bht_payment_detail", settings);
+    }
+
+    public boolean isInwardBhtPaymentDetailTotalPostPaymentsVisible() {
+        return isColumnVisible("inward_bht_payment_detail", "totalPostPayments");
+    }
+
+    public void setInwardBhtPaymentDetailTotalPostPaymentsVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_bht_payment_detail");
+        settings.setColumnVisible("totalPostPayments", visible);
+        saveColumnVisibility("inward_bht_payment_detail", settings);
+    }
+
+    public boolean isInwardBhtPaymentDetailGrandTotalVisible() {
+        return isColumnVisible("inward_bht_payment_detail", "grandTotal");
+    }
+
+    public void setInwardBhtPaymentDetailGrandTotalVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_bht_payment_detail");
+        settings.setColumnVisible("grandTotal", visible);
+        saveColumnVisibility("inward_bht_payment_detail", settings);
+    }
+
+    public boolean isInwardBhtPaymentDetailTotalCreditBilledVisible() {
+        return isColumnVisible("inward_bht_payment_detail", "totalCreditBilled");
+    }
+
+    public void setInwardBhtPaymentDetailTotalCreditBilledVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_bht_payment_detail");
+        settings.setColumnVisible("totalCreditBilled", visible);
+        saveColumnVisibility("inward_bht_payment_detail", settings);
+    }
+
+    public boolean isInwardBhtPaymentDetailCreditSettledVisible() {
+        return isColumnVisible("inward_bht_payment_detail", "creditSettled");
+    }
+
+    public void setInwardBhtPaymentDetailCreditSettledVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_bht_payment_detail");
+        settings.setColumnVisible("creditSettled", visible);
+        saveColumnVisibility("inward_bht_payment_detail", settings);
+    }
+
+    public boolean isInwardBhtPaymentDetailCreditBalanceVisible() {
+        return isColumnVisible("inward_bht_payment_detail", "creditBalance");
+    }
+
+    public void setInwardBhtPaymentDetailCreditBalanceVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_bht_payment_detail");
+        settings.setColumnVisible("creditBalance", visible);
+        saveColumnVisibility("inward_bht_payment_detail", settings);
+    }
+
+    public boolean isInwardBhtPaymentDetailCreditCompanyVisible() {
+        return isColumnVisible("inward_bht_payment_detail", "creditCompany");
+    }
+
+    public void setInwardBhtPaymentDetailCreditCompanyVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_bht_payment_detail");
+        settings.setColumnVisible("creditCompany", visible);
+        saveColumnVisibility("inward_bht_payment_detail", settings);
+    }
+
+    public boolean isInwardBhtPaymentDetailFinalBillNoVisible() {
+        return isColumnVisible("inward_bht_payment_detail", "finalBillNo");
+    }
+
+    public void setInwardBhtPaymentDetailFinalBillNoVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_bht_payment_detail");
+        settings.setColumnVisible("finalBillNo", visible);
+        saveColumnVisibility("inward_bht_payment_detail", settings);
+    }
+
+    public boolean isInwardBhtPaymentDetailTotalBillValueVisible() {
+        return isColumnVisible("inward_bht_payment_detail", "totalBillValue");
+    }
+
+    public void setInwardBhtPaymentDetailTotalBillValueVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_bht_payment_detail");
+        settings.setColumnVisible("totalBillValue", visible);
+        saveColumnVisibility("inward_bht_payment_detail", settings);
+    }
+
+    public boolean isInwardBhtPaymentDetailTotalBalanceVisible() {
+        return isColumnVisible("inward_bht_payment_detail", "totalBalance");
+    }
+
+    public void setInwardBhtPaymentDetailTotalBalanceVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_bht_payment_detail");
+        settings.setColumnVisible("totalBalance", visible);
+        saveColumnVisibility("inward_bht_payment_detail", settings);
+    }
+
+    // Page: inward_professional_payment_summary (Issue #23515)
+    // Backs the Summary table on inward/reports/inward_professional_payment_report_dto.xhtml
+    // (InwardReportControllerBht). Also consumed directly by
+    // InwardReportControllerBht.visibleSummaryColumnKeys() to keep the
+    // hand-built Excel/PDF exports in sync with the on-screen table.
+
+    public boolean isInwardProfessionalPaymentSummaryBhtNoVisible() {
+        return isColumnVisible("inward_professional_payment_summary", "bhtNo");
+    }
+
+    public void setInwardProfessionalPaymentSummaryBhtNoVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_professional_payment_summary");
+        settings.setColumnVisible("bhtNo", visible);
+        saveColumnVisibility("inward_professional_payment_summary", settings);
+    }
+
+    public boolean isInwardProfessionalPaymentSummaryAdmittedVisible() {
+        return isColumnVisible("inward_professional_payment_summary", "admitted");
+    }
+
+    public void setInwardProfessionalPaymentSummaryAdmittedVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_professional_payment_summary");
+        settings.setColumnVisible("admitted", visible);
+        saveColumnVisibility("inward_professional_payment_summary", settings);
+    }
+
+    public boolean isInwardProfessionalPaymentSummaryDischargedVisible() {
+        return isColumnVisible("inward_professional_payment_summary", "discharged");
+    }
+
+    public void setInwardProfessionalPaymentSummaryDischargedVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_professional_payment_summary");
+        settings.setColumnVisible("discharged", visible);
+        saveColumnVisibility("inward_professional_payment_summary", settings);
+    }
+
+    public boolean isInwardProfessionalPaymentSummaryFinalBillNoVisible() {
+        return isColumnVisible("inward_professional_payment_summary", "finalBillNo");
+    }
+
+    public void setInwardProfessionalPaymentSummaryFinalBillNoVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_professional_payment_summary");
+        settings.setColumnVisible("finalBillNo", visible);
+        saveColumnVisibility("inward_professional_payment_summary", settings);
+    }
+
+    public boolean isInwardProfessionalPaymentSummaryConsultantVisible() {
+        return isColumnVisible("inward_professional_payment_summary", "consultant");
+    }
+
+    public void setInwardProfessionalPaymentSummaryConsultantVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_professional_payment_summary");
+        settings.setColumnVisible("consultant", visible);
+        saveColumnVisibility("inward_professional_payment_summary", settings);
+    }
+
+    public boolean isInwardProfessionalPaymentSummarySpecialityVisible() {
+        return isColumnVisible("inward_professional_payment_summary", "speciality");
+    }
+
+    public void setInwardProfessionalPaymentSummarySpecialityVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_professional_payment_summary");
+        settings.setColumnVisible("speciality", visible);
+        saveColumnVisibility("inward_professional_payment_summary", settings);
+    }
+
+    public boolean isInwardProfessionalPaymentSummarySumAddedFeeVisible() {
+        return isColumnVisible("inward_professional_payment_summary", "sumAddedFee");
+    }
+
+    public void setInwardProfessionalPaymentSummarySumAddedFeeVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_professional_payment_summary");
+        settings.setColumnVisible("sumAddedFee", visible);
+        saveColumnVisibility("inward_professional_payment_summary", settings);
+    }
+
+    public boolean isInwardProfessionalPaymentSummarySumPaidFeeVisible() {
+        return isColumnVisible("inward_professional_payment_summary", "sumPaidFee");
+    }
+
+    public void setInwardProfessionalPaymentSummarySumPaidFeeVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_professional_payment_summary");
+        settings.setColumnVisible("sumPaidFee", visible);
+        saveColumnVisibility("inward_professional_payment_summary", settings);
+    }
+
+    public boolean isInwardProfessionalPaymentSummaryBalanceToPayVisible() {
+        return isColumnVisible("inward_professional_payment_summary", "balanceToPay");
+    }
+
+    public void setInwardProfessionalPaymentSummaryBalanceToPayVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_professional_payment_summary");
+        settings.setColumnVisible("balanceToPay", visible);
+        saveColumnVisibility("inward_professional_payment_summary", settings);
+    }
+
+    // Page: inward_professional_payment_detailed (Issue #23515)
+    // Backs the Detailed table on inward/reports/inward_professional_payment_report_dto.xhtml
+    // (InwardReportControllerBht). Also consumed directly by
+    // InwardReportControllerBht.visibleDetailedColumnKeys() to keep the
+    // hand-built Excel/PDF exports in sync with the on-screen table.
+
+    public boolean isInwardProfessionalPaymentDetailedBhtNoVisible() {
+        return isColumnVisible("inward_professional_payment_detailed", "bhtNo");
+    }
+
+    public void setInwardProfessionalPaymentDetailedBhtNoVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_professional_payment_detailed");
+        settings.setColumnVisible("bhtNo", visible);
+        saveColumnVisibility("inward_professional_payment_detailed", settings);
+    }
+
+    public boolean isInwardProfessionalPaymentDetailedAdmittedVisible() {
+        return isColumnVisible("inward_professional_payment_detailed", "admitted");
+    }
+
+    public void setInwardProfessionalPaymentDetailedAdmittedVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_professional_payment_detailed");
+        settings.setColumnVisible("admitted", visible);
+        saveColumnVisibility("inward_professional_payment_detailed", settings);
+    }
+
+    public boolean isInwardProfessionalPaymentDetailedDischargedVisible() {
+        return isColumnVisible("inward_professional_payment_detailed", "discharged");
+    }
+
+    public void setInwardProfessionalPaymentDetailedDischargedVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_professional_payment_detailed");
+        settings.setColumnVisible("discharged", visible);
+        saveColumnVisibility("inward_professional_payment_detailed", settings);
+    }
+
+    public boolean isInwardProfessionalPaymentDetailedFinalBillNoVisible() {
+        return isColumnVisible("inward_professional_payment_detailed", "finalBillNo");
+    }
+
+    public void setInwardProfessionalPaymentDetailedFinalBillNoVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_professional_payment_detailed");
+        settings.setColumnVisible("finalBillNo", visible);
+        saveColumnVisibility("inward_professional_payment_detailed", settings);
+    }
+
+    public boolean isInwardProfessionalPaymentDetailedConsultantVisible() {
+        return isColumnVisible("inward_professional_payment_detailed", "consultant");
+    }
+
+    public void setInwardProfessionalPaymentDetailedConsultantVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_professional_payment_detailed");
+        settings.setColumnVisible("consultant", visible);
+        saveColumnVisibility("inward_professional_payment_detailed", settings);
+    }
+
+    public boolean isInwardProfessionalPaymentDetailedSpecialityVisible() {
+        return isColumnVisible("inward_professional_payment_detailed", "speciality");
+    }
+
+    public void setInwardProfessionalPaymentDetailedSpecialityVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_professional_payment_detailed");
+        settings.setColumnVisible("speciality", visible);
+        saveColumnVisibility("inward_professional_payment_detailed", settings);
+    }
+
+    public boolean isInwardProfessionalPaymentDetailedAddedFeeDateVisible() {
+        return isColumnVisible("inward_professional_payment_detailed", "addedFeeDate");
+    }
+
+    public void setInwardProfessionalPaymentDetailedAddedFeeDateVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_professional_payment_detailed");
+        settings.setColumnVisible("addedFeeDate", visible);
+        saveColumnVisibility("inward_professional_payment_detailed", settings);
+    }
+
+    public boolean isInwardProfessionalPaymentDetailedAddedFeeValueVisible() {
+        return isColumnVisible("inward_professional_payment_detailed", "addedFeeValue");
+    }
+
+    public void setInwardProfessionalPaymentDetailedAddedFeeValueVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_professional_payment_detailed");
+        settings.setColumnVisible("addedFeeValue", visible);
+        saveColumnVisibility("inward_professional_payment_detailed", settings);
+    }
+
+    public boolean isInwardProfessionalPaymentDetailedPaidDateVisible() {
+        return isColumnVisible("inward_professional_payment_detailed", "paidDate");
+    }
+
+    public void setInwardProfessionalPaymentDetailedPaidDateVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_professional_payment_detailed");
+        settings.setColumnVisible("paidDate", visible);
+        saveColumnVisibility("inward_professional_payment_detailed", settings);
+    }
+
+    public boolean isInwardProfessionalPaymentDetailedPaidBillNumberVisible() {
+        return isColumnVisible("inward_professional_payment_detailed", "paidBillNumber");
+    }
+
+    public void setInwardProfessionalPaymentDetailedPaidBillNumberVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_professional_payment_detailed");
+        settings.setColumnVisible("paidBillNumber", visible);
+        saveColumnVisibility("inward_professional_payment_detailed", settings);
+    }
+
+    public boolean isInwardProfessionalPaymentDetailedCommentsVisible() {
+        return isColumnVisible("inward_professional_payment_detailed", "comments");
+    }
+
+    public void setInwardProfessionalPaymentDetailedCommentsVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_professional_payment_detailed");
+        settings.setColumnVisible("comments", visible);
+        saveColumnVisibility("inward_professional_payment_detailed", settings);
+    }
+
+    public boolean isInwardProfessionalPaymentDetailedPaidFeeValueVisible() {
+        return isColumnVisible("inward_professional_payment_detailed", "paidFeeValue");
+    }
+
+    public void setInwardProfessionalPaymentDetailedPaidFeeValueVisible(boolean visible) {
+        ColumnVisibilitySettings settings = getColumnVisibility("inward_professional_payment_detailed");
+        settings.setColumnVisible("paidFeeValue", visible);
+        saveColumnVisibility("inward_professional_payment_detailed", settings);
+    }
+
+    /**
+     * Ordered list of column keys currently visible for a given
+     * "columns.visibility" page id, filtered against the full ordered key
+     * list for that page. Used by pages whose exports are hand-built
+     * (not p:dataExporter-backed) so the export logic can consult the same
+     * source of truth as the on-screen rendered attributes.
+     *
+     * @param pageId the ColumnVisibilitySettings page id
+     * @param allKeysInOrder the full ordered column key list for that page
+     * @return the subset of allKeysInOrder that are currently visible, in order
+     */
+    public java.util.List<String> getVisibleColumnKeysInOrder(String pageId, java.util.List<String> allKeysInOrder) {
+        java.util.List<String> visible = new java.util.ArrayList<>();
+        for (String key : allKeysInOrder) {
+            if (isColumnVisible(pageId, key)) {
+                visible.add(key);
+            }
+        }
+        return visible;
+    }
 }

--- a/src/main/java/com/divudi/bean/inward/InwardReportControllerBht.java
+++ b/src/main/java/com/divudi/bean/inward/InwardReportControllerBht.java
@@ -115,6 +115,8 @@ public class InwardReportControllerBht implements Serializable {
     AdmissionController admissionController;
     @Inject
     InwardSearch inwardSearch;
+    @Inject
+    com.divudi.bean.common.UserSettingsController userSettingsController;
 
     PatientEncounter patientEncounter;
     Bill bill;
@@ -907,7 +909,95 @@ public class InwardReportControllerBht implements Serializable {
         return group.getDetailedAdmissionRowSpan();
     }
 
+    // Issue #23515 - column keys for the Configure Columns panels, in the
+    // same order the columns appear on inward_professional_payment_report_dto.xhtml.
+    // The 4 hand-built Excel/PDF export methods below consult
+    // visibleSummaryColumnKeys()/visibleDetailedColumnKeys() (backed by
+    // UserSettingsController, same "ui.<pageId>.columns.visibility"
+    // ConfigOption the xhtml checkboxes write to) instead of a fixed header
+    // array, so the exports can never drift from what's checked on screen.
+    private static final List<String> SUMMARY_COLUMN_KEYS_IN_ORDER = Arrays.asList(
+            "bhtNo", "admitted", "discharged", "finalBillNo", "consultant",
+            "speciality", "sumAddedFee", "sumPaidFee", "balanceToPay");
+
+    private static final List<String> DETAILED_COLUMN_KEYS_IN_ORDER = Arrays.asList(
+            "bhtNo", "admitted", "discharged", "finalBillNo", "consultant",
+            "speciality", "addedFeeDate", "addedFeeValue", "paidDate",
+            "paidBillNumber", "comments", "paidFeeValue");
+
+    private List<String> visibleSummaryColumnKeys() {
+        return userSettingsController.getVisibleColumnKeysInOrder(
+                "inward_professional_payment_summary", SUMMARY_COLUMN_KEYS_IN_ORDER);
+    }
+
+    private List<String> visibleDetailedColumnKeys() {
+        return userSettingsController.getVisibleColumnKeysInOrder(
+                "inward_professional_payment_detailed", DETAILED_COLUMN_KEYS_IN_ORDER);
+    }
+
+    private static final Map<String, String> SUMMARY_COLUMN_HEADERS = new LinkedHashMap<>();
+    private static final Map<String, String> DETAILED_COLUMN_HEADERS = new LinkedHashMap<>();
+
+    static {
+        SUMMARY_COLUMN_HEADERS.put("bhtNo", "BHT Number");
+        SUMMARY_COLUMN_HEADERS.put("admitted", "Admitted");
+        SUMMARY_COLUMN_HEADERS.put("discharged", "Discharged");
+        SUMMARY_COLUMN_HEADERS.put("finalBillNo", "Final Bill Number");
+        SUMMARY_COLUMN_HEADERS.put("consultant", "Consultant");
+        SUMMARY_COLUMN_HEADERS.put("speciality", "Speciality");
+        SUMMARY_COLUMN_HEADERS.put("sumAddedFee", "Sum Added Fee");
+        SUMMARY_COLUMN_HEADERS.put("sumPaidFee", "Sum Paid Fee");
+        SUMMARY_COLUMN_HEADERS.put("balanceToPay", "Balance to Pay");
+
+        DETAILED_COLUMN_HEADERS.put("bhtNo", "BHT Number");
+        DETAILED_COLUMN_HEADERS.put("admitted", "Admitted");
+        DETAILED_COLUMN_HEADERS.put("discharged", "Discharged");
+        DETAILED_COLUMN_HEADERS.put("finalBillNo", "Final Bill Number");
+        DETAILED_COLUMN_HEADERS.put("consultant", "Consultant");
+        DETAILED_COLUMN_HEADERS.put("speciality", "Speciality");
+        DETAILED_COLUMN_HEADERS.put("addedFeeDate", "Added Fee Date");
+        DETAILED_COLUMN_HEADERS.put("addedFeeValue", "Added Fee Value");
+        DETAILED_COLUMN_HEADERS.put("paidDate", "Paid Date");
+        DETAILED_COLUMN_HEADERS.put("paidBillNumber", "Paid Bill Number");
+        DETAILED_COLUMN_HEADERS.put("comments", "Comments");
+        DETAILED_COLUMN_HEADERS.put("paidFeeValue", "Paid Fee Value");
+    }
+
+    /**
+     * On-screen colspan for the "no fees at all" placeholder row on the
+     * Summary table: one cell per visible column not already covered by
+     * bhtNo/admitted/discharged/finalBillNo (those four render their own
+     * cells in that row).
+     */
+    public int getSummaryEmptyRowColspan() {
+        int count = 0;
+        for (String key : visibleSummaryColumnKeys()) {
+            if (!"bhtNo".equals(key) && !"admitted".equals(key) && !"discharged".equals(key) && !"finalBillNo".equals(key)) {
+                count++;
+            }
+        }
+        return Math.max(count, 1);
+    }
+
+    /**
+     * On-screen colspan for the "no fees at all" placeholder row on the
+     * Detailed table: one cell per visible column not already covered by
+     * bhtNo/admitted/discharged/finalBillNo.
+     */
+    public int getDetailedEmptyRowColspan() {
+        int count = 0;
+        for (String key : visibleDetailedColumnKeys()) {
+            if (!"bhtNo".equals(key) && !"admitted".equals(key) && !"discharged".equals(key) && !"finalBillNo".equals(key)) {
+                count++;
+            }
+        }
+        return Math.max(count, 1);
+    }
+
     // Issue #22803 - Excel export for the Summary report.
+    // Issue #23515 - header/cells now driven by visibleSummaryColumnKeys()
+    // instead of a fixed array, so a hidden column is skipped and later
+    // columns compact left, matching the on-screen table.
     public void downloadProfessionalPaymentSummaryExcel() {
         if (professionalPaymentReportGroups == null || professionalPaymentReportGroups.isEmpty()) {
             JsfUtil.addErrorMessage("No data to export. Please process the report first.");
@@ -917,6 +1007,13 @@ public class InwardReportControllerBht implements Serializable {
         FacesContext facesContext = FacesContext.getCurrentInstance();
         HttpServletResponse response = (HttpServletResponse) facesContext.getExternalContext().getResponse();
         SimpleDateFormat dateFormat = new SimpleDateFormat("dd/MM/yyyy");
+
+        List<String> columnKeys = visibleSummaryColumnKeys();
+        // Position of each rowspan'd admission-level column within columnKeys, or -1 if hidden.
+        int bhtCol = columnKeys.indexOf("bhtNo");
+        int admittedCol = columnKeys.indexOf("admitted");
+        int dischargedCol = columnKeys.indexOf("discharged");
+        int finalBillCol = columnKeys.indexOf("finalBillNo");
 
         try (XSSFWorkbook workbook = new XSSFWorkbook()) {
             XSSFSheet sheet = workbook.createSheet("Professional Payment Summary");
@@ -933,12 +1030,10 @@ public class InwardReportControllerBht implements Serializable {
             CellStyle moneyStyle = workbook.createCellStyle();
             moneyStyle.setDataFormat(dataFormat.getFormat("#,##0.00"));
 
-            String[] headers = {"BHT Number", "Admitted", "Discharged", "Final Bill Number",
-                "Consultant", "Speciality", "Sum Added Fee", "Sum Paid Fee", "Balance to Pay"};
             Row headerRow = sheet.createRow(0);
-            for (int c = 0; c < headers.length; c++) {
+            for (int c = 0; c < columnKeys.size(); c++) {
                 Cell cell = headerRow.createCell(c);
-                cell.setCellValue(headers[c]);
+                cell.setCellValue(SUMMARY_COLUMN_HEADERS.get(columnKeys.get(c)));
                 cell.setCellStyle(headerStyle);
             }
 
@@ -951,35 +1046,65 @@ public class InwardReportControllerBht implements Serializable {
                 for (int i = 0; i < span; i++) {
                     Row row = sheet.createRow(rowIdx++);
                     if (i == 0) {
-                        row.createCell(0).setCellValue(group.getBhtNo() != null ? group.getBhtNo() : "");
-                        row.createCell(1).setCellValue(group.getDateOfAdmission() != null ? dateFormat.format(group.getDateOfAdmission()) : "");
-                        row.createCell(2).setCellValue(group.getDateOfDischarge() != null ? dateFormat.format(group.getDateOfDischarge()) : "");
-                        row.createCell(3).setCellValue(group.getFirstFinalBillNo() != null ? group.getFirstFinalBillNo() : "");
+                        if (bhtCol >= 0) {
+                            row.createCell(bhtCol).setCellValue(group.getBhtNo() != null ? group.getBhtNo() : "");
+                        }
+                        if (admittedCol >= 0) {
+                            row.createCell(admittedCol).setCellValue(group.getDateOfAdmission() != null ? dateFormat.format(group.getDateOfAdmission()) : "");
+                        }
+                        if (dischargedCol >= 0) {
+                            row.createCell(dischargedCol).setCellValue(group.getDateOfDischarge() != null ? dateFormat.format(group.getDateOfDischarge()) : "");
+                        }
+                        if (finalBillCol >= 0) {
+                            row.createCell(finalBillCol).setCellValue(group.getFirstFinalBillNo() != null ? group.getFirstFinalBillNo() : "");
+                        }
                     }
                     if (detailRows != null && i < detailRows.size()) {
                         InwardProfessionalPaymentReportRowDTO detail = detailRows.get(i);
-                        row.createCell(4).setCellValue(detail.getConsultantName() != null ? detail.getConsultantName() : "");
-                        row.createCell(5).setCellValue(detail.getSpecialityName() != null ? detail.getSpecialityName() : "");
-                        Cell addedCell = row.createCell(6);
-                        addedCell.setCellValue(detail.getSumAddedFee());
-                        addedCell.setCellStyle(moneyStyle);
-                        Cell paidCell = row.createCell(7);
-                        paidCell.setCellValue(detail.getSumPaidFee());
-                        paidCell.setCellStyle(moneyStyle);
-                        Cell balanceCell = row.createCell(8);
-                        balanceCell.setCellValue(detail.getSumAddedFee() - detail.getSumPaidFee());
-                        balanceCell.setCellStyle(moneyStyle);
+                        for (int c = 0; c < columnKeys.size(); c++) {
+                            switch (columnKeys.get(c)) {
+                                case "consultant":
+                                    row.createCell(c).setCellValue(detail.getConsultantName() != null ? detail.getConsultantName() : "");
+                                    break;
+                                case "speciality":
+                                    row.createCell(c).setCellValue(detail.getSpecialityName() != null ? detail.getSpecialityName() : "");
+                                    break;
+                                case "sumAddedFee": {
+                                    Cell addedCell = row.createCell(c);
+                                    addedCell.setCellValue(detail.getSumAddedFee());
+                                    addedCell.setCellStyle(moneyStyle);
+                                    break;
+                                }
+                                case "sumPaidFee": {
+                                    Cell paidCell = row.createCell(c);
+                                    paidCell.setCellValue(detail.getSumPaidFee());
+                                    paidCell.setCellStyle(moneyStyle);
+                                    break;
+                                }
+                                case "balanceToPay": {
+                                    Cell balanceCell = row.createCell(c);
+                                    balanceCell.setCellValue(detail.getSumAddedFee() - detail.getSumPaidFee());
+                                    balanceCell.setCellStyle(moneyStyle);
+                                    break;
+                                }
+                                default:
+                                    // bhtNo/admitted/discharged/finalBillNo already written above (rowspan columns)
+                                    break;
+                            }
+                        }
                     }
                 }
 
                 if (span > 1) {
-                    for (int c = 0; c <= 3; c++) {
-                        sheet.addMergedRegion(new CellRangeAddress(admissionStartRow, rowIdx - 1, c, c));
+                    for (int c : new int[]{bhtCol, admittedCol, dischargedCol, finalBillCol}) {
+                        if (c >= 0) {
+                            sheet.addMergedRegion(new CellRangeAddress(admissionStartRow, rowIdx - 1, c, c));
+                        }
                     }
                 }
             }
 
-            for (int c = 0; c < headers.length; c++) {
+            for (int c = 0; c < columnKeys.size(); c++) {
                 sheet.autoSizeColumn(c);
             }
 
@@ -1007,6 +1132,9 @@ public class InwardReportControllerBht implements Serializable {
     }
 
     // Issue #22803 - Excel export for the Detailed report.
+    // Issue #23515 - header/cells now driven by visibleDetailedColumnKeys()
+    // instead of a fixed array, so a hidden column is skipped and later
+    // columns compact left, matching the on-screen table.
     public void downloadProfessionalPaymentDetailedExcel() {
         if (professionalPaymentReportGroups == null || professionalPaymentReportGroups.isEmpty()) {
             JsfUtil.addErrorMessage("No data to export. Please process the report first.");
@@ -1016,6 +1144,19 @@ public class InwardReportControllerBht implements Serializable {
         FacesContext facesContext = FacesContext.getCurrentInstance();
         HttpServletResponse response = (HttpServletResponse) facesContext.getExternalContext().getResponse();
         SimpleDateFormat dateFormat = new SimpleDateFormat("dd/MM/yyyy");
+
+        List<String> columnKeys = visibleDetailedColumnKeys();
+        int bhtCol = columnKeys.indexOf("bhtNo");
+        int admittedCol = columnKeys.indexOf("admitted");
+        int dischargedCol = columnKeys.indexOf("discharged");
+        int finalBillCol = columnKeys.indexOf("finalBillNo");
+        int consultantCol = columnKeys.indexOf("consultant");
+        int specialityCol = columnKeys.indexOf("speciality");
+        int addedFeeDateCol = columnKeys.indexOf("addedFeeDate");
+        int addedFeeValueCol = columnKeys.indexOf("addedFeeValue");
+        int paidDateCol = columnKeys.indexOf("paidDate");
+        int paidBillNumberCol = columnKeys.indexOf("paidBillNumber");
+        int paidFeeValueCol = columnKeys.indexOf("paidFeeValue");
 
         try (XSSFWorkbook workbook = new XSSFWorkbook()) {
             XSSFSheet sheet = workbook.createSheet("Professional Payment Detailed");
@@ -1040,13 +1181,10 @@ public class InwardReportControllerBht implements Serializable {
             boldMoneyStyle.setFont(boldFont);
             boldMoneyStyle.setDataFormat(poiDataFormat.getFormat("#,##0.00"));
 
-            String[] headers = {"BHT Number", "Admitted", "Discharged", "Final Bill Number",
-                "Consultant", "Speciality", "Added Fee Date", "Added Fee Value", "Paid Date",
-                "Paid Bill Number", "Comments", "Paid Fee Value"};
             Row headerRow = sheet.createRow(0);
-            for (int c = 0; c < headers.length; c++) {
+            for (int c = 0; c < columnKeys.size(); c++) {
                 Cell cell = headerRow.createCell(c);
-                cell.setCellValue(headers[c]);
+                cell.setCellValue(DETAILED_COLUMN_HEADERS.get(columnKeys.get(c)));
                 cell.setCellStyle(headerStyle);
             }
 
@@ -1058,7 +1196,7 @@ public class InwardReportControllerBht implements Serializable {
 
                 if (detailedRows == null || detailedRows.isEmpty()) {
                     Row row = sheet.createRow(rowIdx++);
-                    writeDetailedAdmissionCells(row, group, dateFormat);
+                    writeDetailedAdmissionCells(row, group, dateFormat, bhtCol, admittedCol, dischargedCol, finalBillCol);
                     admissionInfoWritten = true;
                 } else {
                     for (InwardProfessionalPaymentDetailRowDTO detail : detailedRows) {
@@ -1068,67 +1206,97 @@ public class InwardReportControllerBht implements Serializable {
                         for (int i = 0; i < dataRows; i++) {
                             Row row = sheet.createRow(rowIdx++);
                             if (!admissionInfoWritten) {
-                                writeDetailedAdmissionCells(row, group, dateFormat);
+                                writeDetailedAdmissionCells(row, group, dateFormat, bhtCol, admittedCol, dischargedCol, finalBillCol);
                                 admissionInfoWritten = true;
                             }
                             if (i == 0) {
-                                row.createCell(4).setCellValue(detail.getConsultantName() != null ? detail.getConsultantName() : "");
-                                row.createCell(5).setCellValue(detail.getSpecialityName() != null ? detail.getSpecialityName() : "");
+                                if (consultantCol >= 0) {
+                                    row.createCell(consultantCol).setCellValue(detail.getConsultantName() != null ? detail.getConsultantName() : "");
+                                }
+                                if (specialityCol >= 0) {
+                                    row.createCell(specialityCol).setCellValue(detail.getSpecialityName() != null ? detail.getSpecialityName() : "");
+                                }
                             }
                             if (i < detail.getAddedFeeValues().size()) {
-                                Date addedDate = detail.getAddedFeeDates().get(i);
-                                row.createCell(6).setCellValue(addedDate != null ? dateFormat.format(addedDate) : "");
-                                Double addedValue = detail.getAddedFeeValues().get(i);
-                                Cell addedCell = row.createCell(7);
-                                addedCell.setCellValue(addedValue != null ? addedValue : 0.0);
-                                addedCell.setCellStyle(moneyStyle);
+                                if (addedFeeDateCol >= 0) {
+                                    Date addedDate = detail.getAddedFeeDates().get(i);
+                                    row.createCell(addedFeeDateCol).setCellValue(addedDate != null ? dateFormat.format(addedDate) : "");
+                                }
+                                if (addedFeeValueCol >= 0) {
+                                    Double addedValue = detail.getAddedFeeValues().get(i);
+                                    Cell addedCell = row.createCell(addedFeeValueCol);
+                                    addedCell.setCellValue(addedValue != null ? addedValue : 0.0);
+                                    addedCell.setCellStyle(moneyStyle);
+                                }
                             }
                             if (i < detail.getPaidFeeValues().size()) {
-                                Date paidDate = detail.getPaidFeeDates().get(i);
-                                row.createCell(8).setCellValue(paidDate != null ? dateFormat.format(paidDate) : "");
-                                String paidBillNo = detail.getPaidBillNumbers().get(i);
-                                row.createCell(9).setCellValue(paidBillNo != null ? paidBillNo : "");
-                                Double paidValue = detail.getPaidFeeValues().get(i);
-                                Cell paidCell = row.createCell(11);
-                                paidCell.setCellValue(paidValue != null ? paidValue : 0.0);
-                                paidCell.setCellStyle(moneyStyle);
+                                if (paidDateCol >= 0) {
+                                    Date paidDate = detail.getPaidFeeDates().get(i);
+                                    row.createCell(paidDateCol).setCellValue(paidDate != null ? dateFormat.format(paidDate) : "");
+                                }
+                                if (paidBillNumberCol >= 0) {
+                                    String paidBillNo = detail.getPaidBillNumbers().get(i);
+                                    row.createCell(paidBillNumberCol).setCellValue(paidBillNo != null ? paidBillNo : "");
+                                }
+                                if (paidFeeValueCol >= 0) {
+                                    Double paidValue = detail.getPaidFeeValues().get(i);
+                                    Cell paidCell = row.createCell(paidFeeValueCol);
+                                    paidCell.setCellValue(paidValue != null ? paidValue : 0.0);
+                                    paidCell.setCellStyle(moneyStyle);
+                                }
                             }
                         }
 
                         Row totalRow = sheet.createRow(rowIdx++);
-                        Cell totalLabelCell = totalRow.createCell(6);
-                        totalLabelCell.setCellValue("Total");
-                        totalLabelCell.setCellStyle(boldStyle);
-                        Cell totalAddedCell = totalRow.createCell(7);
-                        totalAddedCell.setCellValue(detail.getSumAddedFee());
-                        totalAddedCell.setCellStyle(boldMoneyStyle);
-                        Cell totalPaidCell = totalRow.createCell(11);
-                        totalPaidCell.setCellValue(detail.getSumPaidFee());
-                        totalPaidCell.setCellStyle(boldMoneyStyle);
+                        if (addedFeeDateCol >= 0) {
+                            Cell totalLabelCell = totalRow.createCell(addedFeeDateCol);
+                            totalLabelCell.setCellValue("Total");
+                            totalLabelCell.setCellStyle(boldStyle);
+                        }
+                        if (addedFeeValueCol >= 0) {
+                            Cell totalAddedCell = totalRow.createCell(addedFeeValueCol);
+                            totalAddedCell.setCellValue(detail.getSumAddedFee());
+                            totalAddedCell.setCellStyle(boldMoneyStyle);
+                        }
+                        if (paidFeeValueCol >= 0) {
+                            Cell totalPaidCell = totalRow.createCell(paidFeeValueCol);
+                            totalPaidCell.setCellValue(detail.getSumPaidFee());
+                            totalPaidCell.setCellStyle(boldMoneyStyle);
+                        }
 
                         Row balanceRow = sheet.createRow(rowIdx++);
-                        Cell balanceLabelCell = balanceRow.createCell(6);
-                        balanceLabelCell.setCellValue("Balance to Pay");
-                        balanceLabelCell.setCellStyle(boldStyle);
-                        Cell balanceValueCell = balanceRow.createCell(7);
-                        balanceValueCell.setCellValue(detail.getSumAddedFee() - detail.getSumPaidFee());
-                        balanceValueCell.setCellStyle(boldMoneyStyle);
+                        if (addedFeeDateCol >= 0) {
+                            Cell balanceLabelCell = balanceRow.createCell(addedFeeDateCol);
+                            balanceLabelCell.setCellValue("Balance to Pay");
+                            balanceLabelCell.setCellStyle(boldStyle);
+                        }
+                        if (addedFeeValueCol >= 0) {
+                            Cell balanceValueCell = balanceRow.createCell(addedFeeValueCol);
+                            balanceValueCell.setCellValue(detail.getSumAddedFee() - detail.getSumPaidFee());
+                            balanceValueCell.setCellStyle(boldMoneyStyle);
+                        }
 
                         if (rowIdx - 1 > consultantStartRow) {
-                            sheet.addMergedRegion(new CellRangeAddress(consultantStartRow, rowIdx - 1, 4, 4));
-                            sheet.addMergedRegion(new CellRangeAddress(consultantStartRow, rowIdx - 1, 5, 5));
+                            if (consultantCol >= 0) {
+                                sheet.addMergedRegion(new CellRangeAddress(consultantStartRow, rowIdx - 1, consultantCol, consultantCol));
+                            }
+                            if (specialityCol >= 0) {
+                                sheet.addMergedRegion(new CellRangeAddress(consultantStartRow, rowIdx - 1, specialityCol, specialityCol));
+                            }
                         }
                     }
                 }
 
                 if (rowIdx - 1 > admissionStartRow) {
-                    for (int c = 0; c <= 3; c++) {
-                        sheet.addMergedRegion(new CellRangeAddress(admissionStartRow, rowIdx - 1, c, c));
+                    for (int c : new int[]{bhtCol, admittedCol, dischargedCol, finalBillCol}) {
+                        if (c >= 0) {
+                            sheet.addMergedRegion(new CellRangeAddress(admissionStartRow, rowIdx - 1, c, c));
+                        }
                     }
                 }
             }
 
-            for (int c = 0; c < headers.length; c++) {
+            for (int c = 0; c < columnKeys.size(); c++) {
                 sheet.autoSizeColumn(c);
             }
 
@@ -1154,17 +1322,30 @@ public class InwardReportControllerBht implements Serializable {
         }
     }
 
-    private void writeDetailedAdmissionCells(Row row, InwardProfessionalPaymentAdmissionGroupDTO group, SimpleDateFormat dateFormat) {
-        row.createCell(0).setCellValue(group.getBhtNo() != null ? group.getBhtNo() : "");
-        row.createCell(1).setCellValue(group.getDateOfAdmission() != null ? dateFormat.format(group.getDateOfAdmission()) : "");
-        row.createCell(2).setCellValue(group.getDateOfDischarge() != null ? dateFormat.format(group.getDateOfDischarge()) : "");
-        row.createCell(3).setCellValue(group.getFirstFinalBillNo() != null ? group.getFirstFinalBillNo() : "");
+    private void writeDetailedAdmissionCells(Row row, InwardProfessionalPaymentAdmissionGroupDTO group, SimpleDateFormat dateFormat,
+            int bhtCol, int admittedCol, int dischargedCol, int finalBillCol) {
+        if (bhtCol >= 0) {
+            row.createCell(bhtCol).setCellValue(group.getBhtNo() != null ? group.getBhtNo() : "");
+        }
+        if (admittedCol >= 0) {
+            row.createCell(admittedCol).setCellValue(group.getDateOfAdmission() != null ? dateFormat.format(group.getDateOfAdmission()) : "");
+        }
+        if (dischargedCol >= 0) {
+            row.createCell(dischargedCol).setCellValue(group.getDateOfDischarge() != null ? dateFormat.format(group.getDateOfDischarge()) : "");
+        }
+        if (finalBillCol >= 0) {
+            row.createCell(finalBillCol).setCellValue(group.getFirstFinalBillNo() != null ? group.getFirstFinalBillNo() : "");
+        }
     }
 
     // Issue #22803 - PDF export for the Summary report. Mirrors
     // InwardReportController.downloadSurgeryCostEstimationPdf()'s structure
     // (OpenPDF PdfPTable/PdfPCell, direct HttpServletResponse write via
     // ExternalContext).
+    // Issue #23515 - columns now driven by visibleSummaryColumnKeys();
+    // PdfPTable.addCell() is purely sequential (no indexed insert), so
+    // hidden columns are skipped by simply not calling addCell() for them -
+    // no index bookkeeping needed like the Excel exporter above.
     public void downloadProfessionalPaymentSummaryPdf() {
         if (professionalPaymentReportGroups == null || professionalPaymentReportGroups.isEmpty()) {
             JsfUtil.addErrorMessage("No data to export. Please process the report first.");
@@ -1196,15 +1377,43 @@ public class InwardReportControllerBht implements Serializable {
             titlePara.setSpacingAfter(10);
             document.add(titlePara);
 
-            String[] headers = {"BHT Number", "Admitted", "Discharged", "Final Bill Number",
-                "Consultant", "Speciality", "Sum Added Fee", "Sum Paid Fee", "Balance to Pay"};
-            PdfPTable table = new PdfPTable(headers.length);
+            List<String> columnKeys = visibleSummaryColumnKeys();
+            boolean bhtVisible = columnKeys.contains("bhtNo");
+            boolean admittedVisible = columnKeys.contains("admitted");
+            boolean dischargedVisible = columnKeys.contains("discharged");
+            boolean finalBillVisible = columnKeys.contains("finalBillNo");
+            boolean consultantVisible = columnKeys.contains("consultant");
+            boolean specialityVisible = columnKeys.contains("speciality");
+            boolean sumAddedFeeVisible = columnKeys.contains("sumAddedFee");
+            boolean sumPaidFeeVisible = columnKeys.contains("sumPaidFee");
+            boolean balanceToPayVisible = columnKeys.contains("balanceToPay");
+            // Non-rowspan'd columns (consultant/speciality/the 3 fee totals) - used
+            // for the Grand Total row's leading label colspan below.
+            int nonRowspanColumnCount = columnKeys.size()
+                    - (bhtVisible ? 1 : 0) - (admittedVisible ? 1 : 0)
+                    - (dischargedVisible ? 1 : 0) - (finalBillVisible ? 1 : 0);
+
+            Map<String, Float> columnWidths = new HashMap<>();
+            columnWidths.put("bhtNo", 3f);
+            columnWidths.put("admitted", 3f);
+            columnWidths.put("discharged", 3f);
+            columnWidths.put("finalBillNo", 3f);
+            columnWidths.put("consultant", 4f);
+            columnWidths.put("speciality", 4f);
+            columnWidths.put("sumAddedFee", 3f);
+            columnWidths.put("sumPaidFee", 3f);
+            columnWidths.put("balanceToPay", 3f);
+
+            PdfPTable table = new PdfPTable(columnKeys.size());
             table.setWidthPercentage(100);
-            float[] widths = {3f, 3f, 3f, 3f, 4f, 4f, 3f, 3f, 3f};
+            float[] widths = new float[columnKeys.size()];
+            for (int c = 0; c < columnKeys.size(); c++) {
+                widths[c] = columnWidths.get(columnKeys.get(c));
+            }
             table.setWidths(widths);
 
-            for (String h : headers) {
-                PdfPCell cell = new PdfPCell(new Phrase(h, headerFont));
+            for (String key : columnKeys) {
+                PdfPCell cell = new PdfPCell(new Phrase(SUMMARY_COLUMN_HEADERS.get(key), headerFont));
                 cell.setHorizontalAlignment(Element.ALIGN_CENTER);
                 table.addCell(cell);
             }
@@ -1216,44 +1425,54 @@ public class InwardReportControllerBht implements Serializable {
                 int span = summaryAdmissionRowSpan(group);
                 List<InwardProfessionalPaymentReportRowDTO> detailRows = group.getDetailRows();
 
-                PdfPCell bhtCell = new PdfPCell(new Phrase(group.getBhtNo() != null ? group.getBhtNo() : "", normalFont));
-                bhtCell.setRowspan(span);
-                table.addCell(bhtCell);
-
-                PdfPCell admittedCell = new PdfPCell(new Phrase(group.getDateOfAdmission() != null ? sdf.format(group.getDateOfAdmission()) : "", normalFont));
-                admittedCell.setRowspan(span);
-                table.addCell(admittedCell);
-
-                PdfPCell dischargedCell = new PdfPCell(new Phrase(group.getDateOfDischarge() != null ? sdf.format(group.getDateOfDischarge()) : "", normalFont));
-                dischargedCell.setRowspan(span);
-                table.addCell(dischargedCell);
-
-                PdfPCell finalBillCell = new PdfPCell(new Phrase(group.getFirstFinalBillNo() != null ? group.getFirstFinalBillNo() : "", normalFont));
-                finalBillCell.setRowspan(span);
-                table.addCell(finalBillCell);
+                if (bhtVisible) {
+                    PdfPCell bhtCell = new PdfPCell(new Phrase(group.getBhtNo() != null ? group.getBhtNo() : "", normalFont));
+                    bhtCell.setRowspan(span);
+                    table.addCell(bhtCell);
+                }
+                if (admittedVisible) {
+                    PdfPCell admittedCell = new PdfPCell(new Phrase(group.getDateOfAdmission() != null ? sdf.format(group.getDateOfAdmission()) : "", normalFont));
+                    admittedCell.setRowspan(span);
+                    table.addCell(admittedCell);
+                }
+                if (dischargedVisible) {
+                    PdfPCell dischargedCell = new PdfPCell(new Phrase(group.getDateOfDischarge() != null ? sdf.format(group.getDateOfDischarge()) : "", normalFont));
+                    dischargedCell.setRowspan(span);
+                    table.addCell(dischargedCell);
+                }
+                if (finalBillVisible) {
+                    PdfPCell finalBillCell = new PdfPCell(new Phrase(group.getFirstFinalBillNo() != null ? group.getFirstFinalBillNo() : "", normalFont));
+                    finalBillCell.setRowspan(span);
+                    table.addCell(finalBillCell);
+                }
 
                 if (detailRows == null || detailRows.isEmpty()) {
-                    table.addCell(new Phrase("", normalFont));
-                    table.addCell(new Phrase("", normalFont));
-                    table.addCell(new Phrase("", normalFont));
-                    table.addCell(new Phrase("", normalFont));
-                    table.addCell(new Phrase("", normalFont));
+                    for (int c = 0; c < nonRowspanColumnCount; c++) {
+                        table.addCell(new Phrase("", normalFont));
+                    }
                 } else {
                     for (InwardProfessionalPaymentReportRowDTO detail : detailRows) {
-                        table.addCell(new Phrase(detail.getConsultantName() != null ? detail.getConsultantName() : "", normalFont));
-                        table.addCell(new Phrase(detail.getSpecialityName() != null ? detail.getSpecialityName() : "", normalFont));
-
-                        PdfPCell addedCell = new PdfPCell(new Phrase(df.format(detail.getSumAddedFee()), normalFont));
-                        addedCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
-                        table.addCell(addedCell);
-
-                        PdfPCell paidCell = new PdfPCell(new Phrase(df.format(detail.getSumPaidFee()), normalFont));
-                        paidCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
-                        table.addCell(paidCell);
-
-                        PdfPCell balanceCell = new PdfPCell(new Phrase(df.format(detail.getSumAddedFee() - detail.getSumPaidFee()), normalFont));
-                        balanceCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
-                        table.addCell(balanceCell);
+                        if (consultantVisible) {
+                            table.addCell(new Phrase(detail.getConsultantName() != null ? detail.getConsultantName() : "", normalFont));
+                        }
+                        if (specialityVisible) {
+                            table.addCell(new Phrase(detail.getSpecialityName() != null ? detail.getSpecialityName() : "", normalFont));
+                        }
+                        if (sumAddedFeeVisible) {
+                            PdfPCell addedCell = new PdfPCell(new Phrase(df.format(detail.getSumAddedFee()), normalFont));
+                            addedCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
+                            table.addCell(addedCell);
+                        }
+                        if (sumPaidFeeVisible) {
+                            PdfPCell paidCell = new PdfPCell(new Phrase(df.format(detail.getSumPaidFee()), normalFont));
+                            paidCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
+                            table.addCell(paidCell);
+                        }
+                        if (balanceToPayVisible) {
+                            PdfPCell balanceCell = new PdfPCell(new Phrase(df.format(detail.getSumAddedFee() - detail.getSumPaidFee()), normalFont));
+                            balanceCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
+                            table.addCell(balanceCell);
+                        }
 
                         grandAdded += detail.getSumAddedFee();
                         grandPaid += detail.getSumPaidFee();
@@ -1261,22 +1480,32 @@ public class InwardReportControllerBht implements Serializable {
                 }
             }
 
-            PdfPCell totalLblCell = new PdfPCell(new Phrase("Grand Total", boldFont));
-            totalLblCell.setColspan(6);
-            totalLblCell.setHorizontalAlignment(Element.ALIGN_LEFT);
-            table.addCell(totalLblCell);
+            int labelColspan = columnKeys.size()
+                    - (sumAddedFeeVisible ? 1 : 0) - (sumPaidFeeVisible ? 1 : 0) - (balanceToPayVisible ? 1 : 0);
+            if (labelColspan > 0) {
+                PdfPCell totalLblCell = new PdfPCell(new Phrase("Grand Total", boldFont));
+                totalLblCell.setColspan(labelColspan);
+                totalLblCell.setHorizontalAlignment(Element.ALIGN_LEFT);
+                table.addCell(totalLblCell);
+            }
 
-            PdfPCell tgAdded = new PdfPCell(new Phrase(df.format(grandAdded), boldFont));
-            tgAdded.setHorizontalAlignment(Element.ALIGN_RIGHT);
-            table.addCell(tgAdded);
+            if (sumAddedFeeVisible) {
+                PdfPCell tgAdded = new PdfPCell(new Phrase(df.format(grandAdded), boldFont));
+                tgAdded.setHorizontalAlignment(Element.ALIGN_RIGHT);
+                table.addCell(tgAdded);
+            }
 
-            PdfPCell tgPaid = new PdfPCell(new Phrase(df.format(grandPaid), boldFont));
-            tgPaid.setHorizontalAlignment(Element.ALIGN_RIGHT);
-            table.addCell(tgPaid);
+            if (sumPaidFeeVisible) {
+                PdfPCell tgPaid = new PdfPCell(new Phrase(df.format(grandPaid), boldFont));
+                tgPaid.setHorizontalAlignment(Element.ALIGN_RIGHT);
+                table.addCell(tgPaid);
+            }
 
-            PdfPCell tgBalance = new PdfPCell(new Phrase(df.format(grandAdded - grandPaid), boldFont));
-            tgBalance.setHorizontalAlignment(Element.ALIGN_RIGHT);
-            table.addCell(tgBalance);
+            if (balanceToPayVisible) {
+                PdfPCell tgBalance = new PdfPCell(new Phrase(df.format(grandAdded - grandPaid), boldFont));
+                tgBalance.setHorizontalAlignment(Element.ALIGN_RIGHT);
+                table.addCell(tgBalance);
+            }
 
             document.add(table);
             document.close();
@@ -1332,16 +1561,52 @@ public class InwardReportControllerBht implements Serializable {
             titlePara.setSpacingAfter(10);
             document.add(titlePara);
 
-            String[] headers = {"BHT Number", "Admitted", "Discharged", "Final Bill Number",
-                "Consultant", "Speciality", "Added Fee Date", "Added Fee Value", "Paid Date",
-                "Paid Bill Number", "Comments", "Paid Fee Value"};
-            PdfPTable table = new PdfPTable(headers.length);
+            // Issue #23515 - columns now driven by visibleDetailedColumnKeys();
+            // PdfPTable.addCell() is purely sequential, so a hidden column is
+            // skipped by simply not calling addCell() for it in every row shape
+            // below (data row / Total row / Balance row / empty-detail filler).
+            List<String> columnKeys = visibleDetailedColumnKeys();
+            boolean bhtVisible = columnKeys.contains("bhtNo");
+            boolean admittedVisible = columnKeys.contains("admitted");
+            boolean dischargedVisible = columnKeys.contains("discharged");
+            boolean finalBillVisible = columnKeys.contains("finalBillNo");
+            boolean consultantVisible = columnKeys.contains("consultant");
+            boolean specialityVisible = columnKeys.contains("speciality");
+            boolean addedFeeDateVisible = columnKeys.contains("addedFeeDate");
+            boolean addedFeeValueVisible = columnKeys.contains("addedFeeValue");
+            boolean paidDateVisible = columnKeys.contains("paidDate");
+            boolean paidBillNumberVisible = columnKeys.contains("paidBillNumber");
+            boolean commentsVisible = columnKeys.contains("comments");
+            boolean paidFeeValueVisible = columnKeys.contains("paidFeeValue");
+            // Non-rowspan'd columns per admission (everything but bht/admitted/discharged/finalBillNo).
+            int nonRowspanColumnCount = columnKeys.size()
+                    - (bhtVisible ? 1 : 0) - (admittedVisible ? 1 : 0)
+                    - (dischargedVisible ? 1 : 0) - (finalBillVisible ? 1 : 0);
+
+            Map<String, Float> columnWidths = new HashMap<>();
+            columnWidths.put("bhtNo", 3f);
+            columnWidths.put("admitted", 2.5f);
+            columnWidths.put("discharged", 2.5f);
+            columnWidths.put("finalBillNo", 3f);
+            columnWidths.put("consultant", 4f);
+            columnWidths.put("speciality", 4f);
+            columnWidths.put("addedFeeDate", 2.5f);
+            columnWidths.put("addedFeeValue", 2.5f);
+            columnWidths.put("paidDate", 2.5f);
+            columnWidths.put("paidBillNumber", 3f);
+            columnWidths.put("comments", 2.5f);
+            columnWidths.put("paidFeeValue", 2.5f);
+
+            PdfPTable table = new PdfPTable(columnKeys.size());
             table.setWidthPercentage(100);
-            float[] widths = {3f, 2.5f, 2.5f, 3f, 4f, 4f, 2.5f, 2.5f, 2.5f, 3f, 2.5f, 2.5f};
+            float[] widths = new float[columnKeys.size()];
+            for (int c = 0; c < columnKeys.size(); c++) {
+                widths[c] = columnWidths.get(columnKeys.get(c));
+            }
             table.setWidths(widths);
 
-            for (String h : headers) {
-                PdfPCell cell = new PdfPCell(new Phrase(h, headerFont));
+            for (String key : columnKeys) {
+                PdfPCell cell = new PdfPCell(new Phrase(DETAILED_COLUMN_HEADERS.get(key), headerFont));
                 cell.setHorizontalAlignment(Element.ALIGN_CENTER);
                 table.addCell(cell);
             }
@@ -1350,24 +1615,29 @@ public class InwardReportControllerBht implements Serializable {
                 int admissionSpan = detailedAdmissionRowSpan(group);
                 List<InwardProfessionalPaymentDetailRowDTO> detailedRows = group.getDetailedRows();
 
-                PdfPCell bhtCell = new PdfPCell(new Phrase(group.getBhtNo() != null ? group.getBhtNo() : "", normalFont));
-                bhtCell.setRowspan(admissionSpan);
-                table.addCell(bhtCell);
-
-                PdfPCell admittedCell = new PdfPCell(new Phrase(group.getDateOfAdmission() != null ? sdf.format(group.getDateOfAdmission()) : "", normalFont));
-                admittedCell.setRowspan(admissionSpan);
-                table.addCell(admittedCell);
-
-                PdfPCell dischargedCell = new PdfPCell(new Phrase(group.getDateOfDischarge() != null ? sdf.format(group.getDateOfDischarge()) : "", normalFont));
-                dischargedCell.setRowspan(admissionSpan);
-                table.addCell(dischargedCell);
-
-                PdfPCell finalBillCell = new PdfPCell(new Phrase(group.getFirstFinalBillNo() != null ? group.getFirstFinalBillNo() : "", normalFont));
-                finalBillCell.setRowspan(admissionSpan);
-                table.addCell(finalBillCell);
+                if (bhtVisible) {
+                    PdfPCell bhtCell = new PdfPCell(new Phrase(group.getBhtNo() != null ? group.getBhtNo() : "", normalFont));
+                    bhtCell.setRowspan(admissionSpan);
+                    table.addCell(bhtCell);
+                }
+                if (admittedVisible) {
+                    PdfPCell admittedCell = new PdfPCell(new Phrase(group.getDateOfAdmission() != null ? sdf.format(group.getDateOfAdmission()) : "", normalFont));
+                    admittedCell.setRowspan(admissionSpan);
+                    table.addCell(admittedCell);
+                }
+                if (dischargedVisible) {
+                    PdfPCell dischargedCell = new PdfPCell(new Phrase(group.getDateOfDischarge() != null ? sdf.format(group.getDateOfDischarge()) : "", normalFont));
+                    dischargedCell.setRowspan(admissionSpan);
+                    table.addCell(dischargedCell);
+                }
+                if (finalBillVisible) {
+                    PdfPCell finalBillCell = new PdfPCell(new Phrase(group.getFirstFinalBillNo() != null ? group.getFirstFinalBillNo() : "", normalFont));
+                    finalBillCell.setRowspan(admissionSpan);
+                    table.addCell(finalBillCell);
+                }
 
                 if (detailedRows == null || detailedRows.isEmpty()) {
-                    for (int i = 0; i < 8; i++) {
+                    for (int i = 0; i < nonRowspanColumnCount; i++) {
                         table.addCell(new Phrase("", normalFont));
                     }
                     continue;
@@ -1377,66 +1647,93 @@ public class InwardReportControllerBht implements Serializable {
                     int blockSpan = detailedConsultantBlockRowSpan(detail);
                     int dataRows = Math.max(detail.rowCount(), 1);
 
-                    PdfPCell consultantCell = new PdfPCell(new Phrase(detail.getConsultantName() != null ? detail.getConsultantName() : "", normalFont));
-                    consultantCell.setRowspan(blockSpan);
-                    table.addCell(consultantCell);
-
-                    PdfPCell specialityCell = new PdfPCell(new Phrase(detail.getSpecialityName() != null ? detail.getSpecialityName() : "", normalFont));
-                    specialityCell.setRowspan(blockSpan);
-                    table.addCell(specialityCell);
+                    if (consultantVisible) {
+                        PdfPCell consultantCell = new PdfPCell(new Phrase(detail.getConsultantName() != null ? detail.getConsultantName() : "", normalFont));
+                        consultantCell.setRowspan(blockSpan);
+                        table.addCell(consultantCell);
+                    }
+                    if (specialityVisible) {
+                        PdfPCell specialityCell = new PdfPCell(new Phrase(detail.getSpecialityName() != null ? detail.getSpecialityName() : "", normalFont));
+                        specialityCell.setRowspan(blockSpan);
+                        table.addCell(specialityCell);
+                    }
 
                     for (int i = 0; i < dataRows; i++) {
-                        if (i < detail.getAddedFeeValues().size()) {
-                            Date addedDate = detail.getAddedFeeDates().get(i);
+                        boolean hasAdded = i < detail.getAddedFeeValues().size();
+                        if (addedFeeDateVisible) {
+                            Date addedDate = hasAdded ? detail.getAddedFeeDates().get(i) : null;
                             table.addCell(new Phrase(addedDate != null ? sdf.format(addedDate) : "", normalFont));
-                            Double addedValue = detail.getAddedFeeValues().get(i);
-                            PdfPCell addedCell = new PdfPCell(new Phrase(df.format(addedValue != null ? addedValue : 0.0), normalFont));
+                        }
+                        if (addedFeeValueVisible) {
+                            Double addedValue = hasAdded ? detail.getAddedFeeValues().get(i) : null;
+                            PdfPCell addedCell = new PdfPCell(new Phrase(hasAdded ? df.format(addedValue != null ? addedValue : 0.0) : "", normalFont));
                             addedCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
                             table.addCell(addedCell);
-                        } else {
-                            table.addCell(new Phrase("", normalFont));
-                            table.addCell(new Phrase("", normalFont));
                         }
 
-                        if (i < detail.getPaidFeeValues().size()) {
-                            Date paidDate = detail.getPaidFeeDates().get(i);
+                        boolean hasPaid = i < detail.getPaidFeeValues().size();
+                        if (paidDateVisible) {
+                            Date paidDate = hasPaid ? detail.getPaidFeeDates().get(i) : null;
                             table.addCell(new Phrase(paidDate != null ? sdf.format(paidDate) : "", normalFont));
-                            String paidBillNo = detail.getPaidBillNumbers().get(i);
+                        }
+                        if (paidBillNumberVisible) {
+                            String paidBillNo = hasPaid ? detail.getPaidBillNumbers().get(i) : null;
                             table.addCell(new Phrase(paidBillNo != null ? paidBillNo : "", normalFont));
+                        }
+                        if (commentsVisible) {
                             table.addCell(new Phrase("", normalFont));
-                            Double paidValue = detail.getPaidFeeValues().get(i);
-                            PdfPCell paidCell = new PdfPCell(new Phrase(df.format(paidValue != null ? paidValue : 0.0), normalFont));
+                        }
+                        if (paidFeeValueVisible) {
+                            Double paidValue = hasPaid ? detail.getPaidFeeValues().get(i) : null;
+                            PdfPCell paidCell = new PdfPCell(new Phrase(hasPaid ? df.format(paidValue != null ? paidValue : 0.0) : "", normalFont));
                             paidCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
                             table.addCell(paidCell);
-                        } else {
-                            table.addCell(new Phrase("", normalFont));
-                            table.addCell(new Phrase("", normalFont));
-                            table.addCell(new Phrase("", normalFont));
-                            table.addCell(new Phrase("", normalFont));
                         }
                     }
 
-                    PdfPCell totalLabelCell = new PdfPCell(new Phrase("Total", boldFont));
-                    table.addCell(totalLabelCell);
-                    PdfPCell totalAddedCell = new PdfPCell(new Phrase(df.format(detail.getSumAddedFee()), boldFont));
-                    totalAddedCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
-                    table.addCell(totalAddedCell);
-                    table.addCell(new Phrase("", normalFont));
-                    table.addCell(new Phrase("", normalFont));
-                    table.addCell(new Phrase("", normalFont));
-                    PdfPCell totalPaidCell = new PdfPCell(new Phrase(df.format(detail.getSumPaidFee()), boldFont));
-                    totalPaidCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
-                    table.addCell(totalPaidCell);
+                    if (addedFeeDateVisible) {
+                        table.addCell(new PdfPCell(new Phrase("Total", boldFont)));
+                    }
+                    if (addedFeeValueVisible) {
+                        PdfPCell totalAddedCell = new PdfPCell(new Phrase(df.format(detail.getSumAddedFee()), boldFont));
+                        totalAddedCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
+                        table.addCell(totalAddedCell);
+                    }
+                    if (paidDateVisible) {
+                        table.addCell(new Phrase("", normalFont));
+                    }
+                    if (paidBillNumberVisible) {
+                        table.addCell(new Phrase("", normalFont));
+                    }
+                    if (commentsVisible) {
+                        table.addCell(new Phrase("", normalFont));
+                    }
+                    if (paidFeeValueVisible) {
+                        PdfPCell totalPaidCell = new PdfPCell(new Phrase(df.format(detail.getSumPaidFee()), boldFont));
+                        totalPaidCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
+                        table.addCell(totalPaidCell);
+                    }
 
-                    PdfPCell balanceLabelCell = new PdfPCell(new Phrase("Balance to Pay", boldFont));
-                    table.addCell(balanceLabelCell);
-                    PdfPCell balanceValueCell = new PdfPCell(new Phrase(df.format(detail.getSumAddedFee() - detail.getSumPaidFee()), boldFont));
-                    balanceValueCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
-                    table.addCell(balanceValueCell);
-                    table.addCell(new Phrase("", normalFont));
-                    table.addCell(new Phrase("", normalFont));
-                    table.addCell(new Phrase("", normalFont));
-                    table.addCell(new Phrase("", normalFont));
+                    if (addedFeeDateVisible) {
+                        table.addCell(new PdfPCell(new Phrase("Balance to Pay", boldFont)));
+                    }
+                    if (addedFeeValueVisible) {
+                        PdfPCell balanceValueCell = new PdfPCell(new Phrase(df.format(detail.getSumAddedFee() - detail.getSumPaidFee()), boldFont));
+                        balanceValueCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
+                        table.addCell(balanceValueCell);
+                    }
+                    if (paidDateVisible) {
+                        table.addCell(new Phrase("", normalFont));
+                    }
+                    if (paidBillNumberVisible) {
+                        table.addCell(new Phrase("", normalFont));
+                    }
+                    if (commentsVisible) {
+                        table.addCell(new Phrase("", normalFont));
+                    }
+                    if (paidFeeValueVisible) {
+                        table.addCell(new Phrase("", normalFont));
+                    }
                 }
             }
 

--- a/src/main/webapp/inward/inward_report_bht_payment_detail.xhtml
+++ b/src/main/webapp/inward/inward_report_bht_payment_detail.xhtml
@@ -246,6 +246,101 @@
                             </div>
                         </f:facet>
 
+                        <!-- Column Visibility Settings - Subtle placement, same pattern as pharmacy_grn_return_request.xhtml -->
+                        <div class="mb-2 pb-1" style="border-bottom: 1px solid #e9ecef;">
+                            <p:panel id="panelColumnToggler" toggleable="true" collapsed="true" styleClass="ui-panel-sm">
+                                <f:facet name="header">
+                                    <span style="font-size: 0.85rem; color: #6c757d;">
+                                        <i class="fas fa-eye me-1" style="font-size: 0.75rem;"></i>
+                                        Configure Columns
+                                    </span>
+                                </f:facet>
+                                <div class="d-flex flex-wrap gap-2" style="font-size: 0.8rem">
+                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardBhtPaymentDetailBhtNoVisible}" itemLabel="BHT No">
+                                        <p:ajax update="tblReport" />
+                                    </p:selectBooleanCheckbox>
+                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardBhtPaymentDetailPatientNameVisible}" itemLabel="Patient Name">
+                                        <p:ajax update="tblReport" />
+                                    </p:selectBooleanCheckbox>
+                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardBhtPaymentDetailAdmissionTypeVisible}" itemLabel="Admission Type">
+                                        <p:ajax update="tblReport" />
+                                    </p:selectBooleanCheckbox>
+                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardBhtPaymentDetailAdmittedVisible}" itemLabel="Admitted">
+                                        <p:ajax update="tblReport" />
+                                    </p:selectBooleanCheckbox>
+                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardBhtPaymentDetailDischargedVisible}" itemLabel="Discharged">
+                                        <p:ajax update="tblReport" />
+                                    </p:selectBooleanCheckbox>
+                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardBhtPaymentDetailDepositCashVisible}" itemLabel="Deposit Cash">
+                                        <p:ajax update="tblReport" />
+                                    </p:selectBooleanCheckbox>
+                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardBhtPaymentDetailDepositCardVisible}" itemLabel="Deposit Card">
+                                        <p:ajax update="tblReport" />
+                                    </p:selectBooleanCheckbox>
+                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardBhtPaymentDetailDepositOtherVisible}" itemLabel="Deposit Other">
+                                        <p:ajax update="tblReport" />
+                                    </p:selectBooleanCheckbox>
+                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardBhtPaymentDetailTotalDepositsVisible}" itemLabel="Total Deposits">
+                                        <p:ajax update="tblReport" />
+                                    </p:selectBooleanCheckbox>
+                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardBhtPaymentDetailPaymentCashVisible}" itemLabel="Payment Cash">
+                                        <p:ajax update="tblReport" />
+                                    </p:selectBooleanCheckbox>
+                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardBhtPaymentDetailPaymentCardVisible}" itemLabel="Payment Card">
+                                        <p:ajax update="tblReport" />
+                                    </p:selectBooleanCheckbox>
+                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardBhtPaymentDetailPaymentCreditVisible}" itemLabel="Payment Credit">
+                                        <p:ajax update="tblReport" />
+                                    </p:selectBooleanCheckbox>
+                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardBhtPaymentDetailPaymentOtherVisible}" itemLabel="Payment Other">
+                                        <p:ajax update="tblReport" />
+                                    </p:selectBooleanCheckbox>
+                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardBhtPaymentDetailTotalPaymentsVisible}" itemLabel="Total Payments">
+                                        <p:ajax update="tblReport" />
+                                    </p:selectBooleanCheckbox>
+                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardBhtPaymentDetailPostPaymentCashVisible}" itemLabel="Post Payment Cash">
+                                        <p:ajax update="tblReport" />
+                                    </p:selectBooleanCheckbox>
+                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardBhtPaymentDetailPostPaymentCardVisible}" itemLabel="Post Payment Card">
+                                        <p:ajax update="tblReport" />
+                                    </p:selectBooleanCheckbox>
+                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardBhtPaymentDetailPostPaymentCreditVisible}" itemLabel="Post Payment Credit">
+                                        <p:ajax update="tblReport" />
+                                    </p:selectBooleanCheckbox>
+                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardBhtPaymentDetailPostPaymentOtherVisible}" itemLabel="Post Payment Other">
+                                        <p:ajax update="tblReport" />
+                                    </p:selectBooleanCheckbox>
+                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardBhtPaymentDetailTotalPostPaymentsVisible}" itemLabel="Total Post Payments">
+                                        <p:ajax update="tblReport" />
+                                    </p:selectBooleanCheckbox>
+                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardBhtPaymentDetailGrandTotalVisible}" itemLabel="Grand Total">
+                                        <p:ajax update="tblReport" />
+                                    </p:selectBooleanCheckbox>
+                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardBhtPaymentDetailTotalCreditBilledVisible}" itemLabel="Total Credit Billed">
+                                        <p:ajax update="tblReport" />
+                                    </p:selectBooleanCheckbox>
+                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardBhtPaymentDetailCreditSettledVisible}" itemLabel="Credit Settled">
+                                        <p:ajax update="tblReport" />
+                                    </p:selectBooleanCheckbox>
+                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardBhtPaymentDetailCreditBalanceVisible}" itemLabel="Credit Balance">
+                                        <p:ajax update="tblReport" />
+                                    </p:selectBooleanCheckbox>
+                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardBhtPaymentDetailCreditCompanyVisible}" itemLabel="Credit Company">
+                                        <p:ajax update="tblReport" />
+                                    </p:selectBooleanCheckbox>
+                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardBhtPaymentDetailFinalBillNoVisible}" itemLabel="Final Bill No">
+                                        <p:ajax update="tblReport" />
+                                    </p:selectBooleanCheckbox>
+                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardBhtPaymentDetailTotalBillValueVisible}" itemLabel="Total Bill Value">
+                                        <p:ajax update="tblReport" />
+                                    </p:selectBooleanCheckbox>
+                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardBhtPaymentDetailTotalBalanceVisible}" itemLabel="Total Balance">
+                                        <p:ajax update="tblReport" />
+                                    </p:selectBooleanCheckbox>
+                                </div>
+                            </p:panel>
+                        </div>
+
                         <p:dataTable
                             id="tblReport"
                             value="#{bhtPaymentSummaryReportController.reportRows}"
@@ -260,31 +355,37 @@
                             rowsPerPageTemplate="10,20,50,{ShowAll|'All'}"
                             styleClass="w-100">
 
-                            <p:column headerText="BHT No" style="white-space:nowrap;">
+                            <p:column headerText="BHT No" style="white-space:nowrap;"
+                                      rendered="#{userSettingsController.inwardBhtPaymentDetailBhtNoVisible}">
                                 <h:outputText value="#{row.bhtNo}" />
                             </p:column>
 
-                            <p:column headerText="Patient Name">
+                            <p:column headerText="Patient Name"
+                                      rendered="#{userSettingsController.inwardBhtPaymentDetailPatientNameVisible}">
                                 <h:outputText value="#{row.patientName}" />
                             </p:column>
 
-                            <p:column headerText="Admission Type" style="white-space:nowrap;">
+                            <p:column headerText="Admission Type" style="white-space:nowrap;"
+                                      rendered="#{userSettingsController.inwardBhtPaymentDetailAdmissionTypeVisible}">
                                 <h:outputText value="#{row.admissionType != null ? row.admissionType.name : ''}" />
                             </p:column>
 
-                            <p:column headerText="Admitted" style="white-space:nowrap;">
+                            <p:column headerText="Admitted" style="white-space:nowrap;"
+                                      rendered="#{userSettingsController.inwardBhtPaymentDetailAdmittedVisible}">
                                 <h:outputText value="#{row.dateOfAdmission}">
                                     <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" />
                                 </h:outputText>
                             </p:column>
 
-                            <p:column headerText="Discharged" style="white-space:nowrap;">
+                            <p:column headerText="Discharged" style="white-space:nowrap;"
+                                      rendered="#{userSettingsController.inwardBhtPaymentDetailDischargedVisible}">
                                 <h:outputText value="#{row.dateOfDischarge}">
                                     <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" />
                                 </h:outputText>
                             </p:column>
 
-                            <p:column headerText="Deposit Cash" style="text-align:right; white-space:nowrap;">
+                            <p:column headerText="Deposit Cash" style="text-align:right; white-space:nowrap;"
+                                      rendered="#{userSettingsController.inwardBhtPaymentDetailDepositCashVisible}">
                                 <h:outputText value="#{row.depositCash}">
                                     <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
                                 </h:outputText>
@@ -295,7 +396,8 @@
                                 </f:facet>
                             </p:column>
 
-                            <p:column headerText="Deposit Card" style="text-align:right; white-space:nowrap;">
+                            <p:column headerText="Deposit Card" style="text-align:right; white-space:nowrap;"
+                                      rendered="#{userSettingsController.inwardBhtPaymentDetailDepositCardVisible}">
                                 <h:outputText value="#{row.depositCard}">
                                     <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
                                 </h:outputText>
@@ -306,7 +408,8 @@
                                 </f:facet>
                             </p:column>
 
-                            <p:column headerText="Deposit Other" style="text-align:right; white-space:nowrap;">
+                            <p:column headerText="Deposit Other" style="text-align:right; white-space:nowrap;"
+                                      rendered="#{userSettingsController.inwardBhtPaymentDetailDepositOtherVisible}">
                                 <h:outputText value="#{row.depositOther}">
                                     <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
                                 </h:outputText>
@@ -317,7 +420,8 @@
                                 </f:facet>
                             </p:column>
 
-                            <p:column headerText="Total Deposits" style="text-align:right; white-space:nowrap; font-weight:bold;">
+                            <p:column headerText="Total Deposits" style="text-align:right; white-space:nowrap; font-weight:bold;"
+                                      rendered="#{userSettingsController.inwardBhtPaymentDetailTotalDepositsVisible}">
                                 <h:outputText value="#{row.totalDeposits}">
                                     <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
                                 </h:outputText>
@@ -328,7 +432,8 @@
                                 </f:facet>
                             </p:column>
 
-                            <p:column headerText="Payment Cash" style="text-align:right; white-space:nowrap;">
+                            <p:column headerText="Payment Cash" style="text-align:right; white-space:nowrap;"
+                                      rendered="#{userSettingsController.inwardBhtPaymentDetailPaymentCashVisible}">
                                 <h:outputText value="#{row.paymentCash}">
                                     <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
                                 </h:outputText>
@@ -339,7 +444,8 @@
                                 </f:facet>
                             </p:column>
 
-                            <p:column headerText="Payment Card" style="text-align:right; white-space:nowrap;">
+                            <p:column headerText="Payment Card" style="text-align:right; white-space:nowrap;"
+                                      rendered="#{userSettingsController.inwardBhtPaymentDetailPaymentCardVisible}">
                                 <h:outputText value="#{row.paymentCard}">
                                     <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
                                 </h:outputText>
@@ -350,7 +456,8 @@
                                 </f:facet>
                             </p:column>
 
-                            <p:column headerText="Payment Credit" style="text-align:right; white-space:nowrap;">
+                            <p:column headerText="Payment Credit" style="text-align:right; white-space:nowrap;"
+                                      rendered="#{userSettingsController.inwardBhtPaymentDetailPaymentCreditVisible}">
                                 <h:outputText value="#{row.paymentCredit}">
                                     <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
                                 </h:outputText>
@@ -361,7 +468,8 @@
                                 </f:facet>
                             </p:column>
 
-                            <p:column headerText="Payment Other" style="text-align:right; white-space:nowrap;">
+                            <p:column headerText="Payment Other" style="text-align:right; white-space:nowrap;"
+                                      rendered="#{userSettingsController.inwardBhtPaymentDetailPaymentOtherVisible}">
                                 <h:outputText value="#{row.paymentOther}">
                                     <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
                                 </h:outputText>
@@ -372,7 +480,8 @@
                                 </f:facet>
                             </p:column>
 
-                            <p:column headerText="Total Payments" style="text-align:right; white-space:nowrap; font-weight:bold;">
+                            <p:column headerText="Total Payments" style="text-align:right; white-space:nowrap; font-weight:bold;"
+                                      rendered="#{userSettingsController.inwardBhtPaymentDetailTotalPaymentsVisible}">
                                 <h:outputText value="#{row.totalPayments}">
                                     <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
                                 </h:outputText>
@@ -383,7 +492,8 @@
                                 </f:facet>
                             </p:column>
 
-                            <p:column headerText="Post Payment Cash" style="text-align:right; white-space:nowrap;">
+                            <p:column headerText="Post Payment Cash" style="text-align:right; white-space:nowrap;"
+                                      rendered="#{userSettingsController.inwardBhtPaymentDetailPostPaymentCashVisible}">
                                 <h:outputText value="#{row.postFinalCash}">
                                     <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
                                 </h:outputText>
@@ -394,7 +504,8 @@
                                 </f:facet>
                             </p:column>
 
-                            <p:column headerText="Post Payment Card" style="text-align:right; white-space:nowrap;">
+                            <p:column headerText="Post Payment Card" style="text-align:right; white-space:nowrap;"
+                                      rendered="#{userSettingsController.inwardBhtPaymentDetailPostPaymentCardVisible}">
                                 <h:outputText value="#{row.postFinalCard}">
                                     <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
                                 </h:outputText>
@@ -405,7 +516,8 @@
                                 </f:facet>
                             </p:column>
 
-                            <p:column headerText="Post Payment Credit" style="text-align:right; white-space:nowrap;">
+                            <p:column headerText="Post Payment Credit" style="text-align:right; white-space:nowrap;"
+                                      rendered="#{userSettingsController.inwardBhtPaymentDetailPostPaymentCreditVisible}">
                                 <h:outputText value="#{row.postFinalCredit}">
                                     <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
                                 </h:outputText>
@@ -416,7 +528,8 @@
                                 </f:facet>
                             </p:column>
 
-                            <p:column headerText="Post Payment Other" style="text-align:right; white-space:nowrap;">
+                            <p:column headerText="Post Payment Other" style="text-align:right; white-space:nowrap;"
+                                      rendered="#{userSettingsController.inwardBhtPaymentDetailPostPaymentOtherVisible}">
                                 <h:outputText value="#{row.postFinalOther}">
                                     <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
                                 </h:outputText>
@@ -427,7 +540,8 @@
                                 </f:facet>
                             </p:column>
 
-                            <p:column headerText="Total Post Payments" style="text-align:right; white-space:nowrap; font-weight:bold;">
+                            <p:column headerText="Total Post Payments" style="text-align:right; white-space:nowrap; font-weight:bold;"
+                                      rendered="#{userSettingsController.inwardBhtPaymentDetailTotalPostPaymentsVisible}">
                                 <h:outputText value="#{row.totalPostFinalPayments}">
                                     <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
                                 </h:outputText>
@@ -438,7 +552,8 @@
                                 </f:facet>
                             </p:column>
 
-                            <p:column headerText="Grand Total" style="text-align:right; white-space:nowrap; font-weight:bold;">
+                            <p:column headerText="Grand Total" style="text-align:right; white-space:nowrap; font-weight:bold;"
+                                      rendered="#{userSettingsController.inwardBhtPaymentDetailGrandTotalVisible}">
                                 <h:outputText value="#{row.totalAllMoneyIn}">
                                     <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
                                 </h:outputText>
@@ -449,7 +564,8 @@
                                 </f:facet>
                             </p:column>
 
-                            <p:column headerText="Total Credit Billed" style="text-align:right; white-space:nowrap;">
+                            <p:column headerText="Total Credit Billed" style="text-align:right; white-space:nowrap;"
+                                      rendered="#{userSettingsController.inwardBhtPaymentDetailTotalCreditBilledVisible}">
                                 <h:outputText value="#{row.creditBilledTotal}">
                                     <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
                                 </h:outputText>
@@ -460,7 +576,8 @@
                                 </f:facet>
                             </p:column>
 
-                            <p:column headerText="Credit Settled" style="text-align:right; white-space:nowrap;">
+                            <p:column headerText="Credit Settled" style="text-align:right; white-space:nowrap;"
+                                      rendered="#{userSettingsController.inwardBhtPaymentDetailCreditSettledVisible}">
                                 <h:outputText value="#{row.creditSettlementTotal}">
                                     <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
                                 </h:outputText>
@@ -471,7 +588,8 @@
                                 </f:facet>
                             </p:column>
 
-                            <p:column headerText="Credit Balance" style="text-align:right; white-space:nowrap; font-weight:bold;">
+                            <p:column headerText="Credit Balance" style="text-align:right; white-space:nowrap; font-weight:bold;"
+                                      rendered="#{userSettingsController.inwardBhtPaymentDetailCreditBalanceVisible}">
                                 <h:outputText value="#{row.creditBalance}">
                                     <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
                                 </h:outputText>
@@ -482,15 +600,18 @@
                                 </f:facet>
                             </p:column>
 
-                            <p:column headerText="Credit Company">
+                            <p:column headerText="Credit Company"
+                                      rendered="#{userSettingsController.inwardBhtPaymentDetailCreditCompanyVisible}">
                                 <h:outputText value="#{row.creditCompanyNames}" />
                             </p:column>
 
-                            <p:column headerText="Final Bill No" style="white-space:nowrap;">
+                            <p:column headerText="Final Bill No" style="white-space:nowrap;"
+                                      rendered="#{userSettingsController.inwardBhtPaymentDetailFinalBillNoVisible}">
                                 <h:outputText value="#{row.finalBillNumber}" />
                             </p:column>
 
-                            <p:column headerText="Total Bill Value" style="text-align:right; white-space:nowrap;">
+                            <p:column headerText="Total Bill Value" style="text-align:right; white-space:nowrap;"
+                                      rendered="#{userSettingsController.inwardBhtPaymentDetailTotalBillValueVisible}">
                                 <h:outputText value="#{row.finalBillTotal}">
                                     <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
                                 </h:outputText>
@@ -501,7 +622,8 @@
                                 </f:facet>
                             </p:column>
 
-                            <p:column headerText="Total Balance" style="text-align:right; white-space:nowrap; font-weight:bold;">
+                            <p:column headerText="Total Balance" style="text-align:right; white-space:nowrap; font-weight:bold;"
+                                      rendered="#{userSettingsController.inwardBhtPaymentDetailTotalBalanceVisible}">
                                 <h:outputText value="#{row.totalBalance}">
                                     <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
                                 </h:outputText>

--- a/src/main/webapp/inward/inward_report_invoice_journal.xhtml
+++ b/src/main/webapp/inward/inward_report_invoice_journal.xhtml
@@ -228,6 +228,53 @@
                             </div>
                         </f:facet>
 
+                        <!-- Column Visibility Settings - Subtle placement, same pattern as pharmacy_grn_return_request.xhtml -->
+                        <div class="mb-2 pb-1" style="border-bottom: 1px solid #e9ecef;">
+                            <p:panel id="panelColumnToggler" toggleable="true" collapsed="true" styleClass="ui-panel-sm">
+                                <f:facet name="header">
+                                    <span style="font-size: 0.85rem; color: #6c757d;">
+                                        <i class="fas fa-eye me-1" style="font-size: 0.75rem;"></i>
+                                        Configure Columns
+                                    </span>
+                                </f:facet>
+                                <div class="d-flex flex-wrap gap-2" style="font-size: 0.8rem">
+                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardInvoiceJournalBhtNoVisible}" itemLabel="BHT No">
+                                        <p:ajax update="tblReport" />
+                                    </p:selectBooleanCheckbox>
+                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardInvoiceJournalPatientNameVisible}" itemLabel="Patient Name">
+                                        <p:ajax update="tblReport" />
+                                    </p:selectBooleanCheckbox>
+                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardInvoiceJournalAdmittedVisible}" itemLabel="Admitted">
+                                        <p:ajax update="tblReport" />
+                                    </p:selectBooleanCheckbox>
+                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardInvoiceJournalDischargedVisible}" itemLabel="Discharged">
+                                        <p:ajax update="tblReport" />
+                                    </p:selectBooleanCheckbox>
+                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardInvoiceJournalFinalBillNoVisible}" itemLabel="Final Bill No">
+                                        <p:ajax update="tblReport" />
+                                    </p:selectBooleanCheckbox>
+                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardInvoiceJournalAdmissionTypeVisible}" itemLabel="Admission Type">
+                                        <p:ajax update="tblReport" />
+                                    </p:selectBooleanCheckbox>
+                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardInvoiceJournalTotalFinalPaymentVisible}" itemLabel="Total Final Payment">
+                                        <p:ajax update="tblReport" />
+                                    </p:selectBooleanCheckbox>
+                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardInvoiceJournalTotalDepositVisible}" itemLabel="Total Deposit">
+                                        <p:ajax update="tblReport" />
+                                    </p:selectBooleanCheckbox>
+                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardInvoiceJournalCreditSettlementVisible}" itemLabel="Credit Settlement">
+                                        <p:ajax update="tblReport" />
+                                    </p:selectBooleanCheckbox>
+                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardInvoiceJournalCreditCompanyDueVisible}" itemLabel="Credit Company Due">
+                                        <p:ajax update="tblReport" />
+                                    </p:selectBooleanCheckbox>
+                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardInvoiceJournalCreditCompanyNameVisible}" itemLabel="Credit Company">
+                                        <p:ajax update="tblReport" />
+                                    </p:selectBooleanCheckbox>
+                                </div>
+                            </p:panel>
+                        </div>
+
                         <!--
                             PrimeFaces' theme forces table-layout:fixed and width:100% on
                             .ui-datatable table via a class rule, which silently defeats plain
@@ -263,31 +310,37 @@
                             rowsPerPageTemplate="10,20,50,{ShowAll|'All'}">
 
                             <!-- ===== Patient / admission details ===== -->
-                            <p:column headerText="BHT No" style="white-space:nowrap;">
+                            <p:column headerText="BHT No" style="white-space:nowrap;"
+                                      rendered="#{userSettingsController.inwardInvoiceJournalBhtNoVisible}">
                                 <h:outputText value="#{row.bhtNo}" />
                             </p:column>
 
-                            <p:column headerText="Patient Name" style="white-space:nowrap;">
+                            <p:column headerText="Patient Name" style="white-space:nowrap;"
+                                      rendered="#{userSettingsController.inwardInvoiceJournalPatientNameVisible}">
                                 <h:outputText value="#{row.patientName}" />
                             </p:column>
 
-                            <p:column headerText="Admitted" style="white-space:nowrap;">
+                            <p:column headerText="Admitted" style="white-space:nowrap;"
+                                      rendered="#{userSettingsController.inwardInvoiceJournalAdmittedVisible}">
                                 <h:outputText value="#{row.dateOfAdmission}">
                                     <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" />
                                 </h:outputText>
                             </p:column>
 
-                            <p:column headerText="Discharged" style="white-space:nowrap;">
+                            <p:column headerText="Discharged" style="white-space:nowrap;"
+                                      rendered="#{userSettingsController.inwardInvoiceJournalDischargedVisible}">
                                 <h:outputText value="#{row.dateOfDischarge}">
                                     <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" />
                                 </h:outputText>
                             </p:column>
 
-                            <p:column headerText="Final Bill No" style="white-space:nowrap;">
+                            <p:column headerText="Final Bill No" style="white-space:nowrap;"
+                                      rendered="#{userSettingsController.inwardInvoiceJournalFinalBillNoVisible}">
                                 <h:outputText value="#{row.finalBillNo}" />
                             </p:column>
 
-                            <p:column headerText="Admission Type" style="white-space:nowrap;">
+                            <p:column headerText="Admission Type" style="white-space:nowrap;"
+                                      rendered="#{userSettingsController.inwardInvoiceJournalAdmissionTypeVisible}">
                                 <h:outputText value="#{row.admissionType != null ? row.admissionType.name : ''}" />
                             </p:column>
 
@@ -365,7 +418,8 @@
 
                             <!-- ===== Final payment total (formerly mislabeled "Total Deposits") ===== -->
                             <p:column headerText="Total Final Payment"
-                                      style="text-align:right; white-space:nowrap;">
+                                      style="text-align:right; white-space:nowrap;"
+                                      rendered="#{userSettingsController.inwardInvoiceJournalTotalFinalPaymentVisible}">
                                 <h:outputText value="#{row.totalFinalPayment}">
                                     <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
                                 </h:outputText>
@@ -378,7 +432,8 @@
 
                             <!-- ===== Deposit total (genuine "Make a Deposit" totals) ===== -->
                             <p:column headerText="Total Deposit"
-                                      style="text-align:right; white-space:nowrap;">
+                                      style="text-align:right; white-space:nowrap;"
+                                      rendered="#{userSettingsController.inwardInvoiceJournalTotalDepositVisible}">
                                 <h:outputText value="#{row.totalDeposit}">
                                     <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
                                 </h:outputText>
@@ -391,7 +446,8 @@
 
                             <!-- ===== Credit settlement ===== -->
                             <p:column headerText="Credit Settlement"
-                                      style="text-align:right; white-space:nowrap;">
+                                      style="text-align:right; white-space:nowrap;"
+                                      rendered="#{userSettingsController.inwardInvoiceJournalCreditSettlementVisible}">
                                 <h:outputText value="#{row.creditSettlementTotal}">
                                     <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
                                 </h:outputText>
@@ -404,7 +460,8 @@
 
                             <!-- ===== Credit company outstanding due ===== -->
                             <p:column headerText="Credit Company Due"
-                                      style="text-align:right; white-space:nowrap;">
+                                      style="text-align:right; white-space:nowrap;"
+                                      rendered="#{userSettingsController.inwardInvoiceJournalCreditCompanyDueVisible}">
                                 <h:outputText value="#{row.creditCompanyDue}">
                                     <f:convertNumber minFractionDigits="2" maxFractionDigits="2" />
                                 </h:outputText>
@@ -415,7 +472,8 @@
                                 </f:facet>
                             </p:column>
 
-                            <p:column headerText="Credit Company" style="white-space:nowrap;">
+                            <p:column headerText="Credit Company" style="white-space:nowrap;"
+                                      rendered="#{userSettingsController.inwardInvoiceJournalCreditCompanyNameVisible}">
                                 <h:outputText value="#{row.creditCompanyName}" />
                             </p:column>
 

--- a/src/main/webapp/inward/reports/inward_professional_payment_report_dto.xhtml
+++ b/src/main/webapp/inward/reports/inward_professional_payment_report_dto.xhtml
@@ -154,73 +154,132 @@
                                             </p:commandButton>
                                         </f:facet>
 
+                                        <!-- Column Visibility Settings - Subtle placement, same pattern as pharmacy_grn_return_request.xhtml -->
+                                        <div class="mb-2 pb-1" style="border-bottom: 1px solid #e9ecef;">
+                                            <p:panel id="panelSummaryColumnToggler" toggleable="true" collapsed="true" styleClass="ui-panel-sm">
+                                                <f:facet name="header">
+                                                    <span style="font-size: 0.85rem; color: #6c757d;">
+                                                        <i class="fas fa-eye me-1" style="font-size: 0.75rem;"></i>
+                                                        Configure Columns
+                                                    </span>
+                                                </f:facet>
+                                                <div class="d-flex flex-wrap gap-2" style="font-size: 0.8rem">
+                                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardProfessionalPaymentSummaryBhtNoVisible}" itemLabel="BHT Number">
+                                                        <p:ajax update="summaryTbl" />
+                                                    </p:selectBooleanCheckbox>
+                                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardProfessionalPaymentSummaryAdmittedVisible}" itemLabel="Admitted">
+                                                        <p:ajax update="summaryTbl" />
+                                                    </p:selectBooleanCheckbox>
+                                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardProfessionalPaymentSummaryDischargedVisible}" itemLabel="Discharged">
+                                                        <p:ajax update="summaryTbl" />
+                                                    </p:selectBooleanCheckbox>
+                                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardProfessionalPaymentSummaryFinalBillNoVisible}" itemLabel="Final Bill Number">
+                                                        <p:ajax update="summaryTbl" />
+                                                    </p:selectBooleanCheckbox>
+                                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardProfessionalPaymentSummaryConsultantVisible}" itemLabel="Consultant">
+                                                        <p:ajax update="summaryTbl" />
+                                                    </p:selectBooleanCheckbox>
+                                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardProfessionalPaymentSummarySpecialityVisible}" itemLabel="Speciality">
+                                                        <p:ajax update="summaryTbl" />
+                                                    </p:selectBooleanCheckbox>
+                                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardProfessionalPaymentSummarySumAddedFeeVisible}" itemLabel="Sum Added Fee">
+                                                        <p:ajax update="summaryTbl" />
+                                                    </p:selectBooleanCheckbox>
+                                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardProfessionalPaymentSummarySumPaidFeeVisible}" itemLabel="Sum Paid Fee">
+                                                        <p:ajax update="summaryTbl" />
+                                                    </p:selectBooleanCheckbox>
+                                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardProfessionalPaymentSummaryBalanceToPayVisible}" itemLabel="Balance to Pay">
+                                                        <p:ajax update="summaryTbl" />
+                                                    </p:selectBooleanCheckbox>
+                                                </div>
+                                            </p:panel>
+                                        </div>
+
                                         <h:panelGroup id="summaryTbl" layout="block" style="overflow-x: auto;">
                                             <table class="table table-bordered table-sm">
                                                 <thead>
                                                     <tr>
-                                                        <th>BHT Number</th>
-                                                        <th>Admitted</th>
-                                                        <th>Discharged</th>
-                                                        <th>Final Bill Number</th>
-                                                        <th>Consultant</th>
-                                                        <th>Speciality</th>
-                                                        <th class="text-end">Sum Added Fee</th>
-                                                        <th class="text-end">Sum Paid Fee</th>
-                                                        <th class="text-end">Balance to Pay</th>
+                                                        <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentSummaryBhtNoVisible}"><th>BHT Number</th></ui:fragment>
+                                                        <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentSummaryAdmittedVisible}"><th>Admitted</th></ui:fragment>
+                                                        <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentSummaryDischargedVisible}"><th>Discharged</th></ui:fragment>
+                                                        <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentSummaryFinalBillNoVisible}"><th>Final Bill Number</th></ui:fragment>
+                                                        <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentSummaryConsultantVisible}"><th>Consultant</th></ui:fragment>
+                                                        <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentSummarySpecialityVisible}"><th>Speciality</th></ui:fragment>
+                                                        <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentSummarySumAddedFeeVisible}"><th class="text-end">Sum Added Fee</th></ui:fragment>
+                                                        <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentSummarySumPaidFeeVisible}"><th class="text-end">Sum Paid Fee</th></ui:fragment>
+                                                        <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentSummaryBalanceToPayVisible}"><th class="text-end">Balance to Pay</th></ui:fragment>
                                                     </tr>
                                                 </thead>
                                                 <tbody>
                                                     <ui:repeat value="#{inwardReportControllerBht.professionalPaymentReportGroups}" var="admissionRow">
                                                         <ui:fragment rendered="#{empty admissionRow.detailRows}">
                                                             <tr>
-                                                                <td>#{admissionRow.bhtNo}</td>
-                                                                <td>
-                                                                    <h:outputText value="#{admissionRow.dateOfAdmission}">
-                                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" timeZone="Asia/Colombo" />
-                                                                    </h:outputText>
-                                                                </td>
-                                                                <td>
-                                                                    <h:outputText value="#{admissionRow.dateOfDischarge}" rendered="#{admissionRow.dateOfDischarge ne null}">
-                                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" timeZone="Asia/Colombo" />
-                                                                    </h:outputText>
-                                                                </td>
-                                                                <td>#{admissionRow.firstFinalBillNo}</td>
-                                                                <td colspan="5">-</td>
+                                                                <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentSummaryBhtNoVisible}"><td>#{admissionRow.bhtNo}</td></ui:fragment>
+                                                                <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentSummaryAdmittedVisible}">
+                                                                    <td>
+                                                                        <h:outputText value="#{admissionRow.dateOfAdmission}">
+                                                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" timeZone="Asia/Colombo" />
+                                                                        </h:outputText>
+                                                                    </td>
+                                                                </ui:fragment>
+                                                                <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentSummaryDischargedVisible}">
+                                                                    <td>
+                                                                        <h:outputText value="#{admissionRow.dateOfDischarge}" rendered="#{admissionRow.dateOfDischarge ne null}">
+                                                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" timeZone="Asia/Colombo" />
+                                                                        </h:outputText>
+                                                                    </td>
+                                                                </ui:fragment>
+                                                                <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentSummaryFinalBillNoVisible}"><td>#{admissionRow.firstFinalBillNo}</td></ui:fragment>
+                                                                <td colspan="#{inwardReportControllerBht.summaryEmptyRowColspan}">-</td>
                                                             </tr>
                                                         </ui:fragment>
                                                         <ui:repeat value="#{admissionRow.detailRows}" var="detail" varStatus="rowStatus">
                                                             <tr>
                                                                 <ui:fragment rendered="#{rowStatus.first}">
-                                                                    <td rowspan="#{admissionRow.summaryAdmissionRowSpan}">#{admissionRow.bhtNo}</td>
-                                                                    <td rowspan="#{admissionRow.summaryAdmissionRowSpan}">
-                                                                        <h:outputText value="#{admissionRow.dateOfAdmission}">
-                                                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" timeZone="Asia/Colombo" />
-                                                                        </h:outputText>
-                                                                    </td>
-                                                                    <td rowspan="#{admissionRow.summaryAdmissionRowSpan}">
-                                                                        <h:outputText value="#{admissionRow.dateOfDischarge}" rendered="#{admissionRow.dateOfDischarge ne null}">
-                                                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" timeZone="Asia/Colombo" />
-                                                                        </h:outputText>
-                                                                    </td>
-                                                                    <td rowspan="#{admissionRow.summaryAdmissionRowSpan}">#{admissionRow.firstFinalBillNo}</td>
+                                                                    <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentSummaryBhtNoVisible}">
+                                                                        <td rowspan="#{admissionRow.summaryAdmissionRowSpan}">#{admissionRow.bhtNo}</td>
+                                                                    </ui:fragment>
+                                                                    <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentSummaryAdmittedVisible}">
+                                                                        <td rowspan="#{admissionRow.summaryAdmissionRowSpan}">
+                                                                            <h:outputText value="#{admissionRow.dateOfAdmission}">
+                                                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" timeZone="Asia/Colombo" />
+                                                                            </h:outputText>
+                                                                        </td>
+                                                                    </ui:fragment>
+                                                                    <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentSummaryDischargedVisible}">
+                                                                        <td rowspan="#{admissionRow.summaryAdmissionRowSpan}">
+                                                                            <h:outputText value="#{admissionRow.dateOfDischarge}" rendered="#{admissionRow.dateOfDischarge ne null}">
+                                                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" timeZone="Asia/Colombo" />
+                                                                            </h:outputText>
+                                                                        </td>
+                                                                    </ui:fragment>
+                                                                    <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentSummaryFinalBillNoVisible}">
+                                                                        <td rowspan="#{admissionRow.summaryAdmissionRowSpan}">#{admissionRow.firstFinalBillNo}</td>
+                                                                    </ui:fragment>
                                                                 </ui:fragment>
-                                                                <td>#{detail.consultantName}</td>
-                                                                <td>#{detail.specialityName}</td>
-                                                                <td class="text-end">
-                                                                    <h:outputText value="#{detail.sumAddedFee}">
-                                                                        <f:convertNumber pattern="#,##0.00"/>
-                                                                    </h:outputText>
-                                                                </td>
-                                                                <td class="text-end">
-                                                                    <h:outputText value="#{detail.sumPaidFee}">
-                                                                        <f:convertNumber pattern="#,##0.00"/>
-                                                                    </h:outputText>
-                                                                </td>
-                                                                <td class="text-end">
-                                                                    <h:outputText value="#{detail.sumAddedFee - detail.sumPaidFee}">
-                                                                        <f:convertNumber pattern="#,##0.00"/>
-                                                                    </h:outputText>
-                                                                </td>
+                                                                <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentSummaryConsultantVisible}"><td>#{detail.consultantName}</td></ui:fragment>
+                                                                <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentSummarySpecialityVisible}"><td>#{detail.specialityName}</td></ui:fragment>
+                                                                <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentSummarySumAddedFeeVisible}">
+                                                                    <td class="text-end">
+                                                                        <h:outputText value="#{detail.sumAddedFee}">
+                                                                            <f:convertNumber pattern="#,##0.00"/>
+                                                                        </h:outputText>
+                                                                    </td>
+                                                                </ui:fragment>
+                                                                <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentSummarySumPaidFeeVisible}">
+                                                                    <td class="text-end">
+                                                                        <h:outputText value="#{detail.sumPaidFee}">
+                                                                            <f:convertNumber pattern="#,##0.00"/>
+                                                                        </h:outputText>
+                                                                    </td>
+                                                                </ui:fragment>
+                                                                <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentSummaryBalanceToPayVisible}">
+                                                                    <td class="text-end">
+                                                                        <h:outputText value="#{detail.sumAddedFee - detail.sumPaidFee}">
+                                                                            <f:convertNumber pattern="#,##0.00"/>
+                                                                        </h:outputText>
+                                                                    </td>
+                                                                </ui:fragment>
                                                             </tr>
                                                         </ui:repeat>
                                                     </ui:repeat>
@@ -261,117 +320,199 @@
                                             </p:commandButton>
                                         </f:facet>
 
+                                        <!-- Column Visibility Settings - Subtle placement, same pattern as pharmacy_grn_return_request.xhtml -->
+                                        <div class="mb-2 pb-1" style="border-bottom: 1px solid #e9ecef;">
+                                            <p:panel id="panelDetailedColumnToggler" toggleable="true" collapsed="true" styleClass="ui-panel-sm">
+                                                <f:facet name="header">
+                                                    <span style="font-size: 0.85rem; color: #6c757d;">
+                                                        <i class="fas fa-eye me-1" style="font-size: 0.75rem;"></i>
+                                                        Configure Columns
+                                                    </span>
+                                                </f:facet>
+                                                <div class="d-flex flex-wrap gap-2" style="font-size: 0.8rem">
+                                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardProfessionalPaymentDetailedBhtNoVisible}" itemLabel="BHT Number">
+                                                        <p:ajax update="detailedTbl" />
+                                                    </p:selectBooleanCheckbox>
+                                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardProfessionalPaymentDetailedAdmittedVisible}" itemLabel="Admitted">
+                                                        <p:ajax update="detailedTbl" />
+                                                    </p:selectBooleanCheckbox>
+                                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardProfessionalPaymentDetailedDischargedVisible}" itemLabel="Discharged">
+                                                        <p:ajax update="detailedTbl" />
+                                                    </p:selectBooleanCheckbox>
+                                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardProfessionalPaymentDetailedFinalBillNoVisible}" itemLabel="Final Bill Number">
+                                                        <p:ajax update="detailedTbl" />
+                                                    </p:selectBooleanCheckbox>
+                                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardProfessionalPaymentDetailedConsultantVisible}" itemLabel="Consultant">
+                                                        <p:ajax update="detailedTbl" />
+                                                    </p:selectBooleanCheckbox>
+                                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardProfessionalPaymentDetailedSpecialityVisible}" itemLabel="Speciality">
+                                                        <p:ajax update="detailedTbl" />
+                                                    </p:selectBooleanCheckbox>
+                                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardProfessionalPaymentDetailedAddedFeeDateVisible}" itemLabel="Added Fee Date">
+                                                        <p:ajax update="detailedTbl" />
+                                                    </p:selectBooleanCheckbox>
+                                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardProfessionalPaymentDetailedAddedFeeValueVisible}" itemLabel="Added Fee Value">
+                                                        <p:ajax update="detailedTbl" />
+                                                    </p:selectBooleanCheckbox>
+                                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardProfessionalPaymentDetailedPaidDateVisible}" itemLabel="Paid Date">
+                                                        <p:ajax update="detailedTbl" />
+                                                    </p:selectBooleanCheckbox>
+                                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardProfessionalPaymentDetailedPaidBillNumberVisible}" itemLabel="Paid Bill Number">
+                                                        <p:ajax update="detailedTbl" />
+                                                    </p:selectBooleanCheckbox>
+                                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardProfessionalPaymentDetailedCommentsVisible}" itemLabel="Comments">
+                                                        <p:ajax update="detailedTbl" />
+                                                    </p:selectBooleanCheckbox>
+                                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardProfessionalPaymentDetailedPaidFeeValueVisible}" itemLabel="Paid Fee Value">
+                                                        <p:ajax update="detailedTbl" />
+                                                    </p:selectBooleanCheckbox>
+                                                </div>
+                                            </p:panel>
+                                        </div>
+
                                         <h:panelGroup id="detailedTbl" layout="block" style="overflow-x: auto;">
                                             <table class="table table-bordered table-sm">
                                                 <thead>
                                                     <tr>
-                                                        <th>BHT Number</th>
-                                                        <th>Admitted</th>
-                                                        <th>Discharged</th>
-                                                        <th>Final Bill Number</th>
-                                                        <th>Consultant</th>
-                                                        <th>Speciality</th>
-                                                        <th>Added Fee Date</th>
-                                                        <th class="text-end">Added Fee Value</th>
-                                                        <th>Paid Date</th>
-                                                        <th>Paid Bill Number</th>
-                                                        <th>Comments</th>
-                                                        <th class="text-end">Paid Fee Value</th>
+                                                        <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedBhtNoVisible}"><th>BHT Number</th></ui:fragment>
+                                                        <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedAdmittedVisible}"><th>Admitted</th></ui:fragment>
+                                                        <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedDischargedVisible}"><th>Discharged</th></ui:fragment>
+                                                        <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedFinalBillNoVisible}"><th>Final Bill Number</th></ui:fragment>
+                                                        <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedConsultantVisible}"><th>Consultant</th></ui:fragment>
+                                                        <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedSpecialityVisible}"><th>Speciality</th></ui:fragment>
+                                                        <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedAddedFeeDateVisible}"><th>Added Fee Date</th></ui:fragment>
+                                                        <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedAddedFeeValueVisible}"><th class="text-end">Added Fee Value</th></ui:fragment>
+                                                        <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedPaidDateVisible}"><th>Paid Date</th></ui:fragment>
+                                                        <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedPaidBillNumberVisible}"><th>Paid Bill Number</th></ui:fragment>
+                                                        <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedCommentsVisible}"><th>Comments</th></ui:fragment>
+                                                        <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedPaidFeeValueVisible}"><th class="text-end">Paid Fee Value</th></ui:fragment>
                                                     </tr>
                                                 </thead>
                                                 <tbody>
                                                     <ui:repeat value="#{inwardReportControllerBht.professionalPaymentReportGroups}" var="admissionRow">
                                                         <ui:fragment rendered="#{empty admissionRow.detailedRows}">
                                                             <tr>
-                                                                <td>#{admissionRow.bhtNo}</td>
-                                                                <td>
-                                                                    <h:outputText value="#{admissionRow.dateOfAdmission}">
-                                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" timeZone="Asia/Colombo" />
-                                                                    </h:outputText>
-                                                                </td>
-                                                                <td>
-                                                                    <h:outputText value="#{admissionRow.dateOfDischarge}" rendered="#{admissionRow.dateOfDischarge ne null}">
-                                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" timeZone="Asia/Colombo" />
-                                                                    </h:outputText>
-                                                                </td>
-                                                                <td>#{admissionRow.firstFinalBillNo}</td>
-                                                                <td colspan="8">-</td>
+                                                                <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedBhtNoVisible}"><td>#{admissionRow.bhtNo}</td></ui:fragment>
+                                                                <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedAdmittedVisible}">
+                                                                    <td>
+                                                                        <h:outputText value="#{admissionRow.dateOfAdmission}">
+                                                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" timeZone="Asia/Colombo" />
+                                                                        </h:outputText>
+                                                                    </td>
+                                                                </ui:fragment>
+                                                                <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedDischargedVisible}">
+                                                                    <td>
+                                                                        <h:outputText value="#{admissionRow.dateOfDischarge}" rendered="#{admissionRow.dateOfDischarge ne null}">
+                                                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" timeZone="Asia/Colombo" />
+                                                                        </h:outputText>
+                                                                    </td>
+                                                                </ui:fragment>
+                                                                <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedFinalBillNoVisible}"><td>#{admissionRow.firstFinalBillNo}</td></ui:fragment>
+                                                                <td colspan="#{inwardReportControllerBht.detailedEmptyRowColspan}">-</td>
                                                             </tr>
                                                         </ui:fragment>
                                                         <ui:repeat value="#{admissionRow.detailedRows}" var="detail" varStatus="blockStatus">
                                                             <ui:repeat value="#{detail.indexes}" var="i" varStatus="rowStatus">
                                                                 <tr>
                                                                     <ui:fragment rendered="#{blockStatus.first and rowStatus.first}">
-                                                                        <td rowspan="#{admissionRow.detailedAdmissionRowSpan}">#{admissionRow.bhtNo}</td>
-                                                                        <td rowspan="#{admissionRow.detailedAdmissionRowSpan}">
-                                                                            <h:outputText value="#{admissionRow.dateOfAdmission}">
-                                                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" timeZone="Asia/Colombo" />
-                                                                            </h:outputText>
-                                                                        </td>
-                                                                        <td rowspan="#{admissionRow.detailedAdmissionRowSpan}">
-                                                                            <h:outputText value="#{admissionRow.dateOfDischarge}" rendered="#{admissionRow.dateOfDischarge ne null}">
-                                                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" timeZone="Asia/Colombo" />
-                                                                            </h:outputText>
-                                                                        </td>
-                                                                        <td rowspan="#{admissionRow.detailedAdmissionRowSpan}">#{admissionRow.firstFinalBillNo}</td>
+                                                                        <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedBhtNoVisible}">
+                                                                            <td rowspan="#{admissionRow.detailedAdmissionRowSpan}">#{admissionRow.bhtNo}</td>
+                                                                        </ui:fragment>
+                                                                        <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedAdmittedVisible}">
+                                                                            <td rowspan="#{admissionRow.detailedAdmissionRowSpan}">
+                                                                                <h:outputText value="#{admissionRow.dateOfAdmission}">
+                                                                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" timeZone="Asia/Colombo" />
+                                                                                </h:outputText>
+                                                                            </td>
+                                                                        </ui:fragment>
+                                                                        <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedDischargedVisible}">
+                                                                            <td rowspan="#{admissionRow.detailedAdmissionRowSpan}">
+                                                                                <h:outputText value="#{admissionRow.dateOfDischarge}" rendered="#{admissionRow.dateOfDischarge ne null}">
+                                                                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" timeZone="Asia/Colombo" />
+                                                                                </h:outputText>
+                                                                            </td>
+                                                                        </ui:fragment>
+                                                                        <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedFinalBillNoVisible}">
+                                                                            <td rowspan="#{admissionRow.detailedAdmissionRowSpan}">#{admissionRow.firstFinalBillNo}</td>
+                                                                        </ui:fragment>
                                                                     </ui:fragment>
                                                                     <ui:fragment rendered="#{rowStatus.first}">
-                                                                        <td rowspan="#{detail.blockRowSpan}">#{detail.consultantName}</td>
-                                                                        <td rowspan="#{detail.blockRowSpan}">#{detail.specialityName}</td>
+                                                                        <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedConsultantVisible}">
+                                                                            <td rowspan="#{detail.blockRowSpan}">#{detail.consultantName}</td>
+                                                                        </ui:fragment>
+                                                                        <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedSpecialityVisible}">
+                                                                            <td rowspan="#{detail.blockRowSpan}">#{detail.specialityName}</td>
+                                                                        </ui:fragment>
                                                                     </ui:fragment>
-                                                                    <td>
-                                                                        <h:outputText value="#{detail.addedFeeDates[i]}" rendered="#{i lt detail.addedFeeValues.size()}">
-                                                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" timeZone="Asia/Colombo" />
-                                                                        </h:outputText>
-                                                                    </td>
-                                                                    <td class="text-end">
-                                                                        <h:outputText value="#{detail.addedFeeValues[i]}" rendered="#{i lt detail.addedFeeValues.size()}">
-                                                                            <f:convertNumber pattern="#,##0.00"/>
-                                                                        </h:outputText>
-                                                                    </td>
-                                                                    <td>
-                                                                        <h:outputText value="#{detail.paidFeeDates[i]}" rendered="#{i lt detail.paidFeeValues.size()}">
-                                                                            <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" timeZone="Asia/Colombo" />
-                                                                        </h:outputText>
-                                                                    </td>
-                                                                    <td>
-                                                                        <h:outputText value="#{detail.paidBillNumbers[i]}" rendered="#{i lt detail.paidFeeValues.size()}"/>
-                                                                    </td>
-                                                                    <td></td>
-                                                                    <td class="text-end">
-                                                                        <h:outputText value="#{detail.paidFeeValues[i]}" rendered="#{i lt detail.paidFeeValues.size()}">
-                                                                            <f:convertNumber pattern="#,##0.00"/>
-                                                                        </h:outputText>
-                                                                    </td>
+                                                                    <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedAddedFeeDateVisible}">
+                                                                        <td>
+                                                                            <h:outputText value="#{detail.addedFeeDates[i]}" rendered="#{i lt detail.addedFeeValues.size()}">
+                                                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" timeZone="Asia/Colombo" />
+                                                                            </h:outputText>
+                                                                        </td>
+                                                                    </ui:fragment>
+                                                                    <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedAddedFeeValueVisible}">
+                                                                        <td class="text-end">
+                                                                            <h:outputText value="#{detail.addedFeeValues[i]}" rendered="#{i lt detail.addedFeeValues.size()}">
+                                                                                <f:convertNumber pattern="#,##0.00"/>
+                                                                            </h:outputText>
+                                                                        </td>
+                                                                    </ui:fragment>
+                                                                    <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedPaidDateVisible}">
+                                                                        <td>
+                                                                            <h:outputText value="#{detail.paidFeeDates[i]}" rendered="#{i lt detail.paidFeeValues.size()}">
+                                                                                <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" timeZone="Asia/Colombo" />
+                                                                            </h:outputText>
+                                                                        </td>
+                                                                    </ui:fragment>
+                                                                    <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedPaidBillNumberVisible}">
+                                                                        <td>
+                                                                            <h:outputText value="#{detail.paidBillNumbers[i]}" rendered="#{i lt detail.paidFeeValues.size()}"/>
+                                                                        </td>
+                                                                    </ui:fragment>
+                                                                    <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedCommentsVisible}"><td></td></ui:fragment>
+                                                                    <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedPaidFeeValueVisible}">
+                                                                        <td class="text-end">
+                                                                            <h:outputText value="#{detail.paidFeeValues[i]}" rendered="#{i lt detail.paidFeeValues.size()}">
+                                                                                <f:convertNumber pattern="#,##0.00"/>
+                                                                            </h:outputText>
+                                                                        </td>
+                                                                    </ui:fragment>
                                                                 </tr>
                                                             </ui:repeat>
                                                             <tr style="background-color: #f8f9fa; font-weight: bold;">
-                                                                <td>Total</td>
-                                                                <td class="text-end">
-                                                                    <h:outputText value="#{detail.sumAddedFee}">
-                                                                        <f:convertNumber pattern="#,##0.00"/>
-                                                                    </h:outputText>
-                                                                </td>
-                                                                <td></td>
-                                                                <td></td>
-                                                                <td></td>
-                                                                <td class="text-end">
-                                                                    <h:outputText value="#{detail.sumPaidFee}">
-                                                                        <f:convertNumber pattern="#,##0.00"/>
-                                                                    </h:outputText>
-                                                                </td>
+                                                                <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedAddedFeeDateVisible}"><td>Total</td></ui:fragment>
+                                                                <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedAddedFeeValueVisible}">
+                                                                    <td class="text-end">
+                                                                        <h:outputText value="#{detail.sumAddedFee}">
+                                                                            <f:convertNumber pattern="#,##0.00"/>
+                                                                        </h:outputText>
+                                                                    </td>
+                                                                </ui:fragment>
+                                                                <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedPaidDateVisible}"><td></td></ui:fragment>
+                                                                <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedPaidBillNumberVisible}"><td></td></ui:fragment>
+                                                                <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedCommentsVisible}"><td></td></ui:fragment>
+                                                                <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedPaidFeeValueVisible}">
+                                                                    <td class="text-end">
+                                                                        <h:outputText value="#{detail.sumPaidFee}">
+                                                                            <f:convertNumber pattern="#,##0.00"/>
+                                                                        </h:outputText>
+                                                                    </td>
+                                                                </ui:fragment>
                                                             </tr>
                                                             <tr style="font-weight: bold;">
-                                                                <td>Balance to Pay</td>
-                                                                <td class="text-end">
-                                                                    <h:outputText value="#{detail.sumAddedFee - detail.sumPaidFee}">
-                                                                        <f:convertNumber pattern="#,##0.00"/>
-                                                                    </h:outputText>
-                                                                </td>
-                                                                <td></td>
-                                                                <td></td>
-                                                                <td></td>
-                                                                <td></td>
+                                                                <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedAddedFeeDateVisible}"><td>Balance to Pay</td></ui:fragment>
+                                                                <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedAddedFeeValueVisible}">
+                                                                    <td class="text-end">
+                                                                        <h:outputText value="#{detail.sumAddedFee - detail.sumPaidFee}">
+                                                                            <f:convertNumber pattern="#,##0.00"/>
+                                                                        </h:outputText>
+                                                                    </td>
+                                                                </ui:fragment>
+                                                                <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedPaidDateVisible}"><td></td></ui:fragment>
+                                                                <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedPaidBillNumberVisible}"><td></td></ui:fragment>
+                                                                <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedCommentsVisible}"><td></td></ui:fragment>
+                                                                <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedPaidFeeValueVisible}"><td></td></ui:fragment>
                                                             </tr>
                                                         </ui:repeat>
                                                     </ui:repeat>


### PR DESCRIPTION
## Summary

Adds the existing "Configure/Customize Columns" pattern (checkbox panel → auto-saved per-user preference via `UserSettingsController`/`ColumnVisibilitySettings`, already used on Pharmacy GRN pages) to the three reports named in issue #23515:

1. **Inpatient Professional Payment Report** (Summary + Detailed — separate column sets, separate saved preferences)
2. **Inpatient Invoice Journal**
3. **BHT Deposit and Credit Settlement Detail**

Unchecking a column hides it consistently from the on-screen table, **Print**, **Excel**, and **PDF** — no separate "Save" step, the choice persists automatically per user and is restored next time the report is opened.

## Implementation

- **`UserSettingsController.java`** — added 4 new blocks of `isXxxVisible()`/`setXxxVisible(boolean)` JSF-property pairs (one per report/mode), following the exact existing pattern used for the Pharmacy pages. Also added a small shared helper, `getVisibleColumnKeysInOrder(pageId, allKeysInOrder)`, for pages whose exports are hand-built rather than `p:dataExporter`-backed.
- **Invoice Journal & BHT Deposit and Credit Settlement Detail** (`p:dataTable` + `p:dataExporter`/`p:printer`) — added a "Configure Columns" panel and tied each column's `rendered` attribute to its checkbox. No controller changes needed here — `p:dataExporter`/`p:printer` read the same rendered `p:dataTable`, so Excel/PDF/Print automatically stay in sync with the screen.
- **Inpatient Professional Payment Report** (hand-built HTML tables + 4 separate POI/OpenPDF export methods with previously-fixed header arrays and hardcoded cell indices) — this was the bulk of the work:
  - Wrapped each `<th>`/`<td>` in `ui:fragment rendered="..."` (matching the file's existing `ui:fragment` usage for row-first logic), including the rowspan'd admission/consultant cells and the Detailed view's "Total"/"Balance to Pay" summary rows.
  - Added `InwardReportControllerBht.visibleSummaryColumnKeys()` / `visibleDetailedColumnKeys()`, backed by the same `UserSettingsController` state the checkboxes write to.
  - Refactored all 4 export methods (`downloadProfessionalPaymentSummaryExcel/Pdf`, `downloadProfessionalPaymentDetailedExcel/Pdf`) to build their header row and cell writes from the visible-column-key list instead of a fixed array + hardcoded index, so a hidden column is skipped and later columns compact left — in Excel via a computed column index per key, in PDF by simply not calling `addCell()` for a hidden column (PdfPTable is purely sequential).
  - Added `getSummaryEmptyRowColspan()`/`getDetailedEmptyRowColspan()` so the "no fees at all" placeholder row's `colspan` also tracks the current visible-column count.

**Scope decisions** (confirmed with the user before implementation):
- Invoice Journal's ~100 dynamic per-`InwardChargeType` columns keep their existing auto-hide-when-zero behavior and are **not** part of this checkbox panel.
- The existing admin-level ConfigOption `"Inpatient Reports - Show Gross Value, Discount and Service Charge"` remains the sole gate for Discount/Service Charge/Gross Total on Invoice Journal — no additional per-user checkbox for those three.

## Verification

Local Payara + coop DB, department **Inward**, test admission **BHT/57601** (has 2 professional-fee bills, 2 deposit bills, and a confirmed final bill).

**Inpatient Invoice Journal** — unchecked "Patient Name": header/data-cell count dropped 38→38 aligned (one column removed from both), Excel export's `sharedStrings.xml` omits "Patient Name", `CONFIGOPTION` row `ui.inward_invoice_journal.columns.visibility` persisted `patientName:false`.

![All columns](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23515-invoice-journal-all-columns.png)
![Patient Name hidden](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23515-invoice-journal-patient-name-hidden.png)

**BHT Deposit and Credit Settlement Detail** — unchecked "Post Payment Other" + "Credit Company": 27→25 headers/cells, Excel export matches, both persisted `false` in `CONFIGOPTION`.

![All columns](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23515-bht-payment-detail-all-columns.png)
![Two columns hidden](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23515-bht-payment-detail-columns-hidden.png)

**Inpatient Professional Payment Report** — Detailed view, unchecked "Comments": 12→11 headers; every row shape (rowspan'd admission row, per-index detail rows, Total/Balance-to-Pay rows) compacted 12→11 / 6→5 / 8→7 cells correctly. Verified the raw Excel worksheet XML directly (columns compact into consecutive A–K with no gaps) and the PDF export via `pdftotext` (also omits Comments, Grand-Total/Total/Balance-to-Pay rows intact).

![All columns](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23515-professional-payment-detailed-all-columns.png)
![Comments hidden](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23515-professional-payment-detailed-comments-hidden.png)

Summary view (unchecked "Speciality") also verified: screen 9→8 columns, Excel `sharedStrings.xml` omits Speciality, PDF (`pdftotext`) shows 8 columns with the Grand Total label's colspan correctly reduced.

![Summary view](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23515-professional-payment-summary-all-columns.png)

All four `CONFIGOPTION` rows (`ui.inward_invoice_journal.columns.visibility`, `ui.inward_bht_payment_detail.columns.visibility`, `ui.inward_professional_payment_summary.columns.visibility`, `ui.inward_professional_payment_detailed.columns.visibility`) confirmed with `SCOPE='USER'` and the correct `WEBUSER_ID` after each toggle, proving the auto-save/restore round-trip.

## Documentation

- [Inpatient Invoice Journal](https://github.com/hmislk/hmis/wiki/Finance-Inpatient-Invoice-Journal) — added Configure Columns section; also refreshed its stale "Report Columns" table to match the actual current columns (pre-existing staleness found while I was already in this section — the "Generating"/filters list above it is still stale and intentionally left alone, out of this issue's scope)
- [BHT Deposit and Credit Settlement Detail Report](https://github.com/hmislk/hmis/wiki/Inward-BHT-Deposit-and-Credit-Settlement-Detail-Report) — added Configure Columns section
- [Inpatient Professional Payment Report](https://github.com/hmislk/hmis/wiki/Inpatient-Professional-Payment-Report) — added Configure Columns section covering both Summary and Detailed

## Also in this PR

Updated the `dev-issue` skill's step 4: local-DB department/record selection during Playwright testing is now treated as a testing-environment decision the agent makes itself (reporting which it picked), not a discussion gate — only the local-vs-remote environment choice still pauses for user input. This came out of a note from the user during this same issue's development.

Closes #23515

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable column visibility for inpatient invoice, BHT payment, and professional payment reports.
  - Users can show or hide individual columns through a collapsible “Configure Columns” panel.
  - Column preferences are saved and applied consistently to on-screen reports.
  - Excel and PDF exports now reflect selected visible columns and adjust layouts accordingly.

- **Improvements**
  - Report tables refresh automatically when column visibility settings change.
  - Summary and detailed professional payment reports now accommodate hidden columns without disrupting totals or formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->