### PR TITLE
fix(theatre): gate Surgery Time Services Total column behind NursingIPBillingViewRates privilege

### DIFF
--- a/src/main/webapp/theater/patient_surgery.xhtml
+++ b/src/main/webapp/theater/patient_surgery.xhtml
@@ -519,7 +519,8 @@
                                                                        pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
                                                 </h:outputLabel>
                                             </p:column>
-                                            <p:column headerText="Total">
+                                            <p:column headerText="Total"
+                                                      rendered="#{webUserController.hasPrivilege('NursingIPBillingViewRates')}">
                                                 #{ti.billFee.patientItem.serviceValue}
                                             </p:column>
                                             <p:column headerText="Date">


### PR DESCRIPTION
## What changed

Closes #23566.

The issue asked to remove the **Total** column from the Timed Services table
on the Surgery page (`theater/patient_surgery.xhtml`). Per discussion, instead
of deleting the column outright, it's now gated behind the existing generic
privilege HMIS already uses to control rate/value visibility for inpatients:
**`NursingIPBillingViewRates`**.

```xhtml
<p:column headerText="Total"
          rendered="#{webUserController.hasPrivilege('NursingIPBillingViewRates')}">
    #{ti.billFee.patientItem.serviceValue}
</p:column>
```

This reuses an existing privilege (no new privilege added) — the same one
already gating rate/value display across `ward/ward_pharmacy_*` and
`resources/pharmacy/inward_*` pages, e.g.
`ward_pharmacy_reprint_bht_issue_bill_reprint.xhtml`. `webUserController.hasPrivilege(...)`
is already the established check pattern used throughout `patient_surgery.xhtml`.

Per the user's instruction, this is **privilege-only** — no `ConfigOption`
toggle was added on top (some other pages layer `'Nursing IP Billing - Show
Rate and Value'` + the privilege together; this page uses the privilege
alone).

## Testing

This is a pure XHTML change (no Java/entity/controller/schema changes), so
per project convention (CLAUDE.md "JSF-only changes... do not require
compilation or testing") no build/redeploy/Playwright pass was required.
Verified by inspection:
- `NursingIPBillingViewRates` privilege exists in `Privileges.java` and is
  already wired into `UserPrivilageController`/`user_privileges.xhtml` (used
  elsewhere in the app already).
- `webUserController` bean is already referenced elsewhere in this exact
  file, confirming the binding resolves correctly in this view.

## Documentation

Updated the wiki page for this feature:
https://github.com/hmislk/hmis/wiki/Theatre-Timed-Services

Added a note that the **Total** column is now gated by the
`NursingIPBillingViewRates` privilege.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted visibility of the Timed Services “Total” column to users with the appropriate billing rates privilege.
  * The column’s value remains unchanged for authorized users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->