### PR TITLE
fix(inward): attribute room charges per surgery instead of admission

### DIFF
--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -898,13 +898,23 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         }
         List<com.divudi.core.entity.inward.PatientRoom> activeRooms = new java.util.ArrayList<>();
         try {
+            // Theatre rooms tied to a specific surgery point at that
+            // surgery's procedure encounter (a child of this admission), not
+            // the admission itself - include children so an active theatre
+            // stay still shows on this panel.
+            List<PatientEncounter> encounters = new java.util.ArrayList<>();
+            encounters.add(current);
+            List<PatientEncounter> children = inwardBean.fetchChildPatientEncounter(current);
+            if (children != null) {
+                encounters.addAll(children);
+            }
             String jpql = "SELECT pr FROM PatientRoom pr "
                     + "WHERE pr.retired = false "
                     + "AND pr.discharged = false "
-                    + "AND pr.patientEncounter = :enc "
+                    + "AND pr.patientEncounter IN :encs "
                     + "ORDER BY pr.createdAt";
             java.util.HashMap<String, Object> params = new java.util.HashMap<>();
-            params.put("enc", current);
+            params.put("encs", encounters);
             activeRooms = patientRoomFacade.findByJpql(jpql, params);
         } catch (Exception e) {
             logger.log(Level.SEVERE, "Failed to load active rooms for admission ID: "

--- a/src/main/java/com/divudi/bean/inward/PatientTransferController.java
+++ b/src/main/java/com/divudi/bean/inward/PatientTransferController.java
@@ -8,6 +8,7 @@ import com.divudi.core.data.inward.TransferRequestStatus;
 import com.divudi.core.entity.Bill;
 import com.divudi.core.entity.Department;
 import com.divudi.core.entity.Institution;
+import com.divudi.core.entity.PatientEncounter;
 import com.divudi.core.entity.inward.Admission;
 import com.divudi.core.entity.inward.PatientRoom;
 import com.divudi.core.entity.inward.TheatreRoom;
@@ -669,9 +670,11 @@ public class PatientTransferController implements Serializable {
             JsfUtil.addErrorMessage("Please select a theatre room.");
             return;
         }
-        PatientTransferRequest existing = findActiveSendToTheatreRequest(current);
+        PatientTransferRequest existing = findActiveSendToTheatreRequest(current, selectedSurgeryBill);
         if (existing != null) {
-            JsfUtil.addErrorMessage("This patient already has an active theatre transfer in progress.");
+            JsfUtil.addErrorMessage(selectedSurgeryBill != null
+                    ? "This surgery already has an active theatre transfer in progress."
+                    : "This patient already has an active theatre transfer in progress.");
             return;
         }
         PatientTransferRequest req = new PatientTransferRequest();
@@ -713,12 +716,27 @@ public class PatientTransferController implements Serializable {
         persisted.setTheatreOccupancyStatus(TheatreOccupancyStatus.RECEIVED_IN_THEATRE);
 
         if (persisted.getTheatreRoom() == null) {
+            // Attribute the theatre stay to the specific surgery's own
+            // procedure encounter (a child of the admission created by
+            // SurgeryBillController) when one was selected on Send to
+            // Theatre, so per-surgery room charges can be computed
+            // (SurgeryCostReportController.enrichRoomCharges). Falls back to
+            // the admission itself when no surgery bill was selected (the
+            // "Surgery (optional)" field on the send-to-theatre form), and
+            // final-bill totals (InwardBeanController.getRoomCharge et al.)
+            // already sum admission + all child encounters via
+            // fetchChildPatientEncounter, so this doesn't change what the
+            // final bill charges - only how it's broken down per surgery.
+            PatientEncounter theatreRoomEncounter = (persisted.getSurgeryBill() != null
+                    && persisted.getSurgeryBill().getProcedure() != null)
+                    ? persisted.getSurgeryBill().getProcedure()
+                    : persisted.getAdmission();
             TheatreRoom theatreRoom = new TheatreRoom();
             theatreRoom = (TheatreRoom) inwardBean.savePatientRoom(
                     theatreRoom,
                     null,
                     persisted.getToRoomFacilityCharge(),
-                    persisted.getAdmission(),
+                    theatreRoomEncounter,
                     persisted.getInitiatedAt(),
                     sessionController.getLoggedUser());
             persisted.setTheatreRoom(theatreRoom);
@@ -925,6 +943,41 @@ public class PatientTransferController implements Serializable {
         params.put("cancelled", TransferRequestStatus.CANCELLED);
         String jpql = "SELECT r FROM PatientTransferRequest r "
                 + "WHERE r.admission = :admission "
+                + "AND r.theatreTransferType = :type "
+                + "AND r.status <> :cancelled "
+                + "AND (r.theatreOccupancyStatus IS NULL OR r.theatreOccupancyStatus <> :returned) "
+                + "AND r.retired = false "
+                + "ORDER BY r.createdAt DESC";
+        List<PatientTransferRequest> results = patientTransferRequestFacade.findByJpql(jpql, params, 1);
+        return (results != null && !results.isEmpty()) ? results.get(0) : null;
+    }
+
+    /**
+     * Surgery-bill-aware variant of {@link #findActiveSendToTheatreRequest(Admission)}.
+     * A multi-surgery admission can have several surgeries in flight
+     * concurrently (different theatre rooms), so the duplicate-transfer guard
+     * in {@link #sendToTheatre()} must scope by surgery bill, not just the
+     * admission - otherwise sending the second surgery to theatre is blocked
+     * while the first is still pending/in-theatre. When no surgery bill is
+     * selected (the "Surgery (optional)" field), falls back to the
+     * admission-level check since there is nothing else to disambiguate by.
+     */
+    public PatientTransferRequest findActiveSendToTheatreRequest(Admission admission, Bill surgeryBill) {
+        if (admission == null) {
+            return null;
+        }
+        if (surgeryBill == null) {
+            return findActiveSendToTheatreRequest(admission);
+        }
+        HashMap<String, Object> params = new HashMap<>();
+        params.put("admission", admission);
+        params.put("surgeryBill", surgeryBill);
+        params.put("type", TheatreTransferType.SEND_TO_THEATRE);
+        params.put("returned", TheatreOccupancyStatus.RETURNED_TO_WARD);
+        params.put("cancelled", TransferRequestStatus.CANCELLED);
+        String jpql = "SELECT r FROM PatientTransferRequest r "
+                + "WHERE r.admission = :admission "
+                + "AND r.surgeryBill = :surgeryBill "
                 + "AND r.theatreTransferType = :type "
                 + "AND r.status <> :cancelled "
                 + "AND (r.theatreOccupancyStatus IS NULL OR r.theatreOccupancyStatus <> :returned) "

--- a/src/main/java/com/divudi/bean/inward/PatientTransferController.java
+++ b/src/main/java/com/divudi/bean/inward/PatientTransferController.java
@@ -1000,12 +1000,25 @@ public class PatientTransferController implements Serializable {
         params.put("admission", returnReq.getAdmission());
         params.put("type", TheatreTransferType.SEND_TO_THEATRE);
         params.put("accepted", TransferRequestStatus.ACCEPTED);
+        // Scope by surgery bill, matching returnReq's own surgeryBill (copied
+        // from the SEND_TO_THEATRE request in returnToWard()) - otherwise,
+        // with several surgeries' SEND_TO_THEATRE/RETURN_TO_WARD pairs active
+        // concurrently on one admission, "most recent accepted" could grab a
+        // DIFFERENT surgery's still-in-progress theatre request and wrongly
+        // mark it RETURNED_TO_WARD.
         String jpql = "SELECT r FROM PatientTransferRequest r "
                 + "WHERE r.admission = :admission "
                 + "AND r.theatreTransferType = :type "
                 + "AND r.status = :accepted "
-                + "AND r.retired = false "
-                + "ORDER BY r.createdAt DESC";
+                + "AND r.retired = false ";
+        Bill surgeryBill = returnReq.getSurgeryBill();
+        if (surgeryBill != null) {
+            jpql += "AND r.surgeryBill = :surgeryBill ";
+            params.put("surgeryBill", surgeryBill);
+        } else {
+            jpql += "AND r.surgeryBill IS NULL ";
+        }
+        jpql += "ORDER BY r.createdAt DESC";
         List<PatientTransferRequest> results = patientTransferRequestFacade.findByJpql(jpql, params, 1);
         return (results != null && !results.isEmpty()) ? results.get(0) : null;
     }

--- a/src/main/java/com/divudi/bean/inward/PatientTransferController.java
+++ b/src/main/java/com/divudi/bean/inward/PatientTransferController.java
@@ -662,33 +662,46 @@ public class PatientTransferController implements Serializable {
     }
 
     public void sendToTheatre() {
-        if (current == null) {
+        // This bean is @SessionScoped, so two browser tabs sharing one
+        // session can have their requests processed concurrently against
+        // the SAME bean instance. Snapshotting these fields into locals up
+        // front - and using only the locals for the rest of this method -
+        // closes that window: a concurrent request mutating current/
+        // selectedSurgeryBill/etc. after this point can no longer cause the
+        // validated admission/bill/room/notes to diverge from what actually
+        // gets persisted below.
+        Admission admission = current;
+        Bill surgeryBill = selectedSurgeryBill;
+        RoomFacilityCharge targetRoom = targetRoomFacilityCharge;
+        String transferNotes = notes;
+
+        if (admission == null) {
             JsfUtil.addErrorMessage("No patient selected.");
             return;
         }
-        if (targetRoomFacilityCharge == null) {
+        if (targetRoom == null) {
             JsfUtil.addErrorMessage("Please select a theatre room.");
             return;
         }
-        // This bean is @SessionScoped, so a stale postback from a different
-        // browser tab could carry a selectedSurgeryBill left over from a
-        // DIFFERENT admission's send-to-theatre page (current gets reset per
-        // navigation, but two tabs sharing the same session can race). Since
-        // acceptInTheatre() uses selectedSurgeryBill.getProcedure() to
-        // attribute the theatre room (and its charges), a mismatched bill
-        // here would misattribute a totally different patient's surgery -
-        // reject and clear rather than silently trusting client state.
-        if (selectedSurgeryBill != null
-                && (selectedSurgeryBill.getPatientEncounter() == null
-                || selectedSurgeryBill.getPatientEncounter().getId() == null
-                || !selectedSurgeryBill.getPatientEncounter().getId().equals(current.getId()))) {
+        // A stale postback from a different browser tab could carry a
+        // surgeryBill left over from a DIFFERENT admission's send-to-theatre
+        // page (current gets reset per navigation, but two tabs sharing the
+        // same session can race). Since acceptInTheatre() uses
+        // surgeryBill.getProcedure() to attribute the theatre room (and its
+        // charges), a mismatched bill here would misattribute a totally
+        // different patient's surgery - reject and clear rather than
+        // silently trusting client state.
+        if (surgeryBill != null
+                && (surgeryBill.getPatientEncounter() == null
+                || surgeryBill.getPatientEncounter().getId() == null
+                || !surgeryBill.getPatientEncounter().getId().equals(admission.getId()))) {
             JsfUtil.addErrorMessage("Selected surgery does not belong to this admission. Please re-select.");
             selectedSurgeryBill = null;
             return;
         }
-        PatientTransferRequest existing = findActiveSendToTheatreRequest(current, selectedSurgeryBill);
+        PatientTransferRequest existing = findActiveSendToTheatreRequest(admission, surgeryBill);
         if (existing != null) {
-            JsfUtil.addErrorMessage(selectedSurgeryBill != null
+            JsfUtil.addErrorMessage(surgeryBill != null
                     ? "This surgery already has an active theatre transfer in progress."
                     : "This patient already has an active theatre transfer in progress.");
             return;
@@ -701,21 +714,21 @@ public class PatientTransferController implements Serializable {
         // that pending return afterwards could resolve to the wrong (new) row
         // instead of the one it actually belongs to. Block re-sending until
         // the pending return is accepted.
-        if (hasPendingReturnRequest(current, selectedSurgeryBill)) {
-            JsfUtil.addErrorMessage(selectedSurgeryBill != null
+        if (hasPendingReturnRequest(admission, surgeryBill)) {
+            JsfUtil.addErrorMessage(surgeryBill != null
                     ? "This surgery has a return-to-ward request awaiting acceptance. Please accept it before sending to theatre again."
                     : "This patient has a return-to-ward request awaiting acceptance. Please accept it before sending to theatre again.");
             return;
         }
         PatientTransferRequest req = new PatientTransferRequest();
-        req.setAdmission(current);
-        req.setFromPatientRoom(current.getCurrentPatientRoom());
-        req.setToRoomFacilityCharge(targetRoomFacilityCharge);
+        req.setAdmission(admission);
+        req.setFromPatientRoom(admission.getCurrentPatientRoom());
+        req.setToRoomFacilityCharge(targetRoom);
         req.setTheatreTransferType(TheatreTransferType.SEND_TO_THEATRE);
         req.setTheatreOccupancyStatus(TheatreOccupancyStatus.SENT_TO_THEATRE);
-        req.setSurgeryBill(selectedSurgeryBill);
+        req.setSurgeryBill(surgeryBill);
         req.setStatus(TransferRequestStatus.PENDING);
-        req.setNotes(notes);
+        req.setNotes(transferNotes);
         req.setInitiatedAt(new Date());
         req.setInitiatedBy(sessionController.getLoggedUser());
         req.setCreatedAt(new Date());

--- a/src/main/java/com/divudi/bean/inward/PatientTransferController.java
+++ b/src/main/java/com/divudi/bean/inward/PatientTransferController.java
@@ -975,9 +975,14 @@ public class PatientTransferController implements Serializable {
         params.put("type", TheatreTransferType.SEND_TO_THEATRE);
         params.put("returned", TheatreOccupancyStatus.RETURNED_TO_WARD);
         params.put("cancelled", TransferRequestStatus.CANCELLED);
+        // A generic admission-level transfer (no surgery selected) still means
+        // this physical patient is already in transit/theatre, so it must
+        // conflict with a surgery-specific send too - only a DIFFERENT
+        // non-null surgery bill's active request is allowed to run
+        // concurrently.
         String jpql = "SELECT r FROM PatientTransferRequest r "
                 + "WHERE r.admission = :admission "
-                + "AND r.surgeryBill = :surgeryBill "
+                + "AND (r.surgeryBill = :surgeryBill OR r.surgeryBill IS NULL) "
                 + "AND r.theatreTransferType = :type "
                 + "AND r.status <> :cancelled "
                 + "AND (r.theatreOccupancyStatus IS NULL OR r.theatreOccupancyStatus <> :returned) "

--- a/src/main/java/com/divudi/bean/inward/PatientTransferController.java
+++ b/src/main/java/com/divudi/bean/inward/PatientTransferController.java
@@ -693,6 +693,20 @@ public class PatientTransferController implements Serializable {
                     : "This patient already has an active theatre transfer in progress.");
             return;
         }
+        // findActiveSendToTheatreRequestForReturn resolves a return request's
+        // matching SEND_TO_THEATRE row by surgery bill alone, not by the exact
+        // originating request - so if this surgery already has a pending
+        // (not yet accepted) return-to-ward, a new send now would create a
+        // second SEND_TO_THEATRE row for the same surgery bill, and accepting
+        // that pending return afterwards could resolve to the wrong (new) row
+        // instead of the one it actually belongs to. Block re-sending until
+        // the pending return is accepted.
+        if (hasPendingReturnRequest(current, selectedSurgeryBill)) {
+            JsfUtil.addErrorMessage(selectedSurgeryBill != null
+                    ? "This surgery has a return-to-ward request awaiting acceptance. Please accept it before sending to theatre again."
+                    : "This patient has a return-to-ward request awaiting acceptance. Please accept it before sending to theatre again.");
+            return;
+        }
         PatientTransferRequest req = new PatientTransferRequest();
         req.setAdmission(current);
         req.setFromPatientRoom(current.getCurrentPatientRoom());
@@ -1006,6 +1020,36 @@ public class PatientTransferController implements Serializable {
                 + "ORDER BY r.createdAt DESC";
         List<PatientTransferRequest> results = patientTransferRequestFacade.findByJpql(jpql, params, 1);
         return (results != null && !results.isEmpty()) ? results.get(0) : null;
+    }
+
+    /**
+     * True when this admission (optionally scoped to one surgery bill) has a
+     * RETURN_TO_WARD request that is still PENDING (not yet accepted). Used
+     * by sendToTheatre() to block a second theatre trip for the same surgery
+     * while its prior trip's return hasn't been accepted yet -
+     * findActiveSendToTheatreRequestForReturn resolves by surgery bill alone,
+     * so a second SEND_TO_THEATRE row for that same surgery could otherwise
+     * let acceptReturnToWard() resolve to the wrong (newer) row.
+     */
+    private boolean hasPendingReturnRequest(Admission admission, Bill surgeryBill) {
+        if (admission == null) {
+            return false;
+        }
+        HashMap<String, Object> params = new HashMap<>();
+        params.put("admission", admission);
+        params.put("type", TheatreTransferType.RETURN_TO_WARD);
+        params.put("pending", TransferRequestStatus.PENDING);
+        String jpql = "SELECT r FROM PatientTransferRequest r "
+                + "WHERE r.admission = :admission "
+                + "AND r.theatreTransferType = :type "
+                + "AND r.status = :pending "
+                + "AND r.retired = false ";
+        if (surgeryBill != null) {
+            jpql += "AND (r.surgeryBill = :surgeryBill OR r.surgeryBill IS NULL) ";
+            params.put("surgeryBill", surgeryBill);
+        }
+        List<PatientTransferRequest> results = patientTransferRequestFacade.findByJpql(jpql, params, 1);
+        return results != null && !results.isEmpty();
     }
 
     private PatientTransferRequest findActiveSendToTheatreRequestForReturn(PatientTransferRequest returnReq) {

--- a/src/main/java/com/divudi/bean/inward/PatientTransferController.java
+++ b/src/main/java/com/divudi/bean/inward/PatientTransferController.java
@@ -670,6 +670,22 @@ public class PatientTransferController implements Serializable {
             JsfUtil.addErrorMessage("Please select a theatre room.");
             return;
         }
+        // This bean is @SessionScoped, so a stale postback from a different
+        // browser tab could carry a selectedSurgeryBill left over from a
+        // DIFFERENT admission's send-to-theatre page (current gets reset per
+        // navigation, but two tabs sharing the same session can race). Since
+        // acceptInTheatre() uses selectedSurgeryBill.getProcedure() to
+        // attribute the theatre room (and its charges), a mismatched bill
+        // here would misattribute a totally different patient's surgery -
+        // reject and clear rather than silently trusting client state.
+        if (selectedSurgeryBill != null
+                && (selectedSurgeryBill.getPatientEncounter() == null
+                || selectedSurgeryBill.getPatientEncounter().getId() == null
+                || !selectedSurgeryBill.getPatientEncounter().getId().equals(current.getId()))) {
+            JsfUtil.addErrorMessage("Selected surgery does not belong to this admission. Please re-select.");
+            selectedSurgeryBill = null;
+            return;
+        }
         PatientTransferRequest existing = findActiveSendToTheatreRequest(current, selectedSurgeryBill);
         if (existing != null) {
             JsfUtil.addErrorMessage(selectedSurgeryBill != null

--- a/src/main/java/com/divudi/bean/inward/SurgeryCostReportController.java
+++ b/src/main/java/com/divudi/bean/inward/SurgeryCostReportController.java
@@ -15,6 +15,7 @@ import com.divudi.core.entity.Staff;
 import com.divudi.core.entity.inward.EncounterComponent;
 import com.divudi.core.entity.inward.PatientTransferRequest;
 import com.divudi.core.entity.inward.RoomFacilityCharge;
+import com.divudi.core.entity.inward.SurgeryType;
 import com.divudi.core.facade.BillFacade;
 import com.divudi.core.facade.EncounterComponentFacade;
 import com.divudi.core.facade.PatientRoomFacade;
@@ -93,7 +94,7 @@ public class SurgeryCostReportController implements Serializable {
     private Department department;
     private Date fromDate;
     private Date toDate;
-    private Item surgeryType;
+    private SurgeryType surgeryType;
     private Item surgeryItem;
     private PatientEncounterDto selectedPatient;
     private Staff selectedAdmitDoctor;
@@ -193,7 +194,7 @@ public class SurgeryCostReportController implements Serializable {
         enrichSurgeonsAndAssistants(lookups.procIds, lookups.dtosByProcId);
         enrichOtRoomAndStatus(lookups.billIds, lookups.dtoByBillId);
         enrichChildBillCharges(lookups.billIds, lookups.dtoByBillId);
-        enrichRoomCharges(lookups.peIds, lookups.dtosByPeId);
+        enrichRoomCharges(lookups.procIds, lookups.dtosByProcId);
         enrichDrugCharges(lookups.peIds, lookups.dtosByPeId);
 
         computeTotals(list);
@@ -265,11 +266,20 @@ public class SurgeryCostReportController implements Serializable {
             params.put("surgeryItem", surgeryItem);
         }
 
-        String patientSearchTerm = resolvePatientSearchTerm();
-        if (patientSearchTerm != null) {
-            jpql.append(" AND (LOWER(admission.patient.person.name) LIKE :pn ")
-                    .append("     OR LOWER(admission.patient.phn) LIKE :pn) ");
-            params.put("pn", "%" + patientSearchTerm + "%");
+        // Prefer an exact PHN match - selectedPatient comes from a
+        // forceSelection="true" autocomplete, so the user has already picked
+        // one specific patient; a name substring match could silently widen
+        // the filter to other patients sharing part of that name.
+        if (selectedPatient != null && selectedPatient.getPhn() != null && !selectedPatient.getPhn().trim().isEmpty()) {
+            jpql.append(" AND admission.patient.phn = :selectedPatientPhn ");
+            params.put("selectedPatientPhn", selectedPatient.getPhn().trim());
+        } else {
+            String patientSearchTerm = resolvePatientSearchTerm();
+            if (patientSearchTerm != null) {
+                jpql.append(" AND (LOWER(admission.patient.person.name) LIKE :pn ")
+                        .append("     OR LOWER(admission.patient.phn) LIKE :pn) ");
+                params.put("pn", "%" + patientSearchTerm + "%");
+            }
         }
 
         if (selectedAdmitDoctor != null) {
@@ -479,19 +489,33 @@ public class SurgeryCostReportController implements Serializable {
                 }
                 if (sbType == SurgeryBillType.ProfessionalFee) {
                     dto.setProfessionalCharge(dto.getProfessionalCharge() + net);
+                    dto.setBillDiscount(dto.getBillDiscount() + discount);
                 } else if (sbType == SurgeryBillType.Service
                         || sbType == SurgeryBillType.PharmacyItem
                         || sbType == SurgeryBillType.TimedService) {
                     dto.setTotalHospitalCharge(dto.getTotalHospitalCharge() + net);
+                    dto.setBillDiscount(dto.getBillDiscount() + discount);
                 }
-                dto.setBillDiscount(dto.getBillDiscount() + discount);
             }
         }
     }
 
-    private void enrichRoomCharges(Set<Long> peIds,
-            Map<Long, List<SurgeryCostEstimationDTO>> dtosByPeId) {
-        if (peIds.isEmpty()) {
+    /**
+     * Attributes room charges to the specific surgery whose theatre stay
+     * generated them, keyed by procedure id (not the admission id) -
+     * PatientTransferController.acceptInTheatre points a theatre
+     * PatientRoom's patientEncounter at the surgery's own procedure
+     * encounter (when one was selected on Send to Theatre) rather than the
+     * admission, so this now sums per-procedure instead of copying the
+     * whole admission's total onto every surgery row. The admission/final
+     * bill total is unaffected: InwardBeanController.getRoomCharge(...) et
+     * al. already sum across the admission plus all of its child
+     * (procedure) encounters via fetchChildPatientEncounter, so it picks up
+     * every surgery's theatre charge automatically.
+     */
+    private void enrichRoomCharges(Set<Long> procIds,
+            Map<Long, List<SurgeryCostEstimationDTO>> dtosByProcId) {
+        if (procIds.isEmpty()) {
             return;
         }
 
@@ -509,12 +533,12 @@ public class SurgeryCostReportController implements Serializable {
                 + "         FROM PatientRoomTimedItemCharge t "
                 + "         WHERE t.patientRoom = p), 0)) "
                 + "FROM PatientRoom p "
-                + "WHERE p.retired = false AND p.patientEncounter.id IN :peIds "
+                + "WHERE p.retired = false AND p.patientEncounter.id IN :procIds "
                 + "GROUP BY p.patientEncounter.id";
 
-        for (List<Long> batch : partition(peIds, IN_CLAUSE_BATCH_SIZE)) {
+        for (List<Long> batch : partition(procIds, IN_CLAUSE_BATCH_SIZE)) {
             Map<String, Object> params = new HashMap<>();
-            params.put("peIds", batch);
+            params.put("procIds", batch);
 
             List<Object[]> roomList = patientRoomFacade.findAggregates(roomJpql, params);
             if (roomList == null) {
@@ -522,10 +546,10 @@ public class SurgeryCostReportController implements Serializable {
             }
 
             for (Object[] row : roomList) {
-                Long peId = (Long) row[0];
+                Long procId = (Long) row[0];
                 double totalRoomCharge = toDouble(row[1]);
 
-                List<SurgeryCostEstimationDTO> dtos = dtosByPeId.get(peId);
+                List<SurgeryCostEstimationDTO> dtos = dtosByProcId.get(procId);
                 if (dtos == null) {
                     continue;
                 }
@@ -591,6 +615,8 @@ public class SurgeryCostReportController implements Serializable {
             case "bySurgeon":
                 jpql.append("SELECT new com.divudi.core.data.dto.SurgeryCostSummaryDTO(p.person.name, COUNT(DISTINCT sb.id)) ")
                         .append("FROM BilledBill sb ")
+                        .append("JOIN sb.procedure proc ")
+                        .append("JOIN proc.item item ")
                         .append("LEFT JOIN sb.staff p ")
                         .append("JOIN sb.patientEncounter admission ");
                 appendSummaryWhereClause(jpql, params);
@@ -685,11 +711,11 @@ public class SurgeryCostReportController implements Serializable {
                     .setBorderWidth(1);
 
             for (SurgeryCostSummaryDTO dto : surgeryCostSummaryList) {
-                String label = dto.getLabel1();
+                String label = dto.getLabel1() != null ? dto.getLabel1() : "Unknown";
                 if (dto.getLabel2() != null && !dto.getLabel2().isEmpty()) {
                     label += " - " + dto.getLabel2();
                 }
-                barData.addLabel(label != null ? label : "Unknown");
+                barData.addLabel(label);
                 dataset.addData(dto.getCount());
             }
             barData.addDataset(dataset);
@@ -839,7 +865,7 @@ public class SurgeryCostReportController implements Serializable {
             Row titleRow = sheet.createRow(rowIdx++);
             titleRow.setHeightInPoints(22);
             Cell titleCell = titleRow.createCell(0);
-            titleCell.setCellValue("Surgery Cost Costing " + (isSummary ? "Summary" : "Detail") + " Report");
+            titleCell.setCellValue("Surgery Cost Estimation " + (isSummary ? "Summary" : "Detail") + " Report");
             titleCell.setCellStyle(titleStyle);
             sheet.addMergedRegion(new CellRangeAddress(0, 0, 0, Math.max(headers.length - 1, 3)));
 
@@ -859,7 +885,7 @@ public class SurgeryCostReportController implements Serializable {
                 activeFilters.add("Department: " + department.getName());
             }
             if (selectedPatient != null) {
-                activeFilters.add("Patient MRN: " + (selectedPatient.getPatientName() != null ? selectedPatient.getPatientName() : selectedPatient.getPhn()));
+                activeFilters.add("Patient: " + (selectedPatient.getPatientName() != null ? selectedPatient.getPatientName() : selectedPatient.getPhn()));
             }
             if (selectedAdmitDoctor != null) {
                 activeFilters.add("Admit Doctor: " + selectedAdmitDoctor.getPerson().getNameWithTitle());
@@ -1096,7 +1122,7 @@ public class SurgeryCostReportController implements Serializable {
 
             SimpleDateFormat sdf = new SimpleDateFormat("dd/MMM/yyyy HH:mm");
 
-            Paragraph titlePara = new Paragraph("Surgery Cost Costing " + (isSummary ? "Summary" : "Detail") + " Report", titleFont);
+            Paragraph titlePara = new Paragraph("Surgery Cost Estimation " + (isSummary ? "Summary" : "Detail") + " Report", titleFont);
             titlePara.setAlignment(Element.ALIGN_CENTER);
             titlePara.setSpacingAfter(10);
             document.add(titlePara);
@@ -1115,7 +1141,7 @@ public class SurgeryCostReportController implements Serializable {
                 activeFilters.add("Department: " + department.getName());
             }
             if (selectedPatient != null) {
-                activeFilters.add("Patient MRN: " + (selectedPatient.getPatientName() != null ? selectedPatient.getPatientName() : selectedPatient.getPhn()));
+                activeFilters.add("Patient: " + (selectedPatient.getPatientName() != null ? selectedPatient.getPatientName() : selectedPatient.getPhn()));
             }
             if (selectedAdmitDoctor != null) {
                 activeFilters.add("Admit Doctor: " + selectedAdmitDoctor.getPerson().getNameWithTitle());
@@ -1453,11 +1479,11 @@ public class SurgeryCostReportController implements Serializable {
         this.selectedSurgeryStatus = selectedSurgeryStatus;
     }
 
-    public Item getSurgeryType() {
+    public SurgeryType getSurgeryType() {
         return surgeryType;
     }
 
-    public void setSurgeryType(Item surgeryType) {
+    public void setSurgeryType(SurgeryType surgeryType) {
         this.surgeryType = surgeryType;
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #22619 (issue #22097), which merged before this final commit
could be included. Carries the room-charge-per-surgery redesign forward
onto `development`.

- Repoints a theatre `PatientRoom.patientEncounter` at the surgery's own
  procedure encounter (a child of the admission) when a surgery bill is
  selected on Send to Theatre — the same parent/child mechanism already
  used for professional-fee and service child bills.
- `SurgeryCostReportController.enrichRoomCharges` now groups room charges
  by procedure id instead of admission id, so each surgery row shows only
  its own theatre stay instead of the whole admission's total.
- `AdmissionController.getActivePatientRooms` (Room Management panel) now
  searches admission + child (procedure) encounters, matching the pattern
  `BhtSummeryController` already uses everywhere else.
- Fixes a duplicate-active-transfer guard bug in
  `PatientTransferController.sendToTheatre`/`findActiveSendToTheatreRequest`
  that blocked sending a second surgery to theatre while the first was
  still pending/in-theatre — the guard is now surgery-bill-aware, falling
  back to the admission-level check when no surgery bill is selected.

Drug/pharmacy charges remain admission-level (duplicated per surgery row)
since no pharmacy bill type carries a procedure FK — tracked separately.

## Test plan

All verified live against local Payara + MySQL with a real multi-surgery
admission (BHT/57817):

- [x] Created two surgeries (Appendicectomy, Cholecystectomy) on one
      admission, each sent to its own theatre room (OT-1 @ Rs.5,000/block,
      OT-2 @ Rs.90,000/block), accepted, completed, returned to ward.
- [x] Interim bill Room Stay History shows each theatre visit's own charge
      (Rs.5,000 / Rs.90,000) instead of one duplicated total.
- [x] Interim bill Room Charges summary correctly sums admission + both
      surgeries' theatre charges: 900 (ward) + 5,000 + 90,000 = 95,900.
- [x] Direct query mirroring `enrichRoomCharges`'s JPQL confirms per-surgery
      grouping by procedure id returns 5,000 and 90,000 separately.
- [x] Sent both surgeries to theatre concurrently (before either was
      accepted) — succeeded without the previous "already has an active
      theatre transfer" block, confirming the surgery-bill-aware guard.
- [x] `mvn clean package` succeeds; local Payara redeploy succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Active theatre rooms now include rooms assigned through related procedure encounters.
  * Surgery-specific theatre transfers are checked independently, preventing incorrect duplicate-transfer warnings.
  * Theatre stays are attributed to the selected surgery for more accurate room-charge calculations.
  * Surgery cost reports improve patient matching, room-charge alignment, discount calculations, and surgery filtering.
  * Report summaries handle missing labels more consistently.

* **Style**
  * Updated report titles to “Surgery Cost Estimation.”
  * Simplified the patient filter label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->