### PR TITLE
fix(opd): stop NPE and hard block when settling an OPD professional payment

### DIFF
--- a/src/main/java/com/divudi/bean/common/StaffPaymentBillController.java
+++ b/src/main/java/com/divudi/bean/common/StaffPaymentBillController.java
@@ -790,13 +790,17 @@ public class StaffPaymentBillController implements Serializable {
         }
         if (paymentMethod == PaymentMethod.Cash) {
             Drawer userDrawer = drawerService.getUsersDrawer(sessionController.getLoggedUser());
-            double drawerBalance = userDrawer.getCashInHandValue();
-            double paymentAmount = getTotalPayingWithoutWht();
+            if (userDrawer != null) {
+                double drawerBalance = userDrawer.getCashInHandValue() != null ? userDrawer.getCashInHandValue() : 0.0;
+                double paymentAmount = getTotalPayingWithoutWht();
 
-            if (configOptionApplicationController.getBooleanValueByKey("Enable Drawer Manegment", true)) {
-                if (drawerBalance < paymentAmount) {
-                    JsfUtil.addErrorMessage("Not enough cash in your drawer to make this payment");
-                    return;
+                boolean allowNegativeDrawer = configOptionApplicationController.getBooleanValueByKey(
+                        "OPD Professional Payments - Allow Negative Drawer Balance", false);
+                if (configOptionApplicationController.getBooleanValueByKey("Enable Drawer Manegment", true) && !allowNegativeDrawer) {
+                    if (drawerBalance < paymentAmount) {
+                        JsfUtil.addErrorMessage("Not enough cash in your drawer to make this payment");
+                        return;
+                    }
                 }
             }
         }

--- a/src/main/java/com/divudi/bean/common/StaffPaymentBillController.java
+++ b/src/main/java/com/divudi/bean/common/StaffPaymentBillController.java
@@ -790,17 +790,19 @@ public class StaffPaymentBillController implements Serializable {
         }
         if (paymentMethod == PaymentMethod.Cash) {
             Drawer userDrawer = drawerService.getUsersDrawer(sessionController.getLoggedUser());
-            if (userDrawer != null) {
-                double drawerBalance = userDrawer.getCashInHandValue() != null ? userDrawer.getCashInHandValue() : 0.0;
-                double paymentAmount = getTotalPayingWithoutWht();
+            if (userDrawer == null) {
+                JsfUtil.addErrorMessage("Your drawer could not be found. Please contact your administrator.");
+                return;
+            }
+            double drawerBalance = userDrawer.getCashInHandValue() != null ? userDrawer.getCashInHandValue() : 0.0;
+            double paymentAmount = getTotalPayingWithoutWht();
 
-                boolean allowNegativeDrawer = configOptionApplicationController.getBooleanValueByKey(
-                        "OPD Professional Payments - Allow Negative Drawer Balance", false);
-                if (configOptionApplicationController.getBooleanValueByKey("Enable Drawer Manegment", true) && !allowNegativeDrawer) {
-                    if (drawerBalance < paymentAmount) {
-                        JsfUtil.addErrorMessage("Not enough cash in your drawer to make this payment");
-                        return;
-                    }
+            boolean allowNegativeDrawer = configOptionApplicationController.getBooleanValueByKey(
+                    "OPD Professional Payments - Allow Negative Drawer Balance", false);
+            if (configOptionApplicationController.getBooleanValueByKey("Enable Drawer Manegment", true) && !allowNegativeDrawer) {
+                if (drawerBalance < paymentAmount) {
+                    JsfUtil.addErrorMessage("Not enough cash in your drawer to make this payment");
+                    return;
                 }
             }
         }

--- a/src/main/java/com/divudi/bean/inward/InwardSearch.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSearch.java
@@ -2684,12 +2684,14 @@ public class InwardSearch implements Serializable {
             }
             if (paymentMethod == PaymentMethod.Cash) {
                 Drawer userDrawer = drawerService.getUsersDrawer(sessionController.getLoggedUser());
-                double drawerBalance = userDrawer.getCashInHandValue();
-                double paymentAmount = getBill().getNetTotal();
-                if (configOptionApplicationController.getBooleanValueByKey("Enable Drawer Manegment", true)) {
-                    if (drawerBalance < paymentAmount) {
-                        JsfUtil.addErrorMessage("Not enough cash in your drawer to make this payment");
-                        return;
+                if (userDrawer != null) {
+                    double drawerBalance = userDrawer.getCashInHandValue() != null ? userDrawer.getCashInHandValue() : 0.0;
+                    double paymentAmount = getBill().getNetTotal();
+                    if (configOptionApplicationController.getBooleanValueByKey("Enable Drawer Manegment", true)) {
+                        if (drawerBalance < paymentAmount) {
+                            JsfUtil.addErrorMessage("Not enough cash in your drawer to make this payment");
+                            return;
+                        }
                     }
                 }
             }

--- a/src/main/java/com/divudi/bean/inward/InwardSearch.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSearch.java
@@ -2684,14 +2684,16 @@ public class InwardSearch implements Serializable {
             }
             if (paymentMethod == PaymentMethod.Cash) {
                 Drawer userDrawer = drawerService.getUsersDrawer(sessionController.getLoggedUser());
-                if (userDrawer != null) {
-                    double drawerBalance = userDrawer.getCashInHandValue() != null ? userDrawer.getCashInHandValue() : 0.0;
-                    double paymentAmount = getBill().getNetTotal();
-                    if (configOptionApplicationController.getBooleanValueByKey("Enable Drawer Manegment", true)) {
-                        if (drawerBalance < paymentAmount) {
-                            JsfUtil.addErrorMessage("Not enough cash in your drawer to make this payment");
-                            return;
-                        }
+                if (userDrawer == null) {
+                    JsfUtil.addErrorMessage("Your drawer could not be found. Please contact your administrator.");
+                    return;
+                }
+                double drawerBalance = userDrawer.getCashInHandValue() != null ? userDrawer.getCashInHandValue() : 0.0;
+                double paymentAmount = getBill().getNetTotal();
+                if (configOptionApplicationController.getBooleanValueByKey("Enable Drawer Manegment", true)) {
+                    if (drawerBalance < paymentAmount) {
+                        JsfUtil.addErrorMessage("Not enough cash in your drawer to make this payment");
+                        return;
                     }
                 }
             }


### PR DESCRIPTION
Closes #23547

## Why

Settling an OPD professional payment returns a **500 / NullPointerException** for any user whose drawer has never taken a payment. Found on Ruhunu production, where user 30179 could not pay Dr Geeth Sooriyasena (Rs. 33,000 / 21 unpaid fees), but the bug is in shared code and every deployment is exposed.

`StaffPaymentBillController.settleBill()`:

```java
Drawer userDrawer = drawerService.getUsersDrawer(sessionController.getLoggedUser());
double drawerBalance = userDrawer.getCashInHandValue();   // NPE
```

`Drawer.cashInHandValue` is a nullable `Double`. `DrawerService.getUsersDrawer()` auto-creates a drawer with `new Drawer()`, which leaves every amount column NULL, and nothing ever writes 0 — the rest of the drawer code uses `safeAdd`, which treats NULL as 0. Assigning that NULL to a primitive `double` auto-unboxes and throws.

Confirmed from the Ruhunu production server log:

```
java.lang.NullPointerException
	at com.divudi.bean.common.StaffPaymentBillController.settleBill(StaffPaymentBillController.java:741)
	at com.sun.faces.application.ActionListenerImpl.processAction(ActionListenerImpl.java:71)
```

On that one deployment **130 of 156** active drawers held NULL, so any of those users was one click from the same 500.

## What changed

**`StaffPaymentBillController.settleBill()`**
- Null-guard the drawer and coalesce `getCashInHandValue()` to `0.0`, exactly as `InwardStaffPaymentBillController:413` and `InwardSurgeryPaymentBillController:547` already do. Those two were fixed for this in #22638; the OPD path was missed.
- Add `OPD Professional Payments - Allow Negative Drawer Balance` (default `false`) to bypass the insufficient-balance block. This is the OPD counterpart of `Inward Professional Payments - Allow Negative Drawer Balance` from #22638, on the same reasoning: professional payments legitimately need to let the drawer go negative.

**`InwardSearch`**
- Same null guard on the inward bill cancellation path, which had the identical unguarded unboxing. These two were the only remaining unguarded drawer unboxings in the codebase.

## Risk

Low. Default `false` on the new option means no deployment changes behaviour unless an admin turns it on. NULL and 0 are already equivalent everywhere else in the drawer code (`safeAdd(null, x) == safeAdd(0.0, x)`; `hasSufficientDrawerBalance` already treats NULL as insufficient), so the coalesce only replaces a crash with the behaviour the surrounding code already assumed.

## Verification

- `mvn compile` passes.
- Traced the rest of the settle path — `drawerController.updateDrawerForOuts` → `DrawerService.updateDrawer` → `drawerEntryUpdate(Payment, Drawer, WebUser)` — all null-safe via `safeAdd` and ternaries, so a zero/NULL drawer completes the payment rather than failing further down.
- Shipped first as hotfix #23548 against `ruhunu-prod-migrated` to unblock the reported user.

## Menu path

Menu → OPD → Professional Payments → Professional Payment (OPD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JMPKP6eVAKe7ZP2sDy9ohB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cash professional-payment settlement is now blocked when no active cash drawer is available.
  * Cash payment cancellation now reports an error when no cash drawer is available instead of bypassing balance validation.
  * Cash drawer balance checks continue to handle missing balance values safely and respect configured negative-balance rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->