### PR TITLE
feat(inward): rename BHT Issue "Add Items" panel to "Add Additional Items"

### DIFF
--- a/src/main/webapp/ward/ward_pharmacy_bht_issue.xhtml
+++ b/src/main/webapp/ward/ward_pharmacy_bht_issue.xhtml
@@ -110,10 +110,10 @@
 
                         <div class="row">
                             <div class="col-md-6">
-                                <p:panel header="Add Items">
+                                <p:panel header="Add Additional Items">
                                     <f:facet name="header" >
                                         <h:outputText styleClass="fas fa-cube" />
-                                        <h:outputLabel value="Add Items" styleClass="mx-4"></h:outputLabel>
+                                        <h:outputLabel value="Add Additional Items" styleClass="mx-4"></h:outputLabel>
                                     </f:facet>
 
                                     <div class="row">


### PR DESCRIPTION
## Summary

- Issue #23563 asked to remove the "Add Items" option from the BHT Issue page. Discussion with the user clarified the actual need (per the reporting hospital, via Irani): a config option to control the panel's visibility (default visible), plus a clearer label.
- **The visibility config option already existed** — `ward/ward_pharmacy_bht_issue.xhtml` already gates the whole "Add Items" panel behind `configOptionApplicationController.getBooleanValueByKey('Adding new items for inpatient requests are allowed.', true)`, resolved per-department, default `true` (visible). No code change was needed for that part — a hospital that wants to restrict pharmacy staff to issuing only what was requested can already flip this off per department without a deploy.
- This PR renames the panel from **"Add Items"** to **"Add Additional Items"** for clarity (it's for adding extra items beyond the original request, not the primary issuing flow).

## Test plan

- [x] `mvn clean package -DskipTests` — build passed
- [x] Redeployed locally to Payara (`asadmin redeploy`), no errors in `server.log`
- [x] Playwright: logged in, selected **Main Pharmacy** department, navigated via **Menu → Inpatient Medication Management → BHT Issue Requests** (never by URL)
- [x] Created a real (disposable, local-only) pharmacy request for local test admission **BHT/57817**, then opened it as pharmacist to issue
- [x] Confirmed the panel renders **"Add Additional Items"** and is visible by default (config option default `true`)
- [x] Confirmed in the local DB that the `Adding new items for inpatient requests are allowed.` ConfigOption row exists with value `true`, and traced `ConfigOptionApplicationController.setBooleanValueByKey` as the admin-facing update path that persists + refreshes the cache

![BHT Issue page showing the panel renamed to "Add Additional Items", visible by default](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23563-add-additional-items-renamed.png)

## Documentation

Updated wiki page: https://github.com/hmislk/hmis/wiki/Inward-BHT-Issue-Against-Request (section "Adding Extra Items Manually") — reflects the new panel name and documents the visibility toggle.

Closes #23563

🤖 Generated with [Claude Code](https://claude.com/claude-code)