### PR TITLE
fix(inward): stop splitting professional and assisting fees when the merge option is on

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -2692,6 +2692,32 @@ from the component's full client id, not the plain `id` attribute, so don't gues
 commit by reading `document.getElementById('<formId>:<fieldId>:dpDob_input').value` before
 submitting. Verified while testing issue #23509 (baby admission with no NIC/phone).
 
+## A third-level menu item can't be clicked directly — fire its own `onclick`, which is still the menu path, not URL navigation
+
+`Inpatient → Billing → Interim Bill` is three levels deep. Clicking the top-level item opens the
+second level, but the third-level flyout closes again before Playwright can reach the item:
+`click`, `hover`, and `:has-text()` selectors all fail with *element is not visible*, and clicking
+the parent a second time just toggles the whole menu shut.
+
+**Do not fall back to typing the page URL** — §2 explains why that produces false findings. Instead
+invoke the menu item's own anchor:
+
+```js
+() => { const a = Array.from(document.querySelectorAll('.ui-menubar a'))
+          .find(x => x.textContent.trim() === 'Interim Bill');
+        a.click(); }
+```
+
+This is genuinely equivalent to a user's click, not a shortcut around it. The anchor carries the
+menu's own handler —
+`PrimeFaces.addSubmitParam('...:menuForm', {...}).submit('...:menuForm')` — so the JSF action, and
+therefore the `@SessionScoped` navigation method behind it, runs exactly as it does for a real
+click. The page lands with its state populated, which is the whole point of the URL rule. Check the
+anchor's `onclick` attribute first: if it submits the menu form, this is safe; if it is a plain
+`href` to a page, you are back to URL navigation and must find another route.
+
+Verified while testing issue #23543 (professional/assisting fee merge).
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.
@@ -2714,3 +2740,4 @@ submitting. Verified while testing issue #23509 (baby admission with no NIC/phon
 - [ ] Treated a greyed-out admin **Add New**/**Edit** as "wrong department for that privilege row" (§20) before assuming the page is broken.
 - [ ] When a Save did nothing with a clean `server.log` and an unchanged DB, read the form's `<p:messages>` **by id** and grepped the page for `required="true"` (§91) before hunting the controller.
 - [ ] For a guard fix: asserted the **action actually executed** (expected message in the response) before treating unchanged DB state as proof — a JSF-disabled button skips its action entirely — and ran the negative test (clean record still succeeds), reverting it through the app.
+- [ ] For a menu item nested three levels deep, fired the anchor's own `onclick` (which submits the menu form, so the navigation method still runs) instead of falling back to typing the page URL.

--- a/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
+++ b/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
@@ -1563,6 +1563,27 @@ public class ConfigOptionApplicationController implements Serializable {
     }
 
     /**
+     * Key of the option that makes a hospital treat assisting (non-Consultant)
+     * professional fees as ordinary professional charges.
+     */
+    public static final String PROFESSIONAL_AND_ASSISTING_FEES_MERGED
+            = "Professional Fee and Assisting Fees are shown as one charge type on the final bill.";
+
+    /**
+     * True when professional and assisting fees are a single professional
+     * charge for this hospital, i.e. {@code InwardChargeType.DoctorAndNurses}
+     * should not appear anywhere — not as a bill row, a report column, or a
+     * selectable charge type.
+     *
+     * <p>Read-only on purpose: this is consulted from {@code rendered="..."}
+     * gates and from charge-type list building, neither of which should create
+     * a ConfigOption row just because a page was viewed.
+     */
+    public boolean isProfessionalAndAssistingFeesMerged() {
+        return getBooleanValueByKeyReadOnly(PROFESSIONAL_AND_ASSISTING_FEES_MERGED, false);
+    }
+
+    /**
      * Read-only variant of {@link #getBooleanValueByKey(String, boolean)} —
      * returns {@code defaultValue} without persisting a new ConfigOption row
      * when the key does not yet exist. Use this for {@code rendered="..."}

--- a/src/main/java/com/divudi/bean/common/EnumController.java
+++ b/src/main/java/com/divudi/bean/common/EnumController.java
@@ -46,6 +46,9 @@ public class EnumController implements Serializable {
     @Inject
     ConfigOptionApplicationController configOptionApplicationController;
 
+    @EJB
+    com.divudi.service.inward.InwardProfessionalFeeClassificationService professionalFeeClassificationService;
+
     // PaymentScheme removed from instance field to avoid cross-user state in ApplicationScoped bean
     // Use local variables or session-scoped beans for user-specific state
     private List<Class<? extends Enum<?>>> enumList;
@@ -772,14 +775,20 @@ public class EnumController implements Serializable {
         return tmp;
     }
 
+    /**
+     * Every inward charge type the hospital actually uses. A hospital that merges
+     * assisting fees into professional fees does not have an Assisting Charge at
+     * all, so it is filtered out here rather than at each call site (issue #23543).
+     */
     public InwardChargeType[] getInwardChargeTypes() {
-        return InwardChargeType.values();
+        return professionalFeeClassificationService.visible(InwardChargeType.values());
     }
 
     public InwardChargeType[] getInwardChargeTypesForSetting() {
-        return Arrays.stream(InwardChargeType.values())
+        InwardChargeType[] settable = Arrays.stream(InwardChargeType.values())
                 .filter(InwardChargeType::isAllowToSetItems)
                 .toArray(InwardChargeType[]::new);
+        return professionalFeeClassificationService.visible(settable);
     }
 
     public PatientEncounterComponentType[] getPatientEncounterComponentTypes() {

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -175,7 +175,6 @@ public class BhtSummeryController implements Serializable {
     private Map<Long, BillItem> latestCheckedBillItemsByItem;
     private List<BillFee> profesionallFee;
     private List<BillFee> doctorAndNurseFee;
-    private List<BillFee> allDoctorCharges;
     // Holds the doctor whose fee breakdown is shown in the "how the total is calculated" popup.
     private DoctorFeeGroup selectedDoctorFeeGroup;
     List<BillItem> pharmacyItems;
@@ -3421,23 +3420,6 @@ public class BhtSummeryController implements Serializable {
         childPatientEncouters = getInwardBean().fetchChildPatientEncounter(patientEncounter);
         createTables();
 
-        if (configOptionApplicationController.getBooleanValueByKey("Professional Fee and Assisting Fees are shown as one charge type on the final bill.", false)) {
-            // Both lists already have feeAdjusted = feeValue (set by setProfesionallFeeAdjusted /
-            // setAssistingFeeAdjusted in createTables), so the merged list shows matching adjusted values.
-            allDoctorCharges = new ArrayList<>();
-            allDoctorCharges.addAll(profesionallFee);
-            allDoctorCharges.addAll(doctorAndNurseFee);
-
-            profesionallFee.clear();
-            doctorAndNurseFee.clear();
-
-            profesionallFee.addAll(allDoctorCharges);
-
-            allDoctorCharges.clear();
-
-            createChargeItemTotals();
-        }
-
         calculateDiscount();
         updateTotal();
         settleOriginalBill();
@@ -4081,7 +4063,6 @@ public class BhtSummeryController implements Serializable {
         paid = 0.0;
         profesionallFee = null;
         doctorAndNurseFee = null;
-        allDoctorCharges = null;
         patientItems = null;
         paymentBill = null;
         postFinalPaymentBill = null;
@@ -5152,30 +5133,18 @@ public class BhtSummeryController implements Serializable {
             docVat += bf.getFeeVat();
         }
 
-        boolean mergedProAndDoc = configOptionApplicationController.getBooleanValueByKey(
-                "Professional Fee and Assisting Fees are shown as one charge type on the final bill.", false);
-
+        // No merge special case: for a merged hospital getProfesionallFee() already
+        // holds every fee and getDoctorAndNurseFee() is empty, and the assisting
+        // ChargeItemTotal does not exist at all (issue #23543).
         for (ChargeItemTotal cit : chargeItemTotals) {
             if (cit.getInwardChargeType() == InwardChargeType.ProfessionalCharge) {
-                if (mergedProAndDoc) {
-                    cit.setGross(proGross + docGross);
-                    cit.setMargin(proMargin + docMargin);
-                    cit.setVat(proVat + docVat);
-                } else {
-                    cit.setGross(proGross);
-                    cit.setMargin(proMargin);
-                    cit.setVat(proVat);
-                }
+                cit.setGross(proGross);
+                cit.setMargin(proMargin);
+                cit.setVat(proVat);
             } else if (cit.getInwardChargeType() == InwardChargeType.DoctorAndNurses) {
-                if (mergedProAndDoc) {
-                    cit.setGross(0.0);
-                    cit.setMargin(0.0);
-                    cit.setVat(0.0);
-                } else {
-                    cit.setGross(docGross);
-                    cit.setMargin(docMargin);
-                    cit.setVat(docVat);
-                }
+                cit.setGross(docGross);
+                cit.setMargin(docMargin);
+                cit.setVat(docVat);
             } else if (cit.getInwardChargeType() == InwardChargeType.AdmissionFee) {
                 cit.setGross(cit.getTotal());
                 cit.setMargin(0.0);
@@ -5403,20 +5372,11 @@ public class BhtSummeryController implements Serializable {
                     i.setTotal(getInwardBean().calNetCostOfIssue(getPatientEncounter(), BillType.StoreBhtPre, childPatientEncouters));
                     break;
                 case ProfessionalCharge:
-                    if (configOptionApplicationController.getBooleanValueByKey("Professional Fee and Assisting Fees are shown as one charge type on the final bill.", false)) {
-                        double professionalFee = getInwardBean().calculateProfessionalCharges(getPatientEncounter(), childPatientEncouters, estimatedBillView);
-                        double assistingFee = getInwardBean().calculateDoctorAndNurseCharges(getPatientEncounter(), childPatientEncouters);
-                        i.setTotal(professionalFee + assistingFee);
-                    } else {
-                        i.setTotal(getInwardBean().calculateProfessionalCharges(getPatientEncounter(), childPatientEncouters, estimatedBillView));
-                    }
+                    // Already covers assisting fees for a merged hospital.
+                    i.setTotal(getInwardBean().calculateProfessionalCharges(getPatientEncounter(), childPatientEncouters, estimatedBillView));
                     break;
                 case DoctorAndNurses:
-                    if (configOptionApplicationController.getBooleanValueByKey("Professional Fee and Assisting Fees are shown as one charge type on the final bill.", false)) {
-                        i.setTotal(0.0);
-                    } else {
-                        i.setTotal(getInwardBean().calculateDoctorAndNurseCharges(getPatientEncounter(), childPatientEncouters));
-                    }
+                    i.setTotal(getInwardBean().calculateDoctorAndNurseCharges(getPatientEncounter(), childPatientEncouters));
                     break;
             }
         }
@@ -5901,14 +5861,6 @@ public class BhtSummeryController implements Serializable {
             return null;
         }
         return (pr.getMarginRoomCharge() / slotRate) * 100.0;
-    }
-
-    public List<BillFee> getAllDoctorCharges() {
-        return allDoctorCharges;
-    }
-
-    public void setAllDoctorCharges(List<BillFee> allDoctorCharges) {
-        this.allDoctorCharges = allDoctorCharges;
     }
 
     public static class RoomDurationBreakdown {

--- a/src/main/java/com/divudi/bean/inward/InwardBeanController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardBeanController.java
@@ -22,7 +22,6 @@ import com.divudi.core.entity.BillFee;
 import com.divudi.core.entity.BillItem;
 import com.divudi.core.entity.BilledBill;
 import com.divudi.core.entity.CancelledBill;
-import com.divudi.core.entity.Consultant;
 import com.divudi.core.entity.Department;
 import com.divudi.core.entity.Fee;
 import com.divudi.core.entity.Institution;
@@ -134,6 +133,8 @@ public class InwardBeanController implements Serializable {
     ConfigOptionApplicationController configOptionApplicationController;
     @Inject
     com.divudi.bean.common.PriceMatrixController priceMatrixController;
+    @Inject
+    com.divudi.service.inward.InwardProfessionalFeeClassificationService professionalFeeClassificationService;
 
     private Long lastGeneratedBhtLong;
 
@@ -650,10 +651,9 @@ public class InwardBeanController implements Serializable {
         String sql = "SELECT sum(bt.feeValue)"
                 + " FROM BillFee bt"
                 + " WHERE bt.retired=false"
-                + " and type(bt.staff)=:class "
+                + professionalFeeClassificationService.staffCondition("bt", InwardChargeType.ProfessionalCharge, hm)
                 + " and bt.fee.feeType=:ftp  "
                 + " and bt.bill.patientEncounter IN :pe";
-        hm.put("class", Consultant.class);
         hm.put("ftp", FeeType.Staff);
         //  hm.put("btp", BillType.InwardBill);
 
@@ -855,15 +855,19 @@ public class InwardBeanController implements Serializable {
     }
 
     public List<BillFee> createDoctorAndNurseFee(PatientEncounter patientEncounter, List<PatientEncounter> cpts) {
+        if (professionalFeeClassificationService.isSuppressed(InwardChargeType.DoctorAndNurses)) {
+            // Merged hospital: there are no assisting fees — every fee is already
+            // returned by createProfesionallFee().
+            return new ArrayList<>();
+        }
 
         HashMap hm = new HashMap();
         String sql = "SELECT bt FROM BillFee bt WHERE "
                 + " bt.retired=false "
-                + " and type(bt.staff)!=:class "
+                + professionalFeeClassificationService.staffCondition("bt", InwardChargeType.DoctorAndNurses, hm)
                 + " and bt.fee.feeType=:ftp "
                 + " and (bt.bill.billType=:btp)"
                 + " and bt.bill.patientEncounter IN :pe ";
-        hm.put("class", Consultant.class);
         hm.put("ftp", FeeType.Staff);
         hm.put("btp", BillType.InwardProfessional);
         List<PatientEncounter> pts = new ArrayList<>();
@@ -881,12 +885,11 @@ public class InwardBeanController implements Serializable {
         HashMap hm = new HashMap();
         String sql = "SELECT bt FROM BillFee bt WHERE "
                 + " bt.retired=false "
-                + " and type(bt.staff)=:class "
+                + professionalFeeClassificationService.staffCondition("bt", InwardChargeType.ProfessionalCharge, hm)
                 + " and bt.fee.feeType=:ftp "
                 + " and (bt.bill.billType=:btp)"
                 + " and bt.bill.patientEncounter IN :pe "
                 + " order by bt.feeAdjusted desc ";
-        hm.put("class", Consultant.class);
         hm.put("ftp", FeeType.Staff);
         hm.put("btp", BillType.InwardProfessional);
         List<PatientEncounter> pts = new ArrayList<>();
@@ -905,12 +908,11 @@ public class InwardBeanController implements Serializable {
         HashMap hm = new HashMap();
         String sql = "SELECT bt FROM BillFee bt WHERE "
                 + " bt.retired=false "
-                + " and type(bt.staff)=:class "
+                + professionalFeeClassificationService.staffCondition("bt", InwardChargeType.ProfessionalCharge, hm)
                 + " and bt.fee.feeType=:ftp "
                 + " and (bt.bill.billType=:btp)"
                 + " and bt.bill.patientEncounter=:pe "
                 + " order by bt.feeAdjusted desc ";
-        hm.put("class", Consultant.class);
         hm.put("ftp", FeeType.Staff);
         hm.put("btp", BillType.InwardProfessionalEstimates);
         hm.put("pe", patientEncounter);
@@ -929,11 +931,10 @@ public class InwardBeanController implements Serializable {
         HashMap hm = new HashMap();
         String sql = "UPDATE BillFee bt SET bt.feeAdjusted = bt.feeValue"
                 + " WHERE bt.retired=false"
-                + " AND type(bt.staff)=:class"
+                + professionalFeeClassificationService.staffCondition("bt", InwardChargeType.ProfessionalCharge, hm)
                 + " AND bt.fee.feeType=:ftp"
                 + " AND bt.bill.billType=:btp"
                 + " AND bt.bill.patientEncounter IN :pe";
-        hm.put("class", Consultant.class);
         hm.put("ftp", FeeType.Staff);
         hm.put("btp", BillType.InwardProfessional);
         hm.put("pe", pts);
@@ -947,6 +948,10 @@ public class InwardBeanController implements Serializable {
      * Adjusted Fee columns always match - exactly as they do for consultants.
      */
     public void setAssistingFeeAdjusted(PatientEncounter patientEncounter, List<PatientEncounter> cpts) {
+        if (professionalFeeClassificationService.isSuppressed(InwardChargeType.DoctorAndNurses)) {
+            // Merged hospital: setProfesionallFeeAdjusted() already covers every fee.
+            return;
+        }
         List<PatientEncounter> pts = new ArrayList<>();
         pts.add(patientEncounter);
         if (cpts != null && !cpts.isEmpty()) {
@@ -955,11 +960,10 @@ public class InwardBeanController implements Serializable {
         HashMap hm = new HashMap();
         String sql = "UPDATE BillFee bt SET bt.feeAdjusted = bt.feeValue"
                 + " WHERE bt.retired=false"
-                + " AND type(bt.staff)!=:class"
+                + professionalFeeClassificationService.staffCondition("bt", InwardChargeType.DoctorAndNurses, hm)
                 + " AND bt.fee.feeType=:ftp"
                 + " AND bt.bill.billType=:btp"
                 + " AND bt.bill.patientEncounter IN :pe";
-        hm.put("class", Consultant.class);
         hm.put("ftp", FeeType.Staff);
         hm.put("btp", BillType.InwardProfessional);
         hm.put("pe", pts);
@@ -1336,16 +1340,19 @@ public class InwardBeanController implements Serializable {
     }
 
     public double calculateDoctorAndNurseCharges(PatientEncounter patientEncounter, List<PatientEncounter> cpts) {
+        if (professionalFeeClassificationService.isSuppressed(InwardChargeType.DoctorAndNurses)) {
+            // Merged hospital: calculateProfessionalCharges() already includes these fees.
+            return 0.0;
+        }
 
         HashMap hm = new HashMap();
         String sql = "SELECT sum(bt.feeValue)"
                 + " FROM BillFee bt"
                 + " WHERE bt.retired=false"
-                + " and type(bt.staff)!=:class "
+                + professionalFeeClassificationService.staffCondition("bt", InwardChargeType.DoctorAndNurses, hm)
                 + " and bt.fee.feeType=:ftp  "
                 + " and (bt.bill.billType=:btp2) "
                 + " and bt.bill.patientEncounter IN :pe";
-        hm.put("class", Consultant.class);
         hm.put("ftp", FeeType.Staff);
         //     hm.put("btp", BillType.InwardBill);
         hm.put("btp2", BillType.InwardProfessional);

--- a/src/main/java/com/divudi/bean/inward/InwardChargeTypeBreakdownController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardChargeTypeBreakdownController.java
@@ -145,6 +145,14 @@ public class InwardChargeTypeBreakdownController implements Serializable {
             return;
         }
 
+        // Only reachable with a selection made before the merge setting was turned
+        // on — the picker does not offer a suppressed charge type (issue #23543).
+        if (professionalFeeClassificationService.isSuppressed(selectedChargeType)) {
+            errorMessage = "This hospital bills professional and assisting fees as one charge type,"
+                    + " so there are no separate assisting charges. Select Professional Charge instead.";
+            return;
+        }
+
         if ("dischargeDate".equals(dateBasis)
                 && admissionStatus == AdmissionStatus.ADMITTED_BUT_NOT_DISCHARGED) {
             errorMessage = "Cannot filter by discharge date for patients not yet discharged.";
@@ -619,10 +627,6 @@ public class InwardChargeTypeBreakdownController implements Serializable {
     // -------------------------------------------------------------------------
 
     private void buildFromBillFees() {
-        if (professionalFeeClassificationService.isSuppressed(selectedChargeType)) {
-            return;
-        }
-
         Map<String, Object> params = new HashMap<>();
 
         StringBuilder jpql = new StringBuilder(

--- a/src/main/java/com/divudi/bean/inward/InwardChargeTypeBreakdownController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardChargeTypeBreakdownController.java
@@ -64,6 +64,8 @@ public class InwardChargeTypeBreakdownController implements Serializable {
     private ConfigOptionApplicationController configOptionApplicationController;
     @Inject
     private BillBeanController billBeanController;
+    @EJB
+    private com.divudi.service.inward.InwardProfessionalFeeClassificationService professionalFeeClassificationService;
 
     // -------------------------------------------------------------------------
     // Filter fields
@@ -617,14 +619,22 @@ public class InwardChargeTypeBreakdownController implements Serializable {
     // -------------------------------------------------------------------------
 
     private void buildFromBillFees() {
+        if (professionalFeeClassificationService.isSuppressed(selectedChargeType)) {
+            return;
+        }
+
+        Map<String, Object> params = new HashMap<>();
+
         StringBuilder jpql = new StringBuilder(
                 "select bf from BillFee bf join bf.bill b join b.patientEncounter enc"
                 + " where bf.retired = false"
                 + " and b.retired = false"
                 + " and b.cancelled = false"
-                + " and b.billType = :btp");
+                + " and b.billType = :btp"
+                // Without this both professional charge types pivoted the same full set
+                // of fees, so either selection produced an identical table (issue #23543).
+                + professionalFeeClassificationService.staffCondition("bf", selectedChargeType, params));
 
-        Map<String, Object> params = new HashMap<>();
         params.put("btp", BillType.InwardProfessional);
         appendEncounterFilters(jpql, params, "enc");
 
@@ -783,13 +793,13 @@ public class InwardChargeTypeBreakdownController implements Serializable {
     // -------------------------------------------------------------------------
 
     public List<InwardChargeType> getAllChargeTypes() {
-        return Arrays.asList(InwardChargeType.values());
+        return professionalFeeClassificationService.visible(Arrays.asList(InwardChargeType.values()));
     }
 
     public List<InwardChargeType> completeInwardChargeType(String query) {
         String lower = query == null ? "" : query.toLowerCase();
         List<InwardChargeType> results = new ArrayList<>();
-        for (InwardChargeType ct : InwardChargeType.values()) {
+        for (InwardChargeType ct : professionalFeeClassificationService.visible(InwardChargeType.values())) {
             String label = configOptionApplicationController.getInwardChargeTypeLabel(ct);
             if (label == null) {
                 label = "";

--- a/src/main/java/com/divudi/bean/inward/InwardChargeTypeDetailController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardChargeTypeDetailController.java
@@ -106,6 +106,14 @@ public class InwardChargeTypeDetailController implements Serializable {
             return;
         }
 
+        // Only reachable with a selection made before the merge setting was turned
+        // on — the picker does not offer a suppressed charge type (issue #23543).
+        if (professionalFeeClassificationService.isSuppressed(selectedChargeType)) {
+            errorMessage = "This hospital bills professional and assisting fees as one charge type,"
+                    + " so there are no separate assisting charges. Select Professional Charge instead.";
+            return;
+        }
+
         // Reject impossible filter: discharge date range requires discharged patients
         if ("dischargeDate".equals(dateBasis)
                 && admissionStatus == AdmissionStatus.ADMITTED_BUT_NOT_DISCHARGED) {
@@ -362,9 +370,6 @@ public class InwardChargeTypeDetailController implements Serializable {
      */
     private List<InwardChargeTypeDetailRowDto> fetchProfessionalFeeRows() {
         if (selectedChargeType.getCalculationMethod() != CalculationMethod.BILL_FEE) {
-            return new ArrayList<>();
-        }
-        if (professionalFeeClassificationService.isSuppressed(selectedChargeType)) {
             return new ArrayList<>();
         }
         Map<String, Object> params = new HashMap<>();

--- a/src/main/java/com/divudi/bean/inward/InwardChargeTypeDetailController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardChargeTypeDetailController.java
@@ -58,6 +58,8 @@ public class InwardChargeTypeDetailController implements Serializable {
     private PatientEncounterFacade patientEncounterFacade;
     @Inject
     private ConfigOptionApplicationController configOptionApplicationController;
+    @EJB
+    private com.divudi.service.inward.InwardProfessionalFeeClassificationService professionalFeeClassificationService;
 
     // -------------------------------------------------------------------------
     // Filter fields
@@ -362,13 +364,20 @@ public class InwardChargeTypeDetailController implements Serializable {
         if (selectedChargeType.getCalculationMethod() != CalculationMethod.BILL_FEE) {
             return new ArrayList<>();
         }
+        if (professionalFeeClassificationService.isSuppressed(selectedChargeType)) {
+            return new ArrayList<>();
+        }
+        Map<String, Object> params = new HashMap<>();
         StringBuilder jpql = new StringBuilder(
                 "select bf from BillFee bf join bf.bill b join b.patientEncounter enc"
                 + " where bf.retired = false"
                 + " and b.retired = false"
                 + " and b.cancelled = false"
-                + " and b.billType = :btp");
-        Map<String, Object> params = new HashMap<>();
+                + " and b.billType = :btp"
+                // Without this the professional and assisting charge types each returned
+                // every professional fee on the bill, so both drilled down to the same
+                // full list (issue #23543).
+                + professionalFeeClassificationService.staffCondition("bf", selectedChargeType, params));
         params.put("btp", BillType.InwardProfessional);
         appendEncounterFilters(jpql, params, "enc");
 
@@ -506,13 +515,13 @@ public class InwardChargeTypeDetailController implements Serializable {
     // -------------------------------------------------------------------------
 
     public List<InwardChargeType> getAllChargeTypes() {
-        return java.util.Arrays.asList(InwardChargeType.values());
+        return professionalFeeClassificationService.visible(java.util.Arrays.asList(InwardChargeType.values()));
     }
 
     public List<InwardChargeType> completeInwardChargeType(String query) {
         String lower = query == null ? "" : query.toLowerCase();
         List<InwardChargeType> results = new ArrayList<>();
-        for (InwardChargeType ct : InwardChargeType.values()) {
+        for (InwardChargeType ct : professionalFeeClassificationService.visible(InwardChargeType.values())) {
             String label = configOptionApplicationController.getInwardChargeTypeLabel(ct);
             if (label.toLowerCase().contains(lower) || ct.name().toLowerCase().contains(lower)) {
                 results.add(ct);

--- a/src/main/java/com/divudi/bean/inward/InwardInvoiceJournalController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardInvoiceJournalController.java
@@ -65,6 +65,8 @@ public class InwardInvoiceJournalController implements Serializable {
     private com.divudi.ejb.CreditBean creditBean;
     @Inject
     private ConfigOptionApplicationController configOptionApplicationController;
+    @EJB
+    private com.divudi.service.inward.InwardProfessionalFeeClassificationService professionalFeeClassificationService;
 
     // -------------------------------------------------------------------------
     // Filter fields
@@ -122,7 +124,7 @@ public class InwardInvoiceJournalController implements Serializable {
         // Recompute the column order from the admin-configurable Report Order
         // ConfigOption for each InwardChargeType (issue #23340). A stable
         // sort keeps ordinal order among types the admin has not reordered.
-        allChargeTypes = new ArrayList<>(Arrays.asList(InwardChargeType.values()));
+        allChargeTypes = professionalFeeClassificationService.visible(Arrays.asList(InwardChargeType.values()));
         allChargeTypes.sort(Comparator.comparingInt(configOptionApplicationController::getInwardChargeTypeReportOrder));
 
         reportRows               = new ArrayList<>();

--- a/src/main/java/com/divudi/bean/inward/SurgeryBillController.java
+++ b/src/main/java/com/divudi/bean/inward/SurgeryBillController.java
@@ -15,6 +15,7 @@ import com.divudi.core.data.BillNumberSuffix;
 import com.divudi.core.data.BillType;
 import com.divudi.core.data.FeeType;
 import com.divudi.core.data.dataStructure.DepartmentBillItems;
+import com.divudi.core.data.inward.InwardChargeType;
 import com.divudi.core.data.inward.PatientEncounterComponentType;
 import com.divudi.core.data.inward.SurgeryBillType;
 import com.divudi.ejb.BillNumberGenerator;
@@ -23,7 +24,6 @@ import com.divudi.core.entity.Bill;
 import com.divudi.core.entity.BillFee;
 import com.divudi.core.entity.BillItem;
 import com.divudi.core.entity.BilledBill;
-import com.divudi.core.entity.Consultant;
 import com.divudi.core.entity.PatientEncounter;
 import com.divudi.core.entity.PatientItem;
 import com.divudi.core.entity.PreBill;
@@ -116,6 +116,8 @@ public class SurgeryBillController implements Serializable {
     BhtSummeryController bhtSummeryController;
     @Inject
     AuditEventController auditEventController;
+    @Inject
+    com.divudi.service.inward.InwardProfessionalFeeClassificationService professionalFeeClassificationService;
     @EJB
     private AuditService auditService;
 
@@ -244,15 +246,14 @@ public class SurgeryBillController implements Serializable {
 
     public List<BillFee> getSurgeryProfessionalFees() {
         if (surgeryProfessionalFees == null && getSurgeryBill().getId() != null) {
+            HashMap<String, Object> hm = new HashMap<>();
             String jpql = "SELECT bt FROM BillFee bt WHERE bt.retired=false "
-                    + " and type(bt.staff)=:class "
+                    + professionalFeeClassificationService.staffCondition("bt", InwardChargeType.ProfessionalCharge, hm)
                     + " and bt.fee.feeType=:ftp "
                     + " and bt.bill.billType=:btp "
                     + " and bt.bill.cancelled=false "
                     + " and bt.bill.forwardReferenceBill=:surg "
                     + " order by bt.feeAdjusted desc";
-            HashMap<String, Object> hm = new HashMap<>();
-            hm.put("class", Consultant.class);
             hm.put("ftp", FeeType.Staff);
             hm.put("btp", BillType.InwardProfessional);
             hm.put("surg", getSurgeryBill());
@@ -262,15 +263,18 @@ public class SurgeryBillController implements Serializable {
     }
 
     public List<BillFee> getSurgeryAssistingFees() {
+        if (professionalFeeClassificationService.isSuppressed(InwardChargeType.DoctorAndNurses)) {
+            // Merged hospital: getSurgeryProfessionalFees() already returns these.
+            return new ArrayList<>();
+        }
         if (surgeryAssistingFees == null && getSurgeryBill().getId() != null) {
+            HashMap<String, Object> hm = new HashMap<>();
             String jpql = "SELECT bt FROM BillFee bt WHERE bt.retired=false "
-                    + " and type(bt.staff)!=:class "
+                    + professionalFeeClassificationService.staffCondition("bt", InwardChargeType.DoctorAndNurses, hm)
                     + " and bt.fee.feeType=:ftp "
                     + " and bt.bill.billType=:btp "
                     + " and bt.bill.cancelled=false "
                     + " and bt.bill.forwardReferenceBill=:surg";
-            HashMap<String, Object> hm = new HashMap<>();
-            hm.put("class", Consultant.class);
             hm.put("ftp", FeeType.Staff);
             hm.put("btp", BillType.InwardProfessional);
             hm.put("surg", getSurgeryBill());

--- a/src/main/java/com/divudi/service/inward/InwardBhtChargeAggregationService.java
+++ b/src/main/java/com/divudi/service/inward/InwardBhtChargeAggregationService.java
@@ -48,6 +48,8 @@ public class InwardBhtChargeAggregationService implements Serializable {
     private BillFeeFacade billFeeFacade;
     @EJB
     private PatientRoomFacade patientRoomFacade;
+    @EJB
+    private InwardProfessionalFeeClassificationService professionalFeeClassificationService;
 
     /** Filter parameters for fetchEncounters(), mirroring the report filter panels. */
     public static class EncounterFilter {
@@ -322,20 +324,25 @@ public class InwardBhtChargeAggregationService implements Serializable {
         return collectChargeTypeRows(rows);
     }
 
-    /** BILL_FEE — Consultant staff -> ProfessionalCharge. */
+    /** BILL_FEE — professional fees. Covers assisting fees too when the hospital merges them. */
     private Map<Long, Map<InwardChargeType, Double>> fetchProfessionalFeeCharges(List<PatientEncounter> encounters) {
-        return fetchBillFeeCharges(encounters, true, InwardChargeType.ProfessionalCharge);
+        return fetchBillFeeCharges(encounters, InwardChargeType.ProfessionalCharge);
     }
 
-    /** BILL_FEE — non-Consultant staff (assistants/nurses) -> DoctorAndNurses. */
+    /** BILL_FEE — assisting fees (non-Consultant staff). Empty for a merged hospital. */
     private Map<Long, Map<InwardChargeType, Double>> fetchAssistingFeeCharges(List<PatientEncounter> encounters) {
-        return fetchBillFeeCharges(encounters, false, InwardChargeType.DoctorAndNurses);
+        if (professionalFeeClassificationService.isSuppressed(InwardChargeType.DoctorAndNurses)) {
+            return new HashMap<>();
+        }
+        return fetchBillFeeCharges(encounters, InwardChargeType.DoctorAndNurses);
     }
 
     private Map<Long, Map<InwardChargeType, Double>> fetchBillFeeCharges(
-            List<PatientEncounter> encounters, boolean consultantOnly, InwardChargeType targetType) {
+            List<PatientEncounter> encounters, InwardChargeType targetType) {
 
         Map<Long, Map<InwardChargeType, Double>> result = new HashMap<>();
+
+        Map<String, Object> params = new HashMap<>();
 
         String jpql = "select bf.bill.patientEncounter.id, sum(coalesce(bf.feeGrossValue, bf.feeValue))"
                 + " from BillFee bf"
@@ -344,14 +351,12 @@ public class InwardBhtChargeAggregationService implements Serializable {
                 + " and bf.bill.cancelled = false"
                 + " and bf.bill.billType = :btp"
                 + " and bf.fee.feeType = :ftp"
-                + (consultantOnly ? " and type(bf.staff) = :staffClass" : " and type(bf.staff) != :staffClass")
+                + professionalFeeClassificationService.staffCondition("bf", targetType, params)
                 + " and bf.bill.patientEncounter in :encs"
                 + " group by bf.bill.patientEncounter.id";
 
-        Map<String, Object> params = new HashMap<>();
         params.put("btp", BillType.InwardProfessional);
         params.put("ftp", FeeType.Staff);
-        params.put("staffClass", Consultant.class);
         params.put("encs", encounters);
 
         List<Object[]> rows = billFeeFacade.findObjectArrayByJpql(jpql, params, TemporalType.TIMESTAMP);
@@ -496,15 +501,20 @@ public class InwardBhtChargeAggregationService implements Serializable {
     public Map<Long, double[]> fetchDiscountAndMarginSplitByProfessional(List<PatientEncounter> encounters) {
         Map<Long, double[]> result = new HashMap<>();
 
+        // When the hospital merges assisting fees into professional, "professional"
+        // widens to every staffed professional fee and "other" narrows by exactly the
+        // same rows, so the two buckets stay complementary in both configurations.
+        boolean merged = professionalFeeClassificationService.isMerged();
+
         String professionalJpql = "select bf.bill.patientEncounter.id, sum(bf.feeDiscount), sum(bf.feeMargin)"
-                + " from BillFee bf"
+                + " from BillFee bf left join bf.staff s"
                 + " where bf.retired = false"
                 + " and bf.bill.retired = false"
                 + " and bf.bill.cancelled = false"
                 + " and (bf.bill.billTypeAtomic is null or bf.bill.billTypeAtomic not in :excludedTypes)"
                 + " and bf.bill.billType = :btp"
                 + " and bf.fee.feeType = :ftp"
-                + " and type(bf.staff) = :staffClass"
+                + (merged ? " and s.id is not null" : " and type(s) = :staffClass")
                 + " and bf.bill.patientEncounter in :encs"
                 + " group by bf.bill.patientEncounter.id";
 
@@ -514,7 +524,8 @@ public class InwardBhtChargeAggregationService implements Serializable {
                 + " and bf.bill.retired = false"
                 + " and bf.bill.cancelled = false"
                 + " and (bf.bill.billTypeAtomic is null or bf.bill.billTypeAtomic not in :excludedTypes)"
-                + " and (bf.bill.billType != :btp or f.id is null or f.feeType != :ftp or s.id is null or type(s) != :staffClass)"
+                + " and (bf.bill.billType != :btp or f.id is null or f.feeType != :ftp or s.id is null"
+                + (merged ? ")" : " or type(s) != :staffClass)")
                 + " and bf.bill.patientEncounter in :encs"
                 + " group by bf.bill.patientEncounter.id";
 
@@ -524,7 +535,9 @@ public class InwardBhtChargeAggregationService implements Serializable {
                 BillTypeAtomic.INWARD_FINAL_BILL, BillTypeAtomic.INWARD_ORIGINAL_FINAL_BILL));
         params.put("btp", BillType.InwardProfessional);
         params.put("ftp", FeeType.Staff);
-        params.put("staffClass", Consultant.class);
+        if (!merged) {
+            params.put("staffClass", Consultant.class);
+        }
 
         List<Object[]> professionalRows = patientEncounterFacade.findObjectArrayByJpql(professionalJpql, params, TemporalType.TIMESTAMP);
         if (professionalRows != null) {

--- a/src/main/java/com/divudi/service/inward/InwardProfessionalFeeClassificationService.java
+++ b/src/main/java/com/divudi/service/inward/InwardProfessionalFeeClassificationService.java
@@ -90,13 +90,25 @@ public class InwardProfessionalFeeClassificationService implements Serializable 
      *
      * <p>Callers must not ask for {@code DoctorAndNurses} while merged — check
      * {@link #isSuppressed} and skip the query, which is cheaper than running one
-     * that cannot match.
+     * that cannot match. Both that and an unrelated charge type throw rather than
+     * returning a predicate: silently answering with the assisting bucket would
+     * put real money under the wrong heading.
      *
      * @param feeAlias the BillFee alias used in the query, e.g. {@code "bf"}
      * @param target   the charge type being queried
      * @param params   the query's parameter map, added to when required
+     * @throws IllegalArgumentException if {@code target} is not a professional fee
+     *         charge type, or is one this hospital does not use
      */
     public String staffCondition(String feeAlias, InwardChargeType target, Map<String, Object> params) {
+        if (target != InwardChargeType.ProfessionalCharge && target != InwardChargeType.DoctorAndNurses) {
+            throw new IllegalArgumentException(
+                    "Not a professional fee charge type: " + target);
+        }
+        if (isSuppressed(target)) {
+            throw new IllegalArgumentException(
+                    target + " does not exist for this hospital - check isSuppressed() and skip the query");
+        }
         if (isMerged()) {
             return " and " + feeAlias + ".staff is not null ";
         }

--- a/src/main/java/com/divudi/service/inward/InwardProfessionalFeeClassificationService.java
+++ b/src/main/java/com/divudi/service/inward/InwardProfessionalFeeClassificationService.java
@@ -1,0 +1,134 @@
+package com.divudi.service.inward;
+
+import com.divudi.bean.common.ConfigOptionApplicationController;
+import com.divudi.core.data.inward.InwardChargeType;
+import com.divudi.core.entity.Consultant;
+import com.divudi.core.entity.Staff;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import javax.ejb.Stateless;
+import javax.inject.Inject;
+
+/**
+ * The single definition of how an inpatient professional fee is classified as a
+ * professional charge or an assisting charge.
+ *
+ * <p>By default the classification follows the staff record: a {@link Consultant}
+ * is a {@link InwardChargeType#ProfessionalCharge}, anyone else (MO, nurse,
+ * assistant) is a {@link InwardChargeType#DoctorAndNurses} — "Assisting Charge".
+ * Hospitals that bill both as one professional charge enable
+ * {@link ConfigOptionApplicationController#PROFESSIONAL_AND_ASSISTING_FEES_MERGED},
+ * and then {@code DoctorAndNurses} must not appear anywhere: not as a final-bill
+ * row, not as a report column, not as a selectable charge type.
+ *
+ * <p>This rule used to be re-derived inline as {@code type(staff) = Consultant} in
+ * about a dozen queries, with the ConfigOption honoured in only one of them, so a
+ * merged hospital saw a bundled final bill and a split view everywhere else
+ * (issue #23543). Every consumer now goes through this service instead.
+ *
+ * <p>Nothing is persisted: the classification is a rule, not data. It cannot be
+ * stored on the BillFee's BillItem either — one professional BillItem legitimately
+ * carries several fees, and in production those routinely mix a consultant with an
+ * assistant, so a per-item charge type could not represent them.
+ */
+@Stateless
+public class InwardProfessionalFeeClassificationService implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /** Query parameter name used by {@link #staffCondition}. */
+    private static final String STAFF_CLASS_PARAM = "professionalFeeStaffClass";
+
+    @Inject
+    private ConfigOptionApplicationController configOptionApplicationController;
+
+    /**
+     * True when this hospital shows professional and assisting fees as one
+     * professional charge.
+     */
+    public boolean isMerged() {
+        return configOptionApplicationController.isProfessionalAndAssistingFeesMerged();
+    }
+
+    /**
+     * The charge type a professional fee belongs to, given the staff member it
+     * was raised for. Returns {@code ProfessionalCharge} for everyone when the
+     * merge option is on.
+     */
+    public InwardChargeType chargeTypeOf(Staff staff) {
+        if (isMerged()) {
+            return InwardChargeType.ProfessionalCharge;
+        }
+        return (staff instanceof Consultant)
+                ? InwardChargeType.ProfessionalCharge
+                : InwardChargeType.DoctorAndNurses;
+    }
+
+    /**
+     * True when this charge type does not exist for this hospital and must be
+     * left out of bill rows, report columns and charge-type selectors.
+     */
+    public boolean isSuppressed(InwardChargeType type) {
+        return type == InwardChargeType.DoctorAndNurses && isMerged();
+    }
+
+    /**
+     * A JPQL fragment restricting a BillFee alias to the fees of one charge type,
+     * registering its own query parameter in {@code params} when it needs one.
+     *
+     * <p>When merged, every professional fee is a professional charge, so the only
+     * restriction left is {@code staff is not null} — which keeps the result
+     * identical to the sum of the two unmerged buckets. Without it, staff-less fee
+     * rows (11 of them on one production database) would be pulled into the
+     * professional total for the first time, because they are excluded from both
+     * buckets today: {@code type(bf.staff)} forces an implicit inner join that
+     * drops them before the WHERE clause is evaluated.
+     *
+     * <p>Callers must not ask for {@code DoctorAndNurses} while merged — check
+     * {@link #isSuppressed} and skip the query, which is cheaper than running one
+     * that cannot match.
+     *
+     * @param feeAlias the BillFee alias used in the query, e.g. {@code "bf"}
+     * @param target   the charge type being queried
+     * @param params   the query's parameter map, added to when required
+     */
+    public String staffCondition(String feeAlias, InwardChargeType target, Map<String, Object> params) {
+        if (isMerged()) {
+            return " and " + feeAlias + ".staff is not null ";
+        }
+        params.put(STAFF_CLASS_PARAM, Consultant.class);
+        return (target == InwardChargeType.ProfessionalCharge)
+                ? " and type(" + feeAlias + ".staff) = :" + STAFF_CLASS_PARAM + " "
+                : " and type(" + feeAlias + ".staff) != :" + STAFF_CLASS_PARAM + " ";
+    }
+
+    /**
+     * The given charge types with any suppressed one removed — use wherever a
+     * charge-type universe is built (bill rows, report columns, dropdowns).
+     */
+    public List<InwardChargeType> visible(Collection<InwardChargeType> types) {
+        List<InwardChargeType> visible = new ArrayList<>();
+        if (types == null) {
+            return visible;
+        }
+        for (InwardChargeType type : types) {
+            if (!isSuppressed(type)) {
+                visible.add(type);
+            }
+        }
+        return visible;
+    }
+
+    /** Array overload of {@link #visible(Collection)}. */
+    public InwardChargeType[] visible(InwardChargeType[] types) {
+        if (types == null) {
+            return new InwardChargeType[0];
+        }
+        List<InwardChargeType> visible = visible(Arrays.asList(types));
+        return visible.toArray(new InwardChargeType[0]);
+    }
+}

--- a/src/main/webapp/inward/inward_bill_intrim.xhtml
+++ b/src/main/webapp/inward/inward_bill_intrim.xhtml
@@ -1408,7 +1408,7 @@
                                     </p:dataTable>
                                 </p:tab>
 
-                                <p:tab id="tabDoc" title="Assistant Charges"  >
+                                <p:tab id="tabDoc" title="Assistant Charges" rendered="#{not configOptionApplicationController.professionalAndAssistingFeesMerged}" >
                                     <div class="d-flex justify-content-end mb-2">
                                         <p:commandButton value="Excel"
                                                          icon="fas fa-file-excel"

--- a/src/main/webapp/inward/inward_bill_intrim_estimate.xhtml
+++ b/src/main/webapp/inward/inward_bill_intrim_estimate.xhtml
@@ -700,7 +700,7 @@
                             </p:tab>
 
 
-                            <p:tab id="tabDoc" title="Assisting Fee"  >
+                            <p:tab id="tabDoc" title="Assisting Fee" rendered="#{not configOptionApplicationController.professionalAndAssistingFeesMerged}" >
                                 <p:dataTable  scrollable="true" scrollHeight="300"  value="#{bhtSummeryController.doctorAndNurseFee}" var="pf"
                                               rowStyleClass="#{pf.bill.billClass eq 'class com.divudi.core.entity.BilledBill' ? '':'noDisplayRow'}">
                                     <p:column headerText="Name">

--- a/src/main/webapp/inward/inward_bill_intrim_finalized.xhtml
+++ b/src/main/webapp/inward/inward_bill_intrim_finalized.xhtml
@@ -1079,7 +1079,7 @@
                         </p:tab>
 
 
-                        <p:tab id="tabDoc" title="Assisting Fee"  >
+                        <p:tab id="tabDoc" title="Assisting Fee" rendered="#{not configOptionApplicationController.professionalAndAssistingFeesMerged}" >
                             <p:commandButton value="Export Excel" ajax="false"
                                              styleClass="noPrintButton"
                                              >

--- a/src/main/webapp/inward/inward_bill_intrim_finalized_error_correction.xhtml
+++ b/src/main/webapp/inward/inward_bill_intrim_finalized_error_correction.xhtml
@@ -606,7 +606,7 @@
                         </p:tab>
 
 
-                        <p:tab id="tabDoc" title="Assisting Fee"  >
+                        <p:tab id="tabDoc" title="Assisting Fee" rendered="#{not configOptionApplicationController.professionalAndAssistingFeesMerged}" >
                             <p:commandButton value="Export Excel" ajax="false" 
                                              styleClass="noPrintButton"  
                                              >


### PR DESCRIPTION
Closes #23543

## Problem

An inpatient professional fee is filed as a **Professional Charge** when the staff member is a `Consultant` and as an **Assisting Charge** (`DoctorAndNurses`) otherwise. Hospitals that bill both as one doctor's fee enable *"Professional Fee and Assisting Fees are shown as one charge type on the final bill."*

That rule was re-derived independently as `type(staff) = Consultant` in ~12 queries, and the option was honoured in exactly **one** of them — the final-bill settle path in `BhtSummeryController`. Coop therefore got a correctly bundled final bill and a split view everywhere else, including the Inpatient Invoice Journal the users reported.

## Approach — no schema change

The issue originally proposed storing the classification on a new `BillFee.inwardChargeType` column. That was dropped during review: the option is a classification *rule*, not data.

Reusing the existing `BillItem.inwardChargeType` was ruled out on the data — one professional `BillItem` legitimately carries several fees, and in production those routinely mix a consultant with an assistant (401 such items on RMH, 122 on Southern Lanka), so a per-item charge type cannot represent them without splitting bill items on a money-writing path.

Instead, new `InwardProfessionalFeeClassificationService` owns the rule, and every reader goes through it. When the option is on, `DoctorAndNurses` is removed from the charge-type universe entirely — the enum is simply absent from the design rather than present-but-zeroed.

**No DDL, no new field, no backfill.** Trade-off accepted: nothing is persisted, so flipping the option re-classifies history — already today's behaviour for the final bill, now consistent everywhere.

## What changed

| Area | Change |
| --- | --- |
| `InwardProfessionalFeeClassificationService` | **New.** `isMerged()`, `chargeTypeOf(Staff)`, `isSuppressed(type)`, `visible(types)`, and a JPQL `staffCondition()` helper |
| `ConfigOptionApplicationController` | `isProfessionalAndAssistingFeesMerged()` — replaces 5 inline copies of the option-key string |
| `InwardBeanController` (7 queries), `InwardBhtChargeAggregationService`, `SurgeryBillController` | Route through the shared rule |
| `EnumController`, `InwardInvoiceJournalController`, the two charge-type report controllers | Filter the suppressed type out of the charge-type universe |
| 4 interim/finalized bill XHTMLs | Gate the Assisting tab so no empty panel is left |
| `BhtSummeryController` | **−71 lines** — deletes the list merge, total juggling and gross/margin/VAT juggling the shared rule makes unreachable |

Also fixes two defects wrong for **every** hospital regardless of the option: the Charge Type Summary and Breakdown reports had no staff-type filter at all (either selection returned every professional fee), and the Professional & Other Fee Summary counted assisting fees under "Other" for merged hospitals.

An explicit `left join bf.staff s` is used wherever the predicate is applied — `type(bf.staff)` forces an implicit inner join that drops null-staff rows before the WHERE runs (the trap caught in #22964).

## Verification

Local Payara against a coop copy, driven **through the menus** (*Menu → Inpatient → Inpatient Analytics → BHT Summary Reports → Inpatient Invoice Journal*), in **both** option states.

![Inpatient Invoice Journal with the merge option on: Professional Charge column with no Assisting Charge column beside it](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23543-invoice-journal-merged-professional.png)

**Invoice Journal** — BHT/56552 (4 consultant fees = 26,000 + 1 assisting = 6,000):

| option | Professional Charge | Assisting Charge |
| --- | --- | --- |
| on | 32,000.00 | *column not shown* |
| off | 26,000.00 | 6,000.00 |

The off case is the regression check for every other hospital.

![Professional and Other Fee Summary showing Professional Fee Total including the assisting fee](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23543-professional-fee-summary-merged.png)

**Professional & Other Fee Summary** — Professional Fee Total 13,000.00, now including the 6,000.00 assisting fee that previously fell silently into Other.

**Charge Type Summary by BHT** (option off) — Assisting returns 1 row / 6,000.00 and Professional 4 rows / 26,000.00; both previously returned all 5 fees.

**Final bill settled end to end** (BHT/56284, 2 consultant = 7,000 + 1 assisting = 6,000), verified in the DB:

- `ProfessionalCharge` = 13,000; **zero** `DoctorAndNurses` rows (previously a phantom zero-value row — 200 exist on this copy from the old code)
- `netTotal` 81,401.43, matching the pre-settle preview exactly
- per-staff fee rows still written for all three doctors including the assistant (2,000 + 5,000 + 6,000), so *Create Professional Bill Fees For Assistant Chargers* is unaffected
- interim bill shows one Professional Fees tab with all fees and no empty Assisting tab

## Documentation

- [Inpatient Invoice Journal](https://github.com/hmislk/hmis/wiki/Finance-Inpatient-Invoice-Journal) — new section on when the Assisting Charge column appears
- [Professional & Other Fee Summary](https://github.com/hmislk/hmis/wiki/Finance-Professional-Other-Fee-Summary-Report) — **corrected**: stated unconditionally that Professional Fee Total is consultant fees only, true only when the setting is off

Also appended one new Playwright learning to `developer_docs/testing/playwright-e2e-workflow.md`: a menu item three levels deep can't be clicked directly, and the correct workaround is firing the anchor's own `onclick` (which submits the menu form, so the navigation method still runs) rather than falling back to typing the page URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring professional and assisting fees as a single charge type.
  * Charge-type lists, fee breakdowns, invoices, surgery bills, and reports now reflect the configured fee classification.
  * Assisting-fee tabs are hidden when fees are merged.

* **Documentation**
  * Updated Playwright guidance and checklist for navigating third-level menu items during end-to-end testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->