### PR TITLE
fix(inward): surface why Settle silently no-ops when the room is missing

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -2741,3 +2741,41 @@ Verified while testing issue #23543 (professional/assisting fee merge).
 - [ ] When a Save did nothing with a clean `server.log` and an unchanged DB, read the form's `<p:messages>` **by id** and grepped the page for `required="true"` (§91) before hunting the controller.
 - [ ] For a guard fix: asserted the **action actually executed** (expected message in the response) before treating unchanged DB state as proof — a JSF-disabled button skips its action entirely — and ran the negative test (clean record still succeeds), reverting it through the app.
 - [ ] For a menu item nested three levels deep, fired the anchor's own `onclick` (which submits the menu form, so the navigation method still runs) instead of falling back to typing the page URL.
+- [ ] Before trying to reproduce a same-session state-change race (item A staged, then a dependency of A is invalidated by a legitimate app action before A is submitted), checked whether a `@SessionScoped` controller's already-held entity reference would even observe the change (§96) rather than assuming any in-app mutation propagates live.
+
+## 96. A `@SessionScoped` controller's already-loaded entity field does not pick up a sibling controller's later edit to the same row, even when that edit goes through the app's own JPA facade
+
+Tried to reproduce issue #23523 (`BillBhtController.errorCheck()` silently
+no-opping Settle when the admission's current room becomes invalid) by: (1)
+adding a service on `inward_bill_service.xhtml` while the room was valid so
+an item was staged in `lstBillEntries`, then (2) in a second tab of the same
+login session, using `inward_patient_room_details.xhtml`'s "Remove Room" —
+a real UI action, going through `RoomChangeController.removeRoom()` and
+`patientEncounterFacade.edit(encounter)`, not raw SQL — to null the
+encounter's `currentPatientRoom`, then (3) going back to tab one and
+clicking **Settle**.
+
+Expected the new guard message; got `Bill Saved` instead, and confirmed via
+`BILL` table that Settle fully succeeded, using the *old* room. The DB
+correctly showed `CURRENTPATIENTROOM_ID = NULL` before the Settle click.
+`BillBhtController`'s `patientEncounter` field — set once when tab one
+searched for the BHT — is a Java object this session-scoped bean has held
+onto since; `RoomChangeController`'s edit in tab two updates its own
+(different) reference to the same row and, evidently, does not force tab
+one's already-held reference to see the new field values. Confirmed the fix
+itself was genuinely deployed first (`strings` on the compiled `.class` in
+`applications/<app>/WEB-INF/classes/...` showed the new message text) before
+concluding this was a test-setup limitation, not a dead code path.
+
+**Takeaway:** a same-request-lifecycle race like this cannot be reliably
+staged from outside the request (a second tab, a second session, or raw
+SQL) once the first controller has already loaded and cached the entity —
+only an interruption inside the *same* request/thread (a debugger, a
+breakpoint, or an actual concurrent user hitting the exact same in-flight
+transaction) would show it happening. Don't spend a long session trying to
+force this kind of window through the UI; verify instead via the code
+path itself (confirm the guarded condition and message are correct, and
+that an analogous guard with the identical condition and message idiom
+already fires correctly elsewhere in the same controller/page) and say so
+plainly in the PR rather than claiming a live repro that didn't happen.
+Found while verifying issue #23523.

--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -2767,15 +2767,29 @@ itself was genuinely deployed first (`strings` on the compiled `.class` in
 `applications/<app>/WEB-INF/classes/...` showed the new message text) before
 concluding this was a test-setup limitation, not a dead code path.
 
-**Takeaway:** a same-request-lifecycle race like this cannot be reliably
-staged from outside the request (a second tab, a second session, or raw
-SQL) once the first controller has already loaded and cached the entity —
-only an interruption inside the *same* request/thread (a debugger, a
-breakpoint, or an actual concurrent user hitting the exact same in-flight
-transaction) would show it happening. Don't spend a long session trying to
-force this kind of window through the UI; verify instead via the code
-path itself (confirm the guarded condition and message are correct, and
-that an analogous guard with the identical condition and message idiom
-already fires correctly elsewhere in the same controller/page) and say so
-plainly in the PR rather than claiming a live repro that didn't happen.
+**Takeaway for testing this kind of thing:** a same-request-lifecycle race
+like this cannot be reliably staged from *outside* the request (a second
+tab, a second session, or raw SQL) once the first controller has already
+loaded and cached the entity — only an interruption inside the *same*
+request/thread (a debugger, a breakpoint, or an actual concurrent user
+hitting the exact same in-flight transaction) would show it happening.
+Don't spend a long session trying to force this kind of window through the
+UI; verify instead via the code path itself (confirm the guarded condition
+and message are correct, and that an analogous guard with the identical
+condition and message idiom already fires correctly elsewhere in the same
+controller/page) and say so plainly in the PR rather than claiming a live
+repro that didn't happen.
+
+**This is not only a testing-methodology footnote, though** — CodeRabbit
+correctly flagged on PR #23567 that the same staleness is a real
+production correctness risk, not just a Playwright limitation: any actual
+concurrent use (two staff members on the same admission, or one user in
+two tabs) can hit this exact window, silently letting `settleBill()` go
+through on stale room data instead of hitting the guard added in #23523.
+Tracked separately as issue #23568 rather than fixed inline in #23523's
+PR, since the right fix (refreshing `patientEncounter`/`currentPatientRoom`
+before validation) needs its own design discussion — this codebase's
+EclipseLink cache has bitten targeted-refresh attempts before (see the
+"Native settle poisons the Bill entity" gotcha).
+
 Found while verifying issue #23523.

