### PR TITLE
feat(inward): configurable hard block for duplicate active admissions

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -2576,10 +2576,16 @@ The fix: bind the dialog's own `visible` attribute to a session-scoped
 boolean the bean sets before returning (`visible="#{bean.showWarning}"`).
 `p:dialog visible="true"` renders its own show-on-load script regardless of
 whether the surrounding request was ajax or a full page render, so it works
-for both `ajax="false"` and `ajax="true"` buttons. Remember to also clear the
-flag via a real server round-trip on the dialog's "Cancel" button — a
-client-only `PF('dlg').hide()` leaves the session-scoped flag `true`, and it
-will reappear on the next unrelated full postback of that form.
+for both `ajax="false"` and `ajax="true"` buttons — but only if the triggering
+`ajax="true"` request's own `update` actually includes the dialog (or the
+whole form); an ajax caller that updates some narrower region will still
+leave the dialog's old, unrendered markup in the DOM with the stale `visible`
+value baked in. Remember to also clear the flag via a real server round-trip
+on the dialog's "Cancel" button *and* on its header close ("x") icon (`p:dialog
+closable="true"` gives that its own client-side close path via `p:ajax
+event="close"`, separate from any button) — a client-only `PF('dlg').hide()`
+leaves the session-scoped flag `true`, and it will reappear on the next
+unrelated full postback of that form.
 
 ## Some PrimeFaces buttons need a jQuery-triggered click
 

--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -2561,6 +2561,26 @@ which lists every `SurgeryBill` for the current `patientEncounter` and has a
 **Surgery Dashboard** button per row that loads it into
 `surgeryBillController.surgeryBill` correctly.
 
+## 96. `PrimeFaces.current().executeScript(...)` silently no-ops on an `ajax="false"` button — use `p:dialog visible="#{bean.flag}"` instead
+
+Seen fixing issue #23514. `inward_admission.xhtml`'s "Admit" button is
+`ajax="false"` (a full postback, deliberately, per issue #21175's foreigner-
+checkbox fix). The pre-existing "patient already admitted" warning dialog was
+shown via `PrimeFaces.current().executeScript("PF('dlg').show();")` from the
+backing bean — that call only queues JS into an *ajax* partial response, so on
+this button it silently did nothing: no dialog, no error, no admission
+created, no evidence in `server.log` that anything was rejected. It looked
+exactly like the button doing nothing.
+
+The fix: bind the dialog's own `visible` attribute to a session-scoped
+boolean the bean sets before returning (`visible="#{bean.showWarning}"`).
+`p:dialog visible="true"` renders its own show-on-load script regardless of
+whether the surrounding request was ajax or a full page render, so it works
+for both `ajax="false"` and `ajax="true"` buttons. Remember to also clear the
+flag via a real server round-trip on the dialog's "Cancel" button — a
+client-only `PF('dlg').hide()` leaves the session-scoped flag `true`, and it
+will reappear on the next unrelated full postback of that form.
+
 ## Some PrimeFaces buttons need a jQuery-triggered click
 
 Most `p:commandButton`s submit fine with a normal Playwright click — including

--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -2950,6 +2950,14 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
     }
 
     public void saveSelected() {
+        // Reached either past the duplicate-admission gate (proceedWithAdmissionCheck)
+        // or via the warning dialog's own "Yes, Proceed" override — either way that
+        // check is settled for this attempt, so clear it now rather than only on
+        // success. Otherwise an unrelated errorCheck() failure below (e.g. missing
+        // Payment Method) leaves the flag true and the dialog reappears on the
+        // update="@form" response, on top of the real validation error. (Issue #23514,
+        // CodeRabbit review on PR #23565)
+        showActiveAdmissionWarning = false;
         if (admittingProcessStarted) {
             JsfUtil.addErrorMessage("Admittin process already started.");
             return;
@@ -3171,7 +3179,6 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         admittingProcessStarted = false;
         currentReservation = null;
         patientForiegner = false;
-        showActiveAdmissionWarning = false;
         printPreview = true;
     }
 

--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -96,7 +96,6 @@ import javax.faces.convert.FacesConverter;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.persistence.TemporalType;
-import org.primefaces.PrimeFaces;
 import org.primefaces.event.TabChangeEvent;
 
 /**
@@ -238,6 +237,16 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
     private Reservation currentReservation;
     
     private boolean patientForiegner;
+
+    /**
+     * Drives the {@code dlgActiveAdmission} dialog's server-side {@code visible}
+     * attribute. The "Admit" button is a non-ajax ({@code ajax="false"}) full
+     * postback (see Issue #21175), so {@code PrimeFaces.current().executeScript()}
+     * — which only queues JS into an ajax partial response — never reaches the
+     * browser; binding {@code visible} to this flag instead makes the dialog show
+     * on the resulting full page render. (Issue #23514)
+     */
+    private boolean showActiveAdmissionWarning;
 
     @PostConstruct
     public void init() {
@@ -1900,6 +1909,7 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         printPreview = false;
         encounterCreditCompanies = new ArrayList<>();
         encounterCreditCompany = new EncounterCreditCompany();
+        showActiveAdmissionWarning = false;
         bhtNumberCalculation();
     }
 
@@ -1916,6 +1926,7 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         patient = null;
         yearMonthDay = null;
         printPreview = false;
+        showActiveAdmissionWarning = false;
         bhtNumberCalculation();
         return "/inward/inward_admission";
     }
@@ -2167,6 +2178,21 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
 
         if (getCurrent().getPatient() == null) {
             JsfUtil.addErrorMessage("Select Patient");
+            return true;
+        }
+
+        // Hard block on duplicate active admissions (Issue #23514). Runs
+        // unconditionally here — not just from the main "Admit" button's
+        // pre-check — so it also covers baby admission and OPD->Inward
+        // conversion (both call saveSelected()/saveConvertSelected() directly,
+        // skipping proceedWithAdmissionCheck()), and so there is no UI path
+        // (including the soft-warning dialog's own "Yes, Proceed" button) that
+        // can override it once the config option is enabled.
+        if (configOptionApplicationController.getBooleanValueByKey(
+                "Inward Admission - Enforce Hard Block on Duplicate Active Admission", false)
+                && isPatientAlreadyAdmitted()) {
+            JsfUtil.addErrorMessage("This patient already has an active (undischarged) admission. "
+                    + "Discharge the existing admission before admitting again.");
             return true;
         }
 
@@ -2728,8 +2754,29 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
                 + "AND a.discharged = false";
         HashMap<String, Object> params = new HashMap<>();
         params.put("patient", getCurrent().getPatient());
+        // Editing/re-saving an admission that is itself the active one must not
+        // flag itself as a duplicate of itself. (Issue #23514)
+        if (getCurrent().getId() != null) {
+            jpql += " AND a.id != :currentAdmissionId";
+            params.put("currentAdmissionId", getCurrent().getId());
+        }
         long count = getFacade().findLongByJpql(jpql, params);
         return count > 0;
+    }
+
+    public boolean isShowActiveAdmissionWarning() {
+        return showActiveAdmissionWarning;
+    }
+
+    /**
+     * Server round-trip for the {@code dlgActiveAdmission} "Cancel" button so the
+     * session-scoped {@link #showActiveAdmissionWarning} flag is actually cleared
+     * — a purely client-side {@code hide()} would leave it {@code true} and the
+     * dialog would reappear on the next unrelated full postback of this form.
+     * (Issue #23514)
+     */
+    public void cancelActiveAdmissionWarning() {
+        showActiveAdmissionWarning = false;
     }
 
     /**
@@ -2887,8 +2934,16 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
     }
 
     private void proceedWithAdmissionCheck() {
-        if (getCurrent().getPatient() != null && isPatientAlreadyAdmitted()) {
-            PrimeFaces.current().executeScript("PF('dlgActiveAdmission').show();");
+        showActiveAdmissionWarning = false;
+        // Hard block (Issue #23514): errorCheck() enforces this unconditionally
+        // on every save path (including the dialog's own "Yes, Proceed" button),
+        // so when it's on there's no need for — and no correct way to show — the
+        // soft-warning dialog first. Let saveSelected() -> errorCheck() reject it
+        // with a proper error message instead.
+        boolean hardBlockEnabled = configOptionApplicationController.getBooleanValueByKey(
+                "Inward Admission - Enforce Hard Block on Duplicate Active Admission", false);
+        if (!hardBlockEnabled && getCurrent().getPatient() != null && isPatientAlreadyAdmitted()) {
+            showActiveAdmissionWarning = true;
         } else {
             saveSelected();
         }
@@ -3116,6 +3171,7 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         admittingProcessStarted = false;
         currentReservation = null;
         patientForiegner = false;
+        showActiveAdmissionWarning = false;
         printPreview = true;
     }
 

--- a/src/main/webapp/inward/inward_admission.xhtml
+++ b/src/main/webapp/inward/inward_admission.xhtml
@@ -599,6 +599,11 @@
                       closable="true"
                       visible="#{admissionController.showActiveAdmissionWarning}"
                       style="width:500px">
+                <!-- closable="true" gives the header "x" its own close path, which
+                     bypasses the "Cancel" button's action; without this listener the
+                     server-side flag stays true and the dialog reappears on the next
+                     full postback. (CodeRabbit review on PR #23565) -->
+                <p:ajax event="close" listener="#{admissionController.cancelActiveAdmissionWarning}"/>
                 <div style="padding:12px">
                     <p style="color:#b71c1c; font-weight:bold; font-size:1.1em;">
                         &#9888; WARNING: This patient already has an active admission.

--- a/src/main/webapp/inward/inward_admission.xhtml
+++ b/src/main/webapp/inward/inward_admission.xhtml
@@ -586,12 +586,18 @@
             </h:panelGroup>
 
             <!-- Active Admission Warning Dialog -->
+            <!-- The "Admit" button that opens this is a non-ajax (ajax="false")
+                 full postback (Issue #21175), so visibility is driven by the
+                 server-side "visible" attribute rather than a JS show() queued
+                 into an ajax response — the latter never reaches a full page
+                 render. (Issue #23514) -->
             <p:dialog id="dlgActiveAdmission"
                       widgetVar="dlgActiveAdmission"
                       header="&#9888; Patient Already Admitted Warning"
                       modal="true"
                       resizable="false"
                       closable="true"
+                      visible="#{admissionController.showActiveAdmissionWarning}"
                       style="width:500px">
                 <div style="padding:12px">
                     <p style="color:#b71c1c; font-weight:bold; font-size:1.1em;">
@@ -609,7 +615,10 @@
                             value="Cancel — Do Not Admit"
                             icon="fa fa-times"
                             class="ui-button-secondary"
-                            onclick="PF('dlgActiveAdmission').hide(); return false;"/>
+                            action="#{admissionController.cancelActiveAdmissionWarning}"
+                            process="@this"
+                            update="dlgActiveAdmission"
+                            onclick="PF('dlgActiveAdmission').hide();"/>
                         <p:commandButton
                             value="Yes, Proceed with Admission"
                             icon="fa fa-exclamation-triangle"


### PR DESCRIPTION
## Decisions made without approval

This was run via `dev-issue-unattended` — every judgment call below was made without a human checkpoint; please double-check these first.

- **Scope of the soft-block dialog**: kept it on the main admission form only. Baby admission and the OPD→Inward conversion form had no soft-warning dialog before this change and still don't — with the hard-block config off, they behave exactly as before (no duplicate check at all). Only the **hard-block rejection** applies to those two flows. The issue's "Proposed Configuration" section describes a single hard-block toggle, not new per-flow soft dialogs, so this reads as the intended scope.
- **Where the hard-block check lives**: inside `errorCheck()`, which `saveSelected()` (main admission + baby admission) and `saveConvertSelected()` (conversion) all call unconditionally — including the soft-warning dialog's own "Yes, Proceed" override button. One change covers all three flows and guarantees there's truly no UI path around it once enabled.
- **Self-review (code-review skill, high effort) before first push** found 3 issues, all triaged:
  - `showActiveAdmissionWarning` wasn't reset in the actual "start a fresh admission" navigation methods (`prepereToAdmitNewPatient()` / `toAdmitAMember()`), only in the check/save paths — **fixed**, reverified live (stale warning no longer leaks onto an unrelated patient's form).
  - The new Cancel button's ajax submit had no `process` attribute, defaulting to full-form validation — **fixed** with `process="@this"`, reverified live by triggering the dialog with every other field left blank and confirming Cancel still closes cleanly.
  - `isPatientAlreadyAdmitted()` has a TOCTOU race under concurrent submits (no row locking) — **left unfixed**, matches an existing pattern elsewhere in the same controller (`isRoomFilled()`), and fixing it needs a schema/locking decision outside a config-option issue's scope. Filed as #23564.

## What changed

- New boolean config option **`Inward Admission - Enforce Hard Block on Duplicate Active Admission`** (default `false`), toggleable from the Configuration UI (Inward → Config button → Application Options).
- **Off (default)**: existing soft-warning dialog behavior preserved, plus its display bug fixed — the "Admit" button is a deliberate non-ajax full postback (issue #21175, so the "Mark as Foreigner" checkbox commits), and the previous `PrimeFaces.current().executeScript()` call only queues JS into an *ajax* response, so it silently never reached the browser on that button. The dialog's `visible` attribute is now bound to a session-scoped flag instead, which renders correctly on both full and ajax postbacks.
- **On**: admitting a patient with an active undischarged admission is rejected with a clear error message ("This patient already has an active (undischarged) admission...") on all three flows (main admission, baby admission, OPD→Inward conversion), with no UI path to override it.
- `isPatientAlreadyAdmitted()` now excludes the admission's own id from the duplicate count, so editing/re-saving an admission that is itself the active one doesn't flag against itself.

## Verified

All of the below tested live against local Payara + local `coop` DB, reached only via menu clicks (never by typing a URL), using synthetic test patient "Test Multi Surgery Patient" (existing active admission `BHT/57817`) and "Zztest FullSync Update" (no active admission):

- Menu → Inward → Patient Admit → search patient → **Admit** with config **off**: soft-warning dialog now actually displays (previously silently did nothing). **Cancel** closes it via a real server round-trip and creates no admission; confirmed in DB. **Yes, Proceed** still works (existing behavior, untouched).
- Config toggled to **on** via Administration → Application Options → Edit Option (not raw SQL) → **Admit** on the same duplicate patient: rejected with the error message, no dialog, no override button, no DB row created.
- Config toggled back to **off** via the same UI, confirmed via `Application Options` listing and DB.
- Cancel button re-verified after the `process="@this"` fix: triggered the dialog with every other field left blank, Cancel still closed cleanly with no stray validation errors.
- Navigation-reset fix re-verified: admitted the duplicate patient (dialog shown, left uncanceled), then used Patient Lookup → search a *different*, non-duplicate patient → Admit — confirmed the stale dialog does **not** leak onto the new patient's form.
- `mvn compile` / `mvn package` (261 unit tests) both green throughout.

## Documentation

- [`Inpatient-Admit-a-Patient.md`](https://github.com/hmislk/hmis.wiki/blob/master/Inpatient-Admit-a-Patient.md) updated: corrected a stale line claiming a "multiple simultaneous admissions" config that never existed, replaced with a table documenting the actual config key and screenshots of both the soft-warning dialog and the hard-block rejection message.
- Added `developer_docs/testing/playwright-e2e-workflow.md` §96 documenting the `PrimeFaces.current().executeScript()` vs `p:dialog visible="#{bean.flag}"` gotcha for non-ajax buttons, for future Playwright/dev sessions.

Closes #23514

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of the duplicate active-admission warning across AJAX and non-AJAX actions.
  - Prevented an existing admission from being flagged as its own duplicate.
  - Ensured both Cancel and header-close actions clear the warning state and prevent unexpected reappearance.

- **New Features**
  - Added an optional configuration to block duplicate active admissions across all admission workflows.

- **Documentation**
  - Documented server-controlled dialog handling and reset behavior in Playwright end-to-end tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->