### PR TITLE
Block nursing discharge until lab investigations are sent to lab

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -131,6 +131,8 @@ gotcha** — jump straight to the one you need rather than reading the file.
 - [104. A department/room created by direct SQL needs more than the FK columns](#104-a-departmentroom-created-by-direct-sql-needs-more-than-the-fk-columns)
 - [105. A `p:calendar` bound to Date of Birth can ignore real keystrokes — use the widget's `setDate()` API](#105-a-pcalendar-bound-to-date-of-birth-can-ignore-real-keystrokes--use-the-widgets-setdate-api)
 - [106. A third-level menu item can't be clicked directly — fire its own `onclick`, which is still the menu path, not URL navigation](#106-a-third-level-menu-item-cant-be-clicked-directly--fire-its-own-onclick-which-is-still-the-menu-path-not-url-navigation)
+- [107. `inward_lab_dashboard.xhtml`'s "Send to Lab" has no `p:messages`/`p:growl` at all — a missing Transporter silently no-ops the whole action](#107-inward_lab_dashboardxhtmls-send-to-lab-has-no-pmessagespgrowl-at-all--a-missing-transporter-silently-no-ops-the-whole-action)
+- [108. This dashboard's Sample Transporter `p:autoComplete` ignores synthetic keystrokes — drive `widget.search()` directly](#108-this-dashboards-sample-transporter-pautocomplete-ignores-synthetic-keystrokes--drive-widgetsearch-directly)
 - [96. A `@SessionScoped` controller's already-loaded entity field does not pick up a sibling controller's later edit to the same row, even when that edit goes through the app's own JPA facade](#96-a-sessionscoped-controllers-already-loaded-entity-field-does-not-pick-up-a-sibling-controllers-later-edit-to-the-same-row-even-when-that-edit-goes-through-the-apps-own-jpa-facade)
 - [Quick checklist](#quick-checklist)
 
@@ -3010,6 +3012,40 @@ EclipseLink cache has bitten targeted-refresh attempts before (see the
 "Native settle poisons the Bill entity" gotcha).
 
 Found while verifying issue #23523.
+
+## 107. `inward_lab_dashboard.xhtml`'s "Send to Lab" has no `p:messages`/`p:growl` at all — a missing Transporter silently no-ops the whole action
+
+Found while verifying issue #23578 (block Nursing Discharge until lab
+investigations are sent to lab). The dashboard's "Send to Lab" button calls
+`InwardLaboratoryController.sendSamplesToLab()` →
+`PatientInvestigationController.sendSamplesToLab(true)`, which requires the
+"Sample Transporter" `p:autoComplete` to be filled (`transporterMandatory =
+true`) and otherwise calls `JsfUtil.addErrorMessage("Transporter is
+Missing")` and returns. The page has no `p:messages`/`p:growl` component
+anywhere, so clicking Send to Lab with the transporter empty just silently
+reloads the search results with the sample still at "Sample Collected" —
+same failure class as item 88's first finding, different page. If a
+sample's status doesn't advance after clicking Send to Lab with no visible
+error, check the Sample Transporter field is actually populated before
+suspecting the controller logic.
+
+## 108. This dashboard's Sample Transporter `p:autoComplete` ignores synthetic keystrokes — drive `widget.search()` directly
+
+Same page/issue as item 107. Playwright's `browser_type`
+(`pressSequentially`) into the Sample Transporter input updated the DOM
+value but never fired PrimeFaces' autocomplete AJAX query — no network
+request went out, and the suggestion panel stayed empty even after a 1.5s
+wait. Driving the widget directly worked immediately:
+```js
+const w = PrimeFaces.widgets['widget_<formId>_<inputId>'];
+w.search('a');                         // fires the AJAX query
+// then, after the panel populates:
+w.panel[0].querySelector('.ui-autocomplete-item').click();
+```
+Confirmed the resulting hidden value actually stuck (visible input showed
+the selected staff name, and the subsequent Send to Lab submit used it
+correctly) — this is the same class of gotcha as item 50, but for
+`p:autoComplete` specifically rather than `p:calendar`/`p:selectOneMenu`.
 
 ---
 

--- a/src/main/java/com/divudi/bean/inward/NursingDischargeController.java
+++ b/src/main/java/com/divudi/bean/inward/NursingDischargeController.java
@@ -3,10 +3,12 @@ package com.divudi.bean.inward;
 import com.divudi.bean.common.NotificationController;
 import com.divudi.bean.common.SessionController;
 import com.divudi.core.data.BillTypeAtomic;
+import com.divudi.core.data.dto.PendingLabInvestigationDTO;
 import com.divudi.core.data.dto.PendingPharmacyItemDTO;
 import com.divudi.core.entity.PatientEncounter;
 import com.divudi.core.facade.BillFacade;
 import com.divudi.core.facade.PatientEncounterFacade;
+import com.divudi.core.facade.PatientInvestigationFacade;
 import com.divudi.core.facade.PatientRoomFacade;
 import com.divudi.core.util.JsfUtil;
 import java.io.Serializable;
@@ -44,6 +46,9 @@ public class NursingDischargeController implements Serializable {
     @EJB
     private PatientRoomFacade patientRoomFacade;
 
+    @EJB
+    private PatientInvestigationFacade patientInvestigationFacade;
+
     @Inject
     private SessionController sessionController;
 
@@ -52,6 +57,7 @@ public class NursingDischargeController implements Serializable {
 
     private PatientEncounter currentEncounter;
     private List<PendingPharmacyItemDTO> pendingPharmacyItems = new ArrayList<>();
+    private List<PendingLabInvestigationDTO> pendingLabInvestigations = new ArrayList<>();
 
     // -------------------------------------------------------------------------
     // Navigation
@@ -60,6 +66,7 @@ public class NursingDischargeController implements Serializable {
     public String navigateToNursingDischarge(PatientEncounter pe) {
         this.currentEncounter = pe;
         loadPendingPharmacyItems();
+        loadPendingLabInvestigations();
         return "/inward/inward_nursing_discharge?faces-redirect=true";
     }
 
@@ -181,6 +188,36 @@ public class NursingDischargeController implements Serializable {
     }
 
     // -------------------------------------------------------------------------
+    // Pending lab investigation validation
+    // -------------------------------------------------------------------------
+
+    @SuppressWarnings("unchecked")
+    public void loadPendingLabInvestigations() {
+        pendingLabInvestigations = new ArrayList<>();
+        if (currentEncounter == null) {
+            return;
+        }
+        String jpql = "SELECT new com.divudi.core.data.dto.PendingLabInvestigationDTO("
+                + "pi.investigation.name, pi.orderedAt, pi.status)"
+                + " FROM PatientInvestigation pi"
+                + " WHERE pi.encounter = :pe"
+                + " AND pi.retired = false"
+                + " AND (pi.cancelled = false OR pi.cancelled IS NULL)"
+                + " AND pi.sampleSent = false"
+                // Excludes voided orders - a cancelled bill or refunded bill item must not block discharge
+                + " AND pi.billItem.bill.cancelled = false"
+                + " AND pi.billItem.refunded = false";
+        Map<String, Object> params = new HashMap<>();
+        params.put("pe", currentEncounter);
+        pendingLabInvestigations = (List<PendingLabInvestigationDTO>)
+                patientInvestigationFacade.findLightsByJpql(jpql, params, TemporalType.DATE);
+    }
+
+    public boolean hasPendingLabInvestigations() {
+        return !pendingLabInvestigations.isEmpty();
+    }
+
+    // -------------------------------------------------------------------------
     // Nursing Discharge
     // -------------------------------------------------------------------------
 
@@ -224,6 +261,13 @@ public class NursingDischargeController implements Serializable {
             JsfUtil.addErrorMessage("Cannot confirm nursing discharge: "
                     + pendingPharmacyItems.size()
                     + " pending pharmacy item(s) must be resolved first.");
+            return;
+        }
+        loadPendingLabInvestigations();
+        if (!pendingLabInvestigations.isEmpty()) {
+            JsfUtil.addErrorMessage("Cannot confirm nursing discharge: "
+                    + pendingLabInvestigations.size()
+                    + " lab investigation(s) must be sent to lab first.");
             return;
         }
         Map<String, Object> before = nursingDischargeStateMap();
@@ -347,5 +391,9 @@ public class NursingDischargeController implements Serializable {
 
     public List<PendingPharmacyItemDTO> getPendingPharmacyItems() {
         return pendingPharmacyItems;
+    }
+
+    public List<PendingLabInvestigationDTO> getPendingLabInvestigations() {
+        return pendingLabInvestigations;
     }
 }

--- a/src/main/java/com/divudi/core/data/dto/PendingLabInvestigationDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/PendingLabInvestigationDTO.java
@@ -1,0 +1,38 @@
+package com.divudi.core.data.dto;
+
+import com.divudi.core.data.lab.PatientInvestigationStatus;
+import java.util.Date;
+
+/**
+ * Lightweight DTO for lab investigations not yet sent to lab that block nursing
+ * discharge. Populated via a JPQL constructor query in
+ * NursingDischargeController.
+ */
+public class PendingLabInvestigationDTO {
+
+    private String investigationName;
+    private Date orderedAt;
+    private PatientInvestigationStatus status;
+
+    public PendingLabInvestigationDTO(String investigationName, Date orderedAt, PatientInvestigationStatus status) {
+        this.investigationName = investigationName;
+        this.orderedAt = orderedAt;
+        this.status = status;
+    }
+
+    public String getInvestigationName() {
+        return investigationName;
+    }
+
+    public Date getOrderedAt() {
+        return orderedAt;
+    }
+
+    public PatientInvestigationStatus getStatus() {
+        return status;
+    }
+
+    public String getStatusLabel() {
+        return status == null ? "" : status.getLabel();
+    }
+}

--- a/src/main/webapp/inward/inward_nursing_discharge.xhtml
+++ b/src/main/webapp/inward/inward_nursing_discharge.xhtml
@@ -114,6 +114,51 @@
 
                         </h:panelGroup>
 
+                        <!-- Pending lab investigations panel -->
+                        <h:panelGroup id="pnlPendingLabInvestigations" layout="block">
+
+                            <h:panelGroup layout="block"
+                                          rendered="#{not empty nursingDischargeController.pendingLabInvestigations}">
+                                <div class="row px-4 pt-2">
+                                    <div class="col-12">
+                                        <div class="alert alert-warning" role="alert">
+                                            <strong><i class="fa fa-exclamation-triangle mr-2"/>Pending Lab Investigations</strong>
+                                            <p class="mb-2">Nursing discharge is blocked until all investigations below have been sent to lab.</p>
+                                            <p:dataTable id="tblPendingLabInvestigations"
+                                                         value="#{nursingDischargeController.pendingLabInvestigations}"
+                                                         var="item"
+                                                         styleClass="w-100">
+                                                <p:column headerText="Investigation" style="width:15%">
+                                                    <h:outputText value="#{item.investigationName}" />
+                                                </p:column>
+                                                <p:column headerText="Ordered At" style="width:15%">
+                                                    <h:outputText value="#{item.orderedAt}">
+                                                        <f:convertDateTime pattern="#{sessionController.applicationPreference.shortDateFormat}" />
+                                                    </h:outputText>
+                                                </p:column>
+                                                <p:column headerText="Status">
+                                                    <h:outputText value="#{item.statusLabel}" />
+                                                </p:column>
+                                            </p:dataTable>
+                                        </div>
+                                    </div>
+                                </div>
+                            </h:panelGroup>
+
+                            <div class="row px-4">
+                                <div class="col-12 d-flex justify-content-end">
+                                    <p:commandButton
+                                        id="btnRefreshPendingLabInvestigations"
+                                        value="Refresh Pending Items"
+                                        action="#{nursingDischargeController.loadPendingLabInvestigations()}"
+                                        update="pnlPendingLabInvestigations pnlActionButtons"
+                                        icon="fa fa-sync"
+                                        class="ui-button-secondary mx-1 mb-2" />
+                                </div>
+                            </div>
+
+                        </h:panelGroup>
+
                         <div class="row px-4 py-2">
                             <div class="col-12">
 
@@ -151,7 +196,7 @@
                                             action="#{nursingDischargeController.confirmNursingDischarge()}"
                                             icon="fa fa-check"
                                             class="ui-button-success mx-1"
-                                            disabled="#{nursingDischargeController.hasPendingPharmacyItems()}"
+                                            disabled="#{nursingDischargeController.hasPendingPharmacyItems() or nursingDischargeController.hasPendingLabInvestigations()}"
                                             onclick="return confirm('Are you sure you want to confirm nursing discharge? This will lock the record.')" />
                                     </h:panelGroup>
                                     <h:panelGroup rendered="#{nursingDischargeController.currentEncounter.nursingDischarged}">


### PR DESCRIPTION
## Summary

- Adds a third pre-discharge gate to `NursingDischargeController`, alongside the existing room-discharge (#21935) and pending-pharmacy-items (#23222) checks: **Confirm Nursing Discharge** is now disabled while any lab investigation on the admission hasn't been sent to lab yet.
- Blocking condition: `PatientInvestigation.sampleSent = false` (covers Ordered, Barcode Generated, Sample Collected — i.e. anything before Send to Lab). An investigation whose underlying bill is cancelled, or whose bill item was returned/refunded, is excluded (mirrors the existing `billItem.bill.cancelled` / `billItem.refunded` pattern used elsewhere in `PatientInvestigationController`).
- New warning panel "Pending Lab Investigations" on `inward_nursing_discharge.xhtml`, listing investigation name / ordered time / status, with its own Refresh button — same UX pattern as the existing pharmacy panel.
- New `PendingLabInvestigationDTO` (mirrors `PendingPharmacyItemDTO`).

## Test plan

Verified end-to-end against local Payara (menu path: *Nursing Workbench → BHT tab → BHT/57810 → Nursing Discharge*), using a real local admission with 4 pending investigations (FBC, CRP, Creatinine, Electrolytes):

- [x] With all 4 investigations still "Ordered" (not sent to lab): warning panel renders, Confirm button disabled.
- [x] Drove all 4 through the real lab workflow (*Inpatient → Laboratory Dashboard*: Generate Barcode → Collect Samples → Send to Lab); confirmed `SAMPLESENT=1` in DB for all 4.
- [x] Back on Nursing Discharge: warning panel gone, Confirm button enabled.
- [x] Clicked Confirm Nursing Discharge: succeeded; DB shows `NURSINGDISCHARGED=1` with timestamp.

Screenshots and full narrative posted to [issue #23578](https://github.com/hmislk/hmis/issues/23578#issuecomment-5576455758).

## Documentation

Updated [Inpatient — Nursing Discharge](https://github.com/hmislk/hmis/wiki/Inpatient-Nursing-Discharge) with the new prerequisite and both blocked/unblocked screenshots.

Also recorded two new Playwright E2E gotchas found while testing (`inward_lab_dashboard.xhtml` has no `p:messages`/`p:growl`, and its Sample Transporter `p:autoComplete` needs the widget API driven directly) in `developer_docs/testing/playwright-e2e-workflow.md`.

Closes #23578

🤖 Generated with [Claude Code](https://claude.com/claude-code)