### PR TITLE
fix(inward): correct appointment-to-inward-deposit conversion and reporting gaps

### DIFF
--- a/.claude/skills/playwright-e2e/SKILL.md
+++ b/.claude/skills/playwright-e2e/SKILL.md
@@ -66,17 +66,34 @@ Instead, **immediately and without asking the user**, run:
 claude mcp list
 ```
 This performs a fresh, independent health check outside the current session's
-stale connection state. If it reports `playwright: ... - ✔ Connected`, the
-server is actually reachable — the failure was specific to this session's
-startup timing, not a real outage. In that case, tell the user briefly that
-the initial connection attempt timed out but the server is confirmed healthy,
-then fall back to `claude-in-chrome` for *this* session (per
-[[feedback-prefer-playwright-over-claude-in-chrome]] project memory) and
-recommend starting a fresh session next time to pick up the working
-connection. If `claude mcp list` also reports it unhealthy, it's a genuine
-outage — say so explicitly and ask the user how to proceed (fix the server,
-proceed with `claude-in-chrome`, or skip live browser testing) rather than
-silently substituting one tool for the other.
+stale connection state. `claude mcp list` reports one of several distinct
+statuses per server — treat each differently rather than collapsing them into
+a binary "healthy or not":
+
+- **`✔ Connected`** — the server is actually reachable; the earlier failure
+  was specific to this session's startup timing, not a real outage. Tell the
+  user briefly that the initial connection attempt timed out but the server
+  is confirmed healthy, then fall back to `claude-in-chrome` for *this*
+  session (per [[feedback-prefer-playwright-over-claude-in-chrome]] project
+  memory) and recommend starting a fresh session next time to pick up the
+  working connection.
+- **`! Needs authentication`** — not an outage; the server needs a sign-in or
+  header the current session hasn't provided. Tell the user it needs
+  re-authentication (`/mcp` panel or `claude mcp login`) rather than treating
+  it as down.
+- **`⏸ Pending approval`** — project-scoped server awaiting manual approval;
+  tell the user to run `claude` interactively to approve it, not a real
+  outage either.
+- **`! Connected · tools fetch failed`** — the connection itself works but
+  tool listing errored; this is a real (if partial) problem worth surfacing,
+  distinct from a clean outage.
+- **`✘ Failed to connect` / `✘ Connection error`** — only *these* two count
+  as a genuine outage. Say so explicitly and ask the user how to proceed (fix
+  the server, proceed with `claude-in-chrome`, or skip live browser testing)
+  rather than silently substituting one tool for the other.
+
+(Statuses per the Claude Code MCP docs as of this writing — reconfirm against
+current documentation if `claude mcp list`'s output format has changed.)
 
 Never silently swap in `claude-in-chrome` without first running this check and
 telling the user which case applies — `claude-in-chrome` cannot handle native

--- a/.claude/skills/playwright-e2e/SKILL.md
+++ b/.claude/skills/playwright-e2e/SKILL.md
@@ -53,6 +53,37 @@ is the finding — the page is unreachable in production. Do not fall back to th
 URL to get on with the test. See
 [§2](../../../developer_docs/testing/playwright-e2e-workflow.md#-never-navigate-by-typing-a-page-url).
 
+## If the Playwright MCP server shows as unavailable
+
+An MCP server that failed to connect at session start (e.g. a system-reminder
+saying `playwright (CONNECT_TIMEOUT)` or similar) will **not** self-heal
+mid-session — a session's MCP connections are established once at startup, so
+retrying a Playwright tool call again later in the same session wastes a
+round-trip and always fails the same way.
+
+Instead, **immediately and without asking the user**, run:
+```bash
+claude mcp list
+```
+This performs a fresh, independent health check outside the current session's
+stale connection state. If it reports `playwright: ... - ✔ Connected`, the
+server is actually reachable — the failure was specific to this session's
+startup timing, not a real outage. In that case, tell the user briefly that
+the initial connection attempt timed out but the server is confirmed healthy,
+then fall back to `claude-in-chrome` for *this* session (per
+[[feedback-prefer-playwright-over-claude-in-chrome]] project memory) and
+recommend starting a fresh session next time to pick up the working
+connection. If `claude mcp list` also reports it unhealthy, it's a genuine
+outage — say so explicitly and ask the user how to proceed (fix the server,
+proceed with `claude-in-chrome`, or skip live browser testing) rather than
+silently substituting one tool for the other.
+
+Never silently swap in `claude-in-chrome` without first running this check and
+telling the user which case applies — `claude-in-chrome` cannot handle native
+`confirm()`/`alert()`/`prompt()` dialogs (they freeze the extension), which
+HMIS billing/save flows trigger routinely, so the substitution carries real
+risk the user should know about upfront.
+
 ## Workflow
 
 1. **Confirm the target** with the user: which feature/page, which local

--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -18127,6 +18127,11 @@ public class SearchController implements Serializable {
             bundle.getBundles().add(inwardDepositCollection);
             collectionForTheDay += getSafeTotal(inwardDepositCollection);
 
+            // Generate Inward Payment Collection (interim + post-discharge payments) and add to the main bundle
+            ReportTemplateRowBundle inwardPaymentCollection = generateInwardPaymentCollection();
+            bundle.getBundles().add(inwardPaymentCollection);
+            collectionForTheDay += getSafeTotal(inwardPaymentCollection);
+
             // NOTE: Pharmacy Credit Company Payment Collection is NOT generated separately here
             // because pharmacy credit company bill types are already included in the OPD credit
             // company collection above (generateCreditCompanyCollectionForOpd() includes both
@@ -18746,6 +18751,7 @@ public class SearchController implements Serializable {
             List<BillTypeAtomic> inwardPayments = new ArrayList<>();
             inwardPayments.add(BillTypeAtomic.INWARD_PAYMENT);
             inwardPayments.add(BillTypeAtomic.INWARD_APPOINTMENT_BILL);
+            inwardPayments.add(BillTypeAtomic.POST_FINAL_BILL_INWARD_PAYMENT);
             ReportTemplateRowBundle inwardPaymentsBundle = generatePaymentMethodColumnsByBills(inwardPayments);
             inwardPaymentsBundle.setBundleType("InwardPayments");
             inwardPaymentsBundle.setName("Inward Payments");
@@ -18756,6 +18762,7 @@ public class SearchController implements Serializable {
             List<BillTypeAtomic> inwardPaymentsCancel = new ArrayList<>();
             inwardPaymentsCancel.add(BillTypeAtomic.INWARD_PAYMENT_CANCELLATION);
             inwardPaymentsCancel.add(BillTypeAtomic.INWARD_APPOINTMENT_CANCEL_BILL);
+            inwardPaymentsCancel.add(BillTypeAtomic.POST_FINAL_BILL_INWARD_PAYMENT_CANCELLATION);
             ReportTemplateRowBundle inwardPaymentsCancelBundle = generatePaymentMethodColumnsByBills(inwardPaymentsCancel);
             inwardPaymentsCancelBundle.setBundleType("InwardPaymentsCancel");
             inwardPaymentsCancelBundle.setName("Inward Payment Cancellations");
@@ -18765,11 +18772,42 @@ public class SearchController implements Serializable {
 // Generate Inward Payments Refund and add to the main bundle
             List<BillTypeAtomic> inwardPaymentsRefund = new ArrayList<>();
             inwardPaymentsRefund.add(BillTypeAtomic.INWARD_PAYMENT_REFUND);
+            inwardPaymentsRefund.add(BillTypeAtomic.INWARD_PAYMENT_REFUND_CANCELLATION);
+            inwardPaymentsRefund.add(BillTypeAtomic.POST_FINAL_BILL_INWARD_PAYMENT_REFUND);
             ReportTemplateRowBundle inwardPaymentsRefundBundle = generatePaymentMethodColumnsByBills(inwardPaymentsRefund);
             inwardPaymentsRefundBundle.setBundleType("InwardPaymentsRefund");
             inwardPaymentsRefundBundle.setName("Inward Payment Refunds");
             bundle.getBundles().add(inwardPaymentsRefundBundle);
             collectionForTheDay += getSafeTotal(inwardPaymentsRefundBundle);
+
+// Generate Inward Deposits and add to the main bundle (issue #23507 — previously
+// entirely missing from Cashier Summary/Detailed, unlike Daily Return)
+            List<BillTypeAtomic> inwardDeposits = new ArrayList<>();
+            inwardDeposits.add(BillTypeAtomic.INWARD_DEPOSIT);
+            ReportTemplateRowBundle inwardDepositsBundle = generatePaymentMethodColumnsByBills(inwardDeposits);
+            inwardDepositsBundle.setBundleType("InwardDeposits");
+            inwardDepositsBundle.setName("Inward Deposits");
+            bundle.getBundles().add(inwardDepositsBundle);
+            collectionForTheDay += getSafeTotal(inwardDepositsBundle);
+
+// Generate Inward Deposits Cancel and add to the main bundle
+            List<BillTypeAtomic> inwardDepositsCancel = new ArrayList<>();
+            inwardDepositsCancel.add(BillTypeAtomic.INWARD_DEPOSIT_CANCELLATION);
+            ReportTemplateRowBundle inwardDepositsCancelBundle = generatePaymentMethodColumnsByBills(inwardDepositsCancel);
+            inwardDepositsCancelBundle.setBundleType("InwardDepositsCancel");
+            inwardDepositsCancelBundle.setName("Inward Deposit Cancellations");
+            bundle.getBundles().add(inwardDepositsCancelBundle);
+            collectionForTheDay += getSafeTotal(inwardDepositsCancelBundle);
+
+// Generate Inward Deposits Refund and add to the main bundle
+            List<BillTypeAtomic> inwardDepositsRefund = new ArrayList<>();
+            inwardDepositsRefund.add(BillTypeAtomic.INWARD_DEPOSIT_REFUND);
+            inwardDepositsRefund.add(BillTypeAtomic.INWARD_DEPOSIT_REFUND_CANCELLATION);
+            ReportTemplateRowBundle inwardDepositsRefundBundle = generatePaymentMethodColumnsByBills(inwardDepositsRefund);
+            inwardDepositsRefundBundle.setBundleType("InwardDepositsRefund");
+            inwardDepositsRefundBundle.setName("Inward Deposit Refunds");
+            bundle.getBundles().add(inwardDepositsRefundBundle);
+            collectionForTheDay += getSafeTotal(inwardDepositsRefundBundle);
 
 // COMMENTED OUT: Replaced by unified Outpatient Credit Settling section below
 // This section was incomplete - missing OPD_CREDIT_COMPANY_PAYMENT_RECEIVED
@@ -19211,6 +19249,7 @@ public class SearchController implements Serializable {
             List<BillTypeAtomic> inwardPayments = new ArrayList<>();
             inwardPayments.add(BillTypeAtomic.INWARD_PAYMENT);
             inwardPayments.add(BillTypeAtomic.INWARD_APPOINTMENT_BILL);
+            inwardPayments.add(BillTypeAtomic.POST_FINAL_BILL_INWARD_PAYMENT);
             ReportTemplateRowBundle inwardPaymentsBundle = generatePaymentMethodColumnsByBills(inwardPayments);
             inwardPaymentsBundle.setBundleType("InwardPayments");
             inwardPaymentsBundle.setName("Inward Payments");
@@ -19221,6 +19260,7 @@ public class SearchController implements Serializable {
             List<BillTypeAtomic> inwardPaymentsCancel = new ArrayList<>();
             inwardPaymentsCancel.add(BillTypeAtomic.INWARD_PAYMENT_CANCELLATION);
             inwardPaymentsCancel.add(BillTypeAtomic.INWARD_APPOINTMENT_CANCEL_BILL);
+            inwardPaymentsCancel.add(BillTypeAtomic.POST_FINAL_BILL_INWARD_PAYMENT_CANCELLATION);
             ReportTemplateRowBundle inwardPaymentsCancelBundle = generatePaymentMethodColumnsByBills(inwardPaymentsCancel);
             inwardPaymentsCancelBundle.setBundleType("InwardPaymentsCancel");
             inwardPaymentsCancelBundle.setName("Inward Payment Cancellations");
@@ -19230,11 +19270,42 @@ public class SearchController implements Serializable {
 // Generate Inward Payments Refund and add to the main bundle
             List<BillTypeAtomic> inwardPaymentsRefund = new ArrayList<>();
             inwardPaymentsRefund.add(BillTypeAtomic.INWARD_PAYMENT_REFUND);
+            inwardPaymentsRefund.add(BillTypeAtomic.INWARD_PAYMENT_REFUND_CANCELLATION);
+            inwardPaymentsRefund.add(BillTypeAtomic.POST_FINAL_BILL_INWARD_PAYMENT_REFUND);
             ReportTemplateRowBundle inwardPaymentsRefundBundle = generatePaymentMethodColumnsByBills(inwardPaymentsRefund);
             inwardPaymentsRefundBundle.setBundleType("InwardPaymentsRefund");
             inwardPaymentsRefundBundle.setName("Inward Payment Refunds");
             bundle.getBundles().add(inwardPaymentsRefundBundle);
             collectionForTheDay += getSafeTotal(inwardPaymentsRefundBundle);
+
+// Generate Inward Deposits and add to the main bundle (issue #23507 — previously
+// entirely missing from Cashier Summary/Detailed, unlike Daily Return)
+            List<BillTypeAtomic> inwardDeposits = new ArrayList<>();
+            inwardDeposits.add(BillTypeAtomic.INWARD_DEPOSIT);
+            ReportTemplateRowBundle inwardDepositsBundle = generatePaymentMethodColumnsByBills(inwardDeposits);
+            inwardDepositsBundle.setBundleType("InwardDeposits");
+            inwardDepositsBundle.setName("Inward Deposits");
+            bundle.getBundles().add(inwardDepositsBundle);
+            collectionForTheDay += getSafeTotal(inwardDepositsBundle);
+
+// Generate Inward Deposits Cancel and add to the main bundle
+            List<BillTypeAtomic> inwardDepositsCancel = new ArrayList<>();
+            inwardDepositsCancel.add(BillTypeAtomic.INWARD_DEPOSIT_CANCELLATION);
+            ReportTemplateRowBundle inwardDepositsCancelBundle = generatePaymentMethodColumnsByBills(inwardDepositsCancel);
+            inwardDepositsCancelBundle.setBundleType("InwardDepositsCancel");
+            inwardDepositsCancelBundle.setName("Inward Deposit Cancellations");
+            bundle.getBundles().add(inwardDepositsCancelBundle);
+            collectionForTheDay += getSafeTotal(inwardDepositsCancelBundle);
+
+// Generate Inward Deposits Refund and add to the main bundle
+            List<BillTypeAtomic> inwardDepositsRefund = new ArrayList<>();
+            inwardDepositsRefund.add(BillTypeAtomic.INWARD_DEPOSIT_REFUND);
+            inwardDepositsRefund.add(BillTypeAtomic.INWARD_DEPOSIT_REFUND_CANCELLATION);
+            ReportTemplateRowBundle inwardDepositsRefundBundle = generatePaymentMethodColumnsByBills(inwardDepositsRefund);
+            inwardDepositsRefundBundle.setBundleType("InwardDepositsRefund");
+            inwardDepositsRefundBundle.setName("Inward Deposit Refunds");
+            bundle.getBundles().add(inwardDepositsRefundBundle);
+            collectionForTheDay += getSafeTotal(inwardDepositsRefundBundle);
 
 // COMMENTED OUT: These duplicate sections have been consolidated into the unified "Outpatient Credit Settling" sections below
             // This avoids double-counting and provides clearer separation between outpatient (OPD + Pharmacy) and inpatient credit settling
@@ -20877,6 +20948,64 @@ public class SearchController implements Serializable {
         depositCollection.setDescription("Inward Deposit Receipts, Cancellations, and Refunds");
 
         return depositCollection;
+    }
+
+    /**
+     * Interim "Make a Payment" inward payments and post-discharge (post-final-bill)
+     * inward payments, kept as their own bundle distinct from
+     * {@link #generateInwardDepositCollection()} (issue #23507) — these are a
+     * different financial concept (payment against an existing balance) from a
+     * deposit taken up front, and until this fix were never reported in Daily
+     * Return at all, unlike Cashier Summary/Detailed which already included
+     * INWARD_PAYMENT.
+     */
+    public ReportTemplateRowBundle generateInwardPaymentCollection() {
+        ReportTemplateRowBundle paymentCollection = new ReportTemplateRowBundle();
+
+        List<BillTypeAtomic> inwardPaymentBillTypes = new ArrayList<>();
+        inwardPaymentBillTypes.add(BillTypeAtomic.INWARD_PAYMENT);
+        inwardPaymentBillTypes.add(BillTypeAtomic.INWARD_PAYMENT_CANCELLATION);
+        inwardPaymentBillTypes.add(BillTypeAtomic.INWARD_PAYMENT_REFUND);
+        inwardPaymentBillTypes.add(BillTypeAtomic.INWARD_PAYMENT_REFUND_CANCELLATION);
+        inwardPaymentBillTypes.add(BillTypeAtomic.POST_FINAL_BILL_INWARD_PAYMENT);
+        inwardPaymentBillTypes.add(BillTypeAtomic.POST_FINAL_BILL_INWARD_PAYMENT_CANCELLATION);
+        inwardPaymentBillTypes.add(BillTypeAtomic.POST_FINAL_BILL_INWARD_PAYMENT_REFUND);
+
+        String jpql = "select b "
+                + " from Bill b "
+                + " left join fetch b.patient patient "
+                + " left join fetch patient.person "
+                + " where b.retired = :br "
+                + " and b.createdAt between :fd and :td "
+                + " and b.billTypeAtomic in :btas ";
+
+        Map<String, Object> m = new HashMap<>();
+        m.put("br", false);
+        m.put("fd", fromDate);
+        m.put("td", toDate);
+        m.put("btas", inwardPaymentBillTypes);
+
+        if (department != null) {
+            jpql += " and b.department = :dep ";
+            m.put("dep", department);
+        }
+        if (institution != null) {
+            jpql += " and b.department.institution = :ins ";
+            m.put("ins", institution);
+        }
+        if (site != null) {
+            jpql += " and b.department.site = :site ";
+            m.put("site", site);
+        }
+
+        List<Bill> bills = billFacade.findByJpql(jpql, m, TemporalType.TIMESTAMP);
+
+        billToBundleForPatientDeposits(paymentCollection, bills);
+        paymentCollection.setName("Inward Payment Collection");
+        paymentCollection.setBundleType("inwardPaymentCollection");
+        paymentCollection.setDescription("Inward Payments, Post-Discharge Payments, their Cancellations, and Refunds");
+
+        return paymentCollection;
     }
 
     public ReportTemplateRowBundle generatePharmacyCollection() {

--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -2380,6 +2380,8 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
 
     @Inject
     private InwardPaymentController inwardPaymentController;
+    @Inject
+    private InwardDepositController inwardDepositController;
     @EJB
     private AppointmentFacade appointmentFacade;
     @EJB
@@ -2515,15 +2517,15 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
                 : getCurrent().getPaymentMethod();
         PaymentMethodData conversionPaymentMethodData = buildPaymentMethodDataFromOriginalPayment(originalBill, appointmentPaymentMethod, amount);
         if (conversionPaymentMethodData != null) {
-            getInwardPaymentController().setPaymentMethodData(conversionPaymentMethodData);
+            getInwardDepositController().setPaymentMethodData(conversionPaymentMethodData);
         }
-        getInwardPaymentController().setPaymentMethod(appointmentPaymentMethod);
-        getInwardPaymentController().getCurrent().setPaymentMethod(appointmentPaymentMethod);
-        getInwardPaymentController().getCurrent().setPatientEncounter(current);
-        getInwardPaymentController().getCurrent().setTotal(amount);
-        getInwardPaymentController().pay();
-        lastConversionDepositBillId = getInwardPaymentController().getCurrent().getId();
-        getInwardPaymentController().makeNull();
+        getInwardDepositController().setPaymentMethod(appointmentPaymentMethod);
+        getInwardDepositController().getCurrent().setPaymentMethod(appointmentPaymentMethod);
+        getInwardDepositController().getCurrent().setPatientEncounter(current);
+        getInwardDepositController().getCurrent().setTotal(amount);
+        getInwardDepositController().pay();
+        lastConversionDepositBillId = getInwardDepositController().getCurrent().getId();
+        getInwardDepositController().makeNull();
 
         pendingAppointmentConversion = null;
         printPreview = true;
@@ -3580,6 +3582,14 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
 
     public void setInwardPaymentController(InwardPaymentController inwardPaymentController) {
         this.inwardPaymentController = inwardPaymentController;
+    }
+
+    public InwardDepositController getInwardDepositController() {
+        return inwardDepositController;
+    }
+
+    public void setInwardDepositController(InwardDepositController inwardDepositController) {
+        this.inwardDepositController = inwardDepositController;
     }
 
     public AppointmentFacade getAppointmentFacade() {

--- a/src/main/webapp/reports/cashier_reports/cashier_detailed.xhtml
+++ b/src/main/webapp/reports/cashier_reports/cashier_detailed.xhtml
@@ -316,6 +316,13 @@
                                     <ez:inwardPaymentsRefund id="inwardPaymentsRefund" bundle="#{myBundle}"
                                                              rendered="#{myBundle.bundleType eq 'InwardPaymentsRefund'}"/>
 
+                                    <!-- Inward Deposits -->
+                                    <ez:inwardDeposits id="inwardDeposits" bundle="#{myBundle}" rendered="#{myBundle.bundleType eq 'InwardDeposits'}"/>
+                                    <ez:inwardDepositsCancel id="inwardDepositsCancel" bundle="#{myBundle}"
+                                                             rendered="#{myBundle.bundleType eq 'InwardDepositsCancel'}"/>
+                                    <ez:inwardDepositsRefund id="inwardDepositsRefund" bundle="#{myBundle}"
+                                                             rendered="#{myBundle.bundleType eq 'InwardDepositsRefund'}"/>
+
                                     <!-- Credit Company Payments OPD - DEPRECATED: Now using unified OutpatientCreditSettling sections -->
                                     <!--
                                     <ez:creditCompanyPaymentOpReceive id="creditCompanyPaymentOpReceive" bundle="#{myBundle}"

--- a/src/main/webapp/reports/cashier_reports/cashier_summary.xhtml
+++ b/src/main/webapp/reports/cashier_reports/cashier_summary.xhtml
@@ -407,6 +407,14 @@
                                     <ez:inwardPaymentsRefund id="inwardPaymentsRefund" bundle="#{myBundle}"
                                                              rendered="#{myBundle.bundleType eq 'InwardPaymentsRefund'}"/>
 
+                                    <!-- Inward Deposits -->
+                                    <ez:inwardDeposits id="inwardDeposits" bundle="#{myBundle}"
+                                                       rendered="#{myBundle.bundleType eq 'InwardDeposits'}"/>
+                                    <ez:inwardDepositsCancel id="inwardDepositsCancel" bundle="#{myBundle}"
+                                                             rendered="#{myBundle.bundleType eq 'InwardDepositsCancel'}"/>
+                                    <ez:inwardDepositsRefund id="inwardDepositsRefund" bundle="#{myBundle}"
+                                                             rendered="#{myBundle.bundleType eq 'InwardDepositsRefund'}"/>
+
                                     <!-- Credit Company Payments OPD -->
                                     <!-- DEPRECATED: Replaced by unified Outpatient Credit Settling section
                                     <ez:creditCompanyPaymentOpReceive id="creditCompanyPaymentOpReceive" bundle="#{myBundle}"

--- a/src/main/webapp/reports/financialReports/daily_return.xhtml
+++ b/src/main/webapp/reports/financialReports/daily_return.xhtml
@@ -245,6 +245,7 @@
                                 <ez:companyPaymentBillChannelling bundle="#{myBundle}"  rendered="#{myBundle.bundleType eq 'companyPaymentBillChannelling'}"/>
                                 <ez:patientDepositPayments id="ccPatientDepositSection" bundle="#{myBundle}"  rendered="#{myBundle.bundleType eq 'patientDepositPayments'}" ></ez:patientDepositPayments>
                                 <ez:inwardDepositPayments id="inwardPatientDepositSection" bundle="#{myBundle}" rendered="#{myBundle.bundleType eq 'inwardDepositPayments'}"/>
+                                <ez:inwardPaymentCollection id="inwardPaymentCollectionSection" bundle="#{myBundle}" rendered="#{myBundle.bundleType eq 'inwardPaymentCollection'}"/>
                                 <ez:collectionForTheDay bundle="#{myBundle}"  rendered="#{myBundle.bundleType eq 'collectionForTheDay'}"/>
                                 <ez:pettyCashPayments bundle="#{myBundle}"  rendered="#{myBundle.bundleType eq 'pettyCashPayments'}"/>
 

--- a/src/main/webapp/resources/ezcomp/bundles/inwardDeposits.xhtml
+++ b/src/main/webapp/resources/ezcomp/bundles/inwardDeposits.xhtml
@@ -1,0 +1,267 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
+
+    <!-- INTERFACE -->
+    <cc:interface>
+        <cc:attribute name="bundle" type="com.divudi.core.data.ReportTemplateRowBundle" />
+    </cc:interface>
+
+    <!-- IMPLEMENTATION -->
+    <cc:implementation>
+
+        <h:panelGroup rendered="#{empty cc.attrs.bundle.reportTemplateRows}">
+            <table class="table w-100">
+                <thead>
+                    <tr class="text-light bg-dark">
+                        <th class="text-light bg-dark">
+                            <h:outputText value="No Data for #{cc.attrs.bundle.name}" ></h:outputText>
+                        </th>
+                    </tr>
+                </thead>
+            </table>
+        </h:panelGroup>
+
+        <h:panelGroup rendered="#{not empty cc.attrs.bundle.reportTemplateRows}">
+            <table class="table w-100">
+                <thead>
+                    <tr class="text-light bg-success">
+                        <th class="text-light bg-success">
+                            <h:outputText value="#{cc.attrs.bundle.name}" ></h:outputText>
+                        </th>
+                    </tr>
+                </thead>
+            </table>
+            <p:dataTable id="tbl"
+                         class="w-100 m-2"
+                         value="#{cc.attrs.bundle.reportTemplateRows}"
+                         var="row"
+                         paginator="true"
+                         paginatorAlwaysVisible="false"
+                         rows="10"
+                         rowIndexVar="n"
+                         paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                         rowsPerPageTemplate="5,10,20"
+                         rowKey="#{row.id}">
+
+                <f:facet name="header">
+                    <h:outputText value="#{cc.attrs.bundle.name}" />
+                </f:facet>
+
+                <p:column width="2em">
+                    <f:facet name="header">
+                        <h:outputText value="Serial" />
+                    </f:facet>
+                    <h:outputText value="#{n+1}" />
+                </p:column>
+
+
+                <p:column>
+                    <f:facet name="header">
+                        <h:outputText value="Date &amp; Time" />
+                    </f:facet>
+                    <h:outputText value="#{row.bill.createdAt}" >
+                        <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateTimeFormat}" ></f:convertDateTime>
+                    </h:outputText>
+                </p:column>
+
+                <p:column>
+                    <f:facet name="header">
+                        <h:outputText value="Bill No" />
+                    </f:facet>
+                    <h:outputText value="#{row.bill}" />
+                </p:column>
+
+                <p:column>
+                    <f:facet name="header">
+                        <h:outputText value="Bill Type" />
+                    </f:facet>
+                    <h:outputText value="#{row.bill.billTypeAtomic}" />
+                </p:column>
+
+                <p:column>
+                    <f:facet name="header">
+                        <h:outputText value="Patient" />
+                    </f:facet>
+                    <h:outputText value="#{row.bill.patient.person.nameWithTitle}">
+                    </h:outputText>
+                </p:column>
+
+                <p:column rendered="#{configOptionApplicationController.getBooleanValueByKey('Show Payment Type in Inward Payments on Cashier Reports',false)}">
+                    <f:facet name="header">
+                        <h:outputText value="Payment Type" />
+                    </f:facet>
+                    <h:outputText value="#{empty row.bill.comments ? 'N/A' : row.bill.comments}">
+                    </h:outputText>
+                </p:column>
+
+                <p:column class="text-end">
+                    <f:facet name="header">
+                        <h:outputText value="Net Total" />
+                    </f:facet>
+                    <h:outputText value="#{row.bill.netTotal}">
+                        <f:convertNumber pattern="#,##0.00" />
+                    </h:outputText>
+                    <f:facet name="footer">
+                        <h:outputText value="#{cc.attrs.bundle.total}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputText>
+                    </f:facet>
+                </p:column>
+
+                <p:column class="text-end"  sortBy="#{row.cashValue}" filterBy="#{row.cashValue}"  rendered="#{cc.attrs.bundle.hasCashTransaction}" >
+                    <f:facet name="header">
+                        <h:outputText value="Cash" />
+                    </f:facet>
+                    <h:outputText value="#{row.cashValue}">
+                        <f:convertNumber pattern="#,##0.00" />
+                    </h:outputText>
+                    <f:facet name="footer">
+                        <h:outputText value="#{cc.attrs.bundle.cashValue}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputText>
+                    </f:facet>
+                </p:column>
+
+                <p:column  class="text-end"  headerText="Card" sortBy="#{row.cardValue}" filterBy="#{row.cardValue}"  rendered="#{cc.attrs.bundle.hasCardTransaction}" >
+                    <h:outputText value="#{row.cardValue}" >
+                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                    </h:outputText>
+                    <f:facet name="footer">
+                        <h:outputText value="#{cc.attrs.bundle.cardValue}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputText>
+                    </f:facet>
+                </p:column>
+
+                <p:column  class="text-end"  headerText="Credit" sortBy="#{row.creditValue}" filterBy="#{row.creditValue}"  rendered="#{cc.attrs.bundle.hasCreditTransaction}" >
+                    <h:outputText value="#{row.creditValue}" >
+                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                    </h:outputText>
+                    <f:facet name="footer">
+                        <h:outputText value="#{cc.attrs.bundle.creditValue}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputText>
+                    </f:facet>
+                </p:column>
+
+                <!-- Continuing from Credit -->
+                <p:column  class="text-end"  headerText="Staff Welfare" sortBy="#{row.staffWelfareValue}" filterBy="#{row.staffWelfareValue}"  rendered="#{cc.attrs.bundle.hasStaffWelfareTransaction}" >
+                    <h:outputText value="#{row.staffWelfareValue}" >
+                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                    </h:outputText>
+                    <f:facet name="footer">
+                        <h:outputText value="#{cc.attrs.bundle.staffWelfareValue}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputText>
+                    </f:facet>
+                </p:column>
+
+                <p:column  class="text-end"  headerText="Voucher" sortBy="#{row.voucherValue}" filterBy="#{row.voucherValue}"  rendered="#{cc.attrs.bundle.hasVoucherTransaction}" >
+                    <h:outputText value="#{row.voucherValue}" >
+                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                    </h:outputText>
+                    <f:facet name="footer">
+                        <h:outputText value="#{cc.attrs.bundle.voucherValue}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputText>
+                    </f:facet>
+                </p:column>
+
+                <p:column  class="text-end"  headerText="IOU" sortBy="#{row.iouValue}" filterBy="#{row.iouValue}"  rendered="#{cc.attrs.bundle.hasIouTransaction}" >
+                    <h:outputText value="#{row.iouValue}" >
+                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                    </h:outputText>
+                    <f:facet name="footer">
+                        <h:outputText value="#{cc.attrs.bundle.iouValue}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputText>
+                    </f:facet>
+                </p:column>
+
+                <p:column  class="text-end"  headerText="Agent" sortBy="#{row.agentValue}" filterBy="#{row.agentValue}"  rendered="#{cc.attrs.bundle.hasAgentTransaction}" >
+                    <h:outputText value="#{row.agentValue}" >
+                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                    </h:outputText>
+                    <f:facet name="footer">
+                        <h:outputText value="#{cc.attrs.bundle.agentValue}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputText>
+                    </f:facet>
+                </p:column>
+
+                <p:column  class="text-end"  headerText="Cheque" sortBy="#{row.chequeValue}" filterBy="#{row.chequeValue}"  rendered="#{cc.attrs.bundle.hasChequeTransaction}" >
+                    <h:outputText value="#{row.chequeValue}" >
+                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                    </h:outputText>
+                    <f:facet name="footer">
+                        <h:outputText value="#{cc.attrs.bundle.chequeValue}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputText>
+                    </f:facet>
+                </p:column>
+
+                <p:column  class="text-end"  headerText="Slip" sortBy="#{row.slipValue}" filterBy="#{row.slipValue}"  rendered="#{cc.attrs.bundle.hasSlipTransaction}" >
+                    <h:outputText value="#{row.slipValue}" >
+                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                    </h:outputText>
+                    <f:facet name="footer">
+                        <h:outputText value="#{cc.attrs.bundle.slipValue}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputText>
+                    </f:facet>
+                </p:column>
+
+                <p:column  class="text-end"  headerText="eWallet" sortBy="#{row.ewalletValue}" filterBy="#{row.ewalletValue}"  rendered="#{cc.attrs.bundle.hasEWalletTransaction}" >
+                    <h:outputText value="#{row.ewalletValue}" >
+                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                    </h:outputText>
+                    <f:facet name="footer">
+                        <h:outputText value="#{cc.attrs.bundle.ewalletValue}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputText>
+                    </f:facet>
+                </p:column>
+
+                <p:column  class="text-end"  headerText="Patient Deposit" sortBy="#{row.patientDepositValue}" filterBy="#{row.patientDepositValue}"  rendered="#{cc.attrs.bundle.hasPatientDepositTransaction}" >
+                    <h:outputText value="#{row.patientDepositValue}" >
+                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                    </h:outputText>
+                    <f:facet name="footer">
+                        <h:outputText value="#{cc.attrs.bundle.patientDepositValue}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputText>
+                    </f:facet>
+                </p:column>
+
+                <p:column  class="text-end"  headerText="Patient Points" sortBy="#{row.patientPointsValue}" filterBy="#{row.patientPointsValue}"  rendered="#{cc.attrs.bundle.hasPatientPointsTransaction}" >
+                    <h:outputText value="#{row.patientPointsValue}" >
+                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                    </h:outputText>
+                    <f:facet name="footer">
+                        <h:outputText value="#{cc.attrs.bundle.patientPointsValue}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputText>
+                    </f:facet>
+                </p:column>
+
+                <p:column  class="text-end"  headerText="Online Settlement" sortBy="#{row.onlineSettlementValue}" filterBy="#{row.onlineSettlementValue}"  rendered="#{cc.attrs.bundle.hasOnlineSettlementTransaction}" >
+                    <h:outputText value="#{row.onlineSettlementValue}" >
+                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                    </h:outputText>
+                    <f:facet name="footer">
+                        <h:outputText value="#{cc.attrs.bundle.onlineSettlementValue}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputText>
+                    </f:facet>
+                </p:column>
+
+            </p:dataTable>
+        </h:panelGroup>
+    </cc:implementation>
+</html>

--- a/src/main/webapp/resources/ezcomp/bundles/inwardDepositsCancel.xhtml
+++ b/src/main/webapp/resources/ezcomp/bundles/inwardDepositsCancel.xhtml
@@ -1,0 +1,261 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
+
+    <!-- INTERFACE -->
+    <cc:interface>
+        <cc:attribute name="bundle" type="com.divudi.core.data.ReportTemplateRowBundle" />
+    </cc:interface>
+
+    <!-- IMPLEMENTATION -->
+    <cc:implementation>
+
+        <h:panelGroup rendered="#{empty cc.attrs.bundle.reportTemplateRows}">
+            <table class="table w-100">
+                <thead>
+                    <tr class="text-light bg-dark">
+                        <th class="text-light bg-dark">
+                            <h:outputText value="No Data for #{cc.attrs.bundle.name}" ></h:outputText>
+                        </th>
+                    </tr>
+                </thead>
+            </table>
+        </h:panelGroup>
+
+        <h:panelGroup rendered="#{not empty cc.attrs.bundle.reportTemplateRows}">
+            <table class="table w-100">
+                <thead>
+                    <tr class="text-light bg-danger">
+                        <th class="text-light bg-danger">
+                            <h:outputText value="#{cc.attrs.bundle.name}" ></h:outputText>
+                        </th>
+                    </tr>
+                </thead>
+            </table>
+            <p:dataTable id="tbl"
+                         class="w-100 m-2"
+                         value="#{cc.attrs.bundle.reportTemplateRows}"
+                         var="row"
+                         paginator="true"
+                         paginatorAlwaysVisible="false"
+                         rows="10"
+                         rowIndexVar="n"
+                         paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                         rowsPerPageTemplate="5,10,20"
+                         rowKey="#{row.id}">
+
+                <f:facet name="header">
+                    <h:outputText value="#{cc.attrs.bundle.name}" />
+                </f:facet>
+
+                <p:column width="2em">
+                    <f:facet name="header">
+                        <h:outputText value="Serial" />
+                    </f:facet>
+                    <h:outputText value="#{n+1}" />
+                </p:column>
+
+
+                <p:column>
+                    <f:facet name="header">
+                        <h:outputText value="Date &amp; Time" />
+                    </f:facet>
+                    <h:outputText value="#{row.bill.createdAt}" >
+                        <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateTimeFormat}" ></f:convertDateTime>
+                    </h:outputText>
+                </p:column>
+
+                <p:column>
+                    <f:facet name="header">
+                        <h:outputText value="Bill No" />
+                    </f:facet>
+                    <h:outputText value="#{row.bill}" />
+                </p:column>
+
+                <p:column>
+                    <f:facet name="header">
+                        <h:outputText value="Bill Type" />
+                    </f:facet>
+                    <h:outputText value="#{row.bill.billTypeAtomic}" />
+                </p:column>
+
+                <p:column>
+                    <f:facet name="header">
+                        <h:outputText value="Patient" />
+                    </f:facet>
+                    <h:outputText value="#{row.bill.patient.person.nameWithTitle}">
+                    </h:outputText>
+                </p:column>
+
+
+
+                <p:column class="text-end">
+                    <f:facet name="header">
+                        <h:outputText value="Net Total" />
+                    </f:facet>
+                    <h:outputText value="#{row.bill.netTotal}">
+                        <f:convertNumber pattern="#,##0.00" />
+                    </h:outputText>
+                    <f:facet name="footer">
+                        <h:outputText value="#{cc.attrs.bundle.total}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputText>
+                    </f:facet>
+                </p:column>
+
+                <p:column class="text-end"  sortBy="#{row.cashValue}" filterBy="#{row.cashValue}"  rendered="#{cc.attrs.bundle.hasCashTransaction}" >
+                    <f:facet name="header">
+                        <h:outputText value="Cash" />
+                    </f:facet>
+                    <h:outputText value="#{row.cashValue}">
+                        <f:convertNumber pattern="#,##0.00" />
+                    </h:outputText>
+                    <f:facet name="footer">
+                        <h:outputText value="#{cc.attrs.bundle.cashValue}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputText>
+                    </f:facet>
+                </p:column>
+
+                <p:column  class="text-end"  headerText="Card" sortBy="#{row.cardValue}" filterBy="#{row.cardValue}"  rendered="#{cc.attrs.bundle.hasCardTransaction}" >
+                    <h:outputText value="#{row.cardValue}" >
+                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                    </h:outputText>
+                    <f:facet name="footer">
+                        <h:outputText value="#{cc.attrs.bundle.cardValue}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputText>
+                    </f:facet>
+                </p:column>
+
+                <p:column  class="text-end"  headerText="Credit" sortBy="#{row.creditValue}" filterBy="#{row.creditValue}"  rendered="#{cc.attrs.bundle.hasCreditTransaction}" >
+                    <h:outputText value="#{row.creditValue}" >
+                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                    </h:outputText>
+                    <f:facet name="footer">
+                        <h:outputText value="#{cc.attrs.bundle.creditValue}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputText>
+                    </f:facet>
+                </p:column>
+
+                <!-- Continuing from Credit -->
+                <p:column  class="text-end"  headerText="Staff Welfare" sortBy="#{row.staffWelfareValue}" filterBy="#{row.staffWelfareValue}"  rendered="#{cc.attrs.bundle.hasStaffWelfareTransaction}" >
+                    <h:outputText value="#{row.staffWelfareValue}" >
+                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                    </h:outputText>
+                    <f:facet name="footer">
+                        <h:outputText value="#{cc.attrs.bundle.staffWelfareValue}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputText>
+                    </f:facet>
+                </p:column>
+
+                <p:column  class="text-end"  headerText="Voucher" sortBy="#{row.voucherValue}" filterBy="#{row.voucherValue}"  rendered="#{cc.attrs.bundle.hasVoucherTransaction}" >
+                    <h:outputText value="#{row.voucherValue}" >
+                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                    </h:outputText>
+                    <f:facet name="footer">
+                        <h:outputText value="#{cc.attrs.bundle.voucherValue}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputText>
+                    </f:facet>
+                </p:column>
+
+                <p:column  class="text-end"  headerText="IOU" sortBy="#{row.iouValue}" filterBy="#{row.iouValue}"  rendered="#{cc.attrs.bundle.hasIouTransaction}" >
+                    <h:outputText value="#{row.iouValue}" >
+                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                    </h:outputText>
+                    <f:facet name="footer">
+                        <h:outputText value="#{cc.attrs.bundle.iouValue}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputText>
+                    </f:facet>
+                </p:column>
+
+                <p:column  class="text-end"  headerText="Agent" sortBy="#{row.agentValue}" filterBy="#{row.agentValue}"  rendered="#{cc.attrs.bundle.hasAgentTransaction}" >
+                    <h:outputText value="#{row.agentValue}" >
+                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                    </h:outputText>
+                    <f:facet name="footer">
+                        <h:outputText value="#{cc.attrs.bundle.agentValue}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputText>
+                    </f:facet>
+                </p:column>
+
+                <p:column  class="text-end"  headerText="Cheque" sortBy="#{row.chequeValue}" filterBy="#{row.chequeValue}"  rendered="#{cc.attrs.bundle.hasChequeTransaction}" >
+                    <h:outputText value="#{row.chequeValue}" >
+                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                    </h:outputText>
+                    <f:facet name="footer">
+                        <h:outputText value="#{cc.attrs.bundle.chequeValue}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputText>
+                    </f:facet>
+                </p:column>
+
+                <p:column  class="text-end"  headerText="Slip" sortBy="#{row.slipValue}" filterBy="#{row.slipValue}"  rendered="#{cc.attrs.bundle.hasSlipTransaction}" >
+                    <h:outputText value="#{row.slipValue}" >
+                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                    </h:outputText>
+                    <f:facet name="footer">
+                        <h:outputText value="#{cc.attrs.bundle.slipValue}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputText>
+                    </f:facet>
+                </p:column>
+
+                <p:column  class="text-end"  headerText="eWallet" sortBy="#{row.ewalletValue}" filterBy="#{row.ewalletValue}"  rendered="#{cc.attrs.bundle.hasEWalletTransaction}" >
+                    <h:outputText value="#{row.ewalletValue}" >
+                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                    </h:outputText>
+                    <f:facet name="footer">
+                        <h:outputText value="#{cc.attrs.bundle.ewalletValue}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputText>
+                    </f:facet>
+                </p:column>
+
+                <p:column  class="text-end"  headerText="Patient Deposit" sortBy="#{row.patientDepositValue}" filterBy="#{row.patientDepositValue}"  rendered="#{cc.attrs.bundle.hasPatientDepositTransaction}" >
+                    <h:outputText value="#{row.patientDepositValue}" >
+                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                    </h:outputText>
+                    <f:facet name="footer">
+                        <h:outputText value="#{cc.attrs.bundle.patientDepositValue}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputText>
+                    </f:facet>
+                </p:column>
+
+                <p:column  class="text-end"  headerText="Patient Points" sortBy="#{row.patientPointsValue}" filterBy="#{row.patientPointsValue}"  rendered="#{cc.attrs.bundle.hasPatientPointsTransaction}" >
+                    <h:outputText value="#{row.patientPointsValue}" >
+                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                    </h:outputText>
+                    <f:facet name="footer">
+                        <h:outputText value="#{cc.attrs.bundle.patientPointsValue}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputText>
+                    </f:facet>
+                </p:column>
+
+                <p:column  class="text-end"  headerText="Online Settlement" sortBy="#{row.onlineSettlementValue}" filterBy="#{row.onlineSettlementValue}"  rendered="#{cc.attrs.bundle.hasOnlineSettlementTransaction}" >
+                    <h:outputText value="#{row.onlineSettlementValue}" >
+                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                    </h:outputText>
+                    <f:facet name="footer">
+                        <h:outputText value="#{cc.attrs.bundle.onlineSettlementValue}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputText>
+                    </f:facet>
+                </p:column>
+
+            </p:dataTable>
+        </h:panelGroup>
+    </cc:implementation>
+</html>

--- a/src/main/webapp/resources/ezcomp/bundles/inwardDepositsRefund.xhtml
+++ b/src/main/webapp/resources/ezcomp/bundles/inwardDepositsRefund.xhtml
@@ -1,0 +1,261 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
+
+    <!-- INTERFACE -->
+    <cc:interface>
+        <cc:attribute name="bundle" type="com.divudi.core.data.ReportTemplateRowBundle" />
+    </cc:interface>
+
+    <!-- IMPLEMENTATION -->
+    <cc:implementation>
+
+        <h:panelGroup rendered="#{empty cc.attrs.bundle.reportTemplateRows}">
+            <table class="table w-100">
+                <thead>
+                    <tr class="text-light bg-dark">
+                        <th class="text-light bg-dark">
+                            <h:outputText value="No Data for #{cc.attrs.bundle.name}" ></h:outputText>
+                        </th>
+                    </tr>
+                </thead>
+            </table>
+        </h:panelGroup>
+
+        <h:panelGroup rendered="#{not empty cc.attrs.bundle.reportTemplateRows}">
+            <table class="table w-100">
+                <thead>
+                    <tr class="text-light bg-danger">
+                        <th class="text-light bg-danger">
+                            <h:outputText value="#{cc.attrs.bundle.name}" ></h:outputText>
+                        </th>
+                    </tr>
+                </thead>
+            </table>
+            <p:dataTable id="tbl"
+                         class="w-100 m-2"
+                         value="#{cc.attrs.bundle.reportTemplateRows}"
+                         var="row"
+                         paginator="true"
+                         paginatorAlwaysVisible="false"
+                         rows="10"
+                         rowIndexVar="n"
+                         paginatorTemplate="{CurrentPageReport}  {FirstPageLink} {PreviousPageLink} {PageLinks} {NextPageLink} {LastPageLink} {RowsPerPageDropdown}"
+                         rowsPerPageTemplate="5,10,20"
+                         rowKey="#{row.id}">
+
+                <f:facet name="header">
+                    <h:outputText value="#{cc.attrs.bundle.name}" />
+                </f:facet>
+
+                <p:column width="2em">
+                    <f:facet name="header">
+                        <h:outputText value="Serial" />
+                    </f:facet>
+                    <h:outputText value="#{n+1}" />
+                </p:column>
+
+
+                <p:column>
+                    <f:facet name="header">
+                        <h:outputText value="Date &amp; Time" />
+                    </f:facet>
+                    <h:outputText value="#{row.bill.createdAt}" >
+                        <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateTimeFormat}" ></f:convertDateTime>
+                    </h:outputText>
+                </p:column>
+
+                <p:column>
+                    <f:facet name="header">
+                        <h:outputText value="Bill No" />
+                    </f:facet>
+                    <h:outputText value="#{row.bill}" />
+                </p:column>
+
+                <p:column>
+                    <f:facet name="header">
+                        <h:outputText value="Bill Type" />
+                    </f:facet>
+                    <h:outputText value="#{row.bill.billTypeAtomic}" />
+                </p:column>
+
+                <p:column>
+                    <f:facet name="header">
+                        <h:outputText value="Patient" />
+                    </f:facet>
+                    <h:outputText value="#{row.bill.patient.person.nameWithTitle}">
+                    </h:outputText>
+                </p:column>
+
+
+
+                <p:column class="text-end">
+                    <f:facet name="header">
+                        <h:outputText value="Net Total" />
+                    </f:facet>
+                    <h:outputText value="#{row.bill.netTotal}">
+                        <f:convertNumber pattern="#,##0.00" />
+                    </h:outputText>
+                    <f:facet name="footer">
+                        <h:outputText value="#{cc.attrs.bundle.total}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputText>
+                    </f:facet>
+                </p:column>
+
+                <p:column class="text-end"  sortBy="#{row.cashValue}" filterBy="#{row.cashValue}"  rendered="#{cc.attrs.bundle.hasCashTransaction}" >
+                    <f:facet name="header">
+                        <h:outputText value="Cash" />
+                    </f:facet>
+                    <h:outputText value="#{row.cashValue}">
+                        <f:convertNumber pattern="#,##0.00" />
+                    </h:outputText>
+                    <f:facet name="footer">
+                        <h:outputText value="#{cc.attrs.bundle.cashValue}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputText>
+                    </f:facet>
+                </p:column>
+
+                <p:column  class="text-end"  headerText="Card" sortBy="#{row.cardValue}" filterBy="#{row.cardValue}"  rendered="#{cc.attrs.bundle.hasCardTransaction}" >
+                    <h:outputText value="#{row.cardValue}" >
+                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                    </h:outputText>
+                    <f:facet name="footer">
+                        <h:outputText value="#{cc.attrs.bundle.cardValue}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputText>
+                    </f:facet>
+                </p:column>
+
+                <p:column  class="text-end"  headerText="Credit" sortBy="#{row.creditValue}" filterBy="#{row.creditValue}"  rendered="#{cc.attrs.bundle.hasCreditTransaction}" >
+                    <h:outputText value="#{row.creditValue}" >
+                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                    </h:outputText>
+                    <f:facet name="footer">
+                        <h:outputText value="#{cc.attrs.bundle.creditValue}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputText>
+                    </f:facet>
+                </p:column>
+
+                <!-- Continuing from Credit -->
+                <p:column  class="text-end"  headerText="Staff Welfare" sortBy="#{row.staffWelfareValue}" filterBy="#{row.staffWelfareValue}"  rendered="#{cc.attrs.bundle.hasStaffWelfareTransaction}" >
+                    <h:outputText value="#{row.staffWelfareValue}" >
+                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                    </h:outputText>
+                    <f:facet name="footer">
+                        <h:outputText value="#{cc.attrs.bundle.staffWelfareValue}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputText>
+                    </f:facet>
+                </p:column>
+
+                <p:column  class="text-end"  headerText="Voucher" sortBy="#{row.voucherValue}" filterBy="#{row.voucherValue}"  rendered="#{cc.attrs.bundle.hasVoucherTransaction}" >
+                    <h:outputText value="#{row.voucherValue}" >
+                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                    </h:outputText>
+                    <f:facet name="footer">
+                        <h:outputText value="#{cc.attrs.bundle.voucherValue}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputText>
+                    </f:facet>
+                </p:column>
+
+                <p:column  class="text-end"  headerText="IOU" sortBy="#{row.iouValue}" filterBy="#{row.iouValue}"  rendered="#{cc.attrs.bundle.hasIouTransaction}" >
+                    <h:outputText value="#{row.iouValue}" >
+                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                    </h:outputText>
+                    <f:facet name="footer">
+                        <h:outputText value="#{cc.attrs.bundle.iouValue}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputText>
+                    </f:facet>
+                </p:column>
+
+                <p:column  class="text-end"  headerText="Agent" sortBy="#{row.agentValue}" filterBy="#{row.agentValue}"  rendered="#{cc.attrs.bundle.hasAgentTransaction}" >
+                    <h:outputText value="#{row.agentValue}" >
+                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                    </h:outputText>
+                    <f:facet name="footer">
+                        <h:outputText value="#{cc.attrs.bundle.agentValue}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputText>
+                    </f:facet>
+                </p:column>
+
+                <p:column  class="text-end"  headerText="Cheque" sortBy="#{row.chequeValue}" filterBy="#{row.chequeValue}"  rendered="#{cc.attrs.bundle.hasChequeTransaction}" >
+                    <h:outputText value="#{row.chequeValue}" >
+                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                    </h:outputText>
+                    <f:facet name="footer">
+                        <h:outputText value="#{cc.attrs.bundle.chequeValue}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputText>
+                    </f:facet>
+                </p:column>
+
+                <p:column  class="text-end"  headerText="Slip" sortBy="#{row.slipValue}" filterBy="#{row.slipValue}"  rendered="#{cc.attrs.bundle.hasSlipTransaction}" >
+                    <h:outputText value="#{row.slipValue}" >
+                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                    </h:outputText>
+                    <f:facet name="footer">
+                        <h:outputText value="#{cc.attrs.bundle.slipValue}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputText>
+                    </f:facet>
+                </p:column>
+
+                <p:column  class="text-end"  headerText="eWallet" sortBy="#{row.ewalletValue}" filterBy="#{row.ewalletValue}"  rendered="#{cc.attrs.bundle.hasEWalletTransaction}" >
+                    <h:outputText value="#{row.ewalletValue}" >
+                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                    </h:outputText>
+                    <f:facet name="footer">
+                        <h:outputText value="#{cc.attrs.bundle.ewalletValue}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputText>
+                    </f:facet>
+                </p:column>
+
+                <p:column  class="text-end"  headerText="Patient Deposit" sortBy="#{row.patientDepositValue}" filterBy="#{row.patientDepositValue}"  rendered="#{cc.attrs.bundle.hasPatientDepositTransaction}" >
+                    <h:outputText value="#{row.patientDepositValue}" >
+                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                    </h:outputText>
+                    <f:facet name="footer">
+                        <h:outputText value="#{cc.attrs.bundle.patientDepositValue}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputText>
+                    </f:facet>
+                </p:column>
+
+                <p:column  class="text-end"  headerText="Patient Points" sortBy="#{row.patientPointsValue}" filterBy="#{row.patientPointsValue}"  rendered="#{cc.attrs.bundle.hasPatientPointsTransaction}" >
+                    <h:outputText value="#{row.patientPointsValue}" >
+                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                    </h:outputText>
+                    <f:facet name="footer">
+                        <h:outputText value="#{cc.attrs.bundle.patientPointsValue}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputText>
+                    </f:facet>
+                </p:column>
+
+                <p:column  class="text-end"  headerText="Online Settlement" sortBy="#{row.onlineSettlementValue}" filterBy="#{row.onlineSettlementValue}"  rendered="#{cc.attrs.bundle.hasOnlineSettlementTransaction}" >
+                    <h:outputText value="#{row.onlineSettlementValue}" >
+                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                    </h:outputText>
+                    <f:facet name="footer">
+                        <h:outputText value="#{cc.attrs.bundle.onlineSettlementValue}">
+                            <f:convertNumber pattern="#,##0.00" />
+                        </h:outputText>
+                    </f:facet>
+                </p:column>
+
+            </p:dataTable>
+        </h:panelGroup>
+    </cc:implementation>
+</html>

--- a/src/main/webapp/resources/ezcomp/bundles/inwardPaymentCollection.xhtml
+++ b/src/main/webapp/resources/ezcomp/bundles/inwardPaymentCollection.xhtml
@@ -1,0 +1,68 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:p="http://primefaces.org/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
+
+    <cc:interface>
+        <cc:attribute name="bundle" type="com.divudi.core.data.ReportTemplateRowBundle" />
+    </cc:interface>
+
+    <cc:implementation>
+        <h:panelGroup rendered="#{empty cc.attrs.bundle.reportTemplateRows}">
+            <table class="table w-100">
+                <thead>
+                    <tr class="text-light bg-dark">
+                        <th class="text-light bg-dark">
+                            <h:outputText value="No Data for #{cc.attrs.bundle.name}" />
+                        </th>
+                    </tr>
+                </thead>
+            </table>
+        </h:panelGroup>
+
+        <h:panelGroup rendered="#{not empty cc.attrs.bundle.reportTemplateRows}">
+            <table class="table w-100">
+                <thead>
+                    <tr class="text-light bg-dark">
+                        <th colspan="4">#{cc.attrs.bundle.name}</th>
+                        <th class="text-end">
+                            <h:outputText value="#{cc.attrs.bundle.total}">
+                                <f:convertNumber pattern="#,##0.00" />
+                            </h:outputText>
+                        </th>
+                    </tr>
+                    <tr>
+                        <th>Bill No</th>
+                        <th>Date &amp; Time</th>
+                        <th>Patient</th>
+                        <th>Bill Type</th>
+                        <th class="text-end">Value</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <ui:repeat value="#{cc.attrs.bundle.reportTemplateRows}" var="row">
+                        <tr class="#{row.bill ne null ? 'table-primary' : 'table-light'}">
+                            <td>#{row.bill.deptId}</td>
+                            <td>
+                                <h:outputText value="#{row.bill.billTime}">
+                                    <f:convertDateTime pattern="#{sessionController.applicationPreference.longDateTimeFormat}" />
+                                </h:outputText>
+                            </td>
+                            <td>#{(row.bill.patient ne null and row.bill.patient.person ne null) ? row.bill.patient.person.name : 'N/A'}</td>
+                            <td>#{row.bill.billTypeAtomic.label}</td>
+                            <td class="text-end">
+                                <h:outputText value="#{row.bill.netTotal}">
+                                    <f:convertNumber pattern="#,##0.00" />
+                                </h:outputText>
+                            </td>
+                        </tr>
+                    </ui:repeat>
+                </tbody>
+            </table>
+        </h:panelGroup>
+    </cc:implementation>
+</html>


### PR DESCRIPTION
## Summary

Fixes issue #23507: after converting an Appointment Deposit to an Inward Deposit, the amount vanished from the Daily Return report instead of showing correctly.

**Root cause (two independent bugs):**
1. `AdmissionController.convertAppointmentDepositToInwardDeposit()` created the replacement bill via `InwardPaymentController` (tags `INWARD_PAYMENT`) instead of `InwardDepositController` (tags `INWARD_DEPOSIT`).
2. Daily Return's `generateInwardDepositCollection()` never looked for `INWARD_PAYMENT` bills at all, so even a correctly-tagged inward payment wouldn't show there.

Combined effect: the appointment deposit's cancellation showed as a stray negative amount in Daily Return with nothing offsetting it.

**Fix:**
- `AdmissionController` now uses `InwardDepositController`, so the converted bill is genuinely tagged `INWARD_DEPOSIT`.
- Daily Return gets a new "Inward Payment Collection" bundle for `INWARD_PAYMENT` and `POST_FINAL_BILL_INWARD_PAYMENT` (post-discharge payment) families — previously absent from Daily Return entirely.
- Cashier Summary/Detailed gain a new "Inward Deposits" section (`INWARD_DEPOSIT` family) — previously absent from both reports entirely, converted or not.
- Cashier Summary/Detailed's existing "Inward Payments" buckets now also include `POST_FINAL_BILL_INWARD_PAYMENT` and `INWARD_PAYMENT_REFUND_CANCELLATION`, which were missing.

## Scope decision

Per discussion on the issue, this was expanded beyond the literal reported bug to close the full set of report-visibility gaps across all three reports (Daily Return, Cashier Summary, Cashier Detailed) for: appointment deposits, inward deposits, interim inward payments, and post-discharge payments — including their cancellations and refunds.

**Not in this PR** — two genuine workflow gaps found while auditing (missing functionality, not report visibility), filed as follow-ups:
- #23571 — Appointment Deposit has no refund-to-patient workflow
- #23572 — Post-Final-Bill Inward Payment refunds cannot be cancelled/undone

## Test plan

Verified end-to-end on local Payara + coop DB:
- [x] Created an Appointment Deposit (Rs 555) via Inward → Add Appointment
- [x] Admitted the patient via Reservation Admit → Admit
- [x] Converted via Inpatient Dashboard's "Convert to Inward Deposit" banner
- [x] Confirmed in DB: original bill cancelled, cancellation bill created, new bill tagged `INWARD_DEPOSIT` (not `INWARD_PAYMENT`)
- [x] Confirmed Daily Return now shows all four bill rows netting correctly (screenshot below)
- [x] Confirmed Cashier Summary's new "Inward Deposits" section shows the converted bill
- [x] Verified Cashier Detailed via code review (identical JPQL bucket lists to Cashier Summary, confirmed byte-for-byte during implementation)
- [x] `mvn clean package` — build succeeds

### Evidence

![Daily Return showing the fix](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23507-daily-return-inward-deposit-fixed.png)

## Documentation

- https://github.com/hmislk/hmis/wiki/Finance-Daily-Return-Report (new page)
- https://github.com/hmislk/hmis/wiki/Finance-Cashier-Summary-Reports (corrected — previously claimed inward deposits were already shown in Cashier reports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XxzAmRUH8aMLhaSdU3bCjc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Daily Return and Cashier reports now include inward payment collections, deposits, cancellations, and refunds.
  * Added detailed, paginated report sections with payment-method breakdowns and totals.
  * Appointment deposits are now recorded through the inward deposit workflow.
* **Documentation**
  * Added guidance for handling unavailable browser automation services and selecting an approved fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->