### PR TITLE
fix(inward): let a baby admission open its Inpatient Dashboard

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -132,6 +132,7 @@ gotcha** — jump straight to the one you need rather than reading the file.
 - [105. A `p:calendar` bound to Date of Birth can ignore real keystrokes — use the widget's `setDate()` API](#105-a-pcalendar-bound-to-date-of-birth-can-ignore-real-keystrokes--use-the-widgets-setdate-api)
 - [106. A third-level menu item can't be clicked directly — fire its own `onclick`, which is still the menu path, not URL navigation](#106-a-third-level-menu-item-cant-be-clicked-directly--fire-its-own-onclick-which-is-still-the-menu-path-not-url-navigation)
 - [96. A `@SessionScoped` controller's already-loaded entity field does not pick up a sibling controller's later edit to the same row, even when that edit goes through the app's own JPA facade](#96-a-sessionscoped-controllers-already-loaded-entity-field-does-not-pick-up-a-sibling-controllers-later-edit-to-the-same-row-even-when-that-edit-goes-through-the-apps-own-jpa-facade)
+- [107. A bug that "does not reproduce" locally may be gated by a `ConfigOption` whose default hides it — flip the option before concluding the report is wrong](#107-a-bug-that-does-not-reproduce-locally-may-be-gated-by-a-configoption-whose-default-hides-it--flip-the-option-before-concluding-the-report-is-wrong)
 - [Quick checklist](#quick-checklist)
 
 ---
@@ -3013,6 +3014,33 @@ Found while verifying issue #23523.
 
 ---
 
+## 107. A bug that "does not reproduce" locally may be gated by a `ConfigOption` whose default hides it — flip the option before concluding the report is wrong
+
+Issue #23577 ("Cannot navigate to Dashboard for Baby Admission") did not
+reproduce on the first attempt: a baby admission's **Inpatient Dashboard**
+button opened the dashboard exactly as it should. Every local hospital DB copy
+(`coop`, `ruhunu`, `rmh`, `sl`) had *Patient admission and room assignment are
+simultaneous processes.* set to `true`, and `getBooleanValueByKey(key, true)`
+also defaults it to `true` — so the entire `else` branch that contained the bug
+was unreachable locally.
+
+The failing path only exists when that option is **off**. Flipping it (via the
+admin UI — §26, raw SQL is invisible to the running app) reproduced the report
+on the first click, every time.
+
+**Before recording "did not reproduce" on a bug report, read the controller
+method for `configOptionApplicationController.getBooleanValueByKey(...)`
+branches and check the local value of each one against its default.** A
+reporter on a differently-configured hospital is describing a real code path
+you simply are not executing; the option's default is not the only value in
+production. The same check applies in reverse when verifying a fix — exercise
+both settings of any option that gates the code you touched, since the branch
+you did not test is the one someone is running.
+
+Found while fixing issue #23577.
+
+---
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.
@@ -3036,4 +3064,5 @@ Found while verifying issue #23523.
 - [ ] When a Save did nothing with a clean `server.log` and an unchanged DB, read the form's `<p:messages>` **by id** and grepped the page for `required="true"` (§91) before hunting the controller.
 - [ ] For a guard fix: asserted the **action actually executed** (expected message in the response) before treating unchanged DB state as proof — a JSF-disabled button skips its action entirely — and ran the negative test (clean record still succeeds), reverting it through the app.
 - [ ] For a menu item nested three levels deep, fired the anchor's own `onclick` (which submits the menu form, so the navigation method still runs) instead of falling back to typing the page URL — scoping the lookup to its own submenu, since labels repeat within one menu.
+- [ ] Before writing "did not reproduce", checked every `getBooleanValueByKey(...)` branch in the code path and flipped any option whose local value differs from the reporter's likely setting (§107) — and, when verifying a fix, exercised **both** settings of any option gating the changed code.
 - [ ] Before trying to reproduce a same-session state-change race (item A staged, then a dependency of A is invalidated by a legitimate app action before A is submitted), checked whether a `@SessionScoped` controller's already-held entity reference would even observe the change (§96) rather than assuming any in-app mutation propagates live.

--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -1509,8 +1509,17 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
             bhtSummeryController.setPatientEncounterHasProvisionalBill(isAddmissionHaveProvisionalBill((Admission) current));
             return bhtSummeryController.navigateToInpatientProfile();
         } else {
-            if (current.isRoomAdmitted() || current.isDischarged() || current.isPaymentFinalized()
-                    || !current.getAdmissionType().isRoomChargesAllowed()) {
+            // A legacy/converted encounter can still have no admission type. Treat that
+            // as "room charges unknown" and send it to the dashboard rather than NPEing
+            // here, which left the button doing nothing at all. (#23577)
+            boolean roomChargesAllowed = current.getAdmissionType() != null
+                    && current.getAdmissionType().isRoomChargesAllowed();
+            // A baby admission never gets a room of its own - the baby stays in the
+            // mother's room (#9900) - so isRoomAdmitted() is false forever and the
+            // room-assignment diversion below would trap it permanently, leaving the
+            // baby's dashboard unreachable from every entry point. (#23577)
+            if (isBabyAdmission() || current.isRoomAdmitted() || current.isDischarged()
+                    || current.isPaymentFinalized() || !roomChargesAllowed) {
                 current.getPatient().setEditingMode(false);
                 bhtSummeryController.setPatientEncounter(current);
                 bhtSummeryController.setPatientEncounterHasProvisionalBill(isAddmissionHaveProvisionalBill((Admission) current));


### PR DESCRIPTION
## What this fixes

A baby admission's **Inpatient Dashboard** was unreachable when the config option **"Patient admission and room assignment are simultaneous processes."** is turned off.

A baby never gets a room of its own — the baby stays in the mother's room (#9900) — so `roomAdmitted` stays `false` for the life of the encounter. With that option off, `AdmissionController.navigateToAdmissionProfilePage()` sends any not-yet-room-admitted encounter to **Admit to Room** first. A baby can never satisfy that condition, so every route to its dashboard (Admissions Search, the mother's *Baby Admissions* panel, the Admission Report, notifications) was diverted there — and the *Inpatient Dashboard* button on `admit_room.xhtml` runs the same method, so it bounces straight back. That page already tells the user a baby needs no room, which is exactly why it should never have been the destination.

Because the option defaults to `true`, this never shows up on a hospital that leaves it at the default — which is why it read as environment-specific.

## Change

One method, `AdmissionController.navigateToAdmissionProfilePage()`:

- Exempt baby admissions from the room-assignment diversion, reusing the existing private helper `isBabyAdmission()`.
- Make the admission-type check null-safe. `current.getAdmissionType().isRoomChargesAllowed()` threw an NPE on an encounter with no admission type (possible on legacy/converted encounters), leaving the button doing nothing at all. A null admission type now routes to the dashboard — the safe default when we cannot tell whether room charges apply.

No entity or schema change; no XHTML change.

## Verification

Built and redeployed to local Payara, driven with Playwright as the Inward department, reached **only through the menus** (*Menu → Inpatient → Search Admissions → Admissions*).

Test data created through the app: mother `BHT/57813` → baby `BHT/57814` (encounter `13861563`, `parentEncounter` set, `roomAdmitted = 0`, `currentPatientRoom = NULL`, admission type **BHT** with `roomChargesAllowed = 1`) — all confirmed in the local DB before and after.

Both settings of the gating option were exercised, since the branch that was broken is the one most local databases never run:

| Case | Option OFF | Option ON (default) |
|---|---|---|
| Baby admission, no room — from Admissions Search | Dashboard ✅ (was Admit to Room ❌) | Dashboard ✅ |
| Baby, from the mother's "Baby Admissions" panel | Dashboard ✅ | Dashboard ✅ |
| Normal admission, no room yet (`OPDCARD/44351`) | Admit to Room ✅ *(unchanged — intended)* | Dashboard ✅ |
| Room-admitted adult (`BHT/57813`) | Dashboard ✅ | Dashboard ✅ |

The pre-fix build was rebuilt and redeployed specifically to capture the "before" half of the pair below, so the two screenshots differ only by this commit.

**Before** — the baby's Dashboard button lands on Admit to Room:

![Baby admission diverted to the Admit to Room page](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23577-before-baby-diverted-to-admit-room.png)

**After** — same option, same BHT:

![Baby's Inpatient Dashboard opened from Admissions Search](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23577-baby-dashboard-from-search.png)

Patient names in the evidence are local test values; the consultant name is redacted.

## Documentation

- [Inpatient — Baby Admission](https://github.com/hmislk/hmis/wiki/Inpatient-Baby-Admission) — new **Opening the Baby's Dashboard** section covering both routes and the room-step exemption.
- [Inpatient — Admissions Search](https://github.com/hmislk/hmis/wiki/Inpatient-Admissions-Search) — replaced the inaccurate "click any row to navigate" line (you click the bed icon in **Actions**) with the real action buttons, and documented when the Dashboard button opens Room Admission instead.

Also adds §107 to `developer_docs/testing/playwright-e2e-workflow.md`: a bug that "does not reproduce" locally may be gated by a `ConfigOption` whose default hides it — check the branches before concluding the report is wrong, and exercise both settings when verifying the fix.

## Noted, not fixed here

`admit_room.xhtml` remains reachable from the menu and would still let staff assign a room to a baby admission — the #9900 double-charge risk. This PR only removes the *forced* diversion; it does not add a guard on the Room Admission page itself.

Closes #23577

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F5EjQMkgdBq97LToJSpQuE
