### PR TITLE
fix(inward): deduct deposit/payment refunds and cancellations in Invoice Journal

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardInvoiceJournalController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardInvoiceJournalController.java
@@ -213,6 +213,24 @@ public class InwardInvoiceJournalController implements Serializable {
      * total, NOT a deposit — a naming bug from before issue #22804 split Payment
      * and Deposit into separate BillTypeAtomic families. See
      * {@link #fetchDepositTotalsByEncounter(List)} for the genuine deposit total.
+     *
+     * Matches the full INWARD_PAYMENT family — {@code INWARD_PAYMENT},
+     * {@code INWARD_PAYMENT_CANCELLATION}, {@code INWARD_PAYMENT_REFUND} and
+     * {@code INWARD_PAYMENT_REFUND_CANCELLATION} — and deliberately does NOT
+     * filter on {@code bill.cancelled}: neither cancelling nor refunding a
+     * payment flags the original bill as cancelled. A cancellation sets
+     * {@code cancelled=true} on the original but records the reversal as its
+     * own Payment row under the CANCELLATION billTypeAtomic, while a refund
+     * leaves the original bill untouched (only {@code refunded=true}) and
+     * creates a brand-new RefundBill with its own billTypeAtomic and a
+     * negative {@code netTotal}/{@code paidValue} (see
+     * {@code InwardRefundController.saveBill()}). Filtering to a single
+     * billTypeAtomic and/or excluding cancelled bills would leave a refunded
+     * or cancelled payment at its full, un-deducted value. Including every
+     * row and summing {@code p.paidValue} with its already-correct sign (no
+     * {@code Math.abs()} here or in {@link #buildRow}) nets them out
+     * correctly. Mirrors the same 4-type pattern already used for BHT reports
+     * in {@code InwardReportControllerBht}. Issue #23539.
      * Returns Map< encounterId, totalFinalPayment >.
      */
     private Map<Long, Double> fetchFinalPaymentTotalsByEncounter(List<PatientEncounter> encounters) {
@@ -222,13 +240,18 @@ public class InwardInvoiceJournalController implements Serializable {
                 + " from Payment p"
                 + " where p.retired = false"
                 + " and p.bill.retired = false"
-                + " and p.bill.cancelled = false"
-                + " and p.bill.billTypeAtomic = :bta"
+                + " and p.bill.billTypeAtomic in :btas"
                 + " and p.bill.patientEncounter in :encs"
                 + " group by p.bill.patientEncounter.id";
 
+        List<BillTypeAtomic> btas = new ArrayList<>();
+        btas.add(BillTypeAtomic.INWARD_PAYMENT);
+        btas.add(BillTypeAtomic.INWARD_PAYMENT_CANCELLATION);
+        btas.add(BillTypeAtomic.INWARD_PAYMENT_REFUND);
+        btas.add(BillTypeAtomic.INWARD_PAYMENT_REFUND_CANCELLATION);
+
         Map<String, Object> params = new HashMap<>();
-        params.put("bta",  BillTypeAtomic.INWARD_PAYMENT);
+        params.put("btas", btas);
         params.put("encs", encounters);
 
         List<Object[]> rows = patientEncounterFacade.findObjectArrayByJpql(jpql, params, TemporalType.TIMESTAMP);
@@ -247,6 +270,24 @@ public class InwardInvoiceJournalController implements Serializable {
      * BillTypeAtomic.INWARD_DEPOSIT) grouped by encounter. Added by issue
      * #23518 alongside {@link #fetchFinalPaymentTotalsByEncounter(List)} once
      * Payment and Deposit were confirmed to be separate BillTypeAtomic families.
+     *
+     * Matches the full INWARD_DEPOSIT family — {@code INWARD_DEPOSIT},
+     * {@code INWARD_DEPOSIT_CANCELLATION}, {@code INWARD_DEPOSIT_REFUND} and
+     * {@code INWARD_DEPOSIT_REFUND_CANCELLATION} — and deliberately does NOT
+     * filter on {@code bill.cancelled}: neither cancelling nor refunding a
+     * deposit flags the original bill as cancelled. A cancellation sets
+     * {@code cancelled=true} on the original but records the reversal as its
+     * own Payment row under the CANCELLATION billTypeAtomic, while a refund
+     * leaves the original bill untouched (only {@code refunded=true}) and
+     * creates a brand-new RefundBill with its own billTypeAtomic and a
+     * negative {@code netTotal}/{@code paidValue} (see
+     * {@code InwardRefundController.saveBill()}). Filtering to a single
+     * billTypeAtomic and/or excluding cancelled bills would leave a refunded
+     * or cancelled deposit at its full, un-deducted value. Including every
+     * row and summing {@code p.paidValue} with its already-correct sign (no
+     * {@code Math.abs()} here or in {@link #buildRow}) nets them out
+     * correctly. Mirrors the same 4-type pattern already used for BHT reports
+     * in {@code InwardReportControllerBht}. Issue #23539.
      * Returns Map< encounterId, totalDeposit >.
      */
     private Map<Long, Double> fetchDepositTotalsByEncounter(List<PatientEncounter> encounters) {
@@ -256,13 +297,18 @@ public class InwardInvoiceJournalController implements Serializable {
                 + " from Payment p"
                 + " where p.retired = false"
                 + " and p.bill.retired = false"
-                + " and p.bill.cancelled = false"
-                + " and p.bill.billTypeAtomic = :bta"
+                + " and p.bill.billTypeAtomic in :btas"
                 + " and p.bill.patientEncounter in :encs"
                 + " group by p.bill.patientEncounter.id";
 
+        List<BillTypeAtomic> btas = new ArrayList<>();
+        btas.add(BillTypeAtomic.INWARD_DEPOSIT);
+        btas.add(BillTypeAtomic.INWARD_DEPOSIT_CANCELLATION);
+        btas.add(BillTypeAtomic.INWARD_DEPOSIT_REFUND);
+        btas.add(BillTypeAtomic.INWARD_DEPOSIT_REFUND_CANCELLATION);
+
         Map<String, Object> params = new HashMap<>();
-        params.put("bta",  BillTypeAtomic.INWARD_DEPOSIT);
+        params.put("btas", btas);
         params.put("encs", encounters);
 
         List<Object[]> rows = patientEncounterFacade.findObjectArrayByJpql(jpql, params, TemporalType.TIMESTAMP);

--- a/src/main/java/com/divudi/bean/inward/InwardInvoiceJournalController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardInvoiceJournalController.java
@@ -217,8 +217,7 @@ public class InwardInvoiceJournalController implements Serializable {
      * Matches the full INWARD_PAYMENT family — {@code INWARD_PAYMENT},
      * {@code INWARD_PAYMENT_CANCELLATION}, {@code INWARD_PAYMENT_REFUND} and
      * {@code INWARD_PAYMENT_REFUND_CANCELLATION} — and deliberately does NOT
-     * filter on {@code bill.cancelled}: neither cancelling nor refunding a
-     * payment flags the original bill as cancelled. A cancellation sets
+     * filter on {@code bill.cancelled}: a cancellation sets
      * {@code cancelled=true} on the original but records the reversal as its
      * own Payment row under the CANCELLATION billTypeAtomic, while a refund
      * leaves the original bill untouched (only {@code refunded=true}) and
@@ -274,8 +273,7 @@ public class InwardInvoiceJournalController implements Serializable {
      * Matches the full INWARD_DEPOSIT family — {@code INWARD_DEPOSIT},
      * {@code INWARD_DEPOSIT_CANCELLATION}, {@code INWARD_DEPOSIT_REFUND} and
      * {@code INWARD_DEPOSIT_REFUND_CANCELLATION} — and deliberately does NOT
-     * filter on {@code bill.cancelled}: neither cancelling nor refunding a
-     * deposit flags the original bill as cancelled. A cancellation sets
+     * filter on {@code bill.cancelled}: a cancellation sets
      * {@code cancelled=true} on the original but records the reversal as its
      * own Payment row under the CANCELLATION billTypeAtomic, while a refund
      * leaves the original bill untouched (only {@code refunded=true}) and


### PR DESCRIPTION
## Summary

Fixes #23539 — refunding (or cancelling) an inpatient deposit/payment left the **Inpatient Invoice Journal**'s Total Deposit / Total Final Payment columns unchanged at the full, un-deducted value.

## Root Cause

`InwardInvoiceJournalController.fetchDepositTotalsByEncounter()` and `fetchFinalPaymentTotalsByEncounter()` each summed `Payment.paidValue` filtered to a **single** `billTypeAtomic` (`INWARD_DEPOSIT` / `INWARD_PAYMENT`) and excluded `bill.cancelled = true`.

Refunding a deposit/payment does **not** cancel the original bill — `InwardRefundController.saveBill()`/`pay()` sets `originalBillToRefund.setRefunded(true)` and creates a brand-new `RefundBill` with its own `billTypeAtomic` (`INWARD_DEPOSIT_REFUND` / `INWARD_PAYMENT_REFUND`) and a **negative** `netTotal`/`paidValue`. Because the query only matched the single original type, the refund's Payment was invisible to it — the deposit/payment stayed at full value forever. Cancellations have the identical gap (`INWARD_DEPOSIT_CANCELLATION` / `INWARD_PAYMENT_CANCELLATION`), and a cancelled refund adds a further `_REFUND_CANCELLATION` type.

## Fix

Both methods now match the full 4-type family already established elsewhere in the codebase for exactly this scenario — `InwardReportControllerBht.navigateToInpatientPaymentBillListDto()`/`navigateToInwardPaymentBillListForDepartment()` (issue #22783):

- Deposit: `INWARD_DEPOSIT` + `INWARD_DEPOSIT_CANCELLATION` + `INWARD_DEPOSIT_REFUND` + `INWARD_DEPOSIT_REFUND_CANCELLATION`
- Payment: `INWARD_PAYMENT` + `INWARD_PAYMENT_CANCELLATION` + `INWARD_PAYMENT_REFUND` + `INWARD_PAYMENT_REFUND_CANCELLATION`

Dropped the `bill.cancelled = false` filter; `paidValue` was already summed with its natural sign (no `Math.abs()` anywhere in this file), so a refund/cancellation nets out correctly once it's included — same signed-sum approach as #23541/PR #23542.

Scope note: this was expanded from the literal bug report (deposit refunds only) to also fix the structurally-identical, not-yet-reported gap in the sibling "Make a Payment" total query in the same file — confirmed with the user before implementing.

No entity/DTO/XHTML changes; `InwardInvoiceJournalRowDto` fields are unchanged plain doubles.

## Verification

Local Payara, `coop` DB, department **Inward**, test admission **BHT/57817** (synthetic "Test Multi Surgery Patient", currently admitted):

1. **Menu path**: *Inward → Inpatient Analytics → Search → Admissions* → find BHT/57817 → **Inpatient Dashboard** → **Make a Deposit** (Rs 5,000 Cash) → **Refund** (Rs 1,000 Cash).
2. DB confirms exactly the predicted shape:
   | Bill | billTypeAtomic | refunded | netTotal | Payment.paidValue |
   |---|---|---|---|---|
   | `Inward//26/050546` | INWARD_DEPOSIT | true | 5000 | 5000 |
   | `Inward//26/050547` | INWARD_DEPOSIT_REFUND | false | -1000 | -1000 |
3. **Menu path**: *Inward → Inpatient Analytics → Payment Reports (BHT Summary Reports tab) → Inpatient Invoice Journal*, Admission Status = "Admitted but not discharged", Generate.
4. BHT/57817's row: **Total Deposit = 4,000.00** (was 5,000.00 before the fix, since the -1,000 refund is now included).
5. Cross-checked with a direct DB query summing `Payment.paidValue` across all 4 deposit billTypeAtomic values for the encounter: **4000** — matches exactly.

![Inpatient Invoice Journal report showing Total Deposit correctly reduced after a partial refund](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23539-invoice-journal-refund-deducted.png)

*BHT/57817 (test patient): Rs 5,000 deposit + Rs 1,000 refund now shows Total Deposit = 4,000.00. Other rows' patient names redacted.*

## Documentation

- [Finance – Inpatient Invoice Journal](https://github.com/hmislk/hmis/wiki/Finance-Inpatient-Invoice-Journal) — updated the Total Deposit/Total Final Payment column descriptions and added a note + screenshot explaining the fix

Closes #23539

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Payment and deposit totals now accurately account for refunds, cancellations, and refund cancellations.
  * Cancelled transactions are included in calculations so net totals reflect signed payment values.

* **Documentation**
  * Clarified the documented behavior for payment and deposit total calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->