### PR TITLE
fix(inward): guard the nullable discharged flag when routing to the Inpatient Dashboard

### DIFF
--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -1518,7 +1518,13 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
             // mother's room (#9900) - so isRoomAdmitted() is false forever and the
             // room-assignment diversion below would trap it permanently, leaving the
             // baby's dashboard unreachable from every entry point. (#23577)
-            if (isBabyAdmission() || current.isRoomAdmitted() || current.isDischarged()
+            // PatientEncounter.discharged is a nullable Boolean, not a primitive, so
+            // reading it as isDischarged() unboxes null and throws on a legacy row
+            // where DISCHARGED IS NULL - leaving this button doing nothing, the exact
+            // symptom #23577 set out to remove. Read it the way the rest of the
+            // codebase does (navigateToBabyAdmission above, InwardReportControllerBht,
+            // NursingDischargeController).
+            if (isBabyAdmission() || current.isRoomAdmitted() || Boolean.TRUE.equals(current.getDischarged())
                     || current.isPaymentFinalized() || !roomChargesAllowed) {
                 current.getPatient().setEditingMode(false);
                 bhtSummeryController.setPatientEncounter(current);


### PR DESCRIPTION
## What

One line in `AdmissionController.navigateToAdmissionProfilePage()`:

```diff
-if (isBabyAdmission() || current.isRoomAdmitted() || current.isDischarged()
+if (isBabyAdmission() || current.isRoomAdmitted() || Boolean.TRUE.equals(current.getDischarged())
         || current.isPaymentFinalized() || !roomChargesAllowed) {
```

## Why

`PatientEncounter.discharged` is a nullable `Boolean`, not a primitive:

```java
Boolean discharged = false;              // PatientEncounter.java:107 - no nullable = false
public Boolean isDischarged() { ... }    // PatientEncounter.java:736 - returns Boolean
```

Reading it as `isDischarged()` inside that `||` chain auto-unboxes it, so a row with `DISCHARGED IS NULL` throws an NPE and the **Inpatient Dashboard button silently does nothing** — the exact symptom #23577 set out to remove, still reachable on the legacy and migrated rows that issue's admission-type guard was added for.

Unlike `discharged`, the neighbouring `roomAdmitted` and `paymentFinalized` really are primitive `boolean`, which is why only this one operand is affected.

## When it triggers

All of the following at once:

- a row with `DISCHARGED IS NULL` (legacy or migrated data — new rows default to `false` in Java),
- the *"Patient admission and room assignment are simultaneous processes."* option **off**,
- a non-baby admission,
- with no room assigned yet.

The first two operands short-circuit otherwise, and `!roomChargesAllowed` is evaluated *after* this one, so it cannot save the call.

## Consistency

This is how the rest of the codebase already reads the field:

| Location | |
|---|---|
| `AdmissionController.java:957` | `Boolean.TRUE.equals(persistedParent.getDischarged())` — same class |
| `InwardReportControllerBht.java:363, 375` | `!Boolean.TRUE.equals(...getDischarged())` |
| `NursingDischargeController.java:299, 301` | `Boolean.TRUE.equals(...getDischarged())` |
| `AdmissionReportDTO.java:77`, `HospitalCensusDetailDto.java:58` | `Boolean.TRUE.equals(discharged)` |

## Verification

`mvn compile` clean. No behaviour change for any non-null row: `Boolean.TRUE.equals(x)` and unboxed `x` agree on both `TRUE` and `FALSE` — only the `null` case differs, where it now routes to the dashboard instead of throwing. That matches the null-`admissionType` default #23585 chose for the same condition.

## Provenance

Found by a post-merge review of #23585, which was merged about four minutes after CI went green — inside the window CodeRabbit had asked to wait after hitting its rate limit — so that PR landed with no automated review. Codex was out of quota on it as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F5EjQMkgdBq97LToJSpQuE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that could prevent legacy admission records with missing discharge status from opening correctly.
  * Preserved the existing dashboard navigation behavior for admission profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->