### PR TITLE
fix(inward): block Return of a checked bill's services

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardServiceRefundController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardServiceRefundController.java
@@ -211,6 +211,10 @@ public class InwardServiceRefundController implements Serializable {
             JsfUtil.addErrorMessage("No bill to refund");
             return null;
         }
+        if (b.getCheckeAt() != null) {
+            JsfUtil.addErrorMessage("This bill is already checked. A checked bill's services cannot be returned.");
+            return null;
+        }
         inwardSearch.setBill(billFacade.find(b.getId()));
         return "/inward/inward_bill_service_refund?faces-redirect=true";
     }
@@ -257,6 +261,10 @@ public class InwardServiceRefundController implements Serializable {
         Bill bill = billFacade.find(sessionBill.getId());
         if (bill == null || bill.isRetired()) {
             JsfUtil.addErrorMessage("Bill not available");
+            return null;
+        }
+        if (bill.getCheckedBy() != null) {
+            JsfUtil.addErrorMessage("Checked Bill. Can not return");
             return null;
         }
         if (bill.getPatientEncounter() != null && bill.getPatientEncounter().isNursingDischarged()

--- a/src/main/java/com/divudi/bean/inward/InwardServiceRefundController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardServiceRefundController.java
@@ -211,11 +211,19 @@ public class InwardServiceRefundController implements Serializable {
             JsfUtil.addErrorMessage("No bill to refund");
             return null;
         }
-        if (b.getCheckeAt() != null) {
+        // Reload fresh rather than trusting the session-held bill passed in -
+        // it may have been checked by another request since the reprint page
+        // loaded. Same defensive reload refundInwardServiceBill() does below.
+        Bill currentBill = billFacade.find(b.getId());
+        if (currentBill == null) {
+            JsfUtil.addErrorMessage("Bill not available");
+            return null;
+        }
+        if (currentBill.getCheckeAt() != null) {
             JsfUtil.addErrorMessage("This bill is already checked. A checked bill's services cannot be returned.");
             return null;
         }
-        inwardSearch.setBill(billFacade.find(b.getId()));
+        inwardSearch.setBill(currentBill);
         return "/inward/inward_bill_service_refund?faces-redirect=true";
     }
 


### PR DESCRIPTION
## Summary

Fixes #23579 — the Inward IP Bill's item-level **Return** flow could return services on a bill already marked **Checked** (finalized), with no validation message at all.

## Root cause

`InwardServiceRefundController` had no guard against a bill's `checkeAt`/`checkedBy` state, unlike the **Cancel** flow (`InwardSearch`) which already blocks a checked bill both at navigation time (`navigateToCancelInpatientBill()`) and commit time (`cancelBillService()`).

## Fix

Added the same two-layer guard to `InwardServiceRefundController`, mirroring the existing Cancel pattern exactly:

- `navigateToRefundInwardServiceBill()` — blocks before the Return screen even opens
- `refundInwardServiceBill()` — re-checked at commit time (defense-in-depth)

Both use the same error-message UX Cancel already has — no XHTML/UI change needed; the "Return" button isn't disabled, it just shows a validation error and doesn't proceed, exactly like "To Cancel" already does.

## Verification

Local Payara + Playwright, menu path: **Menu → Inpatient → Search → Service Bill → BHT No search → open Bill → Mark As Checked → Return**

Test record: BHT/57815, Inward department, Service Bill `Inward//26/000552` (existing local test data, no prior cancel/refund history).

1. Marked the bill **Checked** via the existing "Mark As Checked" button.
2. Clicked **Return** → blocked immediately, stayed on the Service Reprint screen:

   ![Return blocked with validation message on a checked bill](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23579-return-blocked-checked-bill.png)

3. DB check: `REFUNDED` flag stayed `0`, no `RefundBill` row created for the blocked attempt.
4. Regression check: unmarked the bill (Mark As Uncheck), clicked **Return** again → navigated through to `inward_bill_service_refund.xhtml` normally, confirming unchecked bills are unaffected.
5. No server errors in `server.log` during the test. Test bill left in its original clean state.

Full evidence and discussion: [issue #23579 comment](https://github.com/hmislk/hmis/issues/23579#issuecomment-5576063990)

## Documentation

Updated: https://github.com/hmislk/hmis/wiki/Finance-Inpatient-Service-Bills — "Returning (partial refund)" section now documents the checked-bill guard alongside the existing Cancel guard.

Closes #23579

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented refunds for inward service bills that have already been checked.
  - Displays an error message and stops the refund process when a bill has been checked or reviewed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->