### PR TITLE
hotfix(opd): stop NPE and hard block when settling an OPD professional payment

### DIFF
--- a/src/main/java/com/divudi/bean/common/StaffPaymentBillController.java
+++ b/src/main/java/com/divudi/bean/common/StaffPaymentBillController.java
@@ -738,13 +738,17 @@ public class StaffPaymentBillController implements Serializable {
         }
         if (paymentMethod == PaymentMethod.Cash) {
             Drawer userDrawer = drawerService.getUsersDrawer(sessionController.getLoggedUser());
-            double drawerBalance = userDrawer.getCashInHandValue();
-            double paymentAmount = getTotalPayingWithoutWht();
+            if (userDrawer != null) {
+                double drawerBalance = userDrawer.getCashInHandValue() != null ? userDrawer.getCashInHandValue() : 0.0;
+                double paymentAmount = getTotalPayingWithoutWht();
 
-            if (configOptionApplicationController.getBooleanValueByKey("Enable Drawer Manegment", true)) {
-                if (drawerBalance < paymentAmount) {
-                    JsfUtil.addErrorMessage("Not enough cash in your drawer to make this payment");
-                    return;
+                boolean allowNegativeDrawer = configOptionApplicationController.getBooleanValueByKey(
+                        "OPD Professional Payments - Allow Negative Drawer Balance", false);
+                if (configOptionApplicationController.getBooleanValueByKey("Enable Drawer Manegment", true) && !allowNegativeDrawer) {
+                    if (drawerBalance < paymentAmount) {
+                        JsfUtil.addErrorMessage("Not enough cash in your drawer to make this payment");
+                        return;
+                    }
                 }
             }
         }

--- a/src/main/java/com/divudi/bean/inward/InwardSearch.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSearch.java
@@ -1564,12 +1564,14 @@ public class InwardSearch implements Serializable {
             }
             if (paymentMethod == PaymentMethod.Cash) {
                 Drawer userDrawer = drawerService.getUsersDrawer(sessionController.getLoggedUser());
-                double drawerBalance = userDrawer.getCashInHandValue();
-                double paymentAmount = getBill().getNetTotal();
-                if (configOptionApplicationController.getBooleanValueByKey("Enable Drawer Manegment", true)) {
-                    if (drawerBalance < paymentAmount) {
-                        JsfUtil.addErrorMessage("Not enough cash in your drawer to make this payment");
-                        return;
+                if (userDrawer != null) {
+                    double drawerBalance = userDrawer.getCashInHandValue() != null ? userDrawer.getCashInHandValue() : 0.0;
+                    double paymentAmount = getBill().getNetTotal();
+                    if (configOptionApplicationController.getBooleanValueByKey("Enable Drawer Manegment", true)) {
+                        if (drawerBalance < paymentAmount) {
+                            JsfUtil.addErrorMessage("Not enough cash in your drawer to make this payment");
+                            return;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Closes #23547

## Why

User **30179** on Ruhunu production could not pay **Dr Geeth Sooriyasena** (Rs. 33,000 / 21 unpaid fees). Clicking settle returned a 500.

`StaffPaymentBillController.settleBill()` line 741 unboxed `Drawer.getCashInHandValue()` — a nullable `Double` — into a primitive `double`. `DrawerService.getUsersDrawer()` auto-creates a drawer with `new Drawer()`, leaving every amount column NULL, and nothing ever writes 0 (the rest of the drawer code uses `safeAdd`, which treats NULL as 0). **130 of 156** active Ruhunu drawers held NULL, so every one of those users was one click away from the same 500.

Confirmed from the production server log:

```
java.lang.NullPointerException
	at com.divudi.bean.common.StaffPaymentBillController.settleBill(StaffPaymentBillController.java:741)
```

## What changed

**`StaffPaymentBillController.settleBill()`**
- Null-guard the drawer and coalesce `getCashInHandValue()` to `0.0`, exactly as `InwardStaffPaymentBillController:413` and `InwardSurgeryPaymentBillController:547` already do.
- Add `OPD Professional Payments - Allow Negative Drawer Balance` (default `false`) to bypass the insufficient-balance block. This is the OPD counterpart of `Inward Professional Payments - Allow Negative Drawer Balance`, added for the inward screens in #22638 on the same reasoning: professional payments legitimately need to let the drawer go negative.

**`InwardSearch`**
- Same null guard on the inward bill cancellation path, which had the identical unguarded unboxing. No behaviour change beyond not throwing — NULL and 0 are already equivalent everywhere else in the drawer code.

Default `false` means no existing deployment changes behaviour unless an admin turns the option on.

## Already applied to Ruhunu production (no deploy needed)

- `UPDATE drawer SET cashInHandValue = 0 WHERE cashInHandValue IS NULL AND retired = 0` → 130 rows. Semantically a no-op (`safeAdd(null, x) == safeAdd(0.0, x)`; `hasSufficientDrawerBalance` already treats NULL as insufficient), it removes the crash ahead of this deploy. Rollback list of the affected drawer ids was saved before the update.
- Seeded `OPD Professional Payments - Allow Negative Drawer Balance = true` in `configoption`, so the option is live the moment this build lands.

## Verification

- `mvn compile` passes.
- The reported user's drawer (id `5168653`, WebUser `5158550`) now reads `cashInHandValue = 0`; no active drawer on Ruhunu holds NULL.
- Post-deploy check: user 30179 settles Dr Geeth Sooriyasena's fees via *Menu → OPD → Professional Payments → Professional Payment (OPD)*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JMPKP6eVAKe7ZP2sDy9ohB