### PR TITLE
fix(inward): let day-case admissions bill services without a room

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BillBhtController.java
+++ b/src/main/java/com/divudi/bean/inward/BillBhtController.java
@@ -34,6 +34,7 @@ import com.divudi.core.data.PaymentMethod;
 import com.divudi.core.data.admin.ConfigOptionInfo;
 import com.divudi.core.data.admin.PageMetadata;
 import com.divudi.core.data.admin.PrivilegeInfo;
+import com.divudi.core.data.inward.AdmissionTypeEnum;
 import com.divudi.core.data.inward.SurgeryBillType;
 import com.divudi.ejb.BillNumberGenerator;
 import com.divudi.core.entity.Bill;
@@ -986,13 +987,9 @@ public class BillBhtController implements Serializable {
             return;
         }
         paymentMethod = null;
-        if ((getPatientEncounter().getAdmissionType().isRoomChargesAllowed() && !isBabyAdmission()) || getPatientEncounter().getCurrentPatientRoom() != null) {
-            settleBill(getPatientEncounter().getCurrentPatientRoom().getRoomFacilityCharge().getDepartment(), getPatientEncounter().getPaymentMethod());
-        } else {
-            // Baby admissions may have no room of their own (they stay in the
-            // mother's room), so fall back to the encounter's department. (Issue #23509)
-            settleBill(getPatientEncounter().getDepartment(), getPatientEncounter().getPaymentMethod());
-        }
+        // Room-less encounters - day cases, package admissions, babies - bill
+        // against the encounter's own department instead of the room's.
+        settleBill(feeDepartment(getPatientEncounter()), getPatientEncounter().getPaymentMethod());
     }
 
     public void settleBillSurgery() {
@@ -1163,9 +1160,11 @@ public class BillBhtController implements Serializable {
             return true;
         }
 
-        // Room is optional for baby admissions (they stay in the mother's room), so
-        // this gate only fires for babies when a room was actually assigned. (Issue #23509)
-        if ((getPatientEncounter().getAdmissionType().isRoomChargesAllowed() && !isBabyAdmission()) || getPatientEncounter().getCurrentPatientRoom() != null) {
+        // A room is only required when this encounter is expected to have one, or
+        // when one has actually been assigned. Day cases, package admissions and
+        // baby admissions have no room of their own and still bill services
+        // normally, against the encounter's own department. (Issues #23509, #23570)
+        if (roomRequiredForBilling(getPatientEncounter())) {
             if (getPatientEncounter().getCurrentPatientRoom() == null) {
                 JsfUtil.addErrorMessage("Cannot settle: this admission has no current room. Assign a room first.");
                 return true;
@@ -1205,13 +1204,91 @@ public class BillBhtController implements Serializable {
     }
 
     /**
-     * @return {@code true} when the current encounter is a baby admission
-     * (i.e. it has a parent encounter). Babies stay in the mother's room, so
-     * room selection is optional for them, mirroring AdmissionController's
-     * isBabyAdmission(). (Issue #23509)
+     * @return {@code true} when the encounter is a baby admission (i.e. it has a
+     * parent encounter). Babies stay in the mother's room, so room selection is
+     * optional for them, mirroring AdmissionController's isBabyAdmission().
+     * (Issue #23509)
      */
-    private boolean isBabyAdmission() {
-        return getPatientEncounter() != null && getPatientEncounter().getParentEncounter() != null;
+    private boolean isBabyAdmission(PatientEncounter encounter) {
+        return encounter != null && encounter.getParentEncounter() != null;
+    }
+
+    /**
+     * @return {@code true} when the encounter is a day case - the patient is
+     * admitted and discharged within the same visit and never occupies a bed of
+     * their own. Same test RoomChangeController uses to exempt day cases from
+     * the room-chain rules.
+     */
+    private boolean isDayCase(PatientEncounter encounter) {
+        return encounter != null
+                && encounter.getAdmissionType() != null
+                && encounter.getAdmissionType().getAdmissionTypeEnum() == AdmissionTypeEnum.DayCase;
+    }
+
+    /**
+     * Whether this encounter is <b>expected</b> to occupy a room of its own.
+     *
+     * <p>This is the question the billing screen actually needs answered, and it
+     * is deliberately separate from "is the patient in a room right now". A room
+     * is expected for an ordinary inward stay whose admission type takes room
+     * charges. It is <em>not</em> expected when:</p>
+     * <ul>
+     * <li>the admission type does not take room charges at all (e.g. package
+     * admissions where the stay is priced as a whole);</li>
+     * <li>the encounter is a <b>day case</b> - there is no bed to assign, but
+     * there are still services to bill;</li>
+     * <li>the encounter is a <b>baby admission</b> - the baby is billed in its
+     * own right but stays in the mother's room. (Issue #23509)</li>
+     * </ul>
+     *
+     * <p>An encounter that is not expected to have a room still bills services
+     * normally; it just prices them against the encounter's own department
+     * instead of the room's - see {@link #feeDepartment(PatientEncounter)}.</p>
+     */
+    private boolean roomExpected(PatientEncounter encounter) {
+        if (encounter == null || encounter.getAdmissionType() == null) {
+            return false;
+        }
+        return encounter.getAdmissionType().isRoomChargesAllowed()
+                && !isDayCase(encounter)
+                && !isBabyAdmission(encounter);
+    }
+
+    /**
+     * Whether a room has been assigned to this encounter at all. A room that has
+     * been assigned must be fully configured before anything is billed against
+     * it, whatever the admission type - somebody put the patient there on
+     * purpose, so a half-configured room is an error rather than something to
+     * fall back from silently.
+     */
+    private boolean roomAssigned(PatientEncounter encounter) {
+        return encounter != null && encounter.getCurrentPatientRoom() != null;
+    }
+
+    /**
+     * @return {@code true} when this encounter needs a fully configured room
+     * before anything can be billed on it - i.e. a room is expected, or one has
+     * already been assigned.
+     */
+    private boolean roomRequiredForBilling(PatientEncounter encounter) {
+        return roomExpected(encounter) || roomAssigned(encounter);
+    }
+
+    /**
+     * The department that fees and the inward margin matrix are looked up
+     * against: the current room's facility-charge department when the patient is
+     * in a room, and the encounter's own department when there is no room - day
+     * cases, package admissions and babies all take this second path.
+     */
+    private Department feeDepartment(PatientEncounter encounter) {
+        if (encounter == null) {
+            return null;
+        }
+        if (roomAssigned(encounter)
+                && encounter.getCurrentPatientRoom().getRoomFacilityCharge() != null) {
+            return encounter.getCurrentPatientRoom().getRoomFacilityCharge().getDepartment();
+        }
+        return encounter.getDepartment();
     }
 
     private boolean errorCheckForPatientRoomDepartment() {
@@ -1285,8 +1362,7 @@ public class BillBhtController implements Serializable {
             return;
         }
 
-        // Room is optional for baby admissions (they stay in the mother's room). (Issue #23509)
-        if ((patientEncounter.getAdmissionType().isRoomChargesAllowed() && !isBabyAdmission()) || patientEncounter.getCurrentPatientRoom() != null) {
+        if (roomRequiredForBilling(patientEncounter)) {
             if (errorCheckForPatientRoomDepartment()) {
                 return;
             }
@@ -1336,12 +1412,7 @@ public class BillBhtController implements Serializable {
         }
         addingEntry.setBillItem(bItem);
         addingEntry.setLstBillComponents(getBillBean().billComponentsFromBillItem(bItem));
-        if ((patientEncounter.getAdmissionType().isRoomChargesAllowed() && !isBabyAdmission()) || getPatientEncounter().getCurrentPatientRoom() != null) {
-            addingEntry.setLstBillFees(billFeeFromBillItemWithMatrix(bItem, getPatientEncounter(), getPatientEncounter().getCurrentPatientRoom().getRoomFacilityCharge().getDepartment(), getPatientEncounter().getPaymentMethod()));
-        } else {
-            // Room-less baby admissions fall back to the encounter's department. (Issue #23509)
-            addingEntry.setLstBillFees(billFeeFromBillItemWithMatrix(bItem, getPatientEncounter(), getPatientEncounter().getDepartment(), getPatientEncounter().getPaymentMethod()));
-        }
+        addingEntry.setLstBillFees(billFeeFromBillItemWithMatrix(bItem, getPatientEncounter(), feeDepartment(getPatientEncounter()), getPatientEncounter().getPaymentMethod()));
         addingEntry.setLstBillSessions(getBillBean().billSessionsfromBillItem(bItem));
         bItem.setMarginValue(getBillBean().calBillItemMargin(addingEntry));
 
@@ -1499,12 +1570,7 @@ public class BillBhtController implements Serializable {
             return;
         }
 
-        // Room is optional for baby admissions (they stay in the mother's room), so
-        // skip the room-required check entirely for a room-less baby — same gate as
-        // addToBill()/settleBill()/errorCheck() use. (Issue #23509)
-        if (((getPatientEncounter().getAdmissionType().isRoomChargesAllowed() && !isBabyAdmission())
-                || getPatientEncounter().getCurrentPatientRoom() != null)
-                && errorCheckForPatientRoomDepartment()) {
+        if (roomRequiredForBilling(getPatientEncounter()) && errorCheckForPatientRoomDepartment()) {
             return;
         }
 
@@ -1517,11 +1583,7 @@ public class BillBhtController implements Serializable {
                 ? bf.getBillItem().getQty() : 1.0;
         bf.setFeeUnitGrossValue(bf.getFeeGrossValue() / qty);
 
-        // Room-less baby admissions fall back to the encounter's department for the
-        // matrix/margin lookups, matching addToBill()'s pattern. (Issue #23509)
-        Department feeDepartment = ((getPatientEncounter().getAdmissionType().isRoomChargesAllowed() && !isBabyAdmission()) || getPatientEncounter().getCurrentPatientRoom() != null)
-                ? getPatientEncounter().getCurrentPatientRoom().getRoomFacilityCharge().getDepartment()
-                : getPatientEncounter().getDepartment();
+        Department feeDepartment = feeDepartment(getPatientEncounter());
 
         PriceMatrix priceMatrix = getPriceMatrixController().fetchInwardMargin(bf.getBillItem(), bf.getFeeUnitGrossValue(), feeDepartment, getPatientEncounter().getPaymentMethod(), null, getPatientEncounter().getAdmissionType(), resolveCurrentRoomCategory(getPatientEncounter()));
 

--- a/src/main/java/com/divudi/bean/inward/BillBhtController.java
+++ b/src/main/java/com/divudi/bean/inward/BillBhtController.java
@@ -1160,6 +1160,13 @@ public class BillBhtController implements Serializable {
             return true;
         }
 
+        // Nothing downstream can be trusted without it: it decides whether a room
+        // is required and feeds the inward margin matrix.
+        if (getPatientEncounter().getAdmissionType() == null) {
+            JsfUtil.addErrorMessage("Cannot settle: this admission has no admission type set.");
+            return true;
+        }
+
         // A room is only required when this encounter is expected to have one, or
         // when one has actually been assigned. Day cases, package admissions and
         // baby admissions have no room of their own and still bill services
@@ -1246,8 +1253,16 @@ public class BillBhtController implements Serializable {
      * instead of the room's - see {@link #feeDepartment(PatientEncounter)}.</p>
      */
     private boolean roomExpected(PatientEncounter encounter) {
-        if (encounter == null || encounter.getAdmissionType() == null) {
+        if (encounter == null) {
             return false;
+        }
+        // An encounter with no admission type is incomplete, not room-less: we
+        // cannot tell whether it should have a room, so assume it should rather
+        // than let it bill against the encounter's department unchecked. The
+        // billing entry points reject it outright with a message that names the
+        // real problem - this is the backstop for any other caller.
+        if (encounter.getAdmissionType() == null) {
+            return true;
         }
         return encounter.getAdmissionType().isRoomChargesAllowed()
                 && !isDayCase(encounter)
@@ -1314,6 +1329,11 @@ public class BillBhtController implements Serializable {
     private boolean errorCheckForAdding() {
         if (getPatientEncounter() == null) {
             JsfUtil.addErrorMessage("Please Select BHT");
+            return true;
+        }
+
+        if (getPatientEncounter().getAdmissionType() == null) {
+            JsfUtil.addErrorMessage("Cannot add a service: this admission has no admission type set.");
             return true;
         }
 

--- a/src/main/java/com/divudi/bean/inward/BillBhtController.java
+++ b/src/main/java/com/divudi/bean/inward/BillBhtController.java
@@ -981,6 +981,14 @@ public class BillBhtController implements Serializable {
 
     }
 
+    /**
+     * Settles the bill currently being built for the selected admission.
+     *
+     * <p>Validates through {@link #errorCheck()} first, then settles against
+     * {@link #feeDepartment(PatientEncounter)} - the current room's
+     * facility-charge department when the patient is in a room, and the
+     * encounter's own department when there is none.</p>
+     */
     public void settleBill() {
         bills = null;
         if (errorCheck()) {
@@ -1130,6 +1138,17 @@ public class BillBhtController implements Serializable {
         JsfUtil.addSuccessMessage("Logically Dischaged Success");
     }
 
+    /**
+     * Validation gate for settling: the bill must have entries, the encounter
+     * must carry the patient details and admission type the fee lookups need,
+     * staff must be named on any staff fee, a room must be present when
+     * {@link #roomRequiredForBilling(PatientEncounter)} says one is required,
+     * and the patient must not already be discharged.
+     *
+     * @return {@code true} when settling must not proceed. Every path that
+     * returns {@code true} also adds a message saying why, so the button is
+     * never a silent no-op.
+     */
     private boolean errorCheck() {
         if (getLstBillEntries().isEmpty()) {
 
@@ -1197,6 +1216,10 @@ public class BillBhtController implements Serializable {
         return false;
     }
 
+    /**
+     * @return {@code true} when some staff fee on the bill carries a non-zero
+     * value but no staff member, which would leave the fee unattributable.
+     */
     public boolean checkStaff() {
         for (BillFee bf : lstBillFees) {
             if (bf.getFee() != null && bf.getFee().getFeeType() != null
@@ -1326,6 +1349,14 @@ public class BillBhtController implements Serializable {
         return false;
     }
 
+    /**
+     * Validation gate for adding one item to the bill: an admission must be
+     * selected and carry an admission type, an item must be picked, and that
+     * item must have the department and category the fee lookups need.
+     *
+     * @return {@code true} when the item must not be added, having added a
+     * message saying why.
+     */
     private boolean errorCheckForAdding() {
         if (getPatientEncounter() == null) {
             JsfUtil.addErrorMessage("Please Select BHT");
@@ -1377,6 +1408,15 @@ public class BillBhtController implements Serializable {
         return false;
     }
 
+    /**
+     * Adds the currently selected item to the bill being built.
+     *
+     * <p>Rejects a duplicate item, and requires a fully configured room only
+     * when {@link #roomRequiredForBilling(PatientEncounter)} says so. Fees are
+     * priced against {@link #feeDepartment(PatientEncounter)}, so a day case,
+     * package admission or baby with no room of its own prices against the
+     * encounter's own department.</p>
+     */
     public void addToBill() {
         if (errorCheckForAdding()) {
             return;
@@ -1585,6 +1625,14 @@ public class BillBhtController implements Serializable {
         setVatPlusNetTotal(getNetTotal() + getVat());
     }
 
+    /**
+     * Recalculates one fee after the user edits its gross value: derives the
+     * per-unit rate from the edited total, re-runs the inward margin matrix
+     * against {@link #feeDepartment(PatientEncounter)} and the current room
+     * category, then re-applies VAT and totals.
+     *
+     * @param bf the fee whose gross value was edited
+     */
     public void feeChanged(BillFee bf) {
         if (bf.getFeeGrossValue() == null) {
             return;


### PR DESCRIPTION
Closes #23570

## The problem

Adding a service to an admission assumed the patient was in a room. A **day case** never occupies one — the patient is admitted and discharged in the same visit — so a day-case admission type with **Room Charges Allowed** ticked demanded a room that would never exist. Add Service answered *"Please Set Room or Bed For This Patient"*, Settle answered *"Cannot settle: this admission has no current room. Assign a room first."* (the message added in #23523), and the admission simply could not be billed.

Whether it worked at all depended on an admin having left one checkbox unticked, not on anything structural.

## The redesign

The gate was this expression, repeated in five places (`settleBill`, `errorCheck`, `addToBill`, the bill-fee construction, `feeChanged`):

```java
(admissionType.isRoomChargesAllowed() && !isBabyAdmission())
        || currentPatientRoom != null
```

It asks *what kind of admission is this*, when the question the screen needs answered is *is there a room to bill against*. #23509 had already bolted the `!isBabyAdmission()` term onto it for exactly the same reason; day cases would have been the third special case on one condition.

Replaced with named predicates on the encounter:

| Predicate | Meaning |
|---|---|
| `roomExpected()` | An ordinary inward stay whose admission type takes room charges. False for day cases (`AdmissionTypeEnum.DayCase`), babies, and admission types that take no room charges. |
| `roomAssigned()` | A room has actually been assigned. |
| `roomRequiredForBilling()` | `roomExpected \|\| roomAssigned` — an assigned room must still be fully configured whatever the admission type, because somebody put the patient there on purpose. |
| `feeDepartment()` | The room's facility-charge department when there is a room, otherwise the encounter's own department. |

`AdmissionTypeEnum.DayCase` is already the test `RoomChangeController` uses to exempt day cases from the room-chain rules, so the billing screen now agrees with room management instead of disagreeing with it.

**No behaviour change for ordinary inward stays** — a ward patient with no bed assigned is still blocked, which is the intended safety net.

## Verified

Against local Payara and its database, reaching the screen through the menus (*Inpatient → Services & Items → Add Services & Investigations*).

**Before** — day-case admission, Room Charges Allowed ticked, no room: Add Service → *"Please Set Room or Bed For This Patient"*. Nothing could be billed.

**After** — same admission, same item:
- Item added to the bill at 750.00, no error.
- Settle → *"Bill Saved"* with the print preview.
- Database: the new `InwardBill` carries the **encounter's own department** as its department (the `feeDepartment()` fallback, since the room is null) and the item's department as its to-department.
- The only remaining validation encountered was the unrelated staff-fee guard (*"Please select Staff"*), which is correct and fired for the right reason — proof the room checks were passed rather than skipped wholesale.

**Regression** — normal roomed BHT admission (admission type BHT, room assigned, room charges allowed), same item: still adds and still settles to *"Bill Saved"*, and the new bill has the same department/to-department shape as that admission's own pre-existing bills.

## Note

The `feeChanged()` method keeps a local variable named `feeDepartment` alongside the new `feeDepartment()` method. Java keeps methods and variables in separate namespaces so this compiles and is unambiguous; renaming it was left out to keep the diff to the gating logic.

A Playwright note is worth adding to `developer_docs/testing/playwright-e2e-workflow.md` — the *third*-level menu flyout on this menubar does not open from a CSS-selector click the way the second level does. It is deliberately not in this PR because #23569 is already editing that file and would conflict; it can follow once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F5EjQMkgdBq97LToJSpQuE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inward service billing for day cases, package admissions, and baby admissions that do not require rooms.
  * Billing now consistently uses the appropriate encounter or room department.
  * Reduced incorrect room and department validation errors during bill settlement, item addition, and fee changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->