### PR TITLE
feat(lims): expose the report common template over /api/report-formats

### DIFF
--- a/developer_docs/api/using-apis/API_REPORT_FORMATS.md
+++ b/developer_docs/api/using-apis/API_REPORT_FORMATS.md
@@ -1,0 +1,218 @@
+# Report Formats API — Common Report Template
+
+Base path: `/api/report-formats`
+Authentication: `Finance` header
+Content-Type: `application/json`
+
+A **report format** (`ReportFormat`, a `Category` subclass) owns a **common template**: the
+`CommonReportItem` rows that print on *every* lab report produced in that format — the
+patient-details block (name, age, gender, referring doctor, reference no, reported date,
+specimen), the signature block, and the footer.
+
+This is the half of the report layout that
+[the Investigation Format API](#relationship-to-the-investigation-format-api) cannot reach.
+It is also the half that has to move when a hospital prints onto **pre-printed stationery**
+and the header block collides with a pre-printed band.
+
+The same rows are edited by hand at **Menu → Admin → Lims → Report Template**
+(`admin/lims/report_template.xhtml`).
+
+## Endpoints
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/api/report-formats` | List report formats |
+| `GET` | `/api/report-formats/{categoryId}/items` | List the format's common-template rows |
+| `GET` | `/api/report-formats/{categoryId}/items/{itemId}` | Read one row |
+| `POST` | `/api/report-formats/{categoryId}/items` | Add a row |
+| `PUT` | `/api/report-formats/{categoryId}/items/{itemId}` | Update a row |
+| `DELETE` | `/api/report-formats/{categoryId}/items/{itemId}` | Retire (soft-delete) a row |
+
+---
+
+### GET `/api/report-formats` — List report formats
+
+No parameters. Returns every non-retired `ReportFormat`, ordered by name, with the number of
+common-template rows each one owns.
+
+```bash
+curl -s -H "Finance: YOUR_API_KEY" http://localhost:8080/hmis/api/report-formats
+```
+
+```json
+{
+  "status": "success",
+  "code": 200,
+  "data": [
+    { "id": 1194, "name": "Main", "code": "main", "orderNo": 0, "itemCount": 29 },
+    { "id": 1462, "name": "Culture", "code": "culture", "orderNo": 0, "itemCount": 26 }
+  ]
+}
+```
+
+---
+
+### GET `/api/report-formats/{categoryId}/items` — List common-template rows
+
+Non-retired rows only, ordered by name — the same order the Report Template screen lists them.
+
+```json
+{
+  "status": "success",
+  "code": 200,
+  "data": [
+    {
+      "id": 84472,
+      "categoryId": 1194,
+      "categoryName": "Main",
+      "name": "Name",
+      "reportItemType": "PatientName",
+      "ixItemType": "Value",
+      "riTop": 13.6,
+      "riLeft": 23.0,
+      "riWidth": 71.0,
+      "riHeight": 2.0,
+      "riFontSize": 11.0,
+      "cssTextAlign": "Left",
+      "cssVerticalAlign": "Baseline",
+      "cssFontStyle": "Normal",
+      "cssFontWeight": "normal"
+    }
+  ]
+}
+```
+
+---
+
+### POST `/api/report-formats/{categoryId}/items` — Add a row
+
+`name` is required; everything else is optional. `code` is derived from `name` when omitted.
+Returns `201`.
+
+```json
+{
+  "name": "Reference No",
+  "reportItemType": "DepartmentBillNo",
+  "ixItemType": "Value",
+  "riTop": 15.8,
+  "riLeft": 71,
+  "riWidth": 23,
+  "riHeight": 2,
+  "riFontSize": 10.5,
+  "cssTextAlign": "Left"
+}
+```
+
+---
+
+### PUT `/api/report-formats/{categoryId}/items/{itemId}` — Update a row
+
+**Only the fields present in the body are applied.** Everything omitted is left exactly as it
+was, so a single coordinate can be nudged on its own:
+
+```bash
+curl -s -H "Finance: YOUR_API_KEY" -H "Content-Type: application/json" \
+  -X PUT http://localhost:8080/hmis/api/report-formats/1194/items/84472 \
+  -d '{"riTop": 16.1}'
+```
+
+A request body carrying no recognised field is rejected rather than reported as a no-op success.
+
+---
+
+### DELETE `/api/report-formats/{categoryId}/items/{itemId}` — Retire a row
+
+Soft delete: sets `retired = true` and records the retiring user. The row stops printing but is
+never removed from the database.
+
+---
+
+## Fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `name` | string | Row name on the Report Template screen. Required on POST. |
+| `code` | string | Derived from `name` when omitted. |
+| `description` | string | Free text. |
+| `orderNo` | int | Display order number. |
+| `pageNo` | int | Page the row prints on. |
+| `reportItemType` | enum | What the row prints — `PatientName`, `PatientAge`, `PatientAgeOnBillDate`, `PatientSex`, `ReferringDoctor`, `DepartmentBillNo`, `BillNo`, `Speciman`, `BHT`, `MRN`, `SampledID`, `ApprovedAt`, `CollectedOn`, `ReceivedOn`, `AutherizedSignature`, `QrCodeLink`, … Omit for a static label. |
+| `ixItemType` | enum | How it renders — `Label`, `Value`, `Css`, `Barcode`, `QrCode`, `Html`, `Image`, … Defaults to `Label`. |
+| `ixItemValueType` | enum | `Varchar`, `Memo`, `Double`, `Integer`, `Long`, `Image`, `Line`, `Rectangle`, `Circle`, … |
+| `htmltext` | string | Content of `Html`-type rows. |
+| `formatPrefix` / `formatSuffix` | string | Text printed either side of the value. |
+| `riTop` / `riLeft` | double | Position on the page, **in percent**. |
+| `riWidth` / `riHeight` | double | Size, **in percent**. |
+| `riFontSize` | double | Font size **in points**. |
+| `htPix` / `wtPix` | double | Image height/width in pixels (`Image`-type rows). |
+| `cssTextAlign` | enum | `Left`, `Right`, `Center`, `Justify`, `Inherit`. |
+| `cssVerticalAlign` | enum | `Baseline`, `Sub`, `Super`, `Top`, `TextTop`, `Middle`, `Bottom`, `TextBottom`, `Inherit`. |
+| `cssFontStyle` | enum | `Normal`, `Italic`, `Oblique`, `Inherit`. |
+| `cssFontFamily` | string | Font family name. |
+| `cssFontWeight` | string | e.g. `normal`, `bold`. |
+
+For the enum-backed fields, sending an **empty string** clears the value; omitting the field
+leaves it unchanged. An unrecognised value is rejected with the list of valid constants.
+
+### Reads report the rendered value, not the stored one
+
+`riWidth`, `riHeight` and `riFontSize` are read through the entity getters, which substitute
+**30**, **2** and **12** respectively when the stored value is `0` — and `ixItemType`,
+`cssTextAlign` and `cssFontStyle` likewise fall back to `Label`, `Left` and `Normal`. So a `GET`
+reports the numbers the printed report actually uses, which is what you want when diagnosing a
+layout, but it is not necessarily what is stored. See issue #23528.
+
+## Scope: report formats only
+
+`CommonReportItem` rows are also used for the HR/clinical **form** templates
+(`FormFormatController`, `StaffController`) under ordinary `Category` rows. This API only accepts
+a `ReportFormat` id, exactly like the Report Template screen, so a lab-facing call can never
+rewrite a form layout by passing the wrong category id. A non-`ReportFormat` category id returns
+*"An error occurred: Report format not found with ID: …"*.
+
+## Relationship to the Investigation Format API
+
+| | Investigation Format API | Report Formats API (this one) |
+|---|---|---|
+| Path | `/api/investigations/{id}/format` | `/api/report-formats/{categoryId}` |
+| Entity | `InvestigationItem` | `CommonReportItem` |
+| Keyed on | the investigation (`item_id`) | the report-format category (`category_id`) |
+| Covers | the result table for one test | the header/signature/footer shared by every report of the format |
+
+The two never overlap: `CommonReportItem` rows carry no `item`, so the investigation-scoped
+queries can never return them. That gap is what issue #23529 fixed.
+
+## Why write through the API instead of SQL
+
+Layout tuning used to be done with `UPDATE` statements straight against the database, which then
+needed an `asadmin disable/enable <app>` to clear the EclipseLink L2 cache before the change was
+visible. Writing through this API goes through the facade, so the cache stays correct with no
+redeploy and no downtime.
+
+## Moving a whole block
+
+There is no bulk endpoint — moving the patient-details block down by 2.5% is one `PUT` per row.
+`GET .../items` first, then issue one `{"riTop": <old + 2.5>}` per row. Doing it row by row is
+deliberate: it keeps every change reviewable and reversible.
+
+## Errors
+
+All errors use the standard envelope:
+
+```json
+{ "status": "error", "code": 500, "message": "An error occurred: Report format not found with ID: 999" }
+```
+
+Every failure except the auth one is a 500 carrying the literal prefix **`An error occurred: `**
+before the message below — the same wrapper the sibling Investigation Format API uses. Match on a
+substring, not on the start of the string.
+
+| Condition | HTTP | Message (after the prefix) |
+|---|---|---|
+| Missing/invalid `Finance` header | 401 | `Not a valid key` — no prefix, this path does not go through the wrapper |
+| Unknown or retired format | 500 | `Report format not found with ID: {id}` |
+| Unknown or retired row | 500 | `Common report item not found with ID: {id}` |
+| Row belongs to another format | 500 | `Item {itemId} does not belong to report format {categoryId}` |
+| POST without a name | 500 | `Item name is required` |
+| PUT with an empty body | 500 | `Valid update request is required` |
+| Bad enum value | 500 | `Invalid {field}: {value}. Valid values: [...]` |

--- a/developer_docs/api/using-apis/API_REPORT_FORMATS.md
+++ b/developer_docs/api/using-apis/API_REPORT_FORMATS.md
@@ -36,7 +36,8 @@ No parameters. Returns every non-retired `ReportFormat`, ordered by name, with t
 common-template rows each one owns.
 
 ```bash
-curl -s -H "Finance: YOUR_API_KEY" http://localhost:8080/hmis/api/report-formats
+# Set BASE_URL and FINANCE_KEY from user input before running
+curl -s -H "Finance: $FINANCE_KEY" "$BASE_URL/api/report-formats"
 ```
 
 ```json
@@ -111,8 +112,9 @@ Returns `201`.
 was, so a single coordinate can be nudged on its own:
 
 ```bash
-curl -s -H "Finance: YOUR_API_KEY" -H "Content-Type: application/json" \
-  -X PUT http://localhost:8080/hmis/api/report-formats/1194/items/84472 \
+# Set BASE_URL and FINANCE_KEY from user input before running
+curl -s -H "Finance: $FINANCE_KEY" -H "Content-Type: application/json" \
+  -X PUT "$BASE_URL/api/report-formats/1194/items/84472" \
   -d '{"riTop": 16.1}'
 ```
 

--- a/developer_docs/api/using-apis/API_REPORT_FORMATS.md
+++ b/developer_docs/api/using-apis/API_REPORT_FORMATS.md
@@ -174,7 +174,7 @@ rewrite a form layout by passing the wrong category id. A non-`ReportFormat` cat
 
 | | Investigation Format API | Report Formats API (this one) |
 |---|---|---|
-| Path | `/api/investigations/{id}/format` | `/api/report-formats/{categoryId}` |
+| Path | `/api/investigations/{id}/format` | `/api/report-formats/{categoryId}/items` |
 | Entity | `InvestigationItem` | `CommonReportItem` |
 | Keyed on | the investigation (`item_id`) | the report-format category (`category_id`) |
 | Covers | the result table for one test | the header/signature/footer shared by every report of the format |
@@ -215,4 +215,5 @@ substring, not on the start of the string.
 | Row belongs to another format | 500 | `Item {itemId} does not belong to report format {categoryId}` |
 | POST without a name | 500 | `Item name is required` |
 | PUT with an empty body | 500 | `Valid update request is required` |
+| PUT with a blank `name` | 500 | `Item name cannot be blank` |
 | Bad enum value | 500 | `Invalid {field}: {value}. Valid values: [...]` |

--- a/developer_docs/api/using-apis/README.md
+++ b/developer_docs/api/using-apis/README.md
@@ -36,6 +36,7 @@ All standard endpoints use the `Finance` header unless noted otherwise below.
 | [API_PHARMACEUTICAL_MANAGEMENT.md](API_PHARMACEUTICAL_MANAGEMENT.md) | VTM/ATM/VMP/AMP/VMPP/AMPP item master CRUD + backfill | `Finance` |
 | [API_PHARMACY_STOCK_ADJUSTMENTS.md](API_PHARMACY_STOCK_ADJUSTMENTS.md) | Search stocks, adjust qty/rates/expiry, create batches | `Finance` |
 | [API_QUICKBOOKS.md](API_QUICKBOOKS.md) | Read-only export of financial data for QuickBooks | `Finance` |
+| [API_REPORT_FORMATS.md](API_REPORT_FORMATS.md) | Lab report common template — patient-details/signature/footer layout | `Finance` |
 | [API_SERVICE_MANAGEMENT.md](API_SERVICE_MANAGEMENT.md) | `/api/services` service master data | `Finance` |
 | [API_SITES.md](API_SITES.md) | Sites (collection points, satellite clinics) | `Finance` |
 | [API_STOCK_HISTORY.md](API_STOCK_HISTORY.md) | Transaction-level stock movement records | `Finance` |

--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -62,6 +62,15 @@ $env:JAVA_HOME="<path-to-jdk>"
   then fails with "not deployed" — recover with a plain
   `deploy --name <name-from-list-applications> --contextroot <its-context-root> <war>`
   (the name/context root you confirmed above, not a hardcoded guess).
+- **Running `asadmin` from Git Bash: set `MSYS_NO_PATHCONV=1`.** MSYS rewrites any
+  argument that looks like a Unix path, so `--contextroot /rh` is handed to Payara
+  as `D:/Program Files/Git/rh`. The deploy then fails deep inside JSF parsing —
+  `Unable to parse document 'jndi:/server/D:/Program%20Files/Git/rh/WEB-INF/faces-config.xml'`
+  — which reads like a broken WAR and is nothing of the sort. Worse, that failed
+  `redeploy` leaves the app *undeployed*, so the retry fails with "not deployed" and
+  you have to `deploy` fresh. Prefix the command:
+  `MSYS_NO_PATHCONV=1 asadmin deploy --name rh --contextroot /rh <war>`. PowerShell
+  is unaffected.
 
 ---
 
@@ -2717,6 +2726,41 @@ anchor's `onclick` attribute first: if it submits the menu form, this is safe; i
 `href` to a page, you are back to URL navigation and must find another route.
 
 Verified while testing issue #23543 (professional/assisting fee merge).
+
+### A *second*-level flyout does open — but only from a CSS-selector click on the top-level anchor
+
+Before reaching for the `onclick` escape hatch above, try this: a two-level menu path
+(`Administration → Manage Lab Services`) opens normally, but only if the top-level item is clicked
+through a **CSS selector**, not through its accessibility `ref`.
+
+Clicking the ref sets `ui-menuitem-active ui-menuitem-highlight` on the `<li>` while the child
+`<ul>` stays `display: none` — the item looks selected and nothing opens. `browser_hover` on either
+the `<li>` or its `<a>` does nothing at all. Clicking the same anchor by selector opens it properly
+(`display: block`, with the inline `z-index/top/left` PrimeFaces sets):
+
+```
+browser_click  .ui-menubar > .ui-menu-list > li:nth-child(20) > a
+browser_click  .ui-menubar > .ui-menu-list > li:nth-child(20) a:has-text("Manage Lab Services")
+```
+
+Confirm it actually opened before clicking the child, rather than eating a 5s timeout:
+
+```js
+() => getComputedStyle(document.querySelectorAll('.ui-menubar > .ui-menu-list > li')[19]
+        .querySelector('ul')).display   // 'block' once open
+```
+
+Finding the right `nth-child` is itself awkward, because most top-level items are icon-only with
+their label in visually-hidden markup — `browser_snapshot` shows them as bare `menuitem` entries
+with no name. List them with their index first:
+
+```js
+() => Array.from(document.querySelectorAll('.ui-menubar > .ui-menu-list > li'))
+        .map((li,i) => ({i, text: (li.innerText||'').trim().split('\n')[0]}))
+```
+
+Verified while testing issue #23529 (common report template API), reaching
+*Administration → Manage Lab Services → Report Templates → Report Format Templates*.
 
 ## Quick checklist
 

--- a/src/main/java/com/divudi/core/data/dto/investigation/CommonReportItemDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/investigation/CommonReportItemDTO.java
@@ -1,0 +1,105 @@
+package com.divudi.core.data.dto.investigation;
+
+/**
+ * One row of a report format's common template ({@code CommonReportItem}) — the
+ * patient-details block, signature block and footer that print on every report of
+ * that format.
+ *
+ * <p>Sibling of {@link InvestigationItemDTO}. It carries the same geometry
+ * ({@code riTop}/{@code riLeft}/{@code riWidth}/{@code riHeight}/{@code riFontSize})
+ * but drops the analyzer-only fields (machine, test, resultCode, absolute
+ * low/high values) which are meaningless on a common template, and adds the
+ * fields the common-template screen exposes and the per-investigation one does
+ * not: {@code reportItemType}, {@code cssVerticalAlign}, {@code cssFontFamily},
+ * {@code cssFontWeight}, {@code htPix} and {@code wtPix}.</p>
+ *
+ * <p><b>Geometry is reported as rendered, not as stored.</b> {@code riWidth},
+ * {@code riHeight} and {@code riFontSize} come from the entity getters, which
+ * substitute 30, 2 and 12 respectively when the stored value is 0 — the same
+ * numbers the printed report uses. See issue #23528.</p>
+ */
+public class CommonReportItemDTO {
+
+    private Long id;
+    private Long categoryId;
+    private String categoryName;
+    private String name;
+    private String code;
+    private String description;
+    private Integer orderNo;
+    private Integer pageNo;
+    private String reportItemType;
+    private String ixItemType;
+    private String ixItemValueType;
+    private String htmltext;
+    private String formatPrefix;
+    private String formatSuffix;
+    private Double riTop;
+    private Double riLeft;
+    private Double riWidth;
+    private Double riHeight;
+    private Double riFontSize;
+    private Double htPix;
+    private Double wtPix;
+    private String cssTextAlign;
+    private String cssVerticalAlign;
+    private String cssFontStyle;
+    private String cssFontFamily;
+    private String cssFontWeight;
+    private String message;
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public Long getCategoryId() { return categoryId; }
+    public void setCategoryId(Long categoryId) { this.categoryId = categoryId; }
+    public String getCategoryName() { return categoryName; }
+    public void setCategoryName(String categoryName) { this.categoryName = categoryName; }
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public String getCode() { return code; }
+    public void setCode(String code) { this.code = code; }
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+    public Integer getOrderNo() { return orderNo; }
+    public void setOrderNo(Integer orderNo) { this.orderNo = orderNo; }
+    public Integer getPageNo() { return pageNo; }
+    public void setPageNo(Integer pageNo) { this.pageNo = pageNo; }
+    public String getReportItemType() { return reportItemType; }
+    public void setReportItemType(String reportItemType) { this.reportItemType = reportItemType; }
+    public String getIxItemType() { return ixItemType; }
+    public void setIxItemType(String ixItemType) { this.ixItemType = ixItemType; }
+    public String getIxItemValueType() { return ixItemValueType; }
+    public void setIxItemValueType(String ixItemValueType) { this.ixItemValueType = ixItemValueType; }
+    public String getHtmltext() { return htmltext; }
+    public void setHtmltext(String htmltext) { this.htmltext = htmltext; }
+    public String getFormatPrefix() { return formatPrefix; }
+    public void setFormatPrefix(String formatPrefix) { this.formatPrefix = formatPrefix; }
+    public String getFormatSuffix() { return formatSuffix; }
+    public void setFormatSuffix(String formatSuffix) { this.formatSuffix = formatSuffix; }
+    public Double getRiTop() { return riTop; }
+    public void setRiTop(Double riTop) { this.riTop = riTop; }
+    public Double getRiLeft() { return riLeft; }
+    public void setRiLeft(Double riLeft) { this.riLeft = riLeft; }
+    public Double getRiWidth() { return riWidth; }
+    public void setRiWidth(Double riWidth) { this.riWidth = riWidth; }
+    public Double getRiHeight() { return riHeight; }
+    public void setRiHeight(Double riHeight) { this.riHeight = riHeight; }
+    public Double getRiFontSize() { return riFontSize; }
+    public void setRiFontSize(Double riFontSize) { this.riFontSize = riFontSize; }
+    public Double getHtPix() { return htPix; }
+    public void setHtPix(Double htPix) { this.htPix = htPix; }
+    public Double getWtPix() { return wtPix; }
+    public void setWtPix(Double wtPix) { this.wtPix = wtPix; }
+    public String getCssTextAlign() { return cssTextAlign; }
+    public void setCssTextAlign(String cssTextAlign) { this.cssTextAlign = cssTextAlign; }
+    public String getCssVerticalAlign() { return cssVerticalAlign; }
+    public void setCssVerticalAlign(String cssVerticalAlign) { this.cssVerticalAlign = cssVerticalAlign; }
+    public String getCssFontStyle() { return cssFontStyle; }
+    public void setCssFontStyle(String cssFontStyle) { this.cssFontStyle = cssFontStyle; }
+    public String getCssFontFamily() { return cssFontFamily; }
+    public void setCssFontFamily(String cssFontFamily) { this.cssFontFamily = cssFontFamily; }
+    public String getCssFontWeight() { return cssFontWeight; }
+    public void setCssFontWeight(String cssFontWeight) { this.cssFontWeight = cssFontWeight; }
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+}

--- a/src/main/java/com/divudi/core/data/dto/investigation/CommonReportItemUpdateDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/investigation/CommonReportItemUpdateDTO.java
@@ -1,0 +1,106 @@
+package com.divudi.core.data.dto.investigation;
+
+/**
+ * Request body for creating or updating one common-template row
+ * ({@code CommonReportItem}) of a lab report format.
+ *
+ * <p>Mirrors {@link InvestigationItemUpdateDTO} for the geometry fields, minus the
+ * analyzer-only ones (machineId, testId, resultCode, absolute low/high values) which
+ * a common template never uses, plus the fields the common-template screen
+ * (<code>admin/lims/report_template.xhtml</code>) exposes: {@code reportItemType},
+ * {@code cssVerticalAlign}, {@code cssFontFamily}, {@code cssFontWeight},
+ * {@code htPix} and {@code wtPix}.</p>
+ *
+ * <p>Every field is optional and a {@code null} field is left untouched, so a PUT can
+ * carry just the one value being nudged. For the enum-backed fields
+ * ({@code reportItemType}, {@code ixItemType}, {@code ixItemValueType},
+ * {@code cssTextAlign}, {@code cssVerticalAlign}, {@code cssFontStyle}) an empty
+ * string clears the value instead of setting it.</p>
+ */
+public class CommonReportItemUpdateDTO {
+
+    private String name;
+    private String code;
+    private String description;
+    private Integer orderNo;
+    private Integer pageNo;
+    private String reportItemType;
+    private String ixItemType;
+    private String ixItemValueType;
+    private String htmltext;
+    private String formatPrefix;
+    private String formatSuffix;
+    private Double riTop;
+    private Double riLeft;
+    private Double riWidth;
+    private Double riHeight;
+    private Double riFontSize;
+    private Double htPix;
+    private Double wtPix;
+    private String cssTextAlign;
+    private String cssVerticalAlign;
+    private String cssFontStyle;
+    private String cssFontFamily;
+    private String cssFontWeight;
+
+    /**
+     * True when the body carries at least one field to apply. Guards against a PUT
+     * with an empty or unparseable body silently reporting success.
+     */
+    public boolean isValid() {
+        return name != null || code != null || description != null || orderNo != null
+                || pageNo != null || reportItemType != null || ixItemType != null
+                || ixItemValueType != null || htmltext != null || formatPrefix != null
+                || formatSuffix != null || riTop != null || riLeft != null || riWidth != null
+                || riHeight != null || riFontSize != null || htPix != null || wtPix != null
+                || cssTextAlign != null || cssVerticalAlign != null || cssFontStyle != null
+                || cssFontFamily != null || cssFontWeight != null;
+    }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public String getCode() { return code; }
+    public void setCode(String code) { this.code = code; }
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+    public Integer getOrderNo() { return orderNo; }
+    public void setOrderNo(Integer orderNo) { this.orderNo = orderNo; }
+    public Integer getPageNo() { return pageNo; }
+    public void setPageNo(Integer pageNo) { this.pageNo = pageNo; }
+    public String getReportItemType() { return reportItemType; }
+    public void setReportItemType(String reportItemType) { this.reportItemType = reportItemType; }
+    public String getIxItemType() { return ixItemType; }
+    public void setIxItemType(String ixItemType) { this.ixItemType = ixItemType; }
+    public String getIxItemValueType() { return ixItemValueType; }
+    public void setIxItemValueType(String ixItemValueType) { this.ixItemValueType = ixItemValueType; }
+    public String getHtmltext() { return htmltext; }
+    public void setHtmltext(String htmltext) { this.htmltext = htmltext; }
+    public String getFormatPrefix() { return formatPrefix; }
+    public void setFormatPrefix(String formatPrefix) { this.formatPrefix = formatPrefix; }
+    public String getFormatSuffix() { return formatSuffix; }
+    public void setFormatSuffix(String formatSuffix) { this.formatSuffix = formatSuffix; }
+    public Double getRiTop() { return riTop; }
+    public void setRiTop(Double riTop) { this.riTop = riTop; }
+    public Double getRiLeft() { return riLeft; }
+    public void setRiLeft(Double riLeft) { this.riLeft = riLeft; }
+    public Double getRiWidth() { return riWidth; }
+    public void setRiWidth(Double riWidth) { this.riWidth = riWidth; }
+    public Double getRiHeight() { return riHeight; }
+    public void setRiHeight(Double riHeight) { this.riHeight = riHeight; }
+    public Double getRiFontSize() { return riFontSize; }
+    public void setRiFontSize(Double riFontSize) { this.riFontSize = riFontSize; }
+    public Double getHtPix() { return htPix; }
+    public void setHtPix(Double htPix) { this.htPix = htPix; }
+    public Double getWtPix() { return wtPix; }
+    public void setWtPix(Double wtPix) { this.wtPix = wtPix; }
+    public String getCssTextAlign() { return cssTextAlign; }
+    public void setCssTextAlign(String cssTextAlign) { this.cssTextAlign = cssTextAlign; }
+    public String getCssVerticalAlign() { return cssVerticalAlign; }
+    public void setCssVerticalAlign(String cssVerticalAlign) { this.cssVerticalAlign = cssVerticalAlign; }
+    public String getCssFontStyle() { return cssFontStyle; }
+    public void setCssFontStyle(String cssFontStyle) { this.cssFontStyle = cssFontStyle; }
+    public String getCssFontFamily() { return cssFontFamily; }
+    public void setCssFontFamily(String cssFontFamily) { this.cssFontFamily = cssFontFamily; }
+    public String getCssFontWeight() { return cssFontWeight; }
+    public void setCssFontWeight(String cssFontWeight) { this.cssFontWeight = cssFontWeight; }
+}

--- a/src/main/java/com/divudi/core/data/dto/investigation/ReportFormatDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/investigation/ReportFormatDTO.java
@@ -1,0 +1,38 @@
+package com.divudi.core.data.dto.investigation;
+
+/**
+ * A lab report format (the {@code ReportFormat} Category subclass) that owns a
+ * common report template — the block of {@code CommonReportItem} rows printed on
+ * every report produced in that format.
+ */
+public class ReportFormatDTO {
+
+    private Long id;
+    private String name;
+    private String code;
+    private String description;
+    private Integer orderNo;
+    private Long parentCategoryId;
+    private String parentCategoryName;
+    private Integer itemCount;
+    private String message;
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public String getCode() { return code; }
+    public void setCode(String code) { this.code = code; }
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+    public Integer getOrderNo() { return orderNo; }
+    public void setOrderNo(Integer orderNo) { this.orderNo = orderNo; }
+    public Long getParentCategoryId() { return parentCategoryId; }
+    public void setParentCategoryId(Long parentCategoryId) { this.parentCategoryId = parentCategoryId; }
+    public String getParentCategoryName() { return parentCategoryName; }
+    public void setParentCategoryName(String parentCategoryName) { this.parentCategoryName = parentCategoryName; }
+    public Integer getItemCount() { return itemCount; }
+    public void setItemCount(Integer itemCount) { this.itemCount = itemCount; }
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+}

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -1298,6 +1298,121 @@ public class AnthropicApiService implements Serializable {
                         .add("required", Json.createArrayBuilder().add("method").add("investigation_id")))
                 .build();
 
+        JsonObject manageReportFormatsTool = Json.createObjectBuilder()
+                .add("name", "manage_report_formats")
+                .add("description",
+                        "Manage the COMMON report template of a lab report format — the rows that print on every "
+                        + "report of that format: the patient-details block (name, age, gender, referring doctor, "
+                        + "reference no, reported date, specimen), the signature block, and the footer. "
+                        + "This is the counterpart of manage_investigation_format, which only reaches the rows of one "
+                        + "investigation and can never touch these. Use this tool when a hospital needs the whole "
+                        + "header/footer block nudged to clear pre-printed stationery, or a label resized. "
+                        + "resource_type: FORMAT | ITEM. "
+                        + "FORMAT supports LIST only (lists report formats with their template row counts) — start here "
+                        + "to find the category_id. "
+                        + "ITEM supports LIST | GET | POST | PUT | DELETE and requires category_id; GET/PUT/DELETE also "
+                        + "require item_id, and POST requires name. DELETE soft-retires the row. "
+                        + "Geometry is percentage-based: ri_top and ri_left position the row on the page, ri_width and "
+                        + "ri_height size it, ri_font_size is in points. Only the fields you send are changed, so a PUT "
+                        + "carrying just ri_top moves the row vertically and leaves everything else alone. "
+                        + "Moving a whole block means one PUT per row — LIST the items first and confirm the exact list "
+                        + "with the user before changing them. "
+                        + "Always confirm with the user before POST, PUT, or DELETE — these changes affect every printed "
+                        + "report in the format.")
+                .add("input_schema", Json.createObjectBuilder()
+                        .add("type", "object")
+                        .add("properties", Json.createObjectBuilder()
+                                .add("resource_type", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("enum", Json.createArrayBuilder().add("FORMAT").add("ITEM"))
+                                        .add("description", "FORMAT to list report formats, ITEM for template rows. Required."))
+                                .add("method", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("enum", Json.createArrayBuilder().add("LIST").add("GET").add("POST").add("PUT").add("DELETE"))
+                                        .add("description", "Operation to perform. FORMAT supports LIST only. Required."))
+                                .add("category_id", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Report format (Category) ID. Required for every ITEM operation."))
+                                .add("item_id", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Common report item ID. Required for ITEM GET, PUT and DELETE."))
+                                .add("name", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Row name as shown on the template screen. Required for ITEM POST."))
+                                .add("code", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Short code. Auto-generated from name if omitted."))
+                                .add("description", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Free-text description of the row."))
+                                .add("order_no", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Display order number."))
+                                .add("page_no", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Page number the row prints on."))
+                                .add("report_item_type", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "What the row prints, e.g. PatientName, PatientAge, PatientSex, "
+                                                + "ReferringDoctor, DepartmentBillNo, Speciman, BHT, ApprovedAt, CollectedOn, "
+                                                + "AutherizedSignature, MRN, SampledID. Omit for a static label. Send an empty "
+                                                + "string to clear it."))
+                                .add("ix_item_type", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "How the row renders: Label (static text), Value (a report_item_type "
+                                                + "value), Css, Barcode, QrCode, Html, Image. Defaults to Label."))
+                                .add("ix_item_value_type", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Value shape when ix_item_type is Value: Varchar, Memo, Double, "
+                                                + "Integer, Long, Image, Line, Rectangle, Circle."))
+                                .add("htmltext", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "HTML content for Html-type rows."))
+                                .add("format_prefix", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Text printed before the value."))
+                                .add("format_suffix", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Text printed after the value."))
+                                .add("ri_top", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Distance from the top of the page, in percent."))
+                                .add("ri_left", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Distance from the left of the page, in percent."))
+                                .add("ri_width", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Row width in percent. Reads report 30 when unset."))
+                                .add("ri_height", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Row height in percent. Reads report 2 when unset."))
+                                .add("ri_font_size", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Font size in points. Reads report 12 when unset."))
+                                .add("ht_pix", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Image height in pixels (Image-type rows)."))
+                                .add("wt_pix", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Image width in pixels (Image-type rows)."))
+                                .add("css_text_align", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Left, Right, Center, Justify or Inherit."))
+                                .add("css_vertical_align", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Baseline, Sub, Super, Top, TextTop, Middle, Bottom, TextBottom or Inherit."))
+                                .add("css_font_style", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Normal, Italic, Oblique or Inherit."))
+                                .add("css_font_family", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Font family name."))
+                                .add("css_font_weight", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Font weight, e.g. normal or bold.")))
+                        .add("required", Json.createArrayBuilder().add("resource_type").add("method")))
+                .build();
+
         JsonObject manageInvestigationExportTool = Json.createObjectBuilder()
                 .add("name", "manage_investigation_export")
                 .add("description",
@@ -2052,6 +2167,7 @@ public class AnthropicApiService implements Serializable {
                 .add(manageInvestigationsTool)
                 .add(manageServicesTool)
                 .add(manageInvestigationFormatTool)
+                .add(manageReportFormatsTool)
                 .add(manageInvestigationComponentsTool)
                 .add(manageInvestigationPricingTool)
                 .add(manageInvestigationValidatorsTool)
@@ -2362,6 +2478,8 @@ public class AnthropicApiService implements Serializable {
                             displayFlagMessage, displayHighMessage, displayLowMessage, displayNormalMessage,
                             hmisBaseUrl, hmisApiKey);
                 }
+                case "manage_report_formats":
+                    return callReportFormatApi(toolInput, hmisBaseUrl, hmisApiKey);
                 case "manage_inward_rooms": {
                     String method         = toolInput.getString("method", "LIST_CATEGORIES");
                     String id             = toolInput.containsKey("id")                             ? toolInput.getString("id", "")                             : "";
@@ -4783,6 +4901,136 @@ public class AnthropicApiService implements Serializable {
         }
     }
 
+    /**
+     * Backs the {@code manage_report_formats} tool against {@code /api/report-formats}.
+     *
+     * <p>Unlike its {@code manage_investigation_format} neighbour this takes the raw
+     * {@code toolInput} rather than one parameter per field: the common template row
+     * carries roughly twenty-five settable attributes, and threading each through a
+     * positional signature is how a value ends up silently written into the wrong
+     * column. Fields are copied by name instead, and only the ones actually present
+     * are sent — which is also what makes a single-coordinate PUT possible.</p>
+     */
+    private String callReportFormatApi(JsonObject toolInput, String hmisBaseUrl, String hmisApiKey) {
+        try {
+            String root = (hmisBaseUrl != null) ? hmisBaseUrl.trim().replaceAll("/+$", "") : "";
+            if (root.isEmpty()) return "Error: HMIS base URL is not configured.";
+            String key = (hmisApiKey != null) ? hmisApiKey.trim() : "";
+
+            String resourceType = toolInput.getString("resource_type", "ITEM").toUpperCase();
+            String method = toolInput.getString("method", "LIST").toUpperCase();
+            String basePath = root + "/api/report-formats";
+
+            if ("FORMAT".equals(resourceType)) {
+                if (!"LIST".equals(method)) {
+                    return "Error: FORMAT supports LIST only. Use resource_type=ITEM to change template rows.";
+                }
+                return sendReportFormatRequest(basePath, "GET", null, key);
+            }
+            if (!"ITEM".equals(resourceType)) {
+                return "Error: Unsupported resource_type: " + resourceType + ". Allowed: FORMAT, ITEM.";
+            }
+
+            String categoryId = toolInput.containsKey("category_id") ? toolInput.getString("category_id", "") : "";
+            if (categoryId.isEmpty()) {
+                return "Error: category_id is required for ITEM operations. Use resource_type=FORMAT method=LIST to find it.";
+            }
+            String itemId = toolInput.containsKey("item_id") ? toolInput.getString("item_id", "") : "";
+            String itemsPath = basePath + "/" + requireNumericId(categoryId, "category_id") + "/items";
+
+            switch (method) {
+                case "LIST":
+                    return sendReportFormatRequest(itemsPath, "GET", null, key);
+                case "GET":
+                    if (itemId.isEmpty()) return "Error: item_id is required for ITEM GET.";
+                    return sendReportFormatRequest(itemsPath + "/" + requireNumericId(itemId, "item_id"), "GET", null, key);
+                case "DELETE":
+                    if (itemId.isEmpty()) return "Error: item_id is required for ITEM DELETE.";
+                    return sendReportFormatRequest(itemsPath + "/" + requireNumericId(itemId, "item_id"), "DELETE", null, key);
+                case "POST":
+                case "PUT": {
+                    if ("PUT".equals(method) && itemId.isEmpty()) return "Error: item_id is required for ITEM PUT.";
+                    javax.json.JsonObjectBuilder body = buildCommonReportItemBody(toolInput);
+                    String path = "POST".equals(method)
+                            ? itemsPath
+                            : itemsPath + "/" + requireNumericId(itemId, "item_id");
+                    return sendReportFormatRequest(path, method, body.build().toString(), key);
+                }
+                default:
+                    return "Error: Unsupported method for ITEM: " + method + ". Allowed: LIST, GET, POST, PUT, DELETE.";
+            }
+        } catch (IllegalArgumentException e) {
+            return e.getMessage();
+        } catch (Exception e) {
+            return "Report Format API error: " + e.getMessage();
+        }
+    }
+
+    /**
+     * Copies the common-template fields the tool call actually carries into a request
+     * body, translating each snake_case tool parameter to its camelCase API field and
+     * its declared type. Absent fields are left out so the API leaves them untouched.
+     */
+    private javax.json.JsonObjectBuilder buildCommonReportItemBody(JsonObject toolInput) {
+        javax.json.JsonObjectBuilder body = Json.createObjectBuilder();
+        String[][] strings = {
+            {"name", "name"}, {"code", "code"}, {"description", "description"},
+            {"report_item_type", "reportItemType"}, {"ix_item_type", "ixItemType"},
+            {"ix_item_value_type", "ixItemValueType"}, {"htmltext", "htmltext"},
+            {"format_prefix", "formatPrefix"}, {"format_suffix", "formatSuffix"},
+            {"css_text_align", "cssTextAlign"}, {"css_vertical_align", "cssVerticalAlign"},
+            {"css_font_style", "cssFontStyle"}, {"css_font_family", "cssFontFamily"},
+            {"css_font_weight", "cssFontWeight"}
+        };
+        for (String[] field : strings) {
+            if (toolInput.containsKey(field[0])) {
+                body.add(field[1], toolInput.getString(field[0], ""));
+            }
+        }
+        String[][] integers = {{"order_no", "orderNo"}, {"page_no", "pageNo"}};
+        for (String[] field : integers) {
+            String raw = toolInput.containsKey(field[0]) ? toolInput.getString(field[0], "").trim() : "";
+            if (!raw.isEmpty()) {
+                try {
+                    body.add(field[1], Integer.parseInt(raw));
+                } catch (NumberFormatException e) {
+                    throw new IllegalArgumentException("Error: " + field[0] + " must be a whole number, got: " + raw);
+                }
+            }
+        }
+        String[][] doubles = {
+            {"ri_top", "riTop"}, {"ri_left", "riLeft"}, {"ri_width", "riWidth"},
+            {"ri_height", "riHeight"}, {"ri_font_size", "riFontSize"},
+            {"ht_pix", "htPix"}, {"wt_pix", "wtPix"}
+        };
+        for (String[] field : doubles) {
+            String raw = toolInput.containsKey(field[0]) ? toolInput.getString(field[0], "").trim() : "";
+            if (!raw.isEmpty()) {
+                try {
+                    body.add(field[1], Double.parseDouble(raw));
+                } catch (NumberFormatException e) {
+                    throw new IllegalArgumentException("Error: " + field[0] + " must be a number, got: " + raw);
+                }
+            }
+        }
+        return body;
+    }
+
+    private String sendReportFormatRequest(String url, String method, String body, String key) throws Exception {
+        HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
+        HttpRequest.Builder rb = HttpRequest.newBuilder().uri(URI.create(url));
+        if ("DELETE".equals(method)) {
+            rb.DELETE();
+        } else if (body != null) {
+            rb.method(method, HttpRequest.BodyPublishers.ofString(body)).header("Content-Type", "application/json");
+        } else {
+            rb.GET();
+        }
+        if (!key.isEmpty()) rb.header("Finance", key);
+        HttpResponse<String> resp = client.send(rb.build(), HttpResponse.BodyHandlers.ofString());
+        return "HTTP " + resp.statusCode() + "\n" + resp.body();
+    }
+
     private String requireNumericId(String value, String fieldName) {
         if (value == null || !value.trim().matches("\\d+")) {
             throw new IllegalArgumentException("Error: " + fieldName + " must be a numeric id.");
@@ -6010,6 +6258,22 @@ public class AnthropicApiService implements Serializable {
           .append("For FLAG POST, investigation_item_of_value_type_id and investigation_item_of_flag_type_id are required. ")
           .append("Always LIST items first to get the item IDs before creating calculations, flags, or dynamic labels. ")
           .append("Always confirm with the user before POST, PUT, or DELETE.\n\n");
+        sb.append("### manage_report_formats\n");
+        sb.append("Manage the COMMON report template of a lab report format — the rows printed on every report ")
+          .append("of that format: the patient-details block (name, age, gender, referring doctor, reference no, ")
+          .append("reported date, specimen), the signature block, and the footer. ")
+          .append("manage_investigation_format cannot reach these rows; they belong to the format, not to any one investigation. ")
+          .append("Reach for this tool whenever a hospital prints onto pre-printed stationery and the header or footer ")
+          .append("block has to move to clear a pre-printed band, or a label is coming out at the wrong size. ")
+          .append("resource_type: FORMAT (LIST only — start here to find the category_id) or ITEM. ")
+          .append("ITEM: LIST, GET, POST, PUT, DELETE; category_id is always required, item_id for GET/PUT/DELETE, ")
+          .append("name for POST. ")
+          .append("Geometry is percentage-based: ri_top/ri_left position the row, ri_width/ri_height size it, ")
+          .append("ri_font_size is in points. Only the fields you send change, so a PUT carrying just ri_top nudges ")
+          .append("a row vertically and leaves the rest alone. ")
+          .append("Moving a whole block is one PUT per row — LIST the items first, show the user exactly which rows ")
+          .append("you intend to move and by how much, and get confirmation before the first PUT. ")
+          .append("Always confirm before POST, PUT, or DELETE — every printed report in the format is affected.\n\n");
         sb.append("### manage_investigation_components\n");
         sb.append("Manage InvestigationComponent groupings that organize an investigation's report items under a heading ")
           .append("(e.g. grouping FBC items under 'White Cell Differential'). ")
@@ -6610,6 +6874,23 @@ public class AnthropicApiService implements Serializable {
                     {"POST", "/limsmw/sysmex",                                          "Receive Sysmex ASTM message (HTTP Basic Auth, WRITE)"},
                     {"POST", "/limsmw/limsProcessAnalyzerMessage",                      "Process HL7 analyzer message (HTTP Basic Auth, WRITE)"},
                     {"POST", "/limsmw/login",                                           "Authenticate a middleware client"}
+                });
+
+        appendModule(sb, "LIMS - Report Formats (Common Template)", "/report-formats",
+                "The rows printed on every lab report of a given format: the patient-details block, "
+                + "the signature block and the footer. The Investigation Format API covers only the rows "
+                + "of one investigation and cannot reach these. Geometry is percentage-based "
+                + "(riTop, riLeft, riWidth, riHeight) with riFontSize in points — these are the fields to "
+                + "nudge when a hospital prints onto pre-printed stationery. A PUT applies only the fields "
+                + "it carries, so one coordinate can be moved on its own.",
+                githubUrl(branch, "developer_docs/api/using-apis/API_REPORT_FORMATS.md"),
+                new String[][]{
+                    {"GET",    "/report-formats",                              "List report formats with their template row counts"},
+                    {"GET",    "/report-formats/{categoryId}/items",           "List a format's common-template rows"},
+                    {"GET",    "/report-formats/{categoryId}/items/{itemId}",  "Read one row"},
+                    {"POST",   "/report-formats/{categoryId}/items",           "Add a row (name required)"},
+                    {"PUT",    "/report-formats/{categoryId}/items/{itemId}",  "Update a row (only the fields sent are applied)"},
+                    {"DELETE", "/report-formats/{categoryId}/items/{itemId}",  "Retire (soft-delete) a row"}
                 });
 
         // ── Membership ────────────────────────────────────────────────────────

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -5018,7 +5018,8 @@ public class AnthropicApiService implements Serializable {
 
     private String sendReportFormatRequest(String url, String method, String body, String key) throws Exception {
         HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
-        HttpRequest.Builder rb = HttpRequest.newBuilder().uri(URI.create(url));
+        HttpRequest.Builder rb = HttpRequest.newBuilder().uri(URI.create(url))
+                .timeout(Duration.ofSeconds(15));
         if ("DELETE".equals(method)) {
             rb.DELETE();
         } else if (body != null) {

--- a/src/main/java/com/divudi/service/investigation/ReportFormatApiService.java
+++ b/src/main/java/com/divudi/service/investigation/ReportFormatApiService.java
@@ -116,8 +116,13 @@ public class ReportFormatApiService implements Serializable {
         if (req == null || !req.isValid()) {
             throw new Exception("Valid update request is required");
         }
+        // A name that is present but blank is a mistake, not "leave it alone" -
+        // silently skipping it would report success without changing anything.
+        if (req.getName() != null && req.getName().trim().isEmpty()) {
+            throw new Exception("Item name cannot be blank");
+        }
         CommonReportItem item = loadItem(itemId, categoryId);
-        if (req.getName() != null && !req.getName().trim().isEmpty()) {
+        if (req.getName() != null) {
             item.setName(req.getName().trim());
         }
         if (req.getCode() != null) {

--- a/src/main/java/com/divudi/service/investigation/ReportFormatApiService.java
+++ b/src/main/java/com/divudi/service/investigation/ReportFormatApiService.java
@@ -1,0 +1,289 @@
+package com.divudi.service.investigation;
+
+import com.divudi.core.data.CssFontStyle;
+import com.divudi.core.data.CssTextAlign;
+import com.divudi.core.data.CssVerticalAlign;
+import com.divudi.core.data.InvestigationItemType;
+import com.divudi.core.data.InvestigationItemValueType;
+import com.divudi.core.data.ReportItemType;
+import com.divudi.core.data.dto.investigation.CommonReportItemDTO;
+import com.divudi.core.data.dto.investigation.CommonReportItemUpdateDTO;
+import com.divudi.core.data.dto.investigation.ReportFormatDTO;
+import com.divudi.core.entity.WebUser;
+import com.divudi.core.entity.lab.CommonReportItem;
+import com.divudi.core.entity.lab.ReportFormat;
+import com.divudi.core.facade.CommonReportItemFacade;
+import com.divudi.core.facade.ReportFormatFacade;
+import com.divudi.core.util.CommonFunctions;
+
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import javax.persistence.TemporalType;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Read/write access to a lab report format's <b>common template</b> — the
+ * {@code CommonReportItem} rows (patient-details block, signature block, footer)
+ * that print on every report produced in that format.
+ *
+ * <p>Sibling of {@link InvestigationFormatApiService}, which covers the
+ * per-investigation {@code InvestigationItem} rows and cannot reach these: common
+ * template rows are keyed on the report-format {@code Category} and carry no
+ * {@code item}, so the investigation-scoped queries never match them (#23529).</p>
+ *
+ * <p>Everything here is scoped to the {@code ReportFormat} Category subclass, which
+ * is exactly what the common-template screen
+ * (<code>admin/lims/report_template.xhtml</code>) offers. {@code CommonReportItem}
+ * rows also back the HR/clinical form templates under arbitrary categories
+ * ({@code FormFormatController}, {@code StaffController}); those are deliberately
+ * out of reach of this lab-facing API.</p>
+ */
+@Stateless
+public class ReportFormatApiService implements Serializable {
+
+    @EJB
+    private ReportFormatFacade reportFormatFacade;
+    @EJB
+    private CommonReportItemFacade commonReportItemFacade;
+
+    // =========================================================================
+    // Report formats
+    // =========================================================================
+
+    /**
+     * Lists the non-retired report formats, each with the number of common-template
+     * rows it owns, in the same order the common-template screen shows them.
+     */
+    public List<ReportFormatDTO> listFormats() {
+        String j = "select f from ReportFormat f where f.retired=false order by f.name";
+        List<ReportFormat> rows = reportFormatFacade.findByJpql(j);
+        Map<Long, Integer> counts = countItemsByFormat();
+        List<ReportFormatDTO> out = new ArrayList<>();
+        for (ReportFormat row : rows) {
+            Integer count = counts.get(row.getId());
+            out.add(toFormatDTO(row, count == null ? 0 : count, null));
+        }
+        return out;
+    }
+
+    // =========================================================================
+    // Common template items
+    // =========================================================================
+
+    public List<CommonReportItemDTO> listItems(Long categoryId) throws Exception {
+        loadFormat(categoryId);
+        Map<String, Object> m = new HashMap<>();
+        m.put("catId", categoryId);
+        String j = "select i from CommonReportItem i where i.retired=false "
+                + "and i.category.id=:catId order by i.name";
+        List<CommonReportItem> rows = commonReportItemFacade.findByJpql(j, m);
+        List<CommonReportItemDTO> out = new ArrayList<>();
+        for (CommonReportItem row : rows) {
+            out.add(toItemDTO(row, null));
+        }
+        return out;
+    }
+
+    public CommonReportItemDTO getItem(Long categoryId, Long itemId) throws Exception {
+        return toItemDTO(loadItem(itemId, categoryId), "Item found successfully");
+    }
+
+    public CommonReportItemDTO createItem(Long categoryId, CommonReportItemUpdateDTO req, WebUser user) throws Exception {
+        if (req == null || req.getName() == null || req.getName().trim().isEmpty()) {
+            throw new Exception("Item name is required");
+        }
+        ReportFormat format = loadFormat(categoryId);
+        CommonReportItem item = new CommonReportItem();
+        item.setCategory(format);
+        item.setName(req.getName().trim());
+        item.setCode(req.getCode() != null && !req.getCode().trim().isEmpty()
+                ? req.getCode().trim() : CommonFunctions.nameToCode(req.getName()));
+        applyFields(item, req);
+        item.setCreater(user);
+        item.setCreatedAt(new Date());
+        item.setRetired(false);
+        commonReportItemFacade.createAndFlush(item);
+        return toItemDTO(item, "Item created successfully");
+    }
+
+    public CommonReportItemDTO updateItem(Long categoryId, Long itemId, CommonReportItemUpdateDTO req, WebUser user) throws Exception {
+        if (req == null || !req.isValid()) {
+            throw new Exception("Valid update request is required");
+        }
+        CommonReportItem item = loadItem(itemId, categoryId);
+        if (req.getName() != null && !req.getName().trim().isEmpty()) {
+            item.setName(req.getName().trim());
+        }
+        if (req.getCode() != null) {
+            item.setCode(req.getCode().trim());
+        }
+        applyFields(item, req);
+        commonReportItemFacade.edit(item);
+        return toItemDTO(item, "Item updated successfully");
+    }
+
+    public CommonReportItemDTO deleteItem(Long categoryId, Long itemId, WebUser user) throws Exception {
+        CommonReportItem item = loadItem(itemId, categoryId);
+        item.setRetired(true);
+        item.setRetirer(user);
+        item.setRetiredAt(new Date());
+        commonReportItemFacade.edit(item);
+        return toItemDTO(item, "Item retired successfully");
+    }
+
+    // =========================================================================
+    // Private helpers
+    // =========================================================================
+
+    /**
+     * Applies every field the request actually carries. A null field is left
+     * untouched so a PUT can nudge a single coordinate; for the enum-backed fields
+     * an empty string clears the value.
+     */
+    private void applyFields(CommonReportItem item, CommonReportItemUpdateDTO req) throws Exception {
+        if (req.getDescription() != null) item.setDescription(req.getDescription());
+        if (req.getOrderNo() != null) item.setOrderNo(req.getOrderNo());
+        if (req.getPageNo() != null) item.setPageNo(req.getPageNo());
+        if (req.getHtmltext() != null) item.setHtmltext(req.getHtmltext());
+        if (req.getFormatPrefix() != null) item.setFormatPrefix(req.getFormatPrefix());
+        if (req.getFormatSuffix() != null) item.setFormatSuffix(req.getFormatSuffix());
+        if (req.getRiTop() != null) item.setRiTop(req.getRiTop());
+        if (req.getRiLeft() != null) item.setRiLeft(req.getRiLeft());
+        if (req.getRiWidth() != null) item.setRiWidth(req.getRiWidth());
+        if (req.getRiHeight() != null) item.setRiHeight(req.getRiHeight());
+        if (req.getRiFontSize() != null) item.setRiFontSize(req.getRiFontSize());
+        if (req.getHtPix() != null) item.setHtPix(req.getHtPix());
+        if (req.getWtPix() != null) item.setWtPix(req.getWtPix());
+        if (req.getCssFontFamily() != null) item.setCssFontFamily(req.getCssFontFamily());
+        if (req.getCssFontWeight() != null) item.setCssFontWeight(req.getCssFontWeight());
+        if (req.getReportItemType() != null) {
+            item.setReportItemType(parseEnum(ReportItemType.class, req.getReportItemType(), "reportItemType"));
+        }
+        if (req.getIxItemType() != null) {
+            item.setIxItemType(parseEnum(InvestigationItemType.class, req.getIxItemType(), "ixItemType"));
+        }
+        if (req.getIxItemValueType() != null) {
+            item.setIxItemValueType(parseEnum(InvestigationItemValueType.class, req.getIxItemValueType(), "ixItemValueType"));
+        }
+        if (req.getCssTextAlign() != null) {
+            item.setCssTextAlign(parseEnum(CssTextAlign.class, req.getCssTextAlign(), "cssTextAlign"));
+        }
+        if (req.getCssVerticalAlign() != null) {
+            item.setCssVerticalAlign(parseEnum(CssVerticalAlign.class, req.getCssVerticalAlign(), "cssVerticalAlign"));
+        }
+        if (req.getCssFontStyle() != null) {
+            item.setCssFontStyle(parseEnum(CssFontStyle.class, req.getCssFontStyle(), "cssFontStyle"));
+        }
+    }
+
+    /** Blank clears the value; anything else must name a constant of the enum. */
+    private <E extends Enum<E>> E parseEnum(Class<E> enumClass, String raw, String field) throws Exception {
+        if (raw.trim().isEmpty()) {
+            return null;
+        }
+        try {
+            return Enum.valueOf(enumClass, raw.trim());
+        } catch (IllegalArgumentException ex) {
+            throw new Exception("Invalid " + field + ": " + raw
+                    + ". Valid values: " + Arrays.toString(enumClass.getEnumConstants()));
+        }
+    }
+
+    private ReportFormat loadFormat(Long id) throws Exception {
+        ReportFormat format = id == null ? null : reportFormatFacade.find(id);
+        if (format == null || format.isRetired()) {
+            throw new Exception("Report format not found with ID: " + id);
+        }
+        return format;
+    }
+
+    private CommonReportItem loadItem(Long itemId, Long categoryId) throws Exception {
+        loadFormat(categoryId);
+        CommonReportItem item = itemId == null ? null : commonReportItemFacade.find(itemId);
+        if (item == null || item.isRetired()) {
+            throw new Exception("Common report item not found with ID: " + itemId);
+        }
+        if (item.getCategory() == null || !item.getCategory().getId().equals(categoryId)) {
+            throw new Exception("Item " + itemId + " does not belong to report format " + categoryId);
+        }
+        return item;
+    }
+
+    /** Row counts for every format in one query, so listing formats is not N+1. */
+    private Map<Long, Integer> countItemsByFormat() {
+        String j = "select i.category.id, count(i) from CommonReportItem i "
+                + "where i.retired=false and i.category is not null group by i.category.id";
+        List<Object[]> rows = commonReportItemFacade.findObjectsArrayByJpql(j, new HashMap<>(), TemporalType.TIMESTAMP);
+        Map<Long, Integer> counts = new HashMap<>();
+        if (rows != null) {
+            for (Object[] row : rows) {
+                counts.put(((Number) row[0]).longValue(), ((Number) row[1]).intValue());
+            }
+        }
+        return counts;
+    }
+
+    private ReportFormatDTO toFormatDTO(ReportFormat format, Integer itemCount, String msg) {
+        ReportFormatDTO dto = new ReportFormatDTO();
+        dto.setId(format.getId());
+        dto.setName(format.getName());
+        dto.setCode(format.getCode());
+        dto.setDescription(format.getDescription());
+        dto.setOrderNo(format.getOrderNo());
+        if (format.getParentCategory() != null) {
+            dto.setParentCategoryId(format.getParentCategory().getId());
+            dto.setParentCategoryName(format.getParentCategory().getName());
+        }
+        dto.setItemCount(itemCount);
+        dto.setMessage(msg);
+        return dto;
+    }
+
+    /**
+     * Reports the row as rendered, not as stored. Several {@code ReportItem} getters
+     * substitute a default when the stored value is empty — {@code riWidth} 30,
+     * {@code riHeight} 2, {@code riFontSize} 12 (#23528), {@code ixItemType} Label,
+     * {@code cssTextAlign} Left, {@code cssFontStyle} Normal — and this reports what
+     * they return, i.e. what the printed report uses. Matches
+     * {@code InvestigationFormatApiService.toItemDTO}.
+     */
+    private CommonReportItemDTO toItemDTO(CommonReportItem item, String msg) {
+        CommonReportItemDTO dto = new CommonReportItemDTO();
+        dto.setId(item.getId());
+        if (item.getCategory() != null) {
+            dto.setCategoryId(item.getCategory().getId());
+            dto.setCategoryName(item.getCategory().getName());
+        }
+        dto.setName(item.getName());
+        dto.setCode(item.getCode());
+        dto.setDescription(item.getDescription());
+        dto.setOrderNo(item.getOrderNo());
+        dto.setPageNo(item.getPageNo());
+        dto.setReportItemType(item.getReportItemType() != null ? item.getReportItemType().name() : null);
+        dto.setIxItemType(item.getIxItemType() != null ? item.getIxItemType().name() : null);
+        dto.setIxItemValueType(item.getIxItemValueType() != null ? item.getIxItemValueType().name() : null);
+        dto.setHtmltext(item.getHtmltext());
+        dto.setFormatPrefix(item.getFormatPrefix());
+        dto.setFormatSuffix(item.getFormatSuffix());
+        dto.setRiTop(item.getRiTop());
+        dto.setRiLeft(item.getRiLeft());
+        dto.setRiWidth(item.getRiWidth());
+        dto.setRiHeight(item.getRiHeight());
+        dto.setRiFontSize(item.getRiFontSize());
+        dto.setHtPix(item.getHtPix());
+        dto.setWtPix(item.getWtPix());
+        dto.setCssTextAlign(item.getCssTextAlign() != null ? item.getCssTextAlign().name() : null);
+        dto.setCssVerticalAlign(item.getCssVerticalAlign() != null ? item.getCssVerticalAlign().name() : null);
+        dto.setCssFontStyle(item.getCssFontStyle() != null ? item.getCssFontStyle().name() : null);
+        dto.setCssFontFamily(item.getCssFontFamily());
+        dto.setCssFontWeight(item.getCssFontWeight());
+        dto.setMessage(msg);
+        return dto;
+    }
+}

--- a/src/main/java/com/divudi/ws/common/ApplicationConfig.java
+++ b/src/main/java/com/divudi/ws/common/ApplicationConfig.java
@@ -67,6 +67,7 @@ public class ApplicationConfig extends Application {
         resources.add(com.divudi.ws.investigation.InvestigationFormatApi.class);
         resources.add(com.divudi.ws.investigation.InvestigationFullApi.class);
         resources.add(com.divudi.ws.investigation.InvestigationValidatorApi.class);
+        resources.add(com.divudi.ws.investigation.ReportFormatApi.class);
         resources.add(com.divudi.ws.inward.AdmissionNumberApi.class);
         resources.add(com.divudi.ws.inward.AdmissionSearchApi.class);
         resources.add(com.divudi.ws.inward.ApiInward.class);

--- a/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
+++ b/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
@@ -436,6 +436,22 @@ public class CapabilityStatementResource {
                         + "Sub-resources: /items, /items/{itemId}/values, /calculations, /flags, /dynamic-labels.",
                         "API Key",
                         "GET", "POST", "PUT", "DELETE"))
+                .add(resource("Report Formats (Common Template)", "/api/report-formats",
+                        "Manage the common report template — the CommonReportItem rows (patient-details block, "
+                        + "signature block, footer) that print on every report of a given lab report format. "
+                        + "This is what the Investigation Format API above cannot reach: those rows are keyed on the "
+                        + "report-format Category and carry no investigation. "
+                        + "GET /report-formats lists the non-retired ReportFormat categories with their template row counts. "
+                        + "Sub-resource /{categoryId}/items supports GET (list), GET /{itemId}, POST, PUT /{itemId} and "
+                        + "DELETE /{itemId} (soft-retire). "
+                        + "Geometry is percentage-based (riTop, riLeft, riWidth, riHeight) with riFontSize in points — "
+                        + "the fields to nudge when printing onto pre-printed stationery. Only the fields present in a "
+                        + "PUT body are applied, so a single coordinate can be moved on its own. Reads report the "
+                        + "rendered value, not the stored one: riWidth/riHeight/riFontSize fall back to 30/2/12 when "
+                        + "unset (see #23528). Scoped to ReportFormat categories only — the HR/clinical form templates "
+                        + "that reuse CommonReportItem under other categories are deliberately not reachable here.",
+                        "API Key",
+                        "GET", "POST", "PUT", "DELETE"))
                 .add(resource("Investigation Components", "/api/investigations/{investigationId}/components",
                         "Manage InvestigationComponent groupings used to organize report items within an investigation's format "
                         + "(componentName only). GET lists components for the investigation. POST creates one. "

--- a/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
+++ b/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
@@ -450,7 +450,7 @@ public class CapabilityStatementResource {
                         + "rendered value, not the stored one: riWidth/riHeight/riFontSize fall back to 30/2/12 when "
                         + "unset (see #23528). Scoped to ReportFormat categories only — the HR/clinical form templates "
                         + "that reuse CommonReportItem under other categories are deliberately not reachable here.",
-                        "API Key",
+                        "API Key (Finance header)",
                         "GET", "POST", "PUT", "DELETE"))
                 .add(resource("Investigation Components", "/api/investigations/{investigationId}/components",
                         "Manage InvestigationComponent groupings used to organize report items within an investigation's format "

--- a/src/main/java/com/divudi/ws/investigation/ReportFormatApi.java
+++ b/src/main/java/com/divudi/ws/investigation/ReportFormatApi.java
@@ -1,0 +1,204 @@
+package com.divudi.ws.investigation;
+
+import com.divudi.bean.common.ApiKeyController;
+import com.divudi.core.data.dto.investigation.CommonReportItemDTO;
+import com.divudi.core.data.dto.investigation.CommonReportItemUpdateDTO;
+import com.divudi.core.entity.ApiKey;
+import com.divudi.core.entity.WebUser;
+import com.divudi.service.investigation.ReportFormatApiService;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Common report template endpoints — the counterpart of {@link InvestigationFormatApi},
+ * which is scoped to one investigation and so cannot reach the rows shared by every
+ * report of a format (patient-details block, signature block, footer).
+ *
+ * <p>These are the rows a hospital printing onto pre-printed stationery has to nudge,
+ * and until now the only way to move them was direct SQL against the database
+ * followed by a cache bounce (#23529). Writing through here goes via the facade, so
+ * the EclipseLink L2 cache stays correct with no redeploy.</p>
+ */
+@Path("report-formats")
+@RequestScoped
+public class ReportFormatApi {
+
+    @Context
+    private HttpServletRequest requestContext;
+
+    @Inject
+    private ApiKeyController apiKeyController;
+
+    @Inject
+    private ReportFormatApiService formatService;
+
+    private static final Gson gson = new GsonBuilder()
+            .setDateFormat("yyyy-MM-dd HH:mm:ss")
+            .create();
+
+    // =========================================================================
+    // Report formats
+    // =========================================================================
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response listFormats() {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) return errorResponse("Not a valid key", 401);
+            return successResponse(formatService.listFormats());
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    // =========================================================================
+    // Common template items
+    // =========================================================================
+
+    @GET
+    @Path("/{categoryId}/items")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response listItems(@PathParam("categoryId") Long categoryId) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) return errorResponse("Not a valid key", 401);
+            return successResponse(formatService.listItems(categoryId));
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    @GET
+    @Path("/{categoryId}/items/{itemId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getItem(@PathParam("categoryId") Long categoryId,
+                            @PathParam("itemId") Long itemId) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) return errorResponse("Not a valid key", 401);
+            return successResponse(formatService.getItem(categoryId, itemId));
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    @POST
+    @Path("/{categoryId}/items")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response createItem(@PathParam("categoryId") Long categoryId, String body) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) return errorResponse("Not a valid key", 401);
+            CommonReportItemUpdateDTO req = gson.fromJson(body, CommonReportItemUpdateDTO.class);
+            CommonReportItemDTO dto = formatService.createItem(categoryId, req, user);
+            return Response.status(201).entity(gson.toJson(successData(dto, 201))).build();
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    @PUT
+    @Path("/{categoryId}/items/{itemId}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response updateItem(@PathParam("categoryId") Long categoryId,
+                               @PathParam("itemId") Long itemId, String body) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) return errorResponse("Not a valid key", 401);
+            CommonReportItemUpdateDTO req = gson.fromJson(body, CommonReportItemUpdateDTO.class);
+            return successResponse(formatService.updateItem(categoryId, itemId, req, user));
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    @DELETE
+    @Path("/{categoryId}/items/{itemId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response deleteItem(@PathParam("categoryId") Long categoryId,
+                               @PathParam("itemId") Long itemId) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) return errorResponse("Not a valid key", 401);
+            return successResponse(formatService.deleteItem(categoryId, itemId, user));
+        } catch (Exception e) {
+            return errorResponse("An error occurred: " + e.getMessage(), 500);
+        }
+    }
+
+    // =========================================================================
+    // Private helpers
+    // =========================================================================
+
+    private WebUser validateApiKey(String key) {
+        if (key == null || key.trim().isEmpty()) {
+            return null;
+        }
+        ApiKey apiKey = apiKeyController.findApiKey(key);
+        if (apiKey == null || apiKey.isRetired()) {
+            return null;
+        }
+        WebUser user = apiKey.getWebUser();
+        if (user == null || user.isRetired() || !user.isActivated()) {
+            return null;
+        }
+        Date expiry = apiKey.getDateOfExpiary();
+        if (expiry == null || expiry.before(new Date())) {
+            return null;
+        }
+        return user;
+    }
+
+    private Response successResponse(Object data) {
+        return Response.ok(gson.toJson(successData(data))).build();
+    }
+
+    private Response errorResponse(String message, int statusCode) {
+        return Response.status(statusCode).entity(gson.toJson(errorData(message, statusCode))).build();
+    }
+
+    private Map<String, Object> successData(Object data) {
+        return successData(data, 200);
+    }
+
+    private Map<String, Object> successData(Object data, int statusCode) {
+        Map<String, Object> map = new HashMap<>();
+        map.put("status", "success");
+        map.put("code", statusCode);
+        map.put("timestamp", new Date());
+        map.put("data", data);
+        return map;
+    }
+
+    private Map<String, Object> errorData(String message, int statusCode) {
+        Map<String, Object> map = new HashMap<>();
+        map.put("status", "error");
+        map.put("code", statusCode);
+        map.put("message", message);
+        map.put("timestamp", new Date());
+        map.put("data", Collections.emptyMap());
+        return map;
+    }
+}


### PR DESCRIPTION
Closes #23529

## The gap

`/api/investigation-formats` can only reach `InvestigationItem` rows — its JPQL filters on `i.item.id`. A `CommonReportItem` is keyed on the report-format `Category` and carries no `item`, so the **common template** — the patient-details block, the signature block and the footer, the rows that print on *every* report produced in a format — was unreachable from any API. The only way to move that block was direct SQL.

Direct SQL is also actively misleading here: EclipseLink's L2 cache keeps serving the old geometry until the application is disabled and re-enabled, so the edit looks like it silently failed.

## What this adds

| Method | Path |
|---|---|
| GET | `/api/report-formats` |
| GET | `/api/report-formats/{categoryId}/items` |
| GET | `/api/report-formats/{categoryId}/items/{itemId}` |
| POST | `/api/report-formats/{categoryId}/items` |
| PUT | `/api/report-formats/{categoryId}/items/{itemId}` |
| DELETE | `/api/report-formats/{categoryId}/items/{itemId}` |

`Finance` header auth, the standard `{status, code, timestamp, data}` envelope, the same Gson date format as the sibling API, and all writes through the facades so the L2 cache stays coherent.

Also registered in `ApplicationConfig` and `CapabilityStatementResource`, exposed to the in-app AI chat as the `manage_report_formats` tool, and documented at `developer_docs/api/using-apis/API_REPORT_FORMATS.md`.

## Verified

All against local Payara + the local `coop` MySQL, driving the app through the menus only.

- `GET /api/report-formats` item counts (29 / 26 / 28 / 29 / 29) match a `GROUP BY` straight against the database.
- No `Finance` header → 401 "Not a valid key".
- `PUT` applies only the fields sent — DB confirmed `Name` riTop 13.6 → 16.1 with riLeft/riWidth/riFontSize untouched; `Signature` riLeft 77 → 82; `Bottom Line` riFontSize 12 → 10.5.
- `POST` → 201, row persisted with `dtype='CommonReportItem'`, the right `category_id`, and a `creater_id`.
- A non-`ReportFormat` category is rejected: "Report format not found with ID: 63".
- Empty string on an enum-backed field clears it — `reportItemType` NULL in the DB.
- `DELETE` soft-retires (retired = 1 with `retirer_id` and `retiredAt`); the row then disappears from LIST and is no longer gettable.
- **The issue's own scenario**: moved the whole patient-details block down 2.5% with one PUT per row — the DB shows 16.1 / 18.3 / 20.5 / 22.8 / 25.1 / 27.5 with the signature left alone at 82.5.
- Cross-checked in the app itself: *Administration → Manage Lab Services → Report Templates → Report Format Templates* shows Top = 16.1 for the `Name` row, which proves both cache coherence and that the API touches the rows the renderer actually uses.

## Decisions made without approval

This was built unattended, so every judgment call is listed here rather than asked.

1. **Scope is `ReportFormat` categories only.** `CommonReportItem` also backs HR and clinical form templates hung off arbitrary categories (`FormFormatController`, `StaffController`). This API is lab-facing and mirrors what the Report Format Templates screen offers, so a non-`ReportFormat` category id is rejected rather than quietly served. Widening it later is additive.
2. **One `CommonReportItemUpdateDTO` for both POST and PUT**, mirroring `InvestigationItemUpdateDTO`, instead of separate create/update shapes. The field sets would have been identical.
3. **Null means "leave alone"; empty string on an enum-backed field means "clear it".** There is otherwise no way to null out `reportItemType`, and a partial PUT is what block-moving needs.
4. **Reads report the *rendered* value, not the stored one.** Several `ReportItem` getters substitute a default when the stored value is empty (`riWidth` 30, `riHeight` 2, `riFontSize` 12, `ixItemType` Label, `cssTextAlign` Left, `cssFontStyle` Normal). The API reports what those getters return, i.e. what the printed report uses — matching the screen. The mutating-getter behaviour itself is tracked separately as #23528 and is deliberately not changed here.
5. **DELETE is a soft retire**, setting `retired`/`retirer`/`retiredAt`, consistent with the rest of the codebase. Nothing is removed from the table.
6. **`Finance` header auth, no new privilege and no new key type.** Security-privilege changes are out of bounds for unattended work, and the sibling format API already uses `Finance`.
7. **Ownership is checked explicitly**: an item that exists but belongs to a different format returns "Item {itemId} does not belong to report format {categoryId}" rather than a bare not-found, because that is the mistake a support engineer will actually make.
8. **No bulk / block-move endpoint.** Moving a block is one PUT per row. A bulk endpoint would need its own transactional and partial-failure semantics for a use case that a caller can express in a loop; the doc says so explicitly.
9. **The AI-chat tool takes the raw `toolInput` object** rather than ~25 positional parameters, and maps snake_case tool fields to the DTO's camelCase. The alternative was a 25-argument method signature.
10. **Wiki prose was rewritten, not just appended to.** The documented menu path was wrong (it named a path that does not exist); it is corrected to *Administration → Manage Lab Services → Report Templates → Report Format Templates*, with a screenshot and a new "The Common Template" section covering pre-printed stationery.

## Independent review

A second reviewer pass ran over the whole diff against the sibling `InvestigationFormatApi` implementation and the `ReportItem`/`CommonReportItem` entities. It confirmed the JPQL scoping, the ownership check, the soft-delete semantics, the 201, the envelope shape, the grouped `count(i)` (not a `findDoubleByJpql` misuse), and that `AbstractFacade.find` cannot cross the single-table-inheritance boundary between `CommonReportItem` and `InvestigationItem`.

It raised one defect, now fixed: the Errors table documented the bare messages, but every non-auth failure is a 500 whose `message` carries the literal `An error occurred: ` prefix (the sibling API's wrapper). The doc now states the prefix, gives the HTTP status per row, and tells integrators to match on a substring.

It also flagged `order by i.name` in `listItems` as a possible deviation (the sibling orders by `orderNo`) and then withdrew it: `CommonReportItemController.listCommonRportItems`, the method that actually drives PDF generation, and `StaffController`'s equivalent both already order by name for this entity, so the API matches the renderer.

Two earlier self-review defects were caught before this and folded into the same commit: `listFormats()` was issuing one COUNT per format (N+1, replaced with a single `GROUP BY`), and the AI-chat tool's numeric parsing let a `NumberFormatException` escape into a `catch (IllegalArgumentException)` and surface as a contextless `For input string: "abc"` (now `Error: ri_top must be a number, got: abc`).

## Documentation

- Endpoint reference: `developer_docs/api/using-apis/API_REPORT_FORMATS.md` (indexed in `using-apis/README.md`)
- Wiki: [LIMS Admin — Report Formats](https://github.com/hmislk/hmis/wiki/LIMS-Admin-Report-Formats) — corrected menu path, screenshot, and a new "The Common Template" section
- `developer_docs/testing/playwright-e2e-workflow.md` gained two hard-won notes: `MSYS_NO_PATHCONV=1` for `asadmin` under Git Bash, and how to open a PrimeFaces second-level menu flyout (a CSS-selector click on the top-level anchor; hover and accessibility refs both fail).

## Not done

- No schema change, no migration, no privilege change.
- No production or remote database was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F5EjQMkgdBq97LToJSpQuE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an authenticated Report Formats API for listing report formats and creating, viewing, updating, and deleting shared report-template items.
  - Added support for template layout, positioning, dimensions, typography, formatting, and styling fields.
  - Added report-format management through the AI assistant, including validation and partial updates.
  - Added Report Formats to the available API capability listing.

- **Documentation**
  - Added API usage documentation covering authentication, fields, errors, examples, and template-management guidance.
  - Documented Playwright workflow findings for deployment and nested menu interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->