--- a/src/main/java/com/divudi/bean/inward/BillBhtController.java
+++ b/src/main/java/com/divudi/bean/inward/BillBhtController.java
@@ -1167,10 +1167,12 @@ public class BillBhtController implements Serializable {
         // this gate only fires for babies when a room was actually assigned. (Issue #23509)
         if ((getPatientEncounter().getAdmissionType().isRoomChargesAllowed() && !isBabyAdmission()) || getPatientEncounter().getCurrentPatientRoom() != null) {
             if (getPatientEncounter().getCurrentPatientRoom() == null) {
+                JsfUtil.addErrorMessage("Cannot settle: this admission has no current room. Assign a room first.");
                 return true;
             }
 
             if (getPatientEncounter().getCurrentPatientRoom().getRoomFacilityCharge() == null) {
+                JsfUtil.addErrorMessage("Cannot settle: the patient's current room has no room facility charge configured.");
                 return true;
             }
         }


### PR DESCRIPTION
## Decisions made without approval

- Followed the reporter's suggested message wording verbatim rather than the terser `errorCheckForPatientRoomDepartment()` sibling's "Please Set Room or Bed For This Patient" — this method (`errorCheck()`) already uses a distinct "Cannot X: reason." idiom two lines below (nursing-discharge guard), and the two broken-room causes are different enough that a single generic message would be less actionable. This is the only judgment call in this fix; the root cause and location were unambiguous from the issue itself.

## Problem

On **Inward → Services & Items → Add Services & Investigations** (`inward_bill_service.xhtml`), clicking **Settle** for a patient whose admission has no current room — or whose current room has no room facility charge — did nothing: no bill, no growl, no error, nothing in `server.log`. `BillBhtController.errorCheck()` (called by `settleBill()`) already correctly refused to proceed in both cases (they are load-bearing guards preventing an NPE a few lines later in `settleBill()`), but returned `true` with no `JsfUtil.addErrorMessage`, so the guard itself was invisible to the user.

## Fix

Added the two missing `JsfUtil.addErrorMessage(...)` calls before the existing early returns — no control-flow change, purely additive:
- `"Cannot settle: this admission has no current room. Assign a room first."`
- `"Cannot settle: the patient's current room has no room facility charge configured."`

## Verification

- Confirmed root cause by reading the exact lines cited in the issue.
- Rebuilt, redeployed to local Payara (`asadmin --port 9048`), server log clean.
- Reached the page via **Menu → Inward → Services & Items → Add Services & Investigations**, searched a real BHT, added a service (X RAY) to the cart.
- Set up the "no current room" state through the app itself — **Inward → Search → Admissions → [BHT] → Inpatient Dashboard → Room Details → Remove Room** (twice, to walk past a previous-room fallback) — not raw SQL, so the change goes through `RoomChangeController`/`patientEncounterFacade.edit()` like a real user action.
- Confirmed the sibling guard `errorCheckForPatientRoomDepartment()` — identical condition, identical message-call idiom, on the same page/form — fires and renders correctly for this exact broken-room state (captured via the DOM's `.ui-messages` panel).
- A live click-through repro of `errorCheck()` itself (as opposed to its sibling) proved impractical: once `BillBhtController`'s session-scoped `patientEncounter` field is loaded, it does not observe a later change committed by a different controller instance in another tab of the same login session, even though that change goes through the app's own JPA facade and is durably reflected in the DB. Documented as new gotcha **#96** in `developer_docs/testing/playwright-e2e-workflow.md` so a future session doesn't retry the same approach. This matches the issue reporter's own note that they read this from the code rather than reproducing it live.

## Documentation

Added both new messages to the "Understanding Messages" section of the `Add-services-and-Investigations` wiki page (pushed to `hmis.wiki`), alongside the page's other known Settle/Add error messages.

## Note on self-review

Ran `/code-review medium` on the diff before this push. It returned two findings, but both are in files this branch never touches (`SurgeryCostReportController.java`, `InwardSearch.java`) — unrelated to this change and not verified in this run. Left as-is; flagging here rather than filing a speculative issue for something outside this PR's scope that wasn't independently confirmed.

Fixes #23523

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Settlement validation now provides specific messages when an admission has no current room or the room’s facility charge is not configured.
  * Settlement remains blocked until the missing room information or charge configuration is corrected.

* **Documentation**
  * Expanded Playwright end-to-end testing guidance to distinguish testing limitations from potential stale room data during concurrent sessions or tabs.
  * Documented a follow-up item for refreshing room data before validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->