### PR TITLE
fix(inward): block Cancel/Return of service bills after nursing discharge

### DIFF
--- a/src/main/java/com/divudi/bean/common/UserPrivilageController.java
+++ b/src/main/java/com/divudi/bean/common/UserPrivilageController.java
@@ -195,6 +195,7 @@ public class UserPrivilageController implements Serializable {
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardServicesAndItemsAddTimedServices, "Add Timed Services"), servicesItemsNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardAddChargesAfterNursingDischarge, "Add Charges After Nursing Discharge"), servicesItemsNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardProcessReturnAfterNursingDischarge, "Process Return After Nursing Discharge"), servicesItemsNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardProcessCancelAfterNursingDischarge, "Process Cancel After Nursing Discharge"), servicesItemsNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardHoldProfessionalPayments, "Hold Professional Payments"), servicesItemsNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardPayProfessionalFeesWhileOnHold, "Pay Professional Fees While On Hold"), servicesItemsNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardServiceItemRequestApproval, "Approve Service/Item Requests"), servicesItemsNode);

--- a/src/main/java/com/divudi/bean/inward/InwardSearch.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSearch.java
@@ -503,6 +503,12 @@ public class InwardSearch implements Serializable {
             return "";
         }
 
+        if (bill.getPatientEncounter() != null && bill.getPatientEncounter().isNursingDischarged()
+                && !webUserController.hasPrivilege("InwardProcessCancelAfterNursingDischarge")) {
+            JsfUtil.addErrorMessage("Cannot cancel services: nursing discharge has been confirmed for this patient.");
+            return "";
+        }
+
         DepartmentType toBillDepartmentType = DepartmentType.Other;
 
         if (bill.getToDepartment() != null && bill.getToDepartment().getDepartmentType() != null) {
@@ -1581,6 +1587,12 @@ public class InwardSearch implements Serializable {
 
             if (getBill().getPatientEncounter().isDischarged()) {
                 JsfUtil.addErrorMessage("Sorry, patient is discharged.");
+                return;
+            }
+
+            if (getBill().getPatientEncounter().isNursingDischarged()
+                    && !getWebUserController().hasPrivilege("InwardProcessCancelAfterNursingDischarge")) {
+                JsfUtil.addErrorMessage("Cannot cancel services: nursing discharge has been confirmed for this patient.");
                 return;
             }
 

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -91,6 +91,7 @@ public enum Privileges {
     InwardServiceItemRequestRejection("Inward Service/Item Request Rejection"),
     InwardAddChargesAfterNursingDischarge("Inward Add Charges After Nursing Discharge"),
     InwardProcessReturnAfterNursingDischarge("Inward Process Return After Nursing Discharge"),
+    InwardProcessCancelAfterNursingDischarge("Inward Process Cancel After Nursing Discharge"),
     InwardHoldProfessionalPayments("Hold Professional Payments"),
     InwardPayProfessionalFeesWhileOnHold("Pay Professional Fees While On Hold"),
     InwardBilling("Inward Billing"),
@@ -1666,6 +1667,7 @@ public enum Privileges {
             case InwardPhysicalDischarge:
             case InwardAddChargesAfterNursingDischarge:
             case InwardProcessReturnAfterNursingDischarge:
+            case InwardProcessCancelAfterNursingDischarge:
             case InwardHoldProfessionalPayments:
             case InwardPayProfessionalFeesWhileOnHold:
             case InwardDocumentUpload:

--- a/src/main/webapp/inward/inward_reprint_bill_service.xhtml
+++ b/src/main/webapp/inward/inward_reprint_bill_service.xhtml
@@ -90,7 +90,7 @@
                                         value="Return"
                                         icon="fa fa-undo"
                                         action="#{inwardServiceRefundController.navigateToRefundInwardServiceBill(inwardSearch.bill)}"
-                                        disabled="#{inwardSearch.bill.cancelled or inwardServiceRefundController.fullyReturned}"
+                                        disabled="#{inwardSearch.bill.cancelled or inwardServiceRefundController.fullyReturned or (inwardSearch.bill.patientEncounter.nursingDischarged and !webUserController.hasPrivilege('InwardProcessReturnAfterNursingDischarge'))}"
                                         styleClass="ui-button-warning">
                                     </p:commandButton>
                                     <p:commandButton
@@ -98,7 +98,7 @@
                                         value="To Cancel"
                                         icon="fa fa-ban"
                                         action="#{inwardSearch.navigateToCancelInpatientBill()}"
-                                        disabled="#{inwardSearch.bill.cancelled or inwardSearch.bill.refunded }"
+                                        disabled="#{inwardSearch.bill.cancelled or inwardSearch.bill.refunded or (inwardSearch.bill.patientEncounter.nursingDischarged and !webUserController.hasPrivilege('InwardProcessCancelAfterNursingDischarge'))}"
                                         styleClass="ui-button-danger">
                                     </p:commandButton>
                                     <p:commandButton


### PR DESCRIPTION
## Summary

- Once a patient's nursing discharge is confirmed, the **Return** and **To Cancel** actions on that patient's inward service bills (`inward_reprint_bill_service.xhtml`) are now blocked unless the acting user holds a dedicated escape-hatch privilege — closing the gap reported in #23576.
- **Return** already had a server-side nursing-discharge check (`InwardServiceRefundController.refundInwardServiceBill()`, gated by `InwardProcessReturnAfterNursingDischarge`), but the toolbar button wasn't disabled and the earlier navigation method (`navigateToRefundInwardServiceBill()`) didn't check either.
- **Cancel** (`InwardSearch.cancelBillService()` / `navigateToCancelInpatientBill()`) had **no** nursing-discharge check at all — it only checked the separate, later `isDischarged()` (final billing discharge) flag.
- Added a new privilege `InwardProcessCancelAfterNursingDischarge` as the Cancel-side counterpart to the existing `InwardProcessReturnAfterNursingDischarge`, following the same naming convention already used for `InwardAddChargesAfterNursingDischarge`.

## Changes

- `Privileges.java` / `UserPrivilageController.java`: register `InwardProcessCancelAfterNursingDischarge` in the same "Services & Items" privilege group as the existing Return privilege.
- `InwardSearch.java`: add the nursing-discharge check to both `navigateToCancelInpatientBill()` (early, at button-click time) and `cancelBillService()` (at final submission, defense in depth).
- `inward_reprint_bill_service.xhtml`: extend the `disabled` expression on both the **Return** and **To Cancel** buttons to also require the relevant privilege when nursing discharged.

## Test plan

- [x] Built and redeployed locally (Maven + local Payara, `jdbc/coop`)
- [x] Local DB (`coop`): found admission **BHT/57810** with open service bill **OPDL1//26/048933**, not yet nursing/final discharged, not cancelled/refunded/checked
- [x] Playwright, department **Inward**: confirmed nursing discharge for BHT/57810 via Inward > Search > Admissions > Nursing WorkBench > Nursing Discharge
- [x] Reopened the service bill via Inward > Search > Service Bill — confirmed **To Cancel** is now disabled (test user lacks the new privilege)
- [x] **Return** stayed enabled for the test user, who holds `InwardProcessReturnAfterNursingDischarge` — confirms the escape hatch still works and there's no regression
- [x] Forced the disabled "To Cancel" button re-enabled client-side and clicked it anyway — server-side check held; verified in DB the bill remained `CANCELLED=0` (defense in depth, not just UI)
- [x] Confirmed Return still navigates correctly into the refund page for a privileged user

**Before nursing discharge** — both Return and To Cancel enabled:

![before](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23576-before-nursing-discharge-toolbar.png)

**After nursing discharge** — To Cancel disabled:

![after](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23576-after-nursing-discharge-toolbar.png)

## Documentation

Updated: https://github.com/hmislk/hmis/wiki/Inpatient-Bill-Cancellations-and-Refunds-Overview (new "Nursing Discharge Restriction (Service Bills)" section)

Closes #23576

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XxzAmRUH8aMLhaSdU3bCjc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a privilege to control cancellation of inpatient services after nursing discharge.
  * Users with the appropriate privilege can cancel eligible inpatient bills and services after nursing discharge.

* **Bug Fixes**
  * Prevented unauthorized cancellation of nursing-discharged inpatient bills and services.
  * Updated Return and To Cancel actions to remain unavailable when required privileges are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->