### PR TITLE
fix(pharmacy): allow concurrent stock takes of different department types in the same department

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyStockTakeController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyStockTakeController.java
@@ -540,11 +540,14 @@ public class PharmacyStockTakeController implements Serializable {
             return null;
         }
 
-        // Check if there's an ongoing stock taking for this department
+        // Check if there's an ongoing stock taking for this department and department type
         // Use department from snapshotBill to prevent bypass via mutable controller field
         Department deptFromBill = snapshotBill.getDepartment();
-        if (deptFromBill != null && hasOngoingStockTaking(deptFromBill)) {
-            JsfUtil.addErrorMessage("Cannot start a new stock taking. There is already an ongoing stock taking session for this department. Please complete the existing session first.");
+        com.divudi.core.data.DepartmentType deptTypeFromBill = snapshotBill.getDepartmentType();
+        if (deptFromBill != null && hasOngoingStockTaking(deptFromBill, deptTypeFromBill)) {
+            JsfUtil.addErrorMessage("Cannot start a new stock taking. There is already an ongoing stock taking session for this department"
+                    + (deptTypeFromBill != null ? " and department type (" + deptTypeFromBill.name() + ")" : "")
+                    + ". Please complete the existing session first.");
             //LOGGER.log(Level.WARNING, "[StockTake] Attempted to start new stock taking while one is ongoing. Department: {0}", deptFromBill.getName());
             return null;
         }
@@ -3555,16 +3558,23 @@ public class PharmacyStockTakeController implements Serializable {
 
     /**
      * Check if there's an ongoing (incomplete) stock taking for the given
-     * department. An ongoing stock taking is one where bill.completed = false.
+     * department and department type. An ongoing stock taking is one where
+     * bill.completed = false. Stock takes for different department types
+     * (e.g. Pharmacy vs Store) within the same department cover disjoint
+     * item sets, so they are allowed to run concurrently. A legacy bill
+     * with a NULL departmentType (predating this field) is treated as
+     * conflicting with every department type, since its item scope is
+     * unknown and may overlap.
      */
-    private boolean hasOngoingStockTaking(Department dept) {
+    private boolean hasOngoingStockTaking(Department dept, com.divudi.core.data.DepartmentType deptType) {
         if (dept == null || dept.getId() == null) {
             return false;
         }
-        String jpql = "select count(b) from Bill b where b.billType=:bt and b.department.id=:deptId and b.retired=false and (b.completed is null or b.completed=false)";
+        String jpql = "select count(b) from Bill b where b.billType=:bt and b.department.id=:deptId and b.retired=false and (b.completed is null or b.completed=false) and (b.departmentType is null or b.departmentType=:deptType)";
         HashMap<String, Object> params = new HashMap<>();
         params.put("bt", BillType.PharmacySnapshotBill);
         params.put("deptId", dept.getId());
+        params.put("deptType", deptType);
         Long count = billFacade.countByJpql(jpql, params);
         return count != null && count > 0;
     }


### PR DESCRIPTION
## Summary
- `hasOngoingStockTaking()` (used by `settleStockCount()` in `pharmacy_stock_take.xhtml`'s workflow) only checked `department.id`, so an ongoing Store stock take blocked starting a Pharmacy stock take (or vice versa) in the same department — even though the two cover disjoint item sets.
- Stock take snapshots are always generated with a required, non-null `departmentType` (Pharmacy/Store/Lab/Kitchen — enforced at `generateStockCount()`/`generateStockCountAsync()` time), and item selection is scoped to that type, so different types can safely run concurrently.
- Added `b.departmentType` to the duplicate-check JPQL and passed `snapshotBill.getDepartmentType()` through from `settleStockCount()`. A legacy bill with a NULL `departmentType` (predating this field) still blocks any new stock take for that department, since its item scope is unknown and may overlap.
- Error message now names the conflicting department type when known.

## Test plan
- [ ] Build/deploy locally and verify via Playwright:
  - [ ] Start and leave incomplete a Store stock take for department X → starting a Pharmacy stock take for department X now succeeds.
  - [ ] Starting a second Store stock take for department X while the first is incomplete is still blocked with the (updated) error message.
  - [ ] Complete a stock take, confirm it no longer blocks a new one of the same type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XxzAmRUH8aMLhaSdU3bCjc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Stock-taking checks now distinguish between department types, allowing separate stock-taking activities for different types within the same department to proceed concurrently.
  - Incomplete stock takes without a recorded department type continue to be treated as conflicting with all department types.
  - Conflict notifications now identify the relevant department type when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->