### PR TITLE
fix(inward): include cancelled deposit/payment reversals in BHT payment reports

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtPaymentDetailReportController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtPaymentDetailReportController.java
@@ -120,12 +120,14 @@ public class BhtPaymentDetailReportController implements Serializable {
                 row.setBillNo(p.getBill() != null ? p.getBill().getDeptId() : "");
                 row.setCreatedAt(p.getCreatedAt());
                 row.setPaymentMethod(p.getPaymentMethod());
-                row.setAmount(Math.abs(p.getPaidValue()));
+                // Signed, not abs() - see fetchDepositPayments() javadoc: cancellations
+                // arrive as separate negative-amount rows that must net out.
+                row.setAmount(p.getPaidValue());
                 row.setReferenceNo(p.getReferenceNo());
                 row.setCreditCompanyName("");
                 row.setPaymentCategory("Deposit");
                 reportRows.add(row);
-                double depositAmt = Math.abs(p.getPaidValue());
+                double depositAmt = p.getPaidValue();
                 grandTotal += depositAmt;
                 if (p.getPaymentMethod() != null) {
                     depositTotalByMethod.merge(p.getPaymentMethod(), depositAmt, Double::sum);
@@ -146,12 +148,14 @@ public class BhtPaymentDetailReportController implements Serializable {
                 row.setBillNo(p.getBill() != null ? p.getBill().getDeptId() : "");
                 row.setCreatedAt(p.getCreatedAt());
                 row.setPaymentMethod(p.getPaymentMethod());
-                row.setAmount(Math.abs(p.getPaidValue()));
+                // Signed, not abs() - see fetchPayments() javadoc: cancellations
+                // arrive as separate negative-amount rows that must net out.
+                row.setAmount(p.getPaidValue());
                 row.setReferenceNo(p.getReferenceNo());
                 row.setCreditCompanyName("");
                 row.setPaymentCategory("Payment");
                 reportRows.add(row);
-                double paymentAmt = Math.abs(p.getPaidValue());
+                double paymentAmt = p.getPaidValue();
                 grandTotal += paymentAmt;
                 grandTotalPayments += paymentAmt;
                 if (p.getPaymentMethod() != null) {
@@ -292,16 +296,32 @@ public class BhtPaymentDetailReportController implements Serializable {
         return patientEncounterFacade.findByJpql(jpql.toString(), params, TemporalType.TIMESTAMP);
     }
 
+    /**
+     * Fetch "Make a Deposit" (INWARD_DEPOSIT) payments for this encounter.
+     *
+     * Matches BOTH {@code BillTypeAtomic.INWARD_DEPOSIT} and
+     * {@code BillTypeAtomic.INWARD_DEPOSIT_CANCELLATION}, and deliberately does
+     * NOT filter on {@code p.cancelled} / {@code p.bill.cancelled}: when a
+     * deposit is cancelled, HMIS sets {@code cancelled=true} on the original
+     * bill and creates a companion reversal Bill+Payment with an inverted
+     * (negative) amount under the CANCELLATION billTypeAtomic, rather than
+     * flagging the original row. Filtering to a single billTypeAtomic and
+     * excluding cancelled bills would make a cancelled deposit vanish from
+     * this report with no trace it ever happened. Including both rows and
+     * keeping each row's natural sign (no {@code Math.abs()} in the caller)
+     * lets the per-method totals net out correctly. Mirrors
+     * {@link #fetchPostFinalPayments} and {@link #fetchCreditSettlementItems}.
+     */
     private List<Payment> fetchDepositPayments(PatientEncounter enc) {
         StringBuilder jpql = new StringBuilder("select p from Payment p"
                 + " where p.retired = false"
-                + " and p.cancelled = false"
                 + " and p.bill.retired = false"
-                + " and p.bill.cancelled = false"
-                + " and p.bill.billTypeAtomic = :bta"
+                + " and p.bill.billTypeAtomic in :btas"
                 + " and p.bill.patientEncounter = :enc");
         Map<String, Object> params = new HashMap<>();
-        params.put("bta", BillTypeAtomic.INWARD_DEPOSIT);
+        params.put("btas", Arrays.asList(
+                BillTypeAtomic.INWARD_DEPOSIT,
+                BillTypeAtomic.INWARD_DEPOSIT_CANCELLATION));
         params.put("enc", enc);
         if (paymentMethod != null) {
             jpql.append(" and p.paymentMethod = :pm");
@@ -316,17 +336,30 @@ public class BhtPaymentDetailReportController implements Serializable {
      * payments toward the bill made any time during the stay. Kept separate
      * from deposits (INWARD_DEPOSIT) and post-final-bill payments
      * (BillType.PostFinalBillInwardPayment). Issue #23262.
+     *
+     * Matches BOTH {@code BillTypeAtomic.INWARD_PAYMENT} and
+     * {@code BillTypeAtomic.INWARD_PAYMENT_CANCELLATION}, and deliberately does
+     * NOT filter on {@code p.cancelled} / {@code p.bill.cancelled}: when a
+     * payment is cancelled, HMIS sets {@code cancelled=true} on the original
+     * bill and creates a companion reversal Bill+Payment with an inverted
+     * (negative) amount under the CANCELLATION billTypeAtomic, rather than
+     * flagging the original row. Filtering to a single billTypeAtomic and
+     * excluding cancelled bills would make a cancelled payment vanish from
+     * this report with no trace it ever happened. Including both rows and
+     * keeping each row's natural sign (no {@code Math.abs()} in the caller)
+     * lets the per-method totals net out correctly. Mirrors
+     * {@link #fetchPostFinalPayments} and {@link #fetchCreditSettlementItems}.
      */
     private List<Payment> fetchPayments(PatientEncounter enc) {
         StringBuilder jpql = new StringBuilder("select p from Payment p"
                 + " where p.retired = false"
-                + " and p.cancelled = false"
                 + " and p.bill.retired = false"
-                + " and p.bill.cancelled = false"
-                + " and p.bill.billTypeAtomic = :bta"
+                + " and p.bill.billTypeAtomic in :btas"
                 + " and p.bill.patientEncounter = :enc");
         Map<String, Object> params = new HashMap<>();
-        params.put("bta", BillTypeAtomic.INWARD_PAYMENT);
+        params.put("btas", Arrays.asList(
+                BillTypeAtomic.INWARD_PAYMENT,
+                BillTypeAtomic.INWARD_PAYMENT_CANCELLATION));
         params.put("enc", enc);
         if (paymentMethod != null) {
             jpql.append(" and p.paymentMethod = :pm");

--- a/src/main/java/com/divudi/bean/inward/BhtPaymentSummaryReportController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtPaymentSummaryReportController.java
@@ -16,6 +16,7 @@ import com.divudi.core.facade.PatientEncounterFacade;
 import com.divudi.core.facade.PaymentFacade;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
@@ -241,15 +242,19 @@ public class BhtPaymentSummaryReportController implements Serializable {
         row.setAdmissionType(enc.getAdmissionType());
 
         // --- "Make a Deposit" payments (INWARD_DEPOSIT) ---
+        // No Math.abs() here — see fetchDepositPayments() javadoc: cancellations
+        // arrive as separate negative-amount rows that must net out.
         List<Payment> depositPayments = fetchDepositPayments(enc);
         for (Payment p : depositPayments) {
-            row.addDeposit(p.getPaymentMethod(), Math.abs(p.getPaidValue()));
+            row.addDeposit(p.getPaymentMethod(), p.getPaidValue());
         }
 
         // --- "Make a Payment" payments (INWARD_PAYMENT) ---
+        // No Math.abs() here — see fetchPayments() javadoc: cancellations
+        // arrive as separate negative-amount rows that must net out.
         List<Payment> payments = fetchPayments(enc);
         for (Payment p : payments) {
-            row.addPayment(p.getPaymentMethod(), Math.abs(p.getPaidValue()));
+            row.addPayment(p.getPaymentMethod(), p.getPaidValue());
         }
 
         // --- post-final-bill payments ---
@@ -298,16 +303,29 @@ public class BhtPaymentSummaryReportController implements Serializable {
      * Fetch all Payment records linked to INWARD_DEPOSIT ("Make a Deposit") bills
      * for this encounter. Deposit bills link to the encounter via
      * bill.patientEncounter directly.
+     *
+     * Matches BOTH {@code BillTypeAtomic.INWARD_DEPOSIT} and
+     * {@code BillTypeAtomic.INWARD_DEPOSIT_CANCELLATION}, and deliberately does
+     * NOT filter on {@code bill.cancelled}: when a deposit is cancelled, HMIS
+     * sets {@code cancelled=true} on the original bill and creates a companion
+     * reversal Bill+Payment with an inverted (negative) amount under the
+     * CANCELLATION billTypeAtomic, rather than flagging the original row.
+     * Filtering to a single billTypeAtomic and excluding cancelled bills would
+     * make a cancelled deposit vanish from this report with no trace it ever
+     * happened. Including both rows and summing each with its natural sign
+     * (no {@code Math.abs()} in the caller) nets out correctly. This mirrors
+     * {@link #fetchPostFinalPayments}.
      */
     private List<Payment> fetchDepositPayments(PatientEncounter enc) {
         String jpql = "select p from Payment p"
                 + " where p.retired = false"
                 + " and p.bill.retired = false"
-                + " and p.bill.cancelled = false"
-                + " and p.bill.billTypeAtomic = :bta"
+                + " and p.bill.billTypeAtomic in :btas"
                 + " and p.bill.patientEncounter = :enc";
         Map<String, Object> params = new HashMap<>();
-        params.put("bta", BillTypeAtomic.INWARD_DEPOSIT);
+        params.put("btas", Arrays.asList(
+                BillTypeAtomic.INWARD_DEPOSIT,
+                BillTypeAtomic.INWARD_DEPOSIT_CANCELLATION));
         params.put("enc", enc);
         return paymentFacade.findByJpql(jpql, params);
     }
@@ -317,16 +335,29 @@ public class BhtPaymentSummaryReportController implements Serializable {
      * for this encounter — payments toward the bill made any time during the
      * stay, kept separate from deposits (INWARD_DEPOSIT) and from post-final-bill
      * payments (BillType.PostFinalBillInwardPayment). Issue #23262.
+     *
+     * Matches BOTH {@code BillTypeAtomic.INWARD_PAYMENT} and
+     * {@code BillTypeAtomic.INWARD_PAYMENT_CANCELLATION}, and deliberately does
+     * NOT filter on {@code bill.cancelled}: when a payment is cancelled, HMIS
+     * sets {@code cancelled=true} on the original bill and creates a companion
+     * reversal Bill+Payment with an inverted (negative) amount under the
+     * CANCELLATION billTypeAtomic, rather than flagging the original row.
+     * Filtering to a single billTypeAtomic and excluding cancelled bills would
+     * make a cancelled payment vanish from this report with no trace it ever
+     * happened. Including both rows and summing each with its natural sign
+     * (no {@code Math.abs()} in the caller) nets out correctly. This mirrors
+     * {@link #fetchPostFinalPayments}.
      */
     private List<Payment> fetchPayments(PatientEncounter enc) {
         String jpql = "select p from Payment p"
                 + " where p.retired = false"
                 + " and p.bill.retired = false"
-                + " and p.bill.cancelled = false"
-                + " and p.bill.billTypeAtomic = :bta"
+                + " and p.bill.billTypeAtomic in :btas"
                 + " and p.bill.patientEncounter = :enc";
         Map<String, Object> params = new HashMap<>();
-        params.put("bta", BillTypeAtomic.INWARD_PAYMENT);
+        params.put("btas", Arrays.asList(
+                BillTypeAtomic.INWARD_PAYMENT,
+                BillTypeAtomic.INWARD_PAYMENT_CANCELLATION));
         params.put("enc", enc);
         return paymentFacade.findByJpql(jpql, params);
     }

--- a/src/main/java/com/divudi/core/data/dto/BhtPaymentSummaryDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/BhtPaymentSummaryDTO.java
@@ -68,6 +68,12 @@ public class BhtPaymentSummaryDTO implements Serializable {
         return depositsByMethod.getOrDefault(method, 0.0);
     }
 
+    /**
+     * Amounts are merged with their natural sign — callers must NOT pass
+     * {@code Math.abs(...)} here. A cancelled deposit arrives as a separate
+     * negative-amount row (billTypeAtomic INWARD_DEPOSIT_CANCELLATION) that
+     * must net out against the original positive row.
+     */
     public void addDeposit(PaymentMethod method, double amount) {
         if (method == null) {
             LOG.log(Level.WARNING, "BHT {0}: deposit of {1} has null PaymentMethod — amount dropped from totals",
@@ -97,6 +103,12 @@ public class BhtPaymentSummaryDTO implements Serializable {
         return paymentsByMethod.getOrDefault(method, 0.0);
     }
 
+    /**
+     * Amounts are merged with their natural sign — callers must NOT pass
+     * {@code Math.abs(...)} here. A cancelled payment arrives as a separate
+     * negative-amount row (billTypeAtomic INWARD_PAYMENT_CANCELLATION) that
+     * must net out against the original positive row.
+     */
     public void addPayment(PaymentMethod method, double amount) {
         if (method == null) {
             LOG.log(Level.WARNING, "BHT {0}: payment of {1} has null PaymentMethod — amount dropped from totals",
@@ -132,7 +144,7 @@ public class BhtPaymentSummaryDTO implements Serializable {
 
     /**
      * Amounts are merged with their natural sign — callers must NOT pass
-     * {@code Math.abs(...)} here. Unlike deposits, post-final-bill payment
+     * {@code Math.abs(...)} here. Post-final-bill payment
      * cancellations/refunds arrive as separate negative-amount rows that
      * must net out against the original positive row.
      */


### PR DESCRIPTION
## Summary

Fixes #23541 — a cancelled inpatient **deposit** ("Make a Deposit") or **payment** ("Make a Payment") vanished entirely from the BHT Deposit and Credit Settlement reports, leaving no trace it had ever happened.

## Root Cause

`BhtPaymentSummaryReportController` (per-BHT breakdown, shown under the **"...Detail"** menu label) and `BhtPaymentDetailReportController` (line-level transaction log, shown under the **"...Summary"** menu label — the naming is intentionally swapped, see #23258) each have `fetchDepositPayments()`/`fetchPayments()` methods that filtered on a single `billTypeAtomic` (`INWARD_DEPOSIT` or `INWARD_PAYMENT`) **and** `bill.cancelled = false`.

When a deposit/payment is cancelled, HMIS creates a companion reversal `Bill`+`Payment` with an inverted (negative) amount under a separate `_CANCELLATION` billTypeAtomic, while marking the original bill `cancelled = true`. The old query excluded the original (now cancelled) **and** never matched the reversal (wrong billTypeAtomic) — so the transaction disappeared from both reports with zero trace.

Both files already contain the correct pattern for exactly this case — `fetchPostFinalPayments()` and `fetchCreditSettlementItems()` — which match **both** the original and `_CANCELLATION` type with signed amounts and no `cancelled` filter. Post-discharge payments were never affected by this bug.

## Fix

- `fetchDepositPayments()` / `fetchPayments()` in both controllers now match `billTypeAtomic IN (ORIGINAL, ORIGINAL_CANCELLATION)`, drop the `bill.cancelled` filter (and the dead-weight `p.cancelled` filter in the Detail controller — nothing ever sets it true for these bill types).
- Callers sum the **signed** `paidValue` (no `Math.abs()`), matching the existing post-final-payment/CC-settlement pattern, so a cancellation nets to zero instead of being silently dropped.
- `BhtPaymentSummaryDTO.addDeposit()`/`addPayment()` javadoc updated to state amounts are merged with their natural sign.

No entity/DTO field changes, no DDL needed. No XHTML/export code touched — both pages' Excel/PDF exports read the same `p:dataTable`/DTO list and pick up the fix automatically.

## Verification

**DB evidence** (`coop`, PatientEncounter 13860174 / BHT/57051, real cancelled Rs 1,000 deposit):

| Query | Row count | Amounts |
|---|---|---|
| Old (bug) | 4 | 10000, 165000, 100000, 411529.82 |
| New (fixed) | 6 | **1000, -1000**, 10000, 165000, 100000, 411529.82 |

**Playwright, local Payara**, department **Inward**, menu path *Inward → Reports (Inpatient Analytics) → Payment Reports → BHT Deposit and Credit Settlement Summary*, From date 01 Aug 2026:

![BHT Deposit and Credit Settlement Summary report showing a cancelled deposit as a separate negative-amount row](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23541-cancelled-deposit-visible.png)

*BHT/57051: the Rs 1,000 deposit (InwardINWPAY/85) and its Rs -1,000 cancellation reversal (Inward/INWCAN/1) both now appear as separate rows, netting to zero.*

Cross-checked the per-BHT **Detail** report (`BhtPaymentSummaryReportController`) for the same BHT: Total Deposits = 686,529.82, matching the hand-computed sum of the 5 surviving deposits (the cancelled 1,000/-1,000 pair nets to zero as expected — this total was unchanged by the fix, confirming no regression to the aggregate).

## Documentation

- [Inward BHT Deposit and Credit Settlement Summary Report](https://github.com/hmislk/hmis/wiki/Inward-BHT-Deposit-and-Credit-Settlement-Summary-Report) — added a note + example screenshot
- [Inward BHT Deposit and Credit Settlement Detail Report](https://github.com/hmislk/hmis/wiki/Inward-BHT-Deposit-and-Credit-Settlement-Detail-Report) — added a note on the totals now correctly reflecting cancellations as net-zero pairs

Closes #23541

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - BHT Payment Detail and Summary reports now include cancelled deposits and payments alongside their reversal entries.
  - Report amounts and totals now correctly net original payments against cancellation amounts, including grand totals and payment-method totals.
  - Cancelled transactions are no longer incorrectly excluded or displayed as positive amounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->