### PR TITLE
feat(inward): bill configured routine charges automatically on every admission

### DIFF
--- a/developer_docs/api/using-apis/API_ADMISSION_CHARGES.md
+++ b/developer_docs/api/using-apis/API_ADMISSION_CHARGES.md
@@ -167,10 +167,11 @@ POST /api/admission-charges
 
 `itemId` and `price` are required (`price` must be `>= 0`). `admissionTypeId` omitted/`null` means
 "any admission type". `paymentMethod` omitted/`null` means "both Cash and Credit". `qty` defaults
-to `1.0`; `orderNo` defaults to `0`.
+to `1.0` when omitted, and must be greater than zero when supplied; `orderNo` defaults to `0`.
 
 Rejected with `400` when: the item does not exist, the item fails any of the requirements above,
-`paymentMethod` is anything other than `Cash`/`Credit`/absent, `price` is negative, or a live row
+`paymentMethod` is anything other than `Cash`/`Credit`/absent, `price` is negative, `qty` is not
+greater than zero, or a live row
 already exists for the resulting `(item, admissionType, paymentMethod)` triple.
 
 ## Update
@@ -217,10 +218,9 @@ replacement row was configured while this one was retired) — resolve that conf
 
 | Code | When |
 |---|---|
-| 400 | Validation failure — missing/invalid item, bad `paymentMethod`, negative `price`, duplicate triple, malformed JSON or query param |
+| 400 | Validation failure — missing/invalid item, bad `paymentMethod`, negative `price`, non-positive `qty`, duplicate triple, restoring a row that is not retired, malformed JSON or query param |
 | 401 | Missing, unknown or expired `Finance` key |
 | 404 | Row does not exist, or is retired and `includeRetired` was not set |
-| 409 | Restoring something that is not retired |
 
 ---
 

--- a/developer_docs/api/using-apis/API_ADMISSION_CHARGES.md
+++ b/developer_docs/api/using-apis/API_ADMISSION_CHARGES.md
@@ -1,0 +1,234 @@
+# Admission Charges API
+
+Configuration for **automatic admission charges** — routine charges billed on every matching
+admission by `AdmissionChargeApplicationBean` at the moment an admission is saved, using the same
+`InwardServiceBillService` pipeline the *Add Services / Investigations to BHT* screen uses. Nothing
+here bills a patient directly; it only configures which items are billed for which admissions.
+
+- Base path: `/api/admission-charges`
+- Auth: `Finance: <api-key>` header on every request
+- Entity: `AdmissionChargeItem`
+
+## Response envelope
+
+```json
+{ "status": "success", "code": 200, "data": { } }
+{ "status": "error",   "code": 400, "message": "..." }
+```
+
+---
+
+## The two-dimension resolution rule
+
+Each configured item is resolved independently, in two steps, when an admission is saved:
+
+1. **Admission type** (outer filter) — among the rows configured for an item, the rows whose
+   `admissionTypeId` matches the admission's admission type are considered first. If none match,
+   the rows with `admissionTypeId = null` ("any admission type") are considered instead.
+2. **Payment method** (inner filter) — within whichever set step 1 produced, the row whose
+   `paymentMethod` matches the admission's payment method (`Cash` or `Credit`) is picked. If none
+   matches, the row with `paymentMethod = null` ("both") is picked instead.
+
+A `null` in either column is a real configuration, not "unset" — it means "applies to all" for
+that dimension.
+
+### The configuration trap
+
+Step 1 is a **filter**, not a preference. As soon as *any* row exists for an item with a specific
+`admissionTypeId`, the entire `admissionTypeId = null` row set for that item is ignored for
+admissions of that type — it does not fall back to it.
+
+Concretely: configuring `(Admission Charge, admissionType=Day Case, paymentMethod=Cash)` and
+forgetting the Day Case + Credit row leaves a **Credit Day Case admission with no admission charge
+at all**, even if a `(Admission Charge, admissionType=null, paymentMethod=null)` row exists — that
+null-type row is never reached once a Day Case–specific row exists for this item.
+
+The rule of thumb: the moment you add one admission-type-specific row for an item, you are
+committing to configure **every** payment method you care about for that admission type
+separately, because the general fallback is gone for that type.
+
+### The double-charge trap
+
+`AdmissionType.admissionFee` is an existing, separate, older mechanism. When an admission is
+billed, `InwardBhtChargeAggregationService.fetchAdmissionFeeCharges()` already adds that fee to the
+bill under `InwardChargeType.AdmissionFee` — as a bill total component, **without** persisting a
+`BillItem`.
+
+If an admission type has a non-zero `admissionFee` **and** an `AdmissionChargeItem` is also
+configured for an item that resolves to that same admission (an admission-type-specific row for
+that type, or a null-type row with no more specific override), the admission is charged **twice**
+for what is effectively the same thing: once via `admissionFee`, once via the `AdmissionChargeItem`
+BillItem. Check the admission type's `admissionFee` before configuring a general admission charge
+against it.
+
+---
+
+## Cash/Credit-only restriction
+
+`paymentMethod` accepts exactly `Cash`, `Credit`, or is omitted/`null` (meaning "both"). No other
+`PaymentMethod` value is valid here — an admission's payment method is only ever Cash or Credit
+(`EnumController.getPaymentMethodForAdmission()`). Sending anything else, including a real
+`PaymentMethod` enum constant such as `Card` or `Staff`, is rejected with `400`.
+
+## Uniqueness constraint
+
+At most one **live** (non-retired) row may exist per `(item, admissionType, paymentMethod)`
+triple. Creating or updating a row into a triple that already has a live row is rejected with
+`400`; retire the existing row first, or update it instead.
+
+## Item requirements
+
+The `item` an `AdmissionChargeItem` points at must, at the time the row is created or updated:
+
+- exist and not be retired
+- have a `department` (bills are grouped on it)
+- have an `institution` (fee resolution reads it)
+- have an `inwardChargeType` (it drives the interim/final bill's charge-type breakdown)
+- have at least one **live** `ItemFee` — an item with no fee produces a `BillItem` whose charge
+  cancels and refunds as zero, which is worse than not charging it at all
+
+All of these are enforced here so a row this API accepts is a row `AdmissionChargeApplicationBean`
+can actually bill — the checks mirror `AdmissionChargeApplicationBean.buildEntry` exactly.
+
+---
+
+## Search
+
+```
+GET /api/admission-charges/search
+```
+
+| Param | Notes |
+|---|---|
+| `itemId` | Item id |
+| `admissionTypeId` | `AdmissionType` id |
+| `paymentMethod` | `Cash` or `Credit` — filters to that exact value (a row does not match this filter just because it "would resolve to" that method) |
+| `includeRetired` | `true` to include retired rows. Default `false` |
+| `limit` | Page size, 1–100. Default 30 |
+| `offset` | Rows to skip. Default 0 |
+
+```json
+{
+  "status": "success",
+  "code": 200,
+  "data": {
+    "items": [
+      {
+        "id": 918273,
+        "itemId": 44821,
+        "itemName": "Admission Charge",
+        "itemDepartmentId": 486,
+        "itemDepartmentName": "General Ward",
+        "inwardChargeType": "OtherCharges",
+        "admissionTypeId": 71,
+        "admissionTypeName": "Day Case",
+        "paymentMethod": "Cash",
+        "price": 500.0,
+        "qty": 1.0,
+        "orderNo": 0,
+        "retired": false
+      }
+    ],
+    "total": 4,
+    "limit": 30,
+    "offset": 0
+  }
+}
+```
+
+`total` is the number of rows matching the filters, ignoring `limit`/`offset`.
+
+## Get one
+
+```
+GET /api/admission-charges/{id}
+GET /api/admission-charges/{id}?includeRetired=true
+```
+
+Returns a single row in the same shape as a search result item. A retired row is `404` unless
+`includeRetired=true`.
+
+## Create
+
+```
+POST /api/admission-charges
+```
+
+```json
+{
+  "itemId": 44821,
+  "admissionTypeId": 71,
+  "paymentMethod": "Cash",
+  "price": 500.0,
+  "qty": 1.0,
+  "orderNo": 0
+}
+```
+
+`itemId` and `price` are required (`price` must be `>= 0`). `admissionTypeId` omitted/`null` means
+"any admission type". `paymentMethod` omitted/`null` means "both Cash and Credit". `qty` defaults
+to `1.0`; `orderNo` defaults to `0`.
+
+Rejected with `400` when: the item does not exist, the item fails any of the requirements above,
+`paymentMethod` is anything other than `Cash`/`Credit`/absent, `price` is negative, or a live row
+already exists for the resulting `(item, admissionType, paymentMethod)` triple.
+
+## Update
+
+```
+PUT /api/admission-charges/{id}
+```
+
+```json
+{
+  "price": 550.0
+}
+```
+
+All fields optional; only fields present are applied. Because `admissionTypeId` and
+`paymentMethod` are two of the three columns in the uniqueness key, and `null` is itself a
+meaningful value for both, a plain JSON body cannot tell "field omitted" apart from "field sent as
+null" — so clearing either one back to `null` is done explicitly:
+
+```json
+{ "clearAdmissionType": true }
+{ "clearPaymentMethod": true }
+```
+
+`admissionTypeId`/`paymentMethod`, when present, take priority over the corresponding `clear*`
+flag. Every update re-checks the uniqueness constraint against the row's resulting identity
+(excluding itself), so an update that would create a duplicate is rejected with `400` the same way
+a create is.
+
+## Retire / Restore
+
+```
+DELETE /api/admission-charges/{id}?retireComments=reason   soft-retire
+PATCH  /api/admission-charges/{id}/restore                  un-retire
+```
+
+`DELETE` never removes a row — it sets `retired = true`. `restore` is rejected with `400` if
+another live row now occupies the same `(item, admissionType, paymentMethod)` triple (e.g. a
+replacement row was configured while this one was retired) — resolve that conflict first.
+
+---
+
+## Status codes
+
+| Code | When |
+|---|---|
+| 400 | Validation failure — missing/invalid item, bad `paymentMethod`, negative `price`, duplicate triple, malformed JSON or query param |
+| 401 | Missing, unknown or expired `Finance` key |
+| 404 | Row does not exist, or is retired and `includeRetired` was not set |
+| 409 | Restoring something that is not retired |
+
+---
+
+## Related
+
+- `AdmissionChargeApplicationBean` — runtime resolution and billing (`resolveChargesForEncounter`,
+  `resolveForItem`)
+- `InwardBhtChargeAggregationService.fetchAdmissionFeeCharges()` — the separate `admissionFee`
+  mechanism described in the double-charge trap above
+- [API_TIMED_ITEMS.md](API_TIMED_ITEMS.md) — a similarly-shaped configuration API for timed
+  (duration-based) inward services

--- a/developer_docs/api/using-apis/README.md
+++ b/developer_docs/api/using-apis/README.md
@@ -13,6 +13,7 @@ All standard endpoints use the `Finance` header unless noted otherwise below.
 
 | File | Module | Auth |
 |---|---|---|
+| [API_ADMISSION_CHARGES.md](API_ADMISSION_CHARGES.md) | Configure automatic routine admission charges (AdmissionChargeItem) | `Finance` |
 | [API_ADMISSION_DETAILS.md](API_ADMISSION_DETAILS.md) | Consolidated index: which API to call for admission worklist/BHT numbers/clinical forms | `Finance` |
 | [API_ADMISSION_NUMBERS.md](API_ADMISSION_NUMBERS.md) | View/reset BHT/OPD admission-number sequence counters | `Finance` |
 | [API_BALANCE_HISTORY.md](API_BALANCE_HISTORY.md) | Drawer/patient-deposit/agent balance change history | `Finance` |

--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -3077,6 +3077,46 @@ Found while fixing issue #23577.
 
 ---
 
+## 109. A `p:confirm` dialog is `position: fixed`, so an `offsetParent` visibility probe wrongly reports it hidden — the click did work
+
+Cancelling an inward service bill (`inward_cancel_bill_service.xhtml`) appeared
+to do nothing: clicking **Cancel Service Bill** produced no growl, no page
+change, and no row change in the DB. A probe for open dialogs came back empty:
+
+```js
+[...document.querySelectorAll('.ui-confirm-dialog,.ui-dialog')]
+    .filter(d => d.offsetParent)          // <-- always empty for this dialog
+```
+
+The dialog *was* open. PrimeFaces renders `p:confirm`'s dialog with
+`position: fixed`, and **`offsetParent` is `null` for any fixed-position
+element** — so the usual "is it visible" shorthand reports every confirm dialog
+as hidden. The follow-up symptom is the giveaway: a retried click on the
+underlying button fails with
+
+```
+<div class="ui-widget-overlay ui-dialog-mask" ...> intercepts pointer events
+```
+
+which is the modal mask doing its job, not a broken button.
+
+**Probe `display`/`.ui-dialog-mask` instead, and click the dialog's own button:**
+
+```js
+[...document.querySelectorAll('.ui-confirm-dialog')].map(d => ({
+    id: d.id,
+    display: getComputedStyle(d).display,        // 'block' when open
+    buttons: [...d.querySelectorAll('button')].map(b => ({t: b.innerText.trim(), id: b.id}))
+}))
+```
+
+then click the **Yes** button by its id. Note this is a PrimeFaces dialog, not a
+native `confirm()` — `browser_handle_dialog` does not apply and will time out
+waiting for a dialog that never reaches the browser. The same page can use both:
+`inward_bill_service_refund.xhtml`'s **Refund Bill** is a native `confirm()`
+(handled with `browser_handle_dialog`), while the cancel screen's button is a
+`p:confirm`. Check the markup for `<p:confirm>` before deciding which to use.
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.
@@ -3085,6 +3125,7 @@ Found while fixing issue #23577.
 - [ ] Clicked **Search** on every date-filtered list before expecting rows.
 - [ ] Used real key events (slow type + wait) for autocompletes; for qty fields with blur AJAX, used slow type + Tab (not jQuery-blur — see §3).
 - [ ] Handled `confirm()` dialogs; tested double-click on settle buttons.
+- [ ] Distinguished a native `confirm()` (use `browser_handle_dialog`) from a PrimeFaces `p:confirm` dialog (click its own Yes button) — and did not treat an `offsetParent`-based visibility probe as proof a `p:confirm` dialog is closed (§109).
 - [ ] Filled required fields before non-AJAX actions.
 - [ ] Checked that navigation buttons are not blocked by JSF validation on required fields in the same form.
 - [ ] Verified stock + bill-item integrity in the DB; cleaned up temp files.

--- a/src/main/java/com/divudi/bean/inward/AdmissionChargeItemController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionChargeItemController.java
@@ -1,0 +1,391 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.bean.inward;
+
+import com.divudi.core.data.PaymentMethod;
+import com.divudi.core.entity.Item;
+import com.divudi.core.entity.inward.AdmissionChargeItem;
+import com.divudi.core.entity.inward.AdmissionType;
+import com.divudi.core.facade.AdmissionChargeItemFacade;
+import com.divudi.core.facade.ItemFeeFacade;
+import com.divudi.core.util.JsfUtil;
+import com.divudi.bean.common.SessionController;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.ejb.EJB;
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+/**
+ * Manages {@link AdmissionChargeItem} rows - the routine admission charges
+ * that {@code AdmissionChargeApplicationBean} bills automatically on every
+ * matching admission (issue #23594).
+ *
+ * <p>Resolution is a two-step filter, matching
+ * {@code AdmissionChargeApplicationBean.resolveForItem}: for a given
+ * {@link Item}, admission type is the outer filter (a {@code null}
+ * admission type row applies to every admission type that has no
+ * type-specific row of its own) and payment method is the inner filter
+ * (a {@code null} payment method row applies to both Cash and Credit within
+ * whichever admission-type group matched). Because step one is a filter and
+ * not a preference, configuring even one admission-type-specific row for an
+ * item completely replaces the "any type" rows for that admission type - so
+ * both Cash and Credit must be covered for that admission type, or one of
+ * them silently gets no charge at all. This controller validates against
+ * that trap on save and also warns about the unrelated, but easily confused,
+ * trap of double-charging an admission type that already carries its own
+ * built-in {@code AdmissionType.admissionFee}.</p>
+ *
+ * @author Buddhika
+ */
+@Named
+@SessionScoped
+public class AdmissionChargeItemController implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Inject
+    private SessionController sessionController;
+
+    @EJB
+    private AdmissionChargeItemFacade ejbFacade;
+
+    @EJB
+    private ItemFeeFacade itemFeeFacade;
+
+    @EJB
+    private com.divudi.core.facade.AdmissionTypeFacade admissionTypeFacade;
+
+    private AdmissionChargeItem current;
+    private List<AdmissionChargeItem> items;
+
+    // Filters
+    private Item filterItem;
+    private AdmissionType filterAdmissionType;
+    private PaymentMethod filterPaymentMethod;
+
+    public String navigateToManageAdmissionCharges() {
+        fillItems();
+        prepareAdd();
+        return "/inward/inward_admission_charge_item?faces-redirect=true";
+    }
+
+    public void prepareAdd() {
+        current = new AdmissionChargeItem();
+        current.setQty(1.0);
+    }
+
+    public void search() {
+        fillItems();
+    }
+
+    public void clearFilters() {
+        filterItem = null;
+        filterAdmissionType = null;
+        filterPaymentMethod = null;
+        fillItems();
+    }
+
+    public void fillItems() {
+        Map<String, Object> params = new HashMap<>();
+        StringBuilder j = new StringBuilder("select a from AdmissionChargeItem a where a.retired=false ");
+        if (filterItem != null) {
+            j.append(" and a.item=:itm ");
+            params.put("itm", filterItem);
+        }
+        if (filterAdmissionType != null) {
+            j.append(" and a.admissionType=:at ");
+            params.put("at", filterAdmissionType);
+        }
+        if (filterPaymentMethod != null) {
+            j.append(" and a.paymentMethod=:pm ");
+            params.put("pm", filterPaymentMethod);
+        }
+        j.append(" order by a.item.name, a.orderNo, a.id");
+        items = ejbFacade.findByJpql(j.toString(), params);
+    }
+
+    public List<AdmissionChargeItem> getItems() {
+        if (items == null) {
+            fillItems();
+        }
+        return items;
+    }
+
+    /**
+     * Validates, then creates/edits the current row.
+     *
+     * <p>Validation mirrors what
+     * {@code AdmissionChargeApplicationBean.buildEntry} and
+     * {@code resolveFee} need at runtime, so a row that passes here can
+     * never be silently skipped (or worse, billed at zero) when an admission
+     * is saved.</p>
+     */
+    public void saveSelected() {
+        if (current == null) {
+            JsfUtil.addErrorMessage("Nothing to save.");
+            return;
+        }
+
+        if (current.getItem() == null) {
+            JsfUtil.addErrorMessage("Please select the service item.");
+            return;
+        }
+        Item item = current.getItem();
+
+        if (item.getDepartment() == null) {
+            JsfUtil.addErrorMessage("This item has no department. The department decides how the generated bills are bundled - set it under Item administration first.");
+            return;
+        }
+        if (item.getInstitution() == null) {
+            JsfUtil.addErrorMessage("This item has no institution set. Set it under Item administration first.");
+            return;
+        }
+        if (item.getInwardChargeType() == null) {
+            JsfUtil.addErrorMessage("This item has no inward charge type. Without it the charge cannot appear under the right heading on the interim and final bill.");
+            return;
+        }
+
+        Map<String, Object> feeCountParams = new HashMap<>();
+        feeCountParams.put("itm", item);
+        long liveFeeCount = itemFeeFacade.findLongByJpql(
+                "select count(f) from ItemFee f where f.retired=false and f.item=:itm",
+                feeCountParams);
+        if (liveFeeCount <= 0) {
+            JsfUtil.addErrorMessage("This item has no fee configured, so the charge would cancel and refund as zero.");
+            return;
+        }
+
+        if (current.getPaymentMethod() != null
+                && current.getPaymentMethod() != PaymentMethod.Cash
+                && current.getPaymentMethod() != PaymentMethod.Credit) {
+            JsfUtil.addErrorMessage("An admission is only ever Cash or Credit.");
+            return;
+        }
+
+        if (current.getPrice() < 0) {
+            JsfUtil.addErrorMessage("Price cannot be negative.");
+            return;
+        }
+
+        if (isDuplicate(current)) {
+            JsfUtil.addErrorMessage("A charge for this item, admission type and payment method already exists.");
+            return;
+        }
+
+        boolean editing = current.getId() != null;
+        if (editing) {
+            ejbFacade.edit(current);
+            JsfUtil.addSuccessMessage("Updated Successfully.");
+        } else {
+            current.setCreatedAt(new Date());
+            current.setCreater(sessionController.getLoggedUser());
+            ejbFacade.create(current);
+            JsfUtil.addSuccessMessage("Saved Successfully.");
+        }
+
+        for (String warning : coverageWarningsForItem(item)) {
+            JsfUtil.addWarningMessage(warning);
+        }
+        for (String warning : admissionFeeDoubleChargeWarnings(current.getAdmissionType())) {
+            JsfUtil.addWarningMessage(warning);
+        }
+
+        fillItems();
+        prepareAdd();
+    }
+
+    /**
+     * Warns when the admission types this row will apply to already carry their
+     * own built-in {@code AdmissionType.admissionFee}.
+     *
+     * <p>That fee is a separate, older mechanism: it is added to the interim and
+     * final bill under the <i>Admission Fee</i> charge type without ever being
+     * persisted as a BillItem. Configuring an admission charge here for the same
+     * thing charges the patient twice.</p>
+     *
+     * <p>A row with no admission type applies to <b>every</b> admission type, so
+     * that case has to check them all rather than just the one selected.</p>
+     */
+    private List<String> admissionFeeDoubleChargeWarnings(AdmissionType selectedAdmissionType) {
+        List<String> warnings = new ArrayList<>();
+        List<AdmissionType> typesToCheck = new ArrayList<>();
+
+        if (selectedAdmissionType != null) {
+            typesToCheck.add(selectedAdmissionType);
+        } else {
+            List<AdmissionType> all = admissionTypeFacade.findByJpql(
+                    "select a from AdmissionType a where a.retired=false and a.admissionFee <> 0 order by a.name");
+            if (all != null) {
+                typesToCheck.addAll(all);
+            }
+        }
+
+        for (AdmissionType at : typesToCheck) {
+            if (at.getAdmissionFee() == 0.0) {
+                continue;
+            }
+            warnings.add("Warning: admission type '" + at.getName()
+                    + "' already carries a built-in admission fee of " + at.getAdmissionFee()
+                    + ", which is added to the bill separately. Charging this item on that admission type as well will charge the patient twice.");
+        }
+        return warnings;
+    }
+
+    /**
+     * True when a live row already exists for the same
+     * (item, admissionType, paymentMethod) triple, excluding {@code row}
+     * itself when it is being edited. {@code null} admission type / payment
+     * method are matched with {@code is null} rather than a bound parameter,
+     * since JPQL's {@code = :param} never matches a null value.
+     */
+    private boolean isDuplicate(AdmissionChargeItem row) {
+        Map<String, Object> params = new HashMap<>();
+        StringBuilder j = new StringBuilder("select count(a) from AdmissionChargeItem a where a.retired=false and a.item=:itm ");
+        params.put("itm", row.getItem());
+
+        if (row.getAdmissionType() != null) {
+            j.append(" and a.admissionType=:at ");
+            params.put("at", row.getAdmissionType());
+        } else {
+            j.append(" and a.admissionType is null ");
+        }
+
+        if (row.getPaymentMethod() != null) {
+            j.append(" and a.paymentMethod=:pm ");
+            params.put("pm", row.getPaymentMethod());
+        } else {
+            j.append(" and a.paymentMethod is null ");
+        }
+
+        if (row.getId() != null) {
+            j.append(" and a.id <> :selfId ");
+            params.put("selfId", row.getId());
+        }
+
+        return ejbFacade.findLongByJpql(j.toString(), params) > 0;
+    }
+
+    /**
+     * Warns when, for {@code item}, an admission type has been given a
+     * Cash-only or Credit-only row set with no "any" row - meaning the other
+     * payment method gets no charge at all for that admission type, because
+     * admission-type-specific rows completely replace the "any type" rows.
+     */
+    public List<String> coverageWarningsForItem(Item item) {
+        List<String> warnings = new ArrayList<>();
+        if (item == null) {
+            return warnings;
+        }
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("itm", item);
+        List<AdmissionChargeItem> rows = ejbFacade.findByJpql(
+                "select a from AdmissionChargeItem a where a.retired=false and a.item=:itm",
+                params);
+        if (rows == null || rows.isEmpty()) {
+            return warnings;
+        }
+
+        Set<AdmissionType> admissionTypesUsed = new LinkedHashSet<>();
+        for (AdmissionChargeItem row : rows) {
+            if (row.getAdmissionType() != null) {
+                admissionTypesUsed.add(row.getAdmissionType());
+            }
+        }
+        if (admissionTypesUsed.isEmpty()) {
+            return warnings;
+        }
+
+        for (AdmissionType at : admissionTypesUsed) {
+            boolean hasAny = false;
+            boolean hasCash = false;
+            boolean hasCredit = false;
+            for (AdmissionChargeItem row : rows) {
+                if (!at.equals(row.getAdmissionType())) {
+                    continue;
+                }
+                if (row.getPaymentMethod() == null) {
+                    hasAny = true;
+                } else if (row.getPaymentMethod() == PaymentMethod.Cash) {
+                    hasCash = true;
+                } else if (row.getPaymentMethod() == PaymentMethod.Credit) {
+                    hasCredit = true;
+                }
+            }
+            if (hasAny) {
+                continue;
+            }
+            if (hasCash && !hasCredit) {
+                warnings.add("Warning: '" + item.getName() + "' has a " + at.getName() + " row for Cash only. "
+                        + "A Credit " + at.getName() + " admission will get NO charge for this item at all, "
+                        + "because admission-type-specific rows completely replace the 'any type' rows.");
+            } else if (hasCredit && !hasCash) {
+                warnings.add("Warning: '" + item.getName() + "' has a " + at.getName() + " row for Credit only. "
+                        + "A Cash " + at.getName() + " admission will get NO charge for this item at all, "
+                        + "because admission-type-specific rows completely replace the 'any type' rows.");
+            }
+        }
+        return warnings;
+    }
+
+    public void delete() {
+        if (current == null || current.getId() == null) {
+            JsfUtil.addErrorMessage("Nothing to delete.");
+            return;
+        }
+        current.setRetired(true);
+        current.setRetirer(sessionController.getLoggedUser());
+        current.setRetiredAt(new Date());
+        ejbFacade.edit(current);
+        JsfUtil.addSuccessMessage("Deleted Successfully.");
+        fillItems();
+        prepareAdd();
+    }
+
+    public AdmissionChargeItem getCurrent() {
+        if (current == null) {
+            current = new AdmissionChargeItem();
+        }
+        return current;
+    }
+
+    public void setCurrent(AdmissionChargeItem current) {
+        this.current = current;
+    }
+
+    public Item getFilterItem() {
+        return filterItem;
+    }
+
+    public void setFilterItem(Item filterItem) {
+        this.filterItem = filterItem;
+    }
+
+    public AdmissionType getFilterAdmissionType() {
+        return filterAdmissionType;
+    }
+
+    public void setFilterAdmissionType(AdmissionType filterAdmissionType) {
+        this.filterAdmissionType = filterAdmissionType;
+    }
+
+    public PaymentMethod getFilterPaymentMethod() {
+        return filterPaymentMethod;
+    }
+
+    public void setFilterPaymentMethod(PaymentMethod filterPaymentMethod) {
+        this.filterPaymentMethod = filterPaymentMethod;
+    }
+
+}

--- a/src/main/java/com/divudi/bean/inward/AdmissionChargeItemController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionChargeItemController.java
@@ -178,6 +178,14 @@ public class AdmissionChargeItemController implements Serializable {
             return;
         }
 
+        // Same contract as the REST layer: a non-positive qty is rejected rather
+        // than quietly normalised, so a mistyped row cannot sit in the
+        // configuration looking valid.
+        if (current.getQty() == null || current.getQty() <= 0) {
+            JsfUtil.addErrorMessage("Qty must be greater than zero.");
+            return;
+        }
+
         if (isDuplicate(current)) {
             JsfUtil.addErrorMessage("A charge for this item, admission type and payment method already exists.");
             return;

--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -162,6 +162,10 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         return inpatientPackageApplicationBean;
     }
 
+    /** Bills the configured automatic admission charges. (Issue #23594) */
+    @Inject
+    private com.divudi.service.inward.AdmissionChargeApplicationBean admissionChargeApplicationBean;
+
     @Inject
     BhtEditController bhtEditController;
     @Inject
@@ -3063,6 +3067,11 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
                     getSessionController().getLoggedUser());
         }
 
+        // Held outside the room block so the automatic admission charges below can
+        // retire it if they fail - a room-less Rapid / Temp A&E admission simply
+        // leaves it null. (Issue #23594)
+        PatientRoom createdPatientRoom = null;
+
         // Only create a PatientRoom record when a facility charge is actually selected.
         // For Rapid / Temp A&E admissions the room validation is skipped, so
         // getRoomFacilityCharge() may be null; attempting to save it would NPE. (Issue #21183)
@@ -3073,6 +3082,7 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
             // controls whether a nurse handover request is also created below (Issue #23145).
             currentPatientRoom = getInwardBean().savePatientRoom(getPatientRoom(), null, getPatientRoom().getRoomFacilityCharge(), getCurrent(), getCurrent().getDateOfAdmission(), getSessionController().getLoggedUser(), true);
             getCurrent().setRoomAdmitted(true);
+            createdPatientRoom = currentPatientRoom;
 
             getCurrent().setCurrentPatientRoom(currentPatientRoom);
 
@@ -3183,6 +3193,12 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
 
         saveEncounterCreditCompanies(current);
 
+        // Automatic admission charges — outside the room block on purpose, since a
+        // room-less Rapid / Temp A&E admission still has to be charged. (Issue #23594)
+        if (!applyAutomaticAdmissionCharges(createdPatientRoom)) {
+            return;
+        }
+
         if (isNewAdmission) {
             String auditTrigger = getCurrent().getParentEncounter() != null
                     ? "Baby Admission Created" : "Admission Created";
@@ -3234,9 +3250,14 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
             JsfUtil.addSuccessMessage("Patient admitted successfully with BHT No: " + getCurrent().getBhtNo());
         }
 
+        // Held outside the room block so the automatic admission charges below can
+        // retire it if they fail. (Issue #23594)
+        PatientRoom createdPatientRoom = null;
+
         if (getCurrent().getAdmissionType().isRoomChargesAllowed() || getPatientRoom().getRoomFacilityCharge() != null) {
             PatientRoom currentPatientRoom = getInwardBean().savePatientRoom(getPatientRoom(), null, getPatientRoom().getRoomFacilityCharge(), getCurrent(), getCurrent().getDateOfAdmission(), getSessionController().getLoggedUser());
             getCurrent().setCurrentPatientRoom(currentPatientRoom);
+            createdPatientRoom = currentPatientRoom;
 
             if (currentPatientRoom != null && currentPatientRoom.getRoomFacilityCharge() != null) {
                 PatientTransferRequest handoverRequest = new PatientTransferRequest();
@@ -3264,6 +3285,11 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
 
         saveEncounterCreditCompanies(current);
 
+        // Automatic admission charges — same hook as saveSelected(). (Issue #23594)
+        if (!applyAutomaticAdmissionCharges(createdPatientRoom)) {
+            return;
+        }
+
         getCurrentNonBht().setParentEncounter(current);
         getCurrentNonBht().setDischarged(true);
         getCurrentNonBht().setDateOfDischarge(new Date());
@@ -3278,6 +3304,50 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
         // Save EncounterCreditCompanies
         // Need to create EncounterCredit
         printPreview = true;
+    }
+
+    /**
+     * Bills the configured automatic admission charges for the admission just
+     * saved (issue #23594).
+     *
+     * <p>Compensating transaction, same pattern as the inpatient package
+     * application above: this controller is a CDI bean and is not itself
+     * transactional, so the admission and the room were each already committed
+     * in earlier transactions. A failure here cannot be rolled back by the
+     * container, and would otherwise leave a half-charged admission - so retire
+     * what was created and surface a clear error instead.</p>
+     *
+     * @return {@code true} to carry on, {@code false} when the admission was
+     * rolled back and the caller must stop
+     */
+    private boolean applyAutomaticAdmissionCharges(PatientRoom createdPatientRoom) {
+        try {
+            admissionChargeApplicationBean.applyAdmissionChargesToAdmission(
+                    getCurrent(), getSessionController().getLoggedUser(), getSessionController().getDepartment());
+            return true;
+        } catch (RuntimeException ex) {
+            logger.log(Level.SEVERE, "Automatic admission charges failed for admission " + getCurrent().getBhtNo(), ex);
+            Date now = new Date();
+            String reason = "Auto-retired: automatic admission charges failed - " + ex.getMessage();
+
+            if (createdPatientRoom != null) {
+                createdPatientRoom.setRetired(true);
+                createdPatientRoom.setRetireComments(reason);
+                createdPatientRoom.setRetirer(getSessionController().getLoggedUser());
+                createdPatientRoom.setRetiredAt(now);
+                patientRoomFacade.edit(createdPatientRoom);
+            }
+
+            getCurrent().setRetired(true);
+            getCurrent().setRetireComments(reason);
+            getCurrent().setRetirer(getSessionController().getLoggedUser());
+            getCurrent().setRetiredAt(now);
+            getFacade().edit(getCurrent());
+
+            JsfUtil.addErrorMessage("Automatic admission charges could not be applied and this admission has been cancelled. Please retry. (" + ex.getMessage() + ")");
+            admittingProcessStarted = false;
+            return false;
+        }
     }
 
     public void saveEncounterCreditCompanies(PatientEncounter current) {

--- a/src/main/java/com/divudi/bean/inward/BhtEditController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtEditController.java
@@ -13,6 +13,7 @@ import com.divudi.bean.common.ConfigOptionApplicationController;
 import com.divudi.bean.common.ControllerWithPatient;
 import com.divudi.bean.common.SessionController;
 import com.divudi.core.util.JsfUtil;
+import com.divudi.core.data.BillTypeAtomic;
 import com.divudi.core.data.PaymentMethod;
 import com.divudi.core.data.Sex;
 import com.divudi.core.data.Title;
@@ -87,6 +88,9 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
     InwardStaffPaymentBillController inwardStaffPaymentBillController;
     @Inject
     com.divudi.bean.common.PatientController patientController;
+    /** Reuses the inward service bill reversal when an admission is cancelled. (Issue #23594) */
+    @Inject
+    private InwardSearch inwardSearch;
     // </editor-fold>
 
     // <editor-fold defaultstate="collapsed" desc="EJBs">
@@ -360,6 +364,14 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
                 + " and b.cancelled=false ";
         HashMap hm = new HashMap();
         hm.put("pEnc", current);
+        // The automatic admission charges (issue #23594) are not staff-added bills
+        // the user has to clear first - cancelBht() reverses them itself. Leaving
+        // them in would mean every admission at a hospital that configures this
+        // feature could never be cancelled.
+        if (current != null && current.getAdmissionChargeBatchBill() != null) {
+            sql += " and (b.backwardReferenceBill is null or b.backwardReferenceBill<>:acb) ";
+            hm.put("acb", current.getAdmissionChargeBatchBill());
+        }
         List<Bill> bills = getBillFacade().findByJpql(sql, hm);
         if (bills.isEmpty()) {
             return flag;
@@ -396,6 +408,61 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
 //
 //        return false;
 //    }
+    /**
+     * Reverses the automatic admission charges billed at admission
+     * (issue #23594) with the same contra-bill machinery the manual
+     * <i>Cancel Inward Service Bill</i> screen uses.
+     *
+     * <p>Charges are billed on every admission at a hospital that configures
+     * them, so requiring staff to clear them by hand before cancelling a wrongly
+     * created admission would make cancellation impractical. A charge bill that
+     * genuinely may not be reversed - checked, already returned, or with a
+     * doctor payment against it - still blocks the cancellation, and says why.</p>
+     *
+     * @return the bills reversed, or {@code null} when the cancellation must not
+     * proceed
+     */
+    private List<Bill> reverseAutomaticAdmissionCharges() {
+        List<Bill> reversed = new ArrayList<>();
+        if (current == null || current.getAdmissionChargeBatchBill() == null) {
+            return reversed;
+        }
+
+        Map<String, Object> hm = new HashMap<>();
+        hm.put("acb", current.getAdmissionChargeBatchBill());
+        List<Bill> chargeBills = getBillFacade().findByJpql(
+                "select b from BilledBill b "
+                + " where b.retired=false "
+                + " and b.backwardReferenceBill=:acb ", hm);
+
+        if (chargeBills == null || chargeBills.isEmpty()) {
+            return reversed;
+        }
+
+        for (Bill chargeBill : chargeBills) {
+            String blocked = inwardSearch.inwardServiceBillReversalBlockedReason(chargeBill);
+            if (blocked != null) {
+                JsfUtil.addErrorMessage("This admission's automatic charges cannot be reversed: " + blocked
+                        + ". Resolve that first, then cancel the admission.");
+                return null;
+            }
+        }
+
+        for (Bill chargeBill : chargeBills) {
+            if (chargeBill.isCancelled()) {
+                continue;
+            }
+            inwardSearch.reverseInwardServiceBill(chargeBill,
+                    "Automatic admission charges reversed - admission cancelled",
+                    BillTypeAtomic.INWARD_SERVICE_BILL_CANCELLATION_DURING_BATCH_BILL_CANCELLATION);
+            reversed.add(chargeBill);
+        }
+
+        getBillBean().updateBatchBill(current.getAdmissionChargeBatchBill());
+
+        return reversed;
+    }
+
     public String cancelBht() {
         if (current == null) {
             return "";
@@ -410,6 +477,14 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
 
         if (getComment() == null || getComment().trim().equals("")) {
             JsfUtil.addErrorMessage("A cancellation reason is required. Please enter the reason before proceeding.");
+            return "";
+        }
+
+        // Reverse the automatic admission charges before retiring the admission.
+        // Done after every other check has passed, so a cancellation that is going
+        // to be refused does not leave the charges already reversed. (Issue #23594)
+        List<Bill> reversedChargeBills = reverseAutomaticAdmissionCharges();
+        if (reversedChargeBills == null) {
             return "";
         }
 
@@ -438,6 +513,7 @@ public class BhtEditController implements Serializable, ControllerWithPatient {
         afterCancel.put("retired", current.isRetired());
         afterCancel.put("cancellationReason", comment);
         afterCancel.put("retiredRoomCount", retiredRoomCount);
+        afterCancel.put("reversedAdmissionChargeBills", reversedChargeBills.size());
         auditService.logEncounterAudit(current, "Admission Cancelled",
                 beforeCancel, afterCancel, sessionController.getLoggedUser());
 

--- a/src/main/java/com/divudi/bean/inward/BillBhtController.java
+++ b/src/main/java/com/divudi/bean/inward/BillBhtController.java
@@ -75,6 +75,8 @@ import com.divudi.core.data.lab.InvestigationTubeSticker;
 import com.divudi.core.data.lab.Priority;
 import com.divudi.core.entity.Patient;
 import com.divudi.core.entity.UserPreference;
+import com.divudi.service.inward.InwardServiceBillRequest;
+import com.divudi.service.inward.InwardServiceBillService;
 import com.divudi.ws.lims.Lims;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -734,42 +736,6 @@ public class BillBhtController implements Serializable {
     @Inject
     private BillSearch billSearch;
 
-    private void saveBatchBill() {
-        Bill tmp = new BilledBill();
-        tmp.setCreatedAt(new Date());
-        tmp.setCreater(getSessionController().getLoggedUser());
-        tmp.setBillTypeAtomic(BillTypeAtomic.INWARD_SERVICE_BATCH_BILL);
-        tmp.setPatient(patientEncounter.getPatient());
-        boolean opdBillNumberGenerateStrategySingleNumberForOpdAndInpatientInvestigationsAndServices = configOptionApplicationController.getBooleanValueByKey("OpdBillNumberGenerateStrategy:SingleNumberForOpdAndInpatientInvestigationsAndServices", false);
-        String batchBillId = "";
-        
-        if (opdBillNumberGenerateStrategySingleNumberForOpdAndInpatientInvestigationsAndServices) {
-            List<BillTypeAtomic> opdAndInpatientBills = BillTypeAtomic.findOpdAndInpatientServiceAndInvestigationBatchBillTypes();
-            batchBillId = billNumberBean.departmentBatchBillNumberGeneratorYearlyForInpatientAndOpdServices(getSessionController().getDepartment(), opdAndInpatientBills);
-        }else{
-            batchBillId = billNumberBean.departmentBillNumberGeneratorYearly(sessionController.getDepartment(), BillTypeAtomic.INWARD_SERVICE_BATCH_BILL);
-        }
-        
-        tmp.setDeptId(batchBillId);
-        tmp.setInsId(batchBillId);
-
-        if (tmp.getId() == null) {
-            getBillFacade().create(tmp);
-        }
-
-        for (Bill b : getBills()) {
-            b.setBackwardReferenceBill(tmp);
-            getBillFacade().edit(b);
-        }
-
-        for (Bill b : getBills()) {
-            tmp.getForwardReferenceBills().add(b);
-        }
-
-        getBillFacade().edit(tmp);
-
-    }
-
     public void cancellAll() {
         for (Bill b : getBills()) {
             getBillSearch().setBill((BilledBill) b);
@@ -781,82 +747,15 @@ public class BillBhtController implements Serializable {
 
     }
 
-    public void putToBills(Department matrixDepartment, PaymentMethod paymentMethod) {
-
-        Set<Department> billDepts = new HashSet<>();
-        for (BillEntry e : lstBillEntries) {
-            billDepts.add(e.getBillItem().getItem().getDepartment());
-        }
-        for (Department d : billDepts) {
-            BilledBill myBill = new BilledBill();
-            saveBill(d, myBill, matrixDepartment);
-            List<BillEntry> tmp = new ArrayList<>();
-            for (BillEntry e : lstBillEntries) {
-                if (e.getBillItem().getItem().getDepartment().equals(d)) {
-                    tmp.add(e);
-                }
-            }
-            applyItemRequestReference(myBill, tmp);
-            List<BillItem> tmpBis = saveBillItems(myBill, tmp, getSessionController().getLoggedUser(), matrixDepartment, paymentMethod);
-            for (int i = 0; i < tmpBis.size(); i++) {
-                tmpBis.get(i).setSearialNo(i);
-            }
-            getBillBean().calculateBillItems(myBill, tmp);
-            myBill.setBillItems(tmpBis);
-            getBills().add(myBill);
-        }
-
-    }
-
-    /**
-     * If any of the entries being saved onto this bill originated from an
-     * Item/Service Request line (issue #21793 redesign), set the bill's
-     * referenceBill so the request stays traceable to the bill it produced.
-     * Each such entry's originating request BillItem is threaded onto the
-     * real BillItem in {@link #saveBillItems(Bill, BillItem, BillEntry, List, WebUser, Department)}.
-     */
-    private void applyItemRequestReference(Bill bill, List<BillEntry> entries) {
-        for (BillEntry e : entries) {
-            if (e.getSourceRequestBillItem() != null && e.getSourceRequestBillItem().getBill() != null) {
-                bill.setReferenceBill(e.getSourceRequestBillItem().getBill());
-                return;
-            }
-        }
-    }
-
-    public BillItem saveBillItems(Bill bill, BillItem billItem, BillEntry billEntry, List<BillFee> billFees, WebUser wu, Department matrixDepartment) {
-
-        billItem.setCreatedAt(new Date());
-        billItem.setCreater(wu);
-        billItem.setBill(bill);
-
-        if (billItem.getInwardChargeType() == null && billItem.getItem() != null
-                && billItem.getItem().getInwardChargeType() != null) {
-            billItem.setInwardChargeType(billItem.getItem().getInwardChargeType());
-        }
-
-        if (billEntry != null && billEntry.getSourceRequestBillItem() != null) {
-            billItem.setReferanceBillItem(billEntry.getSourceRequestBillItem());
-        }
-
-        if (billItem.getId() == null) {
-            getBillItemFacade().create(billItem);
-        }
-
-        getBillBean().saveBillComponent(billEntry, bill, wu);
-
-        for (BillFee bf : billFees) {
-            getInwardBean().saveBillFee(bf, billItem, bill, wu);
-            billItem.getBillFees().add(bf);
-        }
-
-        getBillBean().updateBillItemByBillFee(billItem);
-
-        return billItem;
-    }
-
     @Inject
     PriceMatrixController priceMatrixController;
+
+    /**
+     * The shared inward service settle pipeline, also used by the automatic
+     * admission charges (issue #23594) so the two paths cannot drift apart.
+     */
+    @Inject
+    private InwardServiceBillService inwardServiceBillService;
 
     public PriceMatrixController getPriceMatrixController() {
         return priceMatrixController;
@@ -881,57 +780,6 @@ public class BillBhtController implements Serializable {
         return encounter.getCurrentPatientRoom().getRoomFacilityCharge().getRoomCategory();
     }
 
-    public List<BillItem> saveBillItems(Bill bill, List<BillEntry> billEntries, WebUser webUser, Department matrixDepartment, PaymentMethod paymentMethod) {
-        List<BillItem> list = new ArrayList<>();
-        for (BillEntry e : billEntries) {
-            double staffFee = 0.0;
-            double collectingCentreFee = 0.0;
-            double hospitalFee = 0.0;
-            double reagentFee = 0.0;
-            double otherFee = 0.0;
-            double marginFee = 0.0;
-
-            BillItem billItem = saveBillItems(bill, e.getBillItem(), e, e.getLstBillFees(), webUser, matrixDepartment);
-            billItem.setSearialNo(list.size());
-
-            for (BillFee bf : billItem.getBillFees()) {
-                PriceMatrix priceMatrix = getPriceMatrixController().fetchInwardMargin(billItem, bf.getFeeUnitGrossValue() != null ? bf.getFeeUnitGrossValue() : bf.getFeeGrossValue(), matrixDepartment, paymentMethod, null, bill.getPatientEncounter() != null ? bill.getPatientEncounter().getAdmissionType() : null, resolveCurrentRoomCategory(bill.getPatientEncounter()));
-                getInwardBean().setBillFeeMargin(bf, bf.getBillItem().getItem(), priceMatrix, bill.getPatientEncounter());
-                getBillFeeFacade().edit(bf);
-
-                if (bf.getFee().getFeeType() == FeeType.CollectingCentre) {
-                    collectingCentreFee += bf.getFeeValue();
-                } else if (bf.getFee().getFeeType() == FeeType.Staff) {
-                    staffFee += bf.getFeeValue();
-                } else if (bf.getFee().getFeeType() == FeeType.Chemical) {
-                    reagentFee += bf.getFeeValue();
-                } else if (bf.getFee().getFeeType() == FeeType.Additional) {
-                    otherFee += bf.getFeeValue();
-                } else {
-                    hospitalFee += bf.getFeeValue();
-                }
-
-                marginFee += bf.getFeeMargin();
-            }
-
-            billItem.setHospitalFee(hospitalFee);
-            billItem.setCollectingCentreFee(collectingCentreFee);
-            billItem.setReagentFee(reagentFee);
-            billItem.setOtherFee(otherFee);
-            billItem.setStaffFee(staffFee);
-            billItem.setMarginValue(marginFee);
-
-            billItemFacade.editAndCommit(billItem);
-
-            list.add(billItem);
-
-        }
-
-        getBillBean().updateBillByBillFee(bill);
-
-        return list;
-    }
-
     public List<ItemLight> fillInwardItems() {
         UserPreference up = sessionController.getDepartmentPreference();
         switch (up.getInwardItemListingStrategy()) {
@@ -950,35 +798,40 @@ public class BillBhtController implements Serializable {
         }
     }
 
+    /**
+     * Settles the entries currently on the cart through
+     * {@link InwardServiceBillService} - the shared pipeline the automatic
+     * admission charges also run (issue #23594), so the two can never drift.
+     *
+     * <p>Two things stay exactly as they were. The bill's own
+     * {@code paymentMethod} is this controller's field, which
+     * {@link #settleBill()} nulls before getting here - not the encounter's.
+     * And {@code batchBill} is deliberately <b>not</b> assigned from the result:
+     * the old {@code saveBatchBill()} kept its bill local, so
+     * {@link #settleBillSurgery()} still operates on the surgery bill
+     * afterwards.</p>
+     */
     private void settleBill(Department matrixDepartment, PaymentMethod paymentMethod) {
-        if (getBillBean().calculateNumberOfBillsPerOrder(getLstBillEntries()) == 1) {
-            BilledBill temp = new BilledBill();
-            Bill b = saveBill(lstBillEntries.get(0).getBillItem().getItem().getDepartment(), temp, matrixDepartment);
-            applyItemRequestReference(b, getLstBillEntries());
+        InwardServiceBillRequest request = new InwardServiceBillRequest();
+        request.setBillEntries(getLstBillEntries());
+        request.setPatientEncounter(patientEncounter);
+        request.setMatrixDepartment(matrixDepartment);
+        request.setMarginPaymentMethod(paymentMethod);
+        request.setBillPaymentMethod(this.paymentMethod);
+        request.setPaymentScheme(getPaymentScheme());
+        request.setReferredBy(referredBy);
+        request.setSurgeryBatchBill(getBatchBill());
+        request.setLoggedUser(getSessionController().getLoggedUser());
+        request.setLoggedDepartment(sessionController.getDepartment());
+        request.setCreatingDepartment(getSessionController().getLoggedUser().getDepartment());
+        // settleBillSurgery() does not reset bills before settling, and the batch
+        // bill has always been linked over the whole accumulated list.
+        request.setBillCollector(getBills());
+        request.setApplyInwardMargin(true);
 
-            List<BillItem> list = saveBillItems(b, getLstBillEntries(), getSessionController().getLoggedUser(), matrixDepartment, paymentMethod);
-            b.setBillItems(list);
-            
-            Priority highestPriority = Optional
-                    .ofNullable(list)
-                    .orElse(Collections.emptyList())
-                    .stream()
-                    .filter(bi -> bi.getPriority() != null)
-                    .map(BillItem::getPriority)
-                    .max(Comparator.comparingInt(Priority::getLevel))
-                    .orElse(Priority.NORMAL);
-
-            b.setPriority(highestPriority);
-            
-            billFacade.edit(b);
-            getBillBean().calculateBillItems(b, getLstBillEntries());
-            getBills().add(b);
-        } else {
-            putToBills(matrixDepartment, paymentMethod);
-        }
+        inwardServiceBillService.createServiceBills(request);
 
         printPreview = true;
-        saveBatchBill();
 
         JsfUtil.addSuccessMessage("Bill Saved");
 
@@ -1058,76 +911,6 @@ public class BillBhtController implements Serializable {
 
     public void setPaymentMethod(PaymentMethod paymentMethod) {
         this.paymentMethod = paymentMethod;
-    }
-
-    private Bill saveBill(Department bt, BilledBill temp, Department matrixDepartment) {
-        temp.setBillType(BillType.InwardBill);
-        temp.setBillTypeAtomic(BillTypeAtomic.INWARD_SERVICE_BILL);
-        temp.setIpOpOrCc("IP");
-        getBillBean().setSurgeryData(temp, getBatchBill(), SurgeryBillType.Service);
-
-        temp.setDepartment(getSessionController().getLoggedUser().getDepartment());
-        temp.setInstitution(getSessionController().getLoggedUser().getDepartment().getInstitution());
-        temp.setPatient(patientEncounter.getPatient());
-        temp.setFromDepartment(matrixDepartment);
-
-        temp.setToDepartment(bt);
-        temp.setToInstitution(bt.getInstitution());
-
-        temp.setBillDate(date);
-        temp.setBillTime(date);
-        temp.setPatientEncounter(patientEncounter);
-        temp.setPaymentScheme(getPaymentScheme());
-        temp.setPaymentMethod(paymentMethod);
-        temp.setReferredBy(referredBy);
-        temp.setCreatedAt(new Date());
-        temp.setBillDate(new Date());
-        temp.setBillTime(new Date());
-        temp.setCreater(getSessionController().getLoggedUser());
-
-        boolean inpatientServiceBillNumberGenerateStrategyForFromDepartmentAndToDepartmentCombination
-                = configOptionApplicationController.getBooleanValueByKey(
-                        "InpatientServiceBillNumberGenerateStrategy:FromDepartmentToDepartmentBillTypes", false);
-
-        boolean inpatientServiceBillNumberGenerateStrategySingleNumberForOpdAndInpatientInvestigationsAndServices
-                = configOptionApplicationController.getBooleanValueByKey("OPD Bill Number Generation Strategy - Single Number for OPD and Inpatient Investigations and Services", false);
-
-        boolean inpatientServiceBillNumberGenerateStrategyDefault
-                = configOptionApplicationController.getBooleanValueByKey(
-                        "InpatientServiceBillNumberGenerateStrategy:Default", false);
-
-        String deptId;
-        String insId;
-
-        BillNumberGenerator bnb = getBillNumberBean();
-
-        if (inpatientServiceBillNumberGenerateStrategyForFromDepartmentAndToDepartmentCombination) {
-            deptId = bnb.departmentBillNumberGeneratorYearlyByFromDepartmentAndToDepartment(
-                    bt, sessionController.getDepartment(), BillTypeAtomic.INWARD_SERVICE_BILL);
-            insId = deptId;
-        } else if (inpatientServiceBillNumberGenerateStrategySingleNumberForOpdAndInpatientInvestigationsAndServices) {
-            List<BillTypeAtomic> opdAndInpatientBills = BillTypeAtomic.findOpdAndInpatientServiceAndInvestigationIndividualBillTypes();
-            deptId = bnb.departmentBillNumberGeneratorYearly(sessionController.getDepartment(), opdAndInpatientBills);
-            insId = deptId;
-        } else if (inpatientServiceBillNumberGenerateStrategyDefault) {
-            deptId = bnb.departmentBillNumberGeneratorYearly(bt, BillTypeAtomic.INWARD_SERVICE_BILL);
-            insId = deptId;
-        } else {
-            deptId = bnb.departmentBillNumberGenerator(temp.getDepartment(), temp.getToDepartment(), temp.getBillType(), BillClassType.BilledBill);
-            insId = bnb.institutionBillNumberGenerator(temp.getInstitution(), temp.getToDepartment(), temp.getBillType(), BillClassType.BilledBill, BillNumberSuffix.INWSER);
-        }
-
-        temp.setDeptId(deptId);
-        temp.setInsId(insId);
-
-        if (temp.getId() == null) {
-            getFacade().create(temp);
-        } else {
-            getFacade().edit(temp);
-        }
-
-        return temp;
-
     }
 
     public void logicalDischage() {

--- a/src/main/java/com/divudi/bean/inward/InwardSearch.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSearch.java
@@ -1392,7 +1392,11 @@ public class InwardSearch implements Serializable {
     }
 
     private void cancelBillComponents(Bill can, BillItem bt) {
-        for (BillComponent nB : getBillComponents()) {
+        cancelBillComponents(can, bt, getBillComponents());
+    }
+
+    private void cancelBillComponents(Bill can, BillItem bt, List<BillComponent> sourceComponents) {
+        for (BillComponent nB : sourceComponents) {
             BillComponent bC = new BillComponent();
             bC.setCatId(nB.getCatId());
             bC.setDeptId(nB.getDeptId());
@@ -1433,9 +1437,14 @@ public class InwardSearch implements Serializable {
     }
 
     private boolean checkPaid() {
+        return checkPaid(getBill());
+    }
+
+    /** Whether any fee on this bill has already been paid out. */
+    private boolean checkPaid(Bill bill) {
         HashMap hm = new HashMap();
         String sql = "SELECT bf FROM BillFee bf where bf.retired=false and bf.bill=:b ";
-        hm.put("b", getBill());
+        hm.put("b", bill);
         List<BillFee> tempFe = getBillFeeFacade().findByJpql(sql, hm);
 
         for (BillFee f : tempFe) {
@@ -1618,14 +1627,8 @@ public class InwardSearch implements Serializable {
                 }
             }
 
-            CancelledBill cb = createCancelBill();
-            //Copy & paste
-            if (cb.getId() == null) {
-                getBillFacade().create(cb);
-            }
-            cancelBillItems(cb);
-            getBill().setCancelled(true);
-            getBill().setCancelledBill(cb);
+            // Same reversal the admission-cancel path runs, so the two cannot drift.
+            CancelledBill cb = reverseInwardServiceBill(getBill(), comment, BillTypeAtomic.INWARD_SERVICE_BILL_CANCELLATION);
 
             try {
                 if (configOptionApplicationController.getBooleanValueByKey("Lab Test History Enabled", false)) {
@@ -1636,15 +1639,7 @@ public class InwardSearch implements Serializable {
             } catch (Exception e) {
             }
 
-            //To null payment methord
-            getBill().setPaymentMethod(null);
-            cb.setPaymentMethod(null);
-
-            getBillFacade().edit(cb);
-            getBillFacade().edit((BilledBill) getBill());
             JsfUtil.addSuccessMessage("Cancelled");
-
-            getBillBean().updateBatchBill(getBill().getForwardReferenceBill());
 
             if (configOptionApplicationController.getBooleanValueByKey("Mandatory permission to cancel bills.", false)) {
                 Request billRequest = requestService.findRequest(getBill());
@@ -2324,28 +2319,99 @@ public class InwardSearch implements Serializable {
     }
 
     private CancelledBill createCancelBill() {
+        return createCancelBill(getBill(), comment, paymentMethod, BillTypeAtomic.INWARD_SERVICE_BILL_CANCELLATION);
+    }
+
+    /**
+     * The contra-bill for {@code source}, driven by parameters rather than page
+     * state so the same construction serves both the cancel screens and the
+     * programmatic reversal in
+     * {@link #reverseInwardServiceBill(Bill, String, BillTypeAtomic)}.
+     */
+    private CancelledBill createCancelBill(Bill source, String comments, PaymentMethod cancelPaymentMethod, BillTypeAtomic cancellationAtomic) {
         CancelledBill cb = new CancelledBill();
-        cb.copy(getBill());
-        cb.invertAndAssignValuesFromOtherBill(getBill());
-        cb.setBilledBill(getBill());
+        cb.copy(source);
+        cb.invertAndAssignValuesFromOtherBill(source);
+        cb.setBilledBill(source);
 
         ////////////
         cb.setBillDate(new Date());
         cb.setBillTime(new Date());
         cb.setCreatedAt(new Date());
         cb.setCreater(getSessionController().getLoggedUser());
-        cb.setComments(comment);
-        cb.setPaymentMethod(paymentMethod);
+        cb.setComments(comments);
+        cb.setPaymentMethod(cancelPaymentMethod);
         //TODO: Find null Point Exception
 
         cb.setDepartment(getSessionController().getDepartment());
         cb.setInstitution(getSessionController().getInstitution());
 
-        cb.setDeptId(getBillNumberBean().departmentBillNumberGenerator(getSessionController().getDepartment(), getBill().getBillType(), BillClassType.CancelledBill, BillNumberSuffix.INWCAN));
-        cb.setInsId(getBillNumberBean().institutionBillNumberGenerator(getSessionController().getInstitution(), getBill().getBillType(), BillClassType.CancelledBill, BillNumberSuffix.INWCAN));
+        cb.setDeptId(getBillNumberBean().departmentBillNumberGenerator(getSessionController().getDepartment(), source.getBillType(), BillClassType.CancelledBill, BillNumberSuffix.INWCAN));
+        cb.setInsId(getBillNumberBean().institutionBillNumberGenerator(getSessionController().getInstitution(), source.getBillType(), BillClassType.CancelledBill, BillNumberSuffix.INWCAN));
 //        cb.setBillType(BillType.InwardProfessional);
-        cb.setBillTypeAtomic(BillTypeAtomic.INWARD_SERVICE_BILL_CANCELLATION);
+        cb.setBillTypeAtomic(cancellationAtomic);
         return cb;
+    }
+
+    /**
+     * Reverses one already-validated inward service bill with an exact-opposite
+     * contra-bill, without touching this bean's page state.
+     *
+     * <p>Same machinery as {@link #cancelBillService()} - that method keeps every
+     * one of its guards and delegates the reversal here - so a programmatic
+     * caller cannot drift from what the cancel screen produces. Used when an
+     * admission carrying automatic admission charges is itself cancelled
+     * (issue #23594), stamped with
+     * {@code INWARD_SERVICE_BILL_CANCELLATION_DURING_BATCH_BILL_CANCELLATION}.</p>
+     *
+     * <p>The caller is responsible for the eligibility checks: this method
+     * assumes the bill may be reversed.</p>
+     */
+    public CancelledBill reverseInwardServiceBill(Bill source, String comments, BillTypeAtomic cancellationAtomic) {
+        CancelledBill cb = createCancelBill(source, comments, null, cancellationAtomic);
+        if (cb.getId() == null) {
+            getBillFacade().create(cb);
+        }
+
+        cancelBillItems(cb, source);
+
+        source.setCancelled(true);
+        source.setCancelledBill(cb);
+        //To null payment methord
+        source.setPaymentMethod(null);
+        cb.setPaymentMethod(null);
+
+        getBillFacade().edit(cb);
+        getBillFacade().edit(source);
+
+        getBillBean().updateBatchBill(source.getForwardReferenceBill());
+
+        return cb;
+    }
+
+    /**
+     * Whether {@code bill} can be reversed at all. Mirrors the blocking checks
+     * {@link #cancelBillService()} applies to the bill itself.
+     *
+     * @return null when it can, otherwise the reason it cannot
+     */
+    public String inwardServiceBillReversalBlockedReason(Bill bill) {
+        if (bill == null) {
+            return "No bill to cancel";
+        }
+        if (bill.getCheckedBy() != null) {
+            return "Bill " + bill.getDeptId() + " has been checked and cannot be cancelled";
+        }
+        if (bill.isCancelled()) {
+            return null;
+        }
+        if (bill.isRefunded()) {
+            return "Bill " + bill.getDeptId() + " has already been returned and cannot be cancelled";
+        }
+        if (checkPaid(bill)) {
+            return "A doctor payment has already been made against bill " + bill.getDeptId();
+        }
+        return null;
     }
 
     private CancelledBill createCancelDepositBill() {
@@ -2613,26 +2679,55 @@ public class InwardSearch implements Serializable {
 
     private void cancelBillItems(Bill can) {
         for (BillItem nB : getBillItems()) {
-            BillItem b = new BillItem();
-            b.setBill(can);
-            b.copy(nB);
-            b.invertValue(nB);
-
-            b.setCreatedAt(new Date());
-            b.setCreater(getSessionController().getLoggedUser());
-
-            if (b.getId() == null) {
-                getBillItemFacede().create(b);
-            }
-
-            cancelBillComponents(can, b);
-
-            String sql = "Select bf From BillFee bf where bf.retired=false and bf.billItem.id=" + nB.getId();
-            List<BillFee> tmp = getBillFeeFacade().findByJpql(sql);
-
-            cancelBillFee(can, b, tmp);
-
+            copyCancelledBillItem(can, nB, getBillComponents());
         }
+    }
+
+    /**
+     * Same as {@link #cancelBillItems(Bill)} but reading the rows to reverse
+     * from an explicit source bill instead of this bean's page state, so
+     * {@link #reverseInwardServiceBill(Bill, String, BillTypeAtomic)} can run
+     * without a bill being selected on screen.
+     */
+    private void cancelBillItems(Bill can, Bill source) {
+        Map<String, Object> hm = new HashMap<>();
+        hm.put("b", source);
+        List<BillItem> sourceItems = getBillItemFacede().findByJpql(
+                "SELECT b FROM BillItem b WHERE b.retired=false and b.bill=:b ", hm);
+        List<BillComponent> sourceComponents = getBillCommponentFacade().findByJpql(
+                "SELECT b FROM BillComponent b WHERE b.retired=false and b.bill=:b ", hm);
+        if (sourceItems == null) {
+            return;
+        }
+        for (BillItem nB : sourceItems) {
+            copyCancelledBillItem(can, nB, sourceComponents == null ? new ArrayList<>() : sourceComponents);
+        }
+    }
+
+    /**
+     * Writes the inverted BillItem, its components and its fees onto the
+     * contra-bill. The fees are the half that matters: a reversal that copies
+     * only bill items cancels as zero, since the totals are summed from fees.
+     */
+    private void copyCancelledBillItem(Bill can, BillItem nB, List<BillComponent> sourceComponents) {
+        BillItem b = new BillItem();
+        b.setBill(can);
+        b.copy(nB);
+        b.invertValue(nB);
+
+        b.setCreatedAt(new Date());
+        b.setCreater(getSessionController().getLoggedUser());
+
+        if (b.getId() == null) {
+            getBillItemFacede().create(b);
+        }
+
+        cancelBillComponents(can, b, sourceComponents);
+
+        String sql = "Select bf From BillFee bf where bf.retired=false and bf.billItem.id=" + nB.getId();
+        List<BillFee> tmp = getBillFeeFacade().findByJpql(sql);
+
+        cancelBillFee(can, b, tmp);
     }
 
     private boolean errorCheck() {

--- a/src/main/java/com/divudi/core/data/dto/admissioncharge/AdmissionChargeItemCreateRequestDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/admissioncharge/AdmissionChargeItemCreateRequestDTO.java
@@ -1,0 +1,80 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.core.data.dto.admissioncharge;
+
+/**
+ * DTO for creating a new {@code AdmissionChargeItem} (issue #23594).
+ *
+ * <p>{@code admissionTypeId} absent/null means "applies to any admission
+ * type" and {@code paymentMethod} absent/null means "applies to both Cash and
+ * Credit" - both are legitimate configurations, not omissions.</p>
+ *
+ * @author Buddhika
+ */
+public class AdmissionChargeItemCreateRequestDTO {
+
+    private Long itemId; // required
+    private Long admissionTypeId; // optional - null means "any admission type"
+    private String paymentMethod; // optional - "Cash" or "Credit"; null means "both"
+    private double price; // required, must be >= 0
+    private Double qty; // optional, defaults to 1.0
+    private int orderNo; // optional, defaults to 0
+
+    public AdmissionChargeItemCreateRequestDTO() {
+    }
+
+    public boolean isValid() {
+        return itemId != null;
+    }
+
+    public Long getItemId() {
+        return itemId;
+    }
+
+    public void setItemId(Long itemId) {
+        this.itemId = itemId;
+    }
+
+    public Long getAdmissionTypeId() {
+        return admissionTypeId;
+    }
+
+    public void setAdmissionTypeId(Long admissionTypeId) {
+        this.admissionTypeId = admissionTypeId;
+    }
+
+    public String getPaymentMethod() {
+        return paymentMethod;
+    }
+
+    public void setPaymentMethod(String paymentMethod) {
+        this.paymentMethod = paymentMethod;
+    }
+
+    public double getPrice() {
+        return price;
+    }
+
+    public void setPrice(double price) {
+        this.price = price;
+    }
+
+    public Double getQty() {
+        return qty;
+    }
+
+    public void setQty(Double qty) {
+        this.qty = qty;
+    }
+
+    public int getOrderNo() {
+        return orderNo;
+    }
+
+    public void setOrderNo(int orderNo) {
+        this.orderNo = orderNo;
+    }
+}

--- a/src/main/java/com/divudi/core/data/dto/admissioncharge/AdmissionChargeItemDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/admissioncharge/AdmissionChargeItemDTO.java
@@ -1,0 +1,141 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.core.data.dto.admissioncharge;
+
+/**
+ * DTO representing a single {@code AdmissionChargeItem} configuration row
+ * (issue #23594).
+ *
+ * <p>{@code admissionTypeId}/{@code admissionTypeName} null means "applies to
+ * any admission type" and {@code paymentMethod} null means "applies to both
+ * Cash and Credit" - see {@code AdmissionChargeItem} for the two-dimension
+ * resolution rule.</p>
+ *
+ * @author Buddhika
+ */
+public class AdmissionChargeItemDTO {
+
+    private Long id;
+    private Long itemId;
+    private String itemName;
+    private Long itemDepartmentId;
+    private String itemDepartmentName;
+    private String inwardChargeType;
+    private Long admissionTypeId;
+    private String admissionTypeName;
+    private String paymentMethod;
+    private double price;
+    private Double qty;
+    private int orderNo;
+    private boolean retired;
+
+    public AdmissionChargeItemDTO() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getItemId() {
+        return itemId;
+    }
+
+    public void setItemId(Long itemId) {
+        this.itemId = itemId;
+    }
+
+    public String getItemName() {
+        return itemName;
+    }
+
+    public void setItemName(String itemName) {
+        this.itemName = itemName;
+    }
+
+    public Long getItemDepartmentId() {
+        return itemDepartmentId;
+    }
+
+    public void setItemDepartmentId(Long itemDepartmentId) {
+        this.itemDepartmentId = itemDepartmentId;
+    }
+
+    public String getItemDepartmentName() {
+        return itemDepartmentName;
+    }
+
+    public void setItemDepartmentName(String itemDepartmentName) {
+        this.itemDepartmentName = itemDepartmentName;
+    }
+
+    public String getInwardChargeType() {
+        return inwardChargeType;
+    }
+
+    public void setInwardChargeType(String inwardChargeType) {
+        this.inwardChargeType = inwardChargeType;
+    }
+
+    public Long getAdmissionTypeId() {
+        return admissionTypeId;
+    }
+
+    public void setAdmissionTypeId(Long admissionTypeId) {
+        this.admissionTypeId = admissionTypeId;
+    }
+
+    public String getAdmissionTypeName() {
+        return admissionTypeName;
+    }
+
+    public void setAdmissionTypeName(String admissionTypeName) {
+        this.admissionTypeName = admissionTypeName;
+    }
+
+    public String getPaymentMethod() {
+        return paymentMethod;
+    }
+
+    public void setPaymentMethod(String paymentMethod) {
+        this.paymentMethod = paymentMethod;
+    }
+
+    public double getPrice() {
+        return price;
+    }
+
+    public void setPrice(double price) {
+        this.price = price;
+    }
+
+    public Double getQty() {
+        return qty;
+    }
+
+    public void setQty(Double qty) {
+        this.qty = qty;
+    }
+
+    public int getOrderNo() {
+        return orderNo;
+    }
+
+    public void setOrderNo(int orderNo) {
+        this.orderNo = orderNo;
+    }
+
+    public boolean isRetired() {
+        return retired;
+    }
+
+    public void setRetired(boolean retired) {
+        this.retired = retired;
+    }
+}

--- a/src/main/java/com/divudi/core/data/dto/admissioncharge/AdmissionChargeItemPageDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/admissioncharge/AdmissionChargeItemPageDTO.java
@@ -1,0 +1,67 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.core.data.dto.admissioncharge;
+
+import java.util.List;
+
+/**
+ * One page of {@code AdmissionChargeItem} search results (issue #23594).
+ *
+ * <p>Carries {@code total} alongside the rows so a caller can tell whether it
+ * is seeing the whole configuration set or only the first slice.</p>
+ *
+ * @author Buddhika
+ */
+public class AdmissionChargeItemPageDTO {
+
+    private List<AdmissionChargeItemDTO> items;
+    /** Rows matching the filters, ignoring limit/offset. */
+    private long total;
+    private int limit;
+    private int offset;
+
+    public AdmissionChargeItemPageDTO() {
+    }
+
+    public AdmissionChargeItemPageDTO(List<AdmissionChargeItemDTO> items, long total, int limit, int offset) {
+        this.items = items;
+        this.total = total;
+        this.limit = limit;
+        this.offset = offset;
+    }
+
+    public List<AdmissionChargeItemDTO> getItems() {
+        return items;
+    }
+
+    public void setItems(List<AdmissionChargeItemDTO> items) {
+        this.items = items;
+    }
+
+    public long getTotal() {
+        return total;
+    }
+
+    public void setTotal(long total) {
+        this.total = total;
+    }
+
+    public int getLimit() {
+        return limit;
+    }
+
+    public void setLimit(int limit) {
+        this.limit = limit;
+    }
+
+    public int getOffset() {
+        return offset;
+    }
+
+    public void setOffset(int offset) {
+        this.offset = offset;
+    }
+}

--- a/src/main/java/com/divudi/core/data/dto/admissioncharge/AdmissionChargeItemUpdateRequestDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/admissioncharge/AdmissionChargeItemUpdateRequestDTO.java
@@ -1,0 +1,109 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.core.data.dto.admissioncharge;
+
+/**
+ * DTO for updating an existing {@code AdmissionChargeItem} (issue #23594).
+ * All fields optional - only fields present are applied.
+ *
+ * <p>{@code admissionTypeId} and {@code paymentMethod} are two of the three
+ * columns of the row's uniqueness key, and {@code null} is itself a
+ * meaningful value for both ("any admission type" / "both payment methods").
+ * A plain JSON body cannot distinguish "field omitted" from "field sent as
+ * null", so clearing either column back to null is done explicitly with
+ * {@link #clearAdmissionType} / {@link #clearPaymentMethod} rather than by
+ * sending the field as null.</p>
+ *
+ * @author Buddhika
+ */
+public class AdmissionChargeItemUpdateRequestDTO {
+
+    private Long itemId;
+    private Long admissionTypeId;
+    /** When true, sets admissionType to null ("any"). Ignored if admissionTypeId is present. */
+    private Boolean clearAdmissionType;
+    private String paymentMethod;
+    /** When true, sets paymentMethod to null ("both"). Ignored if paymentMethod is present. */
+    private Boolean clearPaymentMethod;
+    private Double price;
+    private Double qty;
+    private Integer orderNo;
+
+    public AdmissionChargeItemUpdateRequestDTO() {
+    }
+
+    public boolean isValid() {
+        return itemId != null || admissionTypeId != null
+                || Boolean.TRUE.equals(clearAdmissionType)
+                || paymentMethod != null
+                || Boolean.TRUE.equals(clearPaymentMethod)
+                || price != null || qty != null || orderNo != null;
+    }
+
+    public Long getItemId() {
+        return itemId;
+    }
+
+    public void setItemId(Long itemId) {
+        this.itemId = itemId;
+    }
+
+    public Long getAdmissionTypeId() {
+        return admissionTypeId;
+    }
+
+    public void setAdmissionTypeId(Long admissionTypeId) {
+        this.admissionTypeId = admissionTypeId;
+    }
+
+    public Boolean getClearAdmissionType() {
+        return clearAdmissionType;
+    }
+
+    public void setClearAdmissionType(Boolean clearAdmissionType) {
+        this.clearAdmissionType = clearAdmissionType;
+    }
+
+    public String getPaymentMethod() {
+        return paymentMethod;
+    }
+
+    public void setPaymentMethod(String paymentMethod) {
+        this.paymentMethod = paymentMethod;
+    }
+
+    public Boolean getClearPaymentMethod() {
+        return clearPaymentMethod;
+    }
+
+    public void setClearPaymentMethod(Boolean clearPaymentMethod) {
+        this.clearPaymentMethod = clearPaymentMethod;
+    }
+
+    public Double getPrice() {
+        return price;
+    }
+
+    public void setPrice(Double price) {
+        this.price = price;
+    }
+
+    public Double getQty() {
+        return qty;
+    }
+
+    public void setQty(Double qty) {
+        this.qty = qty;
+    }
+
+    public Integer getOrderNo() {
+        return orderNo;
+    }
+
+    public void setOrderNo(Integer orderNo) {
+        this.orderNo = orderNo;
+    }
+}

--- a/src/main/java/com/divudi/core/entity/PatientEncounter.java
+++ b/src/main/java/com/divudi/core/entity/PatientEncounter.java
@@ -104,6 +104,15 @@ public class PatientEncounter implements Serializable, RetirableEntity {
     AdmissionType admissionType;
     @javax.persistence.ManyToOne
     private com.divudi.core.entity.inward.InpatientPackage inpatientPackage;
+    /**
+     * The INWARD_SERVICE_BATCH_BILL holding the automatic admission charges
+     * generated for this encounter (issue #23594). Null until they are
+     * generated, and the idempotency key that stops a re-save from charging
+     * twice - the batch bill itself carries only a patient, never an encounter,
+     * so there is nothing else to key off.
+     */
+    @javax.persistence.ManyToOne
+    private Bill admissionChargeBatchBill;
     Boolean discharged = false;
     @Temporal(javax.persistence.TemporalType.TIMESTAMP)
     Date timeOfDischarge;
@@ -731,6 +740,14 @@ public class PatientEncounter implements Serializable, RetirableEntity {
 
     public void setInpatientPackage(com.divudi.core.entity.inward.InpatientPackage inpatientPackage) {
         this.inpatientPackage = inpatientPackage;
+    }
+
+    public Bill getAdmissionChargeBatchBill() {
+        return admissionChargeBatchBill;
+    }
+
+    public void setAdmissionChargeBatchBill(Bill admissionChargeBatchBill) {
+        this.admissionChargeBatchBill = admissionChargeBatchBill;
     }
 
     public Boolean isDischarged() {

--- a/src/main/java/com/divudi/core/entity/inward/AdmissionChargeItem.java
+++ b/src/main/java/com/divudi/core/entity/inward/AdmissionChargeItem.java
@@ -1,0 +1,224 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.core.entity.inward;
+
+import com.divudi.core.data.PaymentMethod;
+import com.divudi.core.entity.Item;
+import com.divudi.core.entity.RetirableEntity;
+import com.divudi.core.entity.WebUser;
+import java.io.Serializable;
+import java.util.Date;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+
+/**
+ * One configured routine charge that is billed automatically on every matching
+ * admission (issue #23594).
+ *
+ * <p>Rows are resolved per distinct {@link #item}, in two steps: admission type
+ * is the outer filter, payment method the inner one. A {@code null} in either
+ * column means "applies to all", which is how a charge that costs the same
+ * either way is configured with a single row.</p>
+ *
+ * <p><b>Configuration trap:</b> because step one is a <i>filter</i>, an
+ * admission-type-specific row set completely replaces the {@code null} set for
+ * that item. Configuring {@code (Admission Charge, Day Case, Cash)} and
+ * forgetting the Day Case credit row leaves a credit Day Case admission with no
+ * admission charge at all. The management page warns about this.</p>
+ *
+ * <p>{@link #item} is mandatory and must carry both an {@code inwardChargeType}
+ * (which gives the interim bill its charge-type breakdown) and a
+ * {@code department} (which decides how the generated bills are bundled).</p>
+ *
+ * @author Buddhika
+ */
+@Entity
+public class AdmissionChargeItem implements Serializable, RetirableEntity {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /**
+     * The service billed. Required - the BillItem must carry an Item so it has
+     * an inwardChargeType and a department.
+     */
+    @ManyToOne
+    private Item item;
+
+    /**
+     * The admission type this row applies to. Null means "any admission type".
+     */
+    @ManyToOne
+    private AdmissionType admissionType;
+
+    /**
+     * Cash or Credit only - the only two values an admission can hold (see
+     * EnumController.getPaymentMethodForAdmission()). Null means "both".
+     */
+    @Enumerated(EnumType.STRING)
+    private PaymentMethod paymentMethod;
+
+    private double price;
+
+    private Double qty = 1.0;
+
+    private int orderNo;
+
+    @ManyToOne
+    private WebUser creater;
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date createdAt;
+
+    private boolean retired;
+    @ManyToOne
+    private WebUser retirer;
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date retiredAt;
+    private String retireComments;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Item getItem() {
+        return item;
+    }
+
+    public void setItem(Item item) {
+        this.item = item;
+    }
+
+    public AdmissionType getAdmissionType() {
+        return admissionType;
+    }
+
+    public void setAdmissionType(AdmissionType admissionType) {
+        this.admissionType = admissionType;
+    }
+
+    public PaymentMethod getPaymentMethod() {
+        return paymentMethod;
+    }
+
+    public void setPaymentMethod(PaymentMethod paymentMethod) {
+        this.paymentMethod = paymentMethod;
+    }
+
+    public double getPrice() {
+        return price;
+    }
+
+    public void setPrice(double price) {
+        this.price = price;
+    }
+
+    public Double getQty() {
+        return qty;
+    }
+
+    public void setQty(Double qty) {
+        this.qty = qty;
+    }
+
+    public int getOrderNo() {
+        return orderNo;
+    }
+
+    public void setOrderNo(int orderNo) {
+        this.orderNo = orderNo;
+    }
+
+    public WebUser getCreater() {
+        return creater;
+    }
+
+    public void setCreater(WebUser creater) {
+        this.creater = creater;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    @Override
+    public boolean isRetired() {
+        return retired;
+    }
+
+    @Override
+    public void setRetired(boolean retired) {
+        this.retired = retired;
+    }
+
+    @Override
+    public WebUser getRetirer() {
+        return retirer;
+    }
+
+    @Override
+    public void setRetirer(WebUser retirer) {
+        this.retirer = retirer;
+    }
+
+    @Override
+    public Date getRetiredAt() {
+        return retiredAt;
+    }
+
+    @Override
+    public void setRetiredAt(Date retiredAt) {
+        this.retiredAt = retiredAt;
+    }
+
+    @Override
+    public String getRetireComments() {
+        return retireComments;
+    }
+
+    @Override
+    public void setRetireComments(String retireComments) {
+        this.retireComments = retireComments;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 0;
+        hash += (id != null ? id.hashCode() : 0);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (!(object instanceof AdmissionChargeItem)) {
+            return false;
+        }
+        AdmissionChargeItem other = (AdmissionChargeItem) object;
+        return (this.id != null || other.id == null) && (this.id == null || this.id.equals(other.id));
+    }
+
+    @Override
+    public String toString() {
+        return "com.divudi.core.entity.inward.AdmissionChargeItem[ id=" + id + " ]";
+    }
+}

--- a/src/main/java/com/divudi/core/facade/AdmissionChargeItemFacade.java
+++ b/src/main/java/com/divudi/core/facade/AdmissionChargeItemFacade.java
@@ -1,0 +1,22 @@
+package com.divudi.core.facade;
+
+import com.divudi.core.entity.inward.AdmissionChargeItem;
+import javax.ejb.Stateless;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Stateless
+public class AdmissionChargeItemFacade extends AbstractFacade<AdmissionChargeItem> {
+
+    @PersistenceContext(unitName = "hmisPU")
+    private EntityManager em;
+
+    @Override
+    protected EntityManager getEntityManager() {
+        return em;
+    }
+
+    public AdmissionChargeItemFacade() {
+        super(AdmissionChargeItem.class);
+    }
+}

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -3,11 +3,18 @@ package com.divudi.service;
 import com.divudi.bean.common.ConfigOptionApplicationController;
 import com.divudi.core.data.OptionScope;
 import com.divudi.core.data.OptionValueType;
+import com.divudi.core.data.dto.admissioncharge.AdmissionChargeItemCreateRequestDTO;
+import com.divudi.core.data.dto.admissioncharge.AdmissionChargeItemDTO;
+import com.divudi.core.data.dto.admissioncharge.AdmissionChargeItemPageDTO;
+import com.divudi.core.data.dto.admissioncharge.AdmissionChargeItemUpdateRequestDTO;
 import com.divudi.core.entity.AiMessage;
 import com.divudi.core.entity.ApiKey;
 import com.divudi.core.entity.ConfigOption;
+import com.divudi.core.entity.WebUser;
 import com.divudi.core.facade.ApiKeyFacade;
 import com.divudi.core.facade.ConfigOptionFacade;
+import com.divudi.service.inward.AdmissionChargeApiService;
+import com.divudi.service.inward.AdmissionChargeValidationException;
 import java.io.Serializable;
 import java.io.StringReader;
 import java.net.URI;
@@ -51,6 +58,9 @@ public class AnthropicApiService implements Serializable {
 
     @Inject
     private ConfigOptionApplicationController configOptionApplicationController;
+
+    @EJB
+    private AdmissionChargeApiService admissionChargeApiService;
 
     // -------------------------------------------------------------------------
     // Public API
@@ -2011,6 +2021,90 @@ public class AnthropicApiService implements Serializable {
                         .add("required", Json.createArrayBuilder().add("method")))
                 .build();
 
+        JsonObject manageAdmissionChargesTool = Json.createObjectBuilder()
+                .add("name", "manage_admission_charges")
+                .add("description",
+                        "Manage AdmissionChargeItem rows — routine charges billed automatically on every matching "
+                        + "admission (issue #23594), additive alongside room and service charges. These are NOT "
+                        + "inpatient packages. "
+                        + "Resolution is two-step per item, applied when an admission is saved: admission type is "
+                        + "the outer filter, payment method the inner one; a null in either column means "
+                        + "\"applies to all\" for that dimension. "
+                        + "Configuration trap: because admission type is a filter, not a preference, adding one "
+                        + "admission-type-specific row for an item completely replaces the null-admissionType row "
+                        + "set for that item and that admission type — it does not fall back to it. Configuring "
+                        + "(Admission Charge, Day Case, Cash) and forgetting the Day Case Credit row leaves a "
+                        + "Credit Day Case admission with NO admission charge at all. Warn the user whenever a "
+                        + "change would leave an item's admission-type-specific rows covering only one of Cash "
+                        + "and Credit for a given admission type — check with LIST filtered by itemId. "
+                        + "paymentMethod is only ever Cash or Credit (or omitted, meaning \"both\") — an admission "
+                        + "can hold no other value; any other PaymentMethod value is rejected. "
+                        + "The item behind a row must have a department, an institution, an inwardChargeType, and "
+                        + "at least one live fee, or the charge cannot be billed — an item with no fee produces a "
+                        + "charge that cancels and refunds as zero. "
+                        + "Double-charge trap: AdmissionType.admissionFee is a separate, older mechanism already "
+                        + "added to the bill under the Admission Fee charge type, without a bill item. An "
+                        + "admission type with a non-zero admissionFee plus an AdmissionChargeItem configured "
+                        + "here charges the patient twice — warn the user before configuring a general admission "
+                        + "charge against an admission type that already has a non-zero admissionFee. "
+                        + "At most one live row may exist per (item, admissionType, paymentMethod) triple — "
+                        + "CREATE/UPDATE reject a duplicate; retire the existing row first, or update it instead. "
+                        + "action: LIST | GET | CREATE | UPDATE | RETIRE | RESTORE. "
+                        + "RETIRE only soft-retires, and RESTORE undoes it, so a mistaken retire is recoverable — "
+                        + "pass includeRetired=true to LIST or GET to see what was retired and get the id to "
+                        + "restore. "
+                        + "Always confirm with the user before CREATE, UPDATE, RETIRE, or RESTORE.")
+                .add("input_schema", Json.createObjectBuilder()
+                        .add("type", "object")
+                        .add("properties", Json.createObjectBuilder()
+                                .add("action", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("enum", Json.createArrayBuilder()
+                                                .add("LIST").add("GET").add("CREATE").add("UPDATE")
+                                                .add("RETIRE").add("RESTORE"))
+                                        .add("description", "Operation to perform."))
+                                .add("id", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "AdmissionChargeItem id. Required for GET, UPDATE, RETIRE, RESTORE."))
+                                .add("itemId", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Item (service) id being charged. Required for CREATE. Optional filter for LIST, and optional for UPDATE to repoint the row at a different item."))
+                                .add("admissionTypeId", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "AdmissionType id this row applies to. Optional; omitted means \"any admission type\". Optional filter for LIST."))
+                                .add("paymentMethod", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Cash or Credit. Optional; omitted means \"both\". No other PaymentMethod value is valid here — an admission is never any other payment method."))
+                                .add("price", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Charge amount, must be >= 0. Required for CREATE."))
+                                .add("qty", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Quantity. Optional; defaults to 1.0."))
+                                .add("orderNo", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Display ordering. Optional; defaults to 0."))
+                                .add("clearAdmissionType", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "true or false — UPDATE only. Sets admissionType back to null (\"any\"). Ignored if admissionTypeId is also given. A plain JSON body cannot tell \"field omitted\" apart from \"field set to null\", so clearing this column is explicit."))
+                                .add("clearPaymentMethod", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "true or false — UPDATE only. Sets paymentMethod back to null (\"both\"). Ignored if paymentMethod is also given."))
+                                .add("includeRetired", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "true or false — include retired rows in LIST/GET. Optional; defaults to false. Use it to find a row retired by mistake so it can be restored with RESTORE."))
+                                .add("retireComments", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "Reason for retirement. Optional for RETIRE."))
+                                .add("size", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "LIST only — page size (1–100). Optional; defaults to 30."))
+                                .add("offset", Json.createObjectBuilder()
+                                        .add("type", "string")
+                                        .add("description", "LIST only — rows to skip, for paging through a configuration set larger than one page. The response carries a total count so you can tell whether more remain. Optional; defaults to 0.")))
+                        .add("required", Json.createArrayBuilder().add("action")))
+                .build();
+
         JsonObject lookupFinanceBillTool = Json.createObjectBuilder()
                 .add("name", "lookup_finance_bill")
                 .add("description",
@@ -2188,6 +2282,7 @@ public class AnthropicApiService implements Serializable {
                 .add(manageChannelBookingTool)
                 .add(manageInpatientTemplates)
                 .add(manageTimedItemsTool)
+                .add(manageAdmissionChargesTool)
                 .add(lookupFinanceBillTool)
                 .build();
     }
@@ -2648,6 +2743,25 @@ public class AnthropicApiService implements Serializable {
                             departmentId, institutionId, categoryId, inactive,
                             fee, ffee, durationHrs, overShoot, durationDays, sortOrder, repeating, durationUnit,
                             feesJson, query, size, offset, includeRetired, retireComments, hmisBaseUrl, hmisApiKey);
+                }
+                case "manage_admission_charges": {
+                    String action              = toolInput.getString("action", "LIST");
+                    String id                  = toolInput.containsKey("id")                 ? toolInput.getString("id", "")                 : "";
+                    String itemId              = toolInput.containsKey("itemId")             ? toolInput.getString("itemId", "")             : "";
+                    String admissionTypeId     = toolInput.containsKey("admissionTypeId")    ? toolInput.getString("admissionTypeId", "")    : "";
+                    String paymentMethod       = toolInput.containsKey("paymentMethod")      ? toolInput.getString("paymentMethod", "")      : "";
+                    String price               = toolInput.containsKey("price")              ? toolInput.getString("price", "")              : "";
+                    String qty                 = toolInput.containsKey("qty")                ? toolInput.getString("qty", "")                : "";
+                    String orderNo             = toolInput.containsKey("orderNo")            ? toolInput.getString("orderNo", "")            : "";
+                    String clearAdmissionType  = toolInput.containsKey("clearAdmissionType") ? toolInput.getString("clearAdmissionType", "") : "";
+                    String clearPaymentMethod  = toolInput.containsKey("clearPaymentMethod") ? toolInput.getString("clearPaymentMethod", "") : "";
+                    String includeRetired      = toolInput.containsKey("includeRetired")     ? toolInput.getString("includeRetired", "")     : "";
+                    String retireComments      = toolInput.containsKey("retireComments")     ? toolInput.getString("retireComments", "")     : "";
+                    String size                = toolInput.containsKey("size")               ? toolInput.getString("size", "")               : "";
+                    String offset              = toolInput.containsKey("offset")             ? toolInput.getString("offset", "")             : "";
+                    return manageAdmissionCharges(action, id, itemId, admissionTypeId, paymentMethod, price, qty,
+                            orderNo, clearAdmissionType, clearPaymentMethod, includeRetired, retireComments,
+                            size, offset, hmisApiKey);
                 }
                 default:
                     return "Unknown tool: " + toolName;
@@ -6155,6 +6269,191 @@ public class AnthropicApiService implements Serializable {
             return "Timed items API error: " + e.getMessage();
         }
     }
+
+    /**
+     * Handles {@code manage_admission_charges}. Unlike the other manage_* tools, this one is
+     * an in-process call to {@link AdmissionChargeApiService} rather than an HTTP round-trip
+     * through the REST API — {@code AnthropicApiService} is itself server-side, so it can call
+     * the same validated business logic directly. {@link AdmissionChargeValidationException} is
+     * caught here and surfaced as a plain "Error: ..." string, never a stack trace.
+     */
+    private String manageAdmissionCharges(String action, String id, String itemId, String admissionTypeId,
+            String paymentMethod, String price, String qty, String orderNo,
+            String clearAdmissionType, String clearPaymentMethod,
+            String includeRetired, String retireComments, String size, String offset,
+            String hmisApiKey) {
+        String normalizedAction = action == null ? "" : action.trim().toUpperCase();
+        try {
+            switch (normalizedAction) {
+                case "LIST": {
+                    Long itemIdL = itemId.isEmpty() ? null : Long.parseLong(itemId);
+                    Long admissionTypeIdL = admissionTypeId.isEmpty() ? null : Long.parseLong(admissionTypeId);
+                    boolean includeRetiredB = Boolean.parseBoolean(includeRetired);
+                    int limit = size.isEmpty() ? 30 : Integer.parseInt(size);
+                    int off = offset.isEmpty() ? 0 : Integer.parseInt(offset);
+                    AdmissionChargeItemPageDTO pageResult = admissionChargeApiService.search(
+                            itemIdL, admissionTypeIdL, paymentMethod.isEmpty() ? null : paymentMethod,
+                            includeRetiredB, limit, off);
+                    return formatAdmissionChargePage(pageResult);
+                }
+                case "GET": {
+                    if (id.isEmpty()) {
+                        return "Error: id is required for GET.";
+                    }
+                    boolean includeRetiredB = Boolean.parseBoolean(includeRetired);
+                    AdmissionChargeItemDTO dto = admissionChargeApiService.findById(Long.parseLong(id), includeRetiredB);
+                    return "Admission charge item:\n" + formatAdmissionChargeItem(dto);
+                }
+                case "CREATE": {
+                    if (itemId.isEmpty()) {
+                        return "Error: itemId is required for CREATE.";
+                    }
+                    if (price.isEmpty()) {
+                        return "Error: price is required for CREATE.";
+                    }
+                    AdmissionChargeItemCreateRequestDTO request = new AdmissionChargeItemCreateRequestDTO();
+                    request.setItemId(Long.parseLong(itemId));
+                    if (!admissionTypeId.isEmpty()) {
+                        request.setAdmissionTypeId(Long.parseLong(admissionTypeId));
+                    }
+                    if (!paymentMethod.isEmpty()) {
+                        request.setPaymentMethod(paymentMethod);
+                    }
+                    request.setPrice(Double.parseDouble(price));
+                    if (!qty.isEmpty()) {
+                        request.setQty(Double.parseDouble(qty));
+                    }
+                    if (!orderNo.isEmpty()) {
+                        request.setOrderNo(Integer.parseInt(orderNo));
+                    }
+                    WebUser user = resolveCallerWebUser(hmisApiKey);
+                    AdmissionChargeItemDTO dto = admissionChargeApiService.create(request, user);
+                    return "Admission charge item created.\n" + formatAdmissionChargeItem(dto);
+                }
+                case "UPDATE": {
+                    if (id.isEmpty()) {
+                        return "Error: id is required for UPDATE.";
+                    }
+                    AdmissionChargeItemUpdateRequestDTO request = new AdmissionChargeItemUpdateRequestDTO();
+                    if (!itemId.isEmpty()) {
+                        request.setItemId(Long.parseLong(itemId));
+                    }
+                    if (!admissionTypeId.isEmpty()) {
+                        request.setAdmissionTypeId(Long.parseLong(admissionTypeId));
+                    } else if (!clearAdmissionType.isEmpty()) {
+                        request.setClearAdmissionType(Boolean.parseBoolean(clearAdmissionType));
+                    }
+                    if (!paymentMethod.isEmpty()) {
+                        request.setPaymentMethod(paymentMethod);
+                    } else if (!clearPaymentMethod.isEmpty()) {
+                        request.setClearPaymentMethod(Boolean.parseBoolean(clearPaymentMethod));
+                    }
+                    if (!price.isEmpty()) {
+                        request.setPrice(Double.parseDouble(price));
+                    }
+                    if (!qty.isEmpty()) {
+                        request.setQty(Double.parseDouble(qty));
+                    }
+                    if (!orderNo.isEmpty()) {
+                        request.setOrderNo(Integer.parseInt(orderNo));
+                    }
+                    WebUser user = resolveCallerWebUser(hmisApiKey);
+                    AdmissionChargeItemDTO dto = admissionChargeApiService.update(Long.parseLong(id), request, user);
+                    return "Admission charge item updated.\n" + formatAdmissionChargeItem(dto);
+                }
+                case "RETIRE": {
+                    if (id.isEmpty()) {
+                        return "Error: id is required for RETIRE.";
+                    }
+                    WebUser user = resolveCallerWebUser(hmisApiKey);
+                    AdmissionChargeItemDTO dto = admissionChargeApiService.retire(
+                            Long.parseLong(id), retireComments.isEmpty() ? null : retireComments, user);
+                    return "Admission charge item retired.\n" + formatAdmissionChargeItem(dto);
+                }
+                case "RESTORE": {
+                    if (id.isEmpty()) {
+                        return "Error: id is required for RESTORE.";
+                    }
+                    WebUser user = resolveCallerWebUser(hmisApiKey);
+                    AdmissionChargeItemDTO dto = admissionChargeApiService.restore(Long.parseLong(id), user);
+                    return "Admission charge item restored.\n" + formatAdmissionChargeItem(dto);
+                }
+                default:
+                    return "Error: Unknown action '" + action + "'. Supported: LIST, GET, CREATE, UPDATE, RETIRE, RESTORE.";
+            }
+        } catch (AdmissionChargeValidationException e) {
+            return "Error: " + e.getMessage();
+        } catch (NumberFormatException e) {
+            return "Error: invalid numeric value — " + e.getMessage();
+        } catch (Exception e) {
+            LOG.log(Level.WARNING, "manage_admission_charges failed for action {0}: {1}",
+                    new Object[]{action, e.getMessage()});
+            return "Error: " + e.getMessage();
+        }
+    }
+
+    private String formatAdmissionChargeItem(AdmissionChargeItemDTO dto) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("id: ").append(dto.getId()).append("\n");
+        sb.append("item: ").append(dto.getItemName()).append(" (itemId=").append(dto.getItemId()).append(")\n");
+        if (dto.getItemDepartmentName() != null) {
+            sb.append("department: ").append(dto.getItemDepartmentName()).append("\n");
+        }
+        if (dto.getInwardChargeType() != null) {
+            sb.append("inwardChargeType: ").append(dto.getInwardChargeType()).append("\n");
+        }
+        sb.append("admissionType: ").append(dto.getAdmissionTypeId() != null
+                ? dto.getAdmissionTypeName() + " (id=" + dto.getAdmissionTypeId() + ")" : "any (applies to every admission type)")
+                .append("\n");
+        sb.append("paymentMethod: ").append(dto.getPaymentMethod() != null
+                ? dto.getPaymentMethod() : "both (applies to Cash and Credit)").append("\n");
+        sb.append("price: ").append(dto.getPrice()).append("\n");
+        sb.append("qty: ").append(dto.getQty()).append("\n");
+        sb.append("orderNo: ").append(dto.getOrderNo()).append("\n");
+        sb.append("retired: ").append(dto.isRetired());
+        return sb.toString();
+    }
+
+    private String formatAdmissionChargePage(AdmissionChargeItemPageDTO page) {
+        List<AdmissionChargeItemDTO> items = page.getItems();
+        if (items == null || items.isEmpty()) {
+            return "No admission charge items found (total=" + page.getTotal() + ").";
+        }
+        StringBuilder sb = new StringBuilder();
+        sb.append("Found ").append(page.getTotal()).append(" admission charge item(s); showing ")
+                .append(items.size()).append(" starting at offset ").append(page.getOffset()).append(":\n\n");
+        for (AdmissionChargeItemDTO dto : items) {
+            sb.append(formatAdmissionChargeItem(dto)).append("\n\n");
+        }
+        long shownThrough = (long) page.getOffset() + items.size();
+        if (shownThrough < page.getTotal()) {
+            sb.append("... ").append(page.getTotal() - shownThrough)
+                    .append(" more row(s) remain. Pass offset=").append(shownThrough).append(" to see the next page.\n");
+        }
+        return sb.toString().trim();
+    }
+
+    /**
+     * Resolves the WebUser behind the caller's HMIS API key, for the {@code creater}/
+     * {@code retirer} fields on records this tool writes. Mirrors {@link #resolveCallerName}'s
+     * lookup but returns the entity rather than a display string.
+     */
+    private WebUser resolveCallerWebUser(String hmisApiKey) {
+        if (hmisApiKey == null || hmisApiKey.trim().isEmpty()) {
+            return null;
+        }
+        try {
+            Map<String, Object> p = new HashMap<>();
+            p.put("k", hmisApiKey);
+            ApiKey ak = apiKeyFacade.findFirstByJpql(
+                    "SELECT a FROM ApiKey a WHERE a.keyValue = :k AND a.retired = false", p);
+            return ak != null ? ak.getWebUser() : null;
+        } catch (Exception e) {
+            LOG.log(Level.FINE, "Could not resolve caller WebUser from hmisApiKey", e);
+            return null;
+        }
+    }
+
     public String buildSystemPrompt(String hmisApiBaseUrl, String userHmisApiKey, String githubBranch) {
         String branch = (githubBranch != null && !githubBranch.trim().isEmpty())
                 ? githubBranch.trim() : "development";
@@ -6384,6 +6683,35 @@ public class AnthropicApiService implements Serializable {
           .append("PUT_FEES replaces the entire slot list in one atomic, fully-validated call — prefer it over a run of POST_FEE calls when ")
           .append("configuring a tiered service; slots you leave out of the array are retired. ")
           .append("Always confirm with the user before POST, PUT, or DELETE — changes affect live inward timed billing.\n\n");
+        sb.append("### manage_admission_charges\n");
+        sb.append("Manage AdmissionChargeItem rows — routine charges billed automatically on every matching admission, ")
+          .append("additive alongside room and service charges. These are NOT inpatient packages. ")
+          .append("Resolution is two-step per item, applied when an admission is saved: admission type is the outer filter, ")
+          .append("payment method the inner one; a null in either column means \"applies to all\" for that dimension. ")
+          .append("Configuration trap: because admission type is a filter, not a preference, adding one admission-type-specific ")
+          .append("row for an item completely replaces the null-admissionType row set for that item and that admission type — ")
+          .append("it does not fall back to it. Configuring (Admission Charge, Day Case, Cash) and forgetting the Day Case ")
+          .append("Credit row leaves a Credit Day Case admission with NO admission charge at all. Warn the user whenever a ")
+          .append("change (CREATE, UPDATE, or RETIRE) would leave an item's admission-type-specific rows covering only one of ")
+          .append("Cash and Credit for a given admission type — check with LIST filtered by itemId before and after the change. ")
+          .append("paymentMethod is only ever Cash or Credit (or omitted, meaning \"both\") — an admission can hold no other ")
+          .append("value; any other PaymentMethod value is rejected. ")
+          .append("The item behind a row must have a department, an institution, an inwardChargeType, and at least one live ")
+          .append("fee, or the charge cannot be billed — an item with no fee produces a charge that cancels and refunds as zero. ")
+          .append("Double-charge trap: AdmissionType.admissionFee is a separate, older mechanism already added to the bill ")
+          .append("under the Admission Fee charge type, without a bill item. An admission type with a non-zero admissionFee ")
+          .append("plus an AdmissionChargeItem configured here charges the patient twice — warn the user before configuring ")
+          .append("a general admission charge against an admission type that already has a non-zero admissionFee. ")
+          .append("At most one live row may exist per (item, admissionType, paymentMethod) triple — CREATE/UPDATE reject a ")
+          .append("duplicate; retire the existing row first, or update it instead. ")
+          .append("action: LIST | GET | CREATE | UPDATE | RETIRE | RESTORE. LIST is paged with size + offset and filters on ")
+          .append("itemId, admissionTypeId, paymentMethod, includeRetired. UPDATE uses clearAdmissionType / clearPaymentMethod ")
+          .append("to explicitly reset either column back to null, since a plain body cannot tell \"omitted\" apart from ")
+          .append("\"set to null\" and both are meaningful. ")
+          .append("RETIRE only soft-retires, and RESTORE undoes it, so a mistaken retire is recoverable — pass ")
+          .append("includeRetired=true to LIST or GET to see what was retired and get the id to restore. ")
+          .append("Always confirm with the user before CREATE, UPDATE, RETIRE, or RESTORE — these changes affect live inward ")
+          .append("billing on every future matching admission.\n\n");
         sb.append("### manage_inpatient_templates\n");
         sb.append("Create, read, update, and retire document templates (HTML with placeholder tokens). ")
           .append("Supported types: Prescription, MedicalCertificate, FitnessCertificate, Referral, InpatientDiagnosisCard, InpatientLetter. ")
@@ -7067,6 +7395,22 @@ public class AnthropicApiService implements Serializable {
                     {"PUT",    "/timed-items/{id}/fees/{feeId}", "Update fee tier"},
                     {"DELETE", "/timed-items/{id}/fees/{feeId}", "Soft-retire fee tier"},
                     {"PATCH",  "/timed-items/{id}/fees/{feeId}/restore", "Un-retire fee tier"}
+                });
+
+        appendModule(sb, "Admission Charges", "/admission-charges",
+                "Manage AdmissionChargeItem rows — routine charges billed automatically on every matching "
+                + "admission, additive alongside room and service charges (not inpatient packages). Each row "
+                + "resolves per (item, admissionType, paymentMethod): admissionType null means any type, "
+                + "paymentMethod null means both Cash and Credit. At most one live row per triple. Retire is "
+                + "soft and reversible via restore.",
+                githubUrl(branch, "developer_docs/api/using-apis/API_ADMISSION_CHARGES.md"),
+                new String[][]{
+                    {"GET",    "/admission-charges/search?itemId=&admissionTypeId=&paymentMethod=&includeRetired=&limit=&offset=", "Search admission charge items. Returns {items, total, limit, offset}"},
+                    {"GET",    "/admission-charges/{id}?includeRetired=", "Fetch one admission charge item"},
+                    {"POST",   "/admission-charges",              "Create. Body: itemId, price (required); admissionTypeId, paymentMethod, qty, orderNo optional"},
+                    {"PUT",    "/admission-charges/{id}",          "Update (all fields optional). Use clearAdmissionType/clearPaymentMethod to explicitly reset either column to null"},
+                    {"DELETE", "/admission-charges/{id}",          "Soft-retire admission charge item. Optional: retireComments (query param)"},
+                    {"PATCH",  "/admission-charges/{id}/restore",  "Un-retire admission charge item"}
                 });
 
         // ── Login History / Config ────────────────────────────────────────────

--- a/src/main/java/com/divudi/service/AnthropicApiService.java
+++ b/src/main/java/com/divudi/service/AnthropicApiService.java
@@ -6289,7 +6289,10 @@ public class AnthropicApiService implements Serializable {
                     Long itemIdL = itemId.isEmpty() ? null : Long.parseLong(itemId);
                     Long admissionTypeIdL = admissionTypeId.isEmpty() ? null : Long.parseLong(admissionTypeId);
                     boolean includeRetiredB = Boolean.parseBoolean(includeRetired);
-                    int limit = size.isEmpty() ? 30 : Integer.parseInt(size);
+                    // Clamped to the range the tool schema advertises; search() passes
+                    // limit straight to setMaxResults, so an unbounded value would page
+                    // the whole table into the model's context.
+                    int limit = size.isEmpty() ? 30 : Math.max(1, Math.min(100, Integer.parseInt(size)));
                     int off = offset.isEmpty() ? 0 : Integer.parseInt(offset);
                     AdmissionChargeItemPageDTO pageResult = admissionChargeApiService.search(
                             itemIdL, admissionTypeIdL, paymentMethod.isEmpty() ? null : paymentMethod,

--- a/src/main/java/com/divudi/service/inward/AdmissionChargeApiService.java
+++ b/src/main/java/com/divudi/service/inward/AdmissionChargeApiService.java
@@ -1,0 +1,433 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.service.inward;
+
+import com.divudi.core.data.PaymentMethod;
+import com.divudi.core.data.dto.admissioncharge.AdmissionChargeItemCreateRequestDTO;
+import com.divudi.core.data.dto.admissioncharge.AdmissionChargeItemDTO;
+import com.divudi.core.data.dto.admissioncharge.AdmissionChargeItemPageDTO;
+import com.divudi.core.data.dto.admissioncharge.AdmissionChargeItemUpdateRequestDTO;
+import com.divudi.core.entity.Item;
+import com.divudi.core.entity.WebUser;
+import com.divudi.core.entity.inward.AdmissionChargeItem;
+import com.divudi.core.entity.inward.AdmissionType;
+import com.divudi.core.facade.AdmissionChargeItemFacade;
+import com.divudi.core.facade.AdmissionTypeFacade;
+import com.divudi.core.facade.ItemFacade;
+import com.divudi.core.facade.ItemFeeFacade;
+
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Business logic for the Admission Charge Item API (issue #23594).
+ *
+ * <p>Validation here must match {@code AdmissionChargeApplicationBean}'s
+ * runtime resolution exactly - a row this service accepts must be a row the
+ * charging pipeline can actually bill:</p>
+ * <ul>
+ *   <li>the item must exist and carry a department, an institution and an
+ *       inward charge type ({@code AdmissionChargeApplicationBean.buildEntry}
+ *       dereferences all three unguarded)</li>
+ *   <li>the item must have at least one live {@link com.divudi.core.entity.ItemFee}
+ *       - an item with none produces a BillItem whose charge cancels and
+ *       refunds as zero</li>
+ *   <li>{@code paymentMethod}, when present, must be exactly {@code Cash} or
+ *       {@code Credit} - the only two values an admission can hold (see
+ *       {@code EnumController.getPaymentMethodForAdmission()})</li>
+ *   <li>only one live row may exist per {@code (item, admissionType,
+ *       paymentMethod)} triple</li>
+ * </ul>
+ *
+ * <p>JPQL only, per project policy. {@code COUNT(...)} queries use
+ * {@code findLongByJpql} - never {@code findDoubleByJpql}, which silently
+ * {@code ClassCastException}s on the {@code Long} result and returns
+ * {@code 0.0}, making every uniqueness/fee check pass by accident.</p>
+ *
+ * @author Buddhika
+ */
+@Stateless
+public class AdmissionChargeApiService implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @EJB
+    private AdmissionChargeItemFacade admissionChargeItemFacade;
+
+    @EJB
+    private ItemFacade itemFacade;
+
+    @EJB
+    private ItemFeeFacade itemFeeFacade;
+
+    @EJB
+    private AdmissionTypeFacade admissionTypeFacade;
+
+    // =========================================================================
+    // Search
+    // =========================================================================
+
+    /**
+     * Search admission charge items, returning one page plus the total number
+     * of matches.
+     */
+    public AdmissionChargeItemPageDTO search(Long itemId, Long admissionTypeId, String paymentMethod,
+            boolean includeRetired, int limit, int offset) throws Exception {
+
+        Map<String, Object> params = new HashMap<>();
+        StringBuilder where = new StringBuilder(" WHERE 1 = 1 ");
+
+        if (!includeRetired) {
+            where.append("AND a.retired = false ");
+        }
+        if (itemId != null) {
+            where.append("AND a.item.id = :itemId ");
+            params.put("itemId", itemId);
+        }
+        if (admissionTypeId != null) {
+            where.append("AND a.admissionType.id = :admissionTypeId ");
+            params.put("admissionTypeId", admissionTypeId);
+        }
+        PaymentMethod pm = parsePaymentMethod(paymentMethod);
+        if (pm != null) {
+            where.append("AND a.paymentMethod = :paymentMethod ");
+            params.put("paymentMethod", pm);
+        }
+
+        // COUNT returns a Long - findLongByJpql, never findDoubleByJpql (which would
+        // swallow the ClassCastException and silently report 0 every time).
+        long total = admissionChargeItemFacade.findLongByJpql(
+                "SELECT COUNT(a) FROM AdmissionChargeItem a" + where, params);
+
+        List<AdmissionChargeItem> rows = admissionChargeItemFacade.findByJpqlWithRange(
+                "SELECT a FROM AdmissionChargeItem a" + where + "ORDER BY a.orderNo, a.id",
+                params, offset, limit);
+
+        List<AdmissionChargeItemDTO> dtos = new ArrayList<>();
+        for (AdmissionChargeItem row : rows) {
+            dtos.add(buildDTO(row));
+        }
+        return new AdmissionChargeItemPageDTO(dtos, total, limit, offset);
+    }
+
+    // =========================================================================
+    // Get by ID
+    // =========================================================================
+
+    public AdmissionChargeItemDTO findById(Long id, boolean includeRetired) throws Exception {
+        AdmissionChargeItem entity = includeRetired ? loadAllowingRetired(id) : loadAndValidate(id);
+        return buildDTO(entity);
+    }
+
+    // =========================================================================
+    // Create
+    // =========================================================================
+
+    public AdmissionChargeItemDTO create(AdmissionChargeItemCreateRequestDTO request, WebUser user) throws Exception {
+        if (request == null || !request.isValid()) {
+            throw new AdmissionChargeValidationException("Valid create request required (itemId is required)");
+        }
+        if (request.getPrice() < 0) {
+            throw new AdmissionChargeValidationException("Price must not be negative");
+        }
+
+        Item item = validateItemForCharging(request.getItemId());
+        AdmissionType admissionType = resolveAdmissionType(request.getAdmissionTypeId());
+        PaymentMethod paymentMethod = parsePaymentMethod(request.getPaymentMethod());
+
+        rejectIfConflicting(item, admissionType, paymentMethod, null);
+
+        AdmissionChargeItem entity = new AdmissionChargeItem();
+        entity.setItem(item);
+        entity.setAdmissionType(admissionType);
+        entity.setPaymentMethod(paymentMethod);
+        entity.setPrice(request.getPrice());
+        entity.setQty(request.getQty() != null && request.getQty() > 0 ? request.getQty() : 1.0);
+        entity.setOrderNo(request.getOrderNo());
+        entity.setCreater(user);
+        entity.setCreatedAt(Calendar.getInstance().getTime());
+        entity.setRetired(false);
+
+        admissionChargeItemFacade.create(entity);
+
+        return buildDTO(entity);
+    }
+
+    // =========================================================================
+    // Update
+    // =========================================================================
+
+    public AdmissionChargeItemDTO update(Long id, AdmissionChargeItemUpdateRequestDTO request, WebUser user) throws Exception {
+        if (request == null || !request.isValid()) {
+            throw new AdmissionChargeValidationException(
+                    "Valid update request required (at least one field must be provided)");
+        }
+
+        AdmissionChargeItem entity = loadAndValidate(id);
+
+        Item item = entity.getItem();
+        if (request.getItemId() != null) {
+            item = validateItemForCharging(request.getItemId());
+        }
+
+        AdmissionType admissionType = entity.getAdmissionType();
+        if (request.getAdmissionTypeId() != null) {
+            admissionType = resolveAdmissionType(request.getAdmissionTypeId());
+        } else if (Boolean.TRUE.equals(request.getClearAdmissionType())) {
+            admissionType = null;
+        }
+
+        PaymentMethod paymentMethod = entity.getPaymentMethod();
+        if (request.getPaymentMethod() != null) {
+            paymentMethod = parsePaymentMethod(request.getPaymentMethod());
+        } else if (Boolean.TRUE.equals(request.getClearPaymentMethod())) {
+            paymentMethod = null;
+        }
+
+        if (request.getPrice() != null && request.getPrice() < 0) {
+            throw new AdmissionChargeValidationException("Price must not be negative");
+        }
+
+        // Re-checked whenever any identity dimension changes; a no-op update excludes
+        // itself and always passes.
+        rejectIfConflicting(item, admissionType, paymentMethod, entity.getId());
+
+        entity.setItem(item);
+        entity.setAdmissionType(admissionType);
+        entity.setPaymentMethod(paymentMethod);
+        if (request.getPrice() != null) {
+            entity.setPrice(request.getPrice());
+        }
+        if (request.getQty() != null && request.getQty() > 0) {
+            entity.setQty(request.getQty());
+        }
+        if (request.getOrderNo() != null) {
+            entity.setOrderNo(request.getOrderNo());
+        }
+
+        admissionChargeItemFacade.edit(entity);
+
+        return buildDTO(entity);
+    }
+
+    // =========================================================================
+    // Retire / Restore
+    // =========================================================================
+
+    public AdmissionChargeItemDTO retire(Long id, String retireComments, WebUser user) throws Exception {
+        AdmissionChargeItem entity = loadAndValidate(id);
+        entity.setRetired(true);
+        entity.setRetirer(user);
+        entity.setRetiredAt(Calendar.getInstance().getTime());
+        entity.setRetireComments(retireComments);
+        admissionChargeItemFacade.edit(entity);
+        return buildDTO(entity);
+    }
+
+    /**
+     * Undo a retire. Rejected if a live row now occupies the same
+     * {@code (item, admissionType, paymentMethod)} triple - restoring must not
+     * silently create a second live row for the same combination.
+     */
+    public AdmissionChargeItemDTO restore(Long id, WebUser user) throws Exception {
+        AdmissionChargeItem entity = loadAllowingRetired(id);
+        if (!entity.isRetired()) {
+            throw new AdmissionChargeValidationException("AdmissionChargeItem with ID " + id + " is not retired");
+        }
+        rejectIfConflicting(entity.getItem(), entity.getAdmissionType(), entity.getPaymentMethod(), entity.getId());
+
+        entity.setRetired(false);
+        entity.setRetiredAt(null);
+        entity.setRetirer(null);
+        entity.setRetireComments(null);
+        admissionChargeItemFacade.edit(entity);
+        return buildDTO(entity);
+    }
+
+    // =========================================================================
+    // Private helpers
+    // =========================================================================
+
+    /**
+     * Validates the item against the same requirements
+     * {@code AdmissionChargeApplicationBean.buildEntry} relies on at charge
+     * time.
+     */
+    private Item validateItemForCharging(Long itemId) throws Exception {
+        if (itemId == null) {
+            throw new AdmissionChargeValidationException("Item is required");
+        }
+        Item item = itemFacade.find(itemId);
+        if (item == null) {
+            throw new AdmissionChargeValidationException("Item not found with ID: " + itemId);
+        }
+        if (item.getDepartment() == null) {
+            throw new AdmissionChargeValidationException(
+                    "Item \"" + item.getName() + "\" has no department configured. "
+                    + "An admission charge item's Item must have a department.");
+        }
+        if (item.getInstitution() == null) {
+            throw new AdmissionChargeValidationException(
+                    "Item \"" + item.getName() + "\" has no institution configured. "
+                    + "An admission charge item's Item must have an institution.");
+        }
+        if (item.getInwardChargeType() == null) {
+            throw new AdmissionChargeValidationException(
+                    "Item \"" + item.getName() + "\" has no inward charge type configured. "
+                    + "An admission charge item's Item must have one.");
+        }
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("item", item);
+        long liveFees = itemFeeFacade.findLongByJpql(
+                "SELECT COUNT(f) FROM ItemFee f WHERE f.item = :item AND f.retired = false", params);
+        if (liveFees <= 0) {
+            throw new AdmissionChargeValidationException(
+                    "Item \"" + item.getName() + "\" has no active fee configured. "
+                    + "A charge with no fee would cancel and refund as zero.");
+        }
+
+        return item;
+    }
+
+    private AdmissionType resolveAdmissionType(Long admissionTypeId) throws Exception {
+        if (admissionTypeId == null) {
+            return null;
+        }
+        AdmissionType admissionType = admissionTypeFacade.find(admissionTypeId);
+        if (admissionType == null) {
+            throw new AdmissionChargeValidationException("AdmissionType not found with ID: " + admissionTypeId);
+        }
+        return admissionType;
+    }
+
+    /**
+     * @param raw "Cash", "Credit", or null/blank for "both". Anything else -
+     *            including other {@link PaymentMethod} values - is rejected: an
+     *            admission is only ever Cash or Credit
+     *            ({@code EnumController.getPaymentMethodForAdmission()}).
+     */
+    private PaymentMethod parsePaymentMethod(String raw) throws Exception {
+        if (raw == null || raw.trim().isEmpty()) {
+            return null;
+        }
+        PaymentMethod pm;
+        try {
+            pm = PaymentMethod.valueOf(raw.trim());
+        } catch (IllegalArgumentException e) {
+            throw new AdmissionChargeValidationException(
+                    "Invalid paymentMethod: " + raw + ". Must be Cash or Credit, or omitted for both.");
+        }
+        if (pm != PaymentMethod.Cash && pm != PaymentMethod.Credit) {
+            throw new AdmissionChargeValidationException(
+                    "Invalid paymentMethod: " + raw + ". An admission charge item may only be "
+                    + "Cash or Credit (or omitted for both) - an admission is never any other payment method.");
+        }
+        return pm;
+    }
+
+    /**
+     * Enforces "only one live row per (item, admissionType, paymentMethod)
+     * triple". Built as a conditional JPQL string rather than binding null
+     * parameters: {@code a.admissionType = :admissionType} never matches a null
+     * column, so the null case must use a literal {@code IS NULL} clause.
+     */
+    private void rejectIfConflicting(Item item, AdmissionType admissionType, PaymentMethod paymentMethod,
+            Long excludeId) throws Exception {
+        StringBuilder jpql = new StringBuilder(
+                "SELECT COUNT(a) FROM AdmissionChargeItem a WHERE a.item = :item AND a.retired = false ");
+        Map<String, Object> params = new HashMap<>();
+        params.put("item", item);
+
+        if (admissionType != null) {
+            jpql.append("AND a.admissionType = :admissionType ");
+            params.put("admissionType", admissionType);
+        } else {
+            jpql.append("AND a.admissionType IS NULL ");
+        }
+
+        if (paymentMethod != null) {
+            jpql.append("AND a.paymentMethod = :paymentMethod ");
+            params.put("paymentMethod", paymentMethod);
+        } else {
+            jpql.append("AND a.paymentMethod IS NULL ");
+        }
+
+        if (excludeId != null) {
+            jpql.append("AND a.id <> :excludeId ");
+            params.put("excludeId", excludeId);
+        }
+
+        long conflicts = admissionChargeItemFacade.findLongByJpql(jpql.toString(), params);
+        if (conflicts > 0) {
+            throw new AdmissionChargeValidationException(
+                    "An admission charge item already exists for item \"" + item.getName() + "\" with admissionType="
+                    + (admissionType != null ? admissionType.getName() : "any") + " and paymentMethod="
+                    + (paymentMethod != null ? paymentMethod.name() : "both")
+                    + ". Retire the existing row first, or update it instead of creating a duplicate.");
+        }
+    }
+
+    private AdmissionChargeItem loadAndValidate(Long id) throws Exception {
+        AdmissionChargeItem entity = loadAllowingRetired(id);
+        if (entity.isRetired()) {
+            throw new Exception("AdmissionChargeItem with ID " + id + " is retired");
+        }
+        return entity;
+    }
+
+    /** Load without rejecting a retired row - for reads that opted in, and for restore. */
+    private AdmissionChargeItem loadAllowingRetired(Long id) throws Exception {
+        if (id == null) {
+            throw new AdmissionChargeValidationException("AdmissionChargeItem ID is required");
+        }
+        AdmissionChargeItem entity = admissionChargeItemFacade.find(id);
+        if (entity == null) {
+            throw new Exception("AdmissionChargeItem not found with ID: " + id);
+        }
+        return entity;
+    }
+
+    private AdmissionChargeItemDTO buildDTO(AdmissionChargeItem entity) {
+        AdmissionChargeItemDTO dto = new AdmissionChargeItemDTO();
+        dto.setId(entity.getId());
+
+        Item item = entity.getItem();
+        if (item != null) {
+            dto.setItemId(item.getId());
+            dto.setItemName(item.getName());
+            if (item.getDepartment() != null) {
+                dto.setItemDepartmentId(item.getDepartment().getId());
+                dto.setItemDepartmentName(item.getDepartment().getName());
+            }
+            if (item.getInwardChargeType() != null) {
+                dto.setInwardChargeType(item.getInwardChargeType().name());
+            }
+        }
+
+        AdmissionType admissionType = entity.getAdmissionType();
+        if (admissionType != null) {
+            dto.setAdmissionTypeId(admissionType.getId());
+            dto.setAdmissionTypeName(admissionType.getName());
+        }
+
+        if (entity.getPaymentMethod() != null) {
+            dto.setPaymentMethod(entity.getPaymentMethod().name());
+        }
+
+        dto.setPrice(entity.getPrice());
+        dto.setQty(entity.getQty());
+        dto.setOrderNo(entity.getOrderNo());
+        dto.setRetired(entity.isRetired());
+        return dto;
+    }
+}

--- a/src/main/java/com/divudi/service/inward/AdmissionChargeApiService.java
+++ b/src/main/java/com/divudi/service/inward/AdmissionChargeApiService.java
@@ -139,6 +139,11 @@ public class AdmissionChargeApiService implements Serializable {
         if (request.getPrice() < 0) {
             throw new AdmissionChargeValidationException("Price must not be negative");
         }
+        // Rejected rather than silently coerced: a qty the caller did not mean is a
+        // wrong charge on every future admission. Omitting it still defaults to 1.
+        if (request.getQty() != null && request.getQty() <= 0) {
+            throw new AdmissionChargeValidationException("Qty must be greater than zero");
+        }
 
         Item item = validateItemForCharging(request.getItemId());
         AdmissionType admissionType = resolveAdmissionType(request.getAdmissionTypeId());
@@ -151,7 +156,7 @@ public class AdmissionChargeApiService implements Serializable {
         entity.setAdmissionType(admissionType);
         entity.setPaymentMethod(paymentMethod);
         entity.setPrice(request.getPrice());
-        entity.setQty(request.getQty() != null && request.getQty() > 0 ? request.getQty() : 1.0);
+        entity.setQty(request.getQty() != null ? request.getQty() : 1.0);
         entity.setOrderNo(request.getOrderNo());
         entity.setCreater(user);
         entity.setCreatedAt(Calendar.getInstance().getTime());
@@ -196,6 +201,9 @@ public class AdmissionChargeApiService implements Serializable {
         if (request.getPrice() != null && request.getPrice() < 0) {
             throw new AdmissionChargeValidationException("Price must not be negative");
         }
+        if (request.getQty() != null && request.getQty() <= 0) {
+            throw new AdmissionChargeValidationException("Qty must be greater than zero");
+        }
 
         // Re-checked whenever any identity dimension changes; a no-op update excludes
         // itself and always passes.
@@ -207,7 +215,7 @@ public class AdmissionChargeApiService implements Serializable {
         if (request.getPrice() != null) {
             entity.setPrice(request.getPrice());
         }
-        if (request.getQty() != null && request.getQty() > 0) {
+        if (request.getQty() != null) {
             entity.setQty(request.getQty());
         }
         if (request.getOrderNo() != null) {

--- a/src/main/java/com/divudi/service/inward/AdmissionChargeApplicationBean.java
+++ b/src/main/java/com/divudi/service/inward/AdmissionChargeApplicationBean.java
@@ -20,9 +20,14 @@ import com.divudi.core.entity.PatientEncounter;
 import com.divudi.core.entity.WebUser;
 import com.divudi.core.entity.inward.AdmissionChargeItem;
 import com.divudi.core.facade.AdmissionChargeItemFacade;
+import com.divudi.core.facade.BillFacade;
+import com.divudi.core.facade.BillFeeFacade;
+import com.divudi.core.facade.BillItemFacade;
 import com.divudi.core.facade.PatientEncounterFacade;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -67,6 +72,12 @@ public class AdmissionChargeApplicationBean implements Serializable {
     private AdmissionChargeItemFacade admissionChargeItemFacade;
     @EJB
     private PatientEncounterFacade patientEncounterFacade;
+    @EJB
+    private BillFacade billFacade;
+    @EJB
+    private BillItemFacade billItemFacade;
+    @EJB
+    private BillFeeFacade billFeeFacade;
 
     /**
      * Resolves and bills the automatic admission charges for this encounter.
@@ -110,17 +121,97 @@ public class AdmissionChargeApplicationBean implements Serializable {
         request.setLoggedUser(loggedUser);
         request.setLoggedDepartment(loggedDepartment);
         request.setCreatingDepartment(loggedUser.getDepartment());
-        request.setBillCollector(new ArrayList<>());
         // The price comes from the configuration, so it is neither marked up by
         // the inward price matrix nor marked down by the inward discount matrix.
         request.setApplyInwardMargin(false);
 
-        InwardServiceBillResult result = inwardServiceBillService.createServiceBills(request);
+        List<Bill> createdBills = new ArrayList<>();
+        request.setBillCollector(createdBills);
 
-        encounter.setAdmissionChargeBatchBill(result.getBatchBill());
-        patientEncounterFacade.edit(encounter);
+        // The facades are stateless, so every bill this run creates is already
+        // committed by the time the next one is built. A failure part-way through
+        // therefore leaves live charge bills behind, and until the encounter
+        // carries its batch bill they are invisible to the reversal path in
+        // BhtEditController - which looks them up by that very field. Retire what
+        // was actually created before letting the failure propagate.
+        InwardServiceBillResult result;
+        try {
+            result = inwardServiceBillService.createServiceBills(request);
+        } catch (RuntimeException ex) {
+            retireCreatedBills(createdBills, null, loggedUser, ex);
+            throw ex;
+        }
+
+        try {
+            encounter.setAdmissionChargeBatchBill(result.getBatchBill());
+            patientEncounterFacade.edit(encounter);
+        } catch (RuntimeException ex) {
+            retireCreatedBills(createdBills, result.getBatchBill(), loggedUser, ex);
+            throw ex;
+        }
 
         return result.getBatchBill();
+    }
+
+    /**
+     * Retires the bills a failed run had already committed, along with their bill
+     * items and bill fees, so nothing half-charged survives.
+     *
+     * <p>Retiring all three levels matters: the interim/final bill aggregation
+     * filters {@code BillItem.retired = false} and the fee sums filter
+     * {@code BillFee.retired = false}, so retiring only the parent bill would
+     * leave the charge visible in the charge-type breakdown.</p>
+     *
+     * <p>Never throws - it runs while an exception is already in flight, and
+     * masking that exception with a second one would hide the real cause.</p>
+     */
+    private void retireCreatedBills(List<Bill> bills, Bill batchBill, WebUser loggedUser, RuntimeException cause) {
+        String reason = "Auto-retired: automatic admission charges failed - "
+                + (cause != null ? cause.getMessage() : "unknown error");
+        Date now = new Date();
+
+        List<Bill> toRetire = new ArrayList<>(bills);
+        if (batchBill != null) {
+            toRetire.add(batchBill);
+        }
+
+        for (Bill bill : toRetire) {
+            if (bill == null || bill.getId() == null) {
+                continue;
+            }
+            try {
+                Map<String, Object> params = new HashMap<>();
+                params.put("b", bill);
+
+                for (BillFee bf : billFeeFacade.findByJpql(
+                        "select bf from BillFee bf where bf.retired = false and bf.bill = :b", params)) {
+                    bf.setRetired(true);
+                    bf.setRetirer(loggedUser);
+                    bf.setRetiredAt(now);
+                    bf.setRetireComments(reason);
+                    billFeeFacade.edit(bf);
+                }
+
+                for (BillItem bi : billItemFacade.findByJpql(
+                        "select bi from BillItem bi where bi.retired = false and bi.bill = :b", params)) {
+                    bi.setRetired(true);
+                    bi.setRetirer(loggedUser);
+                    bi.setRetiredAt(now);
+                    bi.setRetireComments(reason);
+                    billItemFacade.edit(bi);
+                }
+
+                bill.setRetired(true);
+                bill.setRetirer(loggedUser);
+                bill.setRetiredAt(now);
+                bill.setRetireComments(reason);
+                billFacade.edit(bill);
+            } catch (RuntimeException cleanupFailure) {
+                logger.log(Level.SEVERE,
+                        "Could not retire admission charge bill " + bill.getId()
+                        + " after a failed run; it needs cancelling by hand.", cleanupFailure);
+            }
+        }
     }
 
     /**

--- a/src/main/java/com/divudi/service/inward/AdmissionChargeApplicationBean.java
+++ b/src/main/java/com/divudi/service/inward/AdmissionChargeApplicationBean.java
@@ -142,13 +142,41 @@ public class AdmissionChargeApplicationBean implements Serializable {
             throw ex;
         }
 
+        // Claim the encounter atomically rather than with a plain edit(). The
+        // guard at the top of this method is a check-then-act: two concurrent
+        // saves of the same admission (a fast double-submit - the controller is
+        // @SessionScoped, so both would act on the same encounter) can both read
+        // a null batch bill and both charge the patient. This conditional update
+        // lets exactly one of them win, at the database, with no extra locking.
+        int claimed;
         try {
-            encounter.setAdmissionChargeBatchBill(result.getBatchBill());
-            patientEncounterFacade.edit(encounter);
+            Map<String, Object> claim = new HashMap<>();
+            claim.put("batch", result.getBatchBill());
+            claim.put("enc", encounter.getId());
+            claimed = patientEncounterFacade.updateByJpql(
+                    "update PatientEncounter pe "
+                    + " set pe.admissionChargeBatchBill = :batch "
+                    + " where pe.id = :enc "
+                    + " and pe.admissionChargeBatchBill is null", claim);
         } catch (RuntimeException ex) {
             retireCreatedBills(createdBills, result.getBatchBill(), loggedUser, ex);
             throw ex;
         }
+
+        if (claimed == 0) {
+            // Another run got there first. Undo everything this one created so the
+            // patient is charged once, and say nothing to the caller - the charges
+            // exist, they are just not ours.
+            logger.log(Level.WARNING,
+                    "Automatic admission charges were already applied to admission {0} by a concurrent save; "
+                    + "retiring the duplicate bills this run created.", encounter.getId());
+            retireCreatedBills(createdBills, result.getBatchBill(), loggedUser, null);
+            return null;
+        }
+
+        // The bulk update bypasses the persistence context, so refresh the
+        // in-memory encounter the caller is still holding.
+        encounter.setAdmissionChargeBatchBill(result.getBatchBill());
 
         return result.getBatchBill();
     }
@@ -162,12 +190,16 @@ public class AdmissionChargeApplicationBean implements Serializable {
      * {@code BillFee.retired = false}, so retiring only the parent bill would
      * leave the charge visible in the charge-type breakdown.</p>
      *
-     * <p>Never throws - it runs while an exception is already in flight, and
+     * <p>Never throws - it may run while an exception is already in flight, and
      * masking that exception with a second one would hide the real cause.</p>
+     *
+     * @param cause the failure being compensated, or {@code null} when this run
+     * simply lost the race to claim the encounter
      */
     private void retireCreatedBills(List<Bill> bills, Bill batchBill, WebUser loggedUser, RuntimeException cause) {
-        String reason = "Auto-retired: automatic admission charges failed - "
-                + (cause != null ? cause.getMessage() : "unknown error");
+        String reason = cause != null
+                ? "Auto-retired: automatic admission charges failed - " + cause.getMessage()
+                : "Auto-retired: duplicate automatic admission charges from a concurrent save";
         Date now = new Date();
 
         List<Bill> toRetire = new ArrayList<>(bills);

--- a/src/main/java/com/divudi/service/inward/AdmissionChargeApplicationBean.java
+++ b/src/main/java/com/divudi/service/inward/AdmissionChargeApplicationBean.java
@@ -174,9 +174,15 @@ public class AdmissionChargeApplicationBean implements Serializable {
             return null;
         }
 
-        // The bulk update bypasses the persistence context, so refresh the
-        // in-memory encounter the caller is still holding.
+        // A bulk update bypasses the persistence context and the shared cache, so
+        // the claim alone would leave a cached encounter still reporting a null
+        // batch bill - and BhtEditController reads exactly that field to find the
+        // charges when an admission is cancelled. Merge the same value back so the
+        // in-memory copy, the persistence context and the L2 cache all agree. The
+        // conditional update above is what decided the winner; this only restores
+        // coherence, so writing the same value again is harmless.
         encounter.setAdmissionChargeBatchBill(result.getBatchBill());
+        patientEncounterFacade.edit(encounter);
 
         return result.getBatchBill();
     }

--- a/src/main/java/com/divudi/service/inward/AdmissionChargeApplicationBean.java
+++ b/src/main/java/com/divudi/service/inward/AdmissionChargeApplicationBean.java
@@ -1,0 +1,315 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.service.inward;
+
+import com.divudi.bean.common.BillBeanController;
+import com.divudi.bean.common.ItemFeeManager;
+import com.divudi.core.data.FeeType;
+import com.divudi.core.data.PaymentMethod;
+import com.divudi.core.entity.Bill;
+import com.divudi.core.entity.BillEntry;
+import com.divudi.core.entity.BillFee;
+import com.divudi.core.entity.BillItem;
+import com.divudi.core.entity.Department;
+import com.divudi.core.entity.Item;
+import com.divudi.core.entity.ItemFee;
+import com.divudi.core.entity.PatientEncounter;
+import com.divudi.core.entity.WebUser;
+import com.divudi.core.entity.inward.AdmissionChargeItem;
+import com.divudi.core.facade.AdmissionChargeItemFacade;
+import com.divudi.core.facade.PatientEncounterFacade;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.ejb.EJB;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+/**
+ * Bills the configured routine charges for a newly saved admission
+ * (issue #23594).
+ *
+ * <p>Deliberately additive: nothing here zeroes a room charge, and neither
+ * {@code fromPackage} nor {@code sourcePackageItem} is set - those mark
+ * package-locked pricing, which this is not.</p>
+ *
+ * <p>The bills themselves are produced by {@link InwardServiceBillService}, the
+ * same pipeline the <i>Add Services / Investigations to BHT</i> screen runs, so
+ * every downstream screen - interim bill, final bill, cancellation, refund,
+ * credit company debtor reporting - handles them with no special-casing.</p>
+ *
+ * @author Buddhika
+ */
+@Named
+@ApplicationScoped
+public class AdmissionChargeApplicationBean implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final Logger logger = Logger.getLogger(AdmissionChargeApplicationBean.class.getName());
+
+    @Inject
+    private InwardServiceBillService inwardServiceBillService;
+    @Inject
+    private BillBeanController billBean;
+    @Inject
+    private ItemFeeManager itemFeeManager;
+
+    @EJB
+    private AdmissionChargeItemFacade admissionChargeItemFacade;
+    @EJB
+    private PatientEncounterFacade patientEncounterFacade;
+
+    /**
+     * Resolves and bills the automatic admission charges for this encounter.
+     *
+     * <p>Idempotent: an encounter that already carries an admission charge batch
+     * bill is left alone, so re-saving an admission cannot charge it twice.</p>
+     *
+     * @return the batch bill created, or null when nothing was charged
+     */
+    public Bill applyAdmissionChargesToAdmission(PatientEncounter encounter, WebUser loggedUser, Department loggedDepartment) {
+        if (encounter == null || encounter.getId() == null) {
+            return null;
+        }
+        if (encounter.getAdmissionChargeBatchBill() != null) {
+            return null;
+        }
+
+        List<AdmissionChargeItem> resolved = resolveChargesForEncounter(encounter);
+        if (resolved.isEmpty()) {
+            return null;
+        }
+
+        List<BillEntry> entries = new ArrayList<>();
+        for (AdmissionChargeItem config : resolved) {
+            BillEntry entry = buildEntry(config, encounter);
+            if (entry != null) {
+                entries.add(entry);
+            }
+        }
+        if (entries.isEmpty()) {
+            return null;
+        }
+
+        InwardServiceBillRequest request = new InwardServiceBillRequest();
+        request.setBillEntries(entries);
+        request.setPatientEncounter(encounter);
+        request.setMatrixDepartment(feeDepartment(encounter));
+        request.setMarginPaymentMethod(encounter.getPaymentMethod());
+        request.setBillPaymentMethod(encounter.getPaymentMethod());
+        request.setPaymentScheme(encounter.getPaymentScheme());
+        request.setLoggedUser(loggedUser);
+        request.setLoggedDepartment(loggedDepartment);
+        request.setCreatingDepartment(loggedUser.getDepartment());
+        request.setBillCollector(new ArrayList<>());
+        // The price comes from the configuration, so it is neither marked up by
+        // the inward price matrix nor marked down by the inward discount matrix.
+        request.setApplyInwardMargin(false);
+
+        InwardServiceBillResult result = inwardServiceBillService.createServiceBills(request);
+
+        encounter.setAdmissionChargeBatchBill(result.getBatchBill());
+        patientEncounterFacade.edit(encounter);
+
+        return result.getBatchBill();
+    }
+
+    /**
+     * The charges that apply to this encounter, at most one row per configured
+     * item.
+     *
+     * <p>Admission type is the outer filter and payment method the inner one.
+     * Because step one is a filter rather than a preference, an
+     * admission-type-specific row set completely replaces the {@code null} set
+     * for that item - the configuration trap the management page warns about.</p>
+     */
+    public List<AdmissionChargeItem> resolveChargesForEncounter(PatientEncounter encounter) {
+        List<AdmissionChargeItem> resolved = new ArrayList<>();
+        if (encounter == null) {
+            return resolved;
+        }
+
+        List<AdmissionChargeItem> all = admissionChargeItemFacade.findByJpql(
+                "select a from AdmissionChargeItem a "
+                + " where a.retired = false "
+                + " and a.item is not null "
+                + " order by a.orderNo, a.id");
+        if (all == null || all.isEmpty()) {
+            return resolved;
+        }
+
+        Map<Item, List<AdmissionChargeItem>> byItem = new LinkedHashMap<>();
+        for (AdmissionChargeItem row : all) {
+            byItem.computeIfAbsent(row.getItem(), k -> new ArrayList<>()).add(row);
+        }
+
+        for (Map.Entry<Item, List<AdmissionChargeItem>> perItem : byItem.entrySet()) {
+            AdmissionChargeItem match = resolveForItem(perItem.getValue(), encounter);
+            if (match != null) {
+                resolved.add(match);
+            }
+        }
+        return resolved;
+    }
+
+    private AdmissionChargeItem resolveForItem(List<AdmissionChargeItem> rows, PatientEncounter encounter) {
+        List<AdmissionChargeItem> byType = new ArrayList<>();
+        if (encounter.getAdmissionType() != null) {
+            for (AdmissionChargeItem row : rows) {
+                if (encounter.getAdmissionType().equals(row.getAdmissionType())) {
+                    byType.add(row);
+                }
+            }
+        }
+        if (byType.isEmpty()) {
+            for (AdmissionChargeItem row : rows) {
+                if (row.getAdmissionType() == null) {
+                    byType.add(row);
+                }
+            }
+        }
+        if (byType.isEmpty()) {
+            return null;
+        }
+
+        List<AdmissionChargeItem> byPaymentMethod = new ArrayList<>();
+        PaymentMethod encounterPaymentMethod = encounter.getPaymentMethod();
+        if (encounterPaymentMethod != null) {
+            for (AdmissionChargeItem row : byType) {
+                if (encounterPaymentMethod == row.getPaymentMethod()) {
+                    byPaymentMethod.add(row);
+                }
+            }
+        }
+        if (byPaymentMethod.isEmpty()) {
+            // A null encounter payment method (older records) and any legacy value
+            // that is neither Cash nor Credit both fall through to the null row,
+            // which is the correct default.
+            for (AdmissionChargeItem row : byType) {
+                if (row.getPaymentMethod() == null) {
+                    byPaymentMethod.add(row);
+                }
+            }
+        }
+        if (byPaymentMethod.isEmpty()) {
+            return null;
+        }
+        return byPaymentMethod.get(0);
+    }
+
+    /**
+     * One entry carrying one BillItem and exactly one BillFee holding the
+     * configured price. The BillFee is not optional decoration: cancellation and
+     * refund both read fees rather than bill items, so an item with no fee would
+     * cancel and refund as zero.
+     *
+     * @return null when the configured item cannot produce a valid bill row
+     */
+    private BillEntry buildEntry(AdmissionChargeItem config, PatientEncounter encounter) {
+        Item item = config.getItem();
+
+        // putToBills() groups on item.getDepartment() and createBillFee() reads
+        // the item's institution, so both are required. A row that fails this is
+        // a configuration error the management page rejects; skip rather than
+        // fail the whole admission.
+        if (item.getDepartment() == null || item.getInstitution() == null) {
+            logger.log(Level.WARNING, "Automatic admission charge skipped: item {0} has no department or institution.", item.getName());
+            return null;
+        }
+
+        ItemFee fee = resolveFee(item);
+        if (fee == null) {
+            logger.log(Level.WARNING, "Automatic admission charge skipped: item {0} has no fee configured.", item.getName());
+            return null;
+        }
+
+        double qty = (config.getQty() != null && config.getQty() > 0) ? config.getQty() : 1.0;
+        double price = config.getPrice();
+
+        BillItem billItem = new BillItem();
+        billItem.setItem(item);
+        billItem.setQty(qty);
+        billItem.setRate(price);
+        // The existing signal that this price is fixed and must not be re-derived
+        // from the item's ItemFee rows.
+        billItem.setOverriddenRate(price);
+        billItem.setPatientEncounter(encounter);
+        billItem.setInwardChargeType(item.getInwardChargeType());
+
+        BillFee billFee = billBean.createBillFee(billItem, fee, encounter);
+        billFee.setFeeUnitGrossValue(price);
+        billFee.setFeeUnitValue(price);
+        billFee.setFeeGrossValue(price * qty);
+        billFee.setFeeValue(price * qty);
+        billFee.setFeeUnitMargin(0.0);
+        billFee.setFeeMargin(0.0);
+        billFee.setFeeUnitDiscount(0.0);
+        billFee.setFeeDiscount(0.0);
+        applyFeeVat(billFee, item);
+
+        List<BillFee> billFees = new ArrayList<>();
+        billFees.add(billFee);
+
+        BillEntry entry = new BillEntry();
+        entry.setBillItem(billItem);
+        entry.setLstBillFees(billFees);
+        entry.setLstBillComponents(billBean.billComponentsFromBillItem(billItem));
+        entry.setLstBillSessions(billBean.billSessionsfromBillItem(billItem));
+
+        return entry;
+    }
+
+    /**
+     * The ItemFee the single BillFee points at. {@code BillFee.fee} is a
+     * required relationship that downstream code dereferences unguarded (fee
+     * bucketing in the settle pipeline, {@code calculateBillItems}), so an item
+     * with no fee at all cannot be charged. A non-Staff fee is preferred:
+     * a routine hospital charge is not a professional fee, and Staff fees route
+     * into the professional-payment paths.
+     */
+    private ItemFee resolveFee(Item item) {
+        List<ItemFee> fees = itemFeeManager.fillFees(item);
+        if (fees == null || fees.isEmpty()) {
+            return null;
+        }
+        for (ItemFee f : fees) {
+            if (f.getFeeType() != FeeType.Staff) {
+                return f;
+            }
+        }
+        return fees.get(0);
+    }
+
+    /** Same VAT rule as {@code BillBhtController.recalculateFeeVat(BillFee)}. */
+    private void applyFeeVat(BillFee billFee, Item item) {
+        if (item.isVatable() && item.getVatPercentage() > 0) {
+            billFee.setFeeVat(Math.round(billFee.getFeeValue() * item.getVatPercentage() / 100 * 100.0) / 100.0);
+        } else {
+            billFee.setFeeVat(0.0);
+        }
+        billFee.setFeeVatPlusValue(billFee.getFeeValue() + billFee.getFeeVat());
+    }
+
+    /**
+     * Same rule as {@code BillBhtController.feeDepartment(PatientEncounter)}:
+     * the current room's facility-charge department when the patient is in a
+     * room, and the encounter's own department when there is none. The fallback
+     * is what lets these charges reach room-less Rapid / Temp A&amp;E admissions.
+     */
+    private Department feeDepartment(PatientEncounter encounter) {
+        if (encounter.getCurrentPatientRoom() != null
+                && encounter.getCurrentPatientRoom().getRoomFacilityCharge() != null) {
+            return encounter.getCurrentPatientRoom().getRoomFacilityCharge().getDepartment();
+        }
+        return encounter.getDepartment();
+    }
+}

--- a/src/main/java/com/divudi/service/inward/AdmissionChargeValidationException.java
+++ b/src/main/java/com/divudi/service/inward/AdmissionChargeValidationException.java
@@ -1,0 +1,23 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.service.inward;
+
+/**
+ * Raised when an {@code AdmissionChargeItem} payload breaks one of the rules
+ * enforced by {@link AdmissionChargeApiService} (issue #23594).
+ *
+ * <p>The message is written for the person configuring the charge, not for a
+ * log: the REST API returns it verbatim as the body of a 400 - one rule, one
+ * wording.</p>
+ *
+ * @author Buddhika
+ */
+public class AdmissionChargeValidationException extends Exception {
+
+    public AdmissionChargeValidationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/divudi/service/inward/InwardServiceBillRequest.java
+++ b/src/main/java/com/divudi/service/inward/InwardServiceBillRequest.java
@@ -1,0 +1,196 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.service.inward;
+
+import com.divudi.core.data.PaymentMethod;
+import com.divudi.core.entity.Bill;
+import com.divudi.core.entity.BillEntry;
+import com.divudi.core.entity.Department;
+import com.divudi.core.entity.PatientEncounter;
+import com.divudi.core.entity.PaymentScheme;
+import com.divudi.core.entity.Doctor;
+import com.divudi.core.entity.WebUser;
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Everything {@link InwardServiceBillService} needs to turn a list of
+ * {@link BillEntry} into inward service bills. Exists so the settle pipeline can
+ * be shared between the hand-driven <i>Add Services / Investigations to BHT</i>
+ * screen and the automatic admission charges (issue #23594) without either side
+ * reaching into the other's page state.
+ *
+ * @author Buddhika
+ */
+public class InwardServiceBillRequest implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /** The entries to bill. Each carries a BillItem and its BillFees. */
+    private List<BillEntry> billEntries;
+
+    private PatientEncounter patientEncounter;
+
+    /**
+     * The bill's {@code fromDepartment}, and the department the inward margin
+     * matrix is looked up against. Callers resolve it the way
+     * {@code BillBhtController.feeDepartment(PatientEncounter)} does.
+     */
+    private Department matrixDepartment;
+
+    /** Payment method used for the inward margin matrix lookup. */
+    private PaymentMethod marginPaymentMethod;
+
+    /**
+     * Payment method written onto the generated bills. Deliberately separate
+     * from {@link #marginPaymentMethod}: the hand-driven path nulls its own
+     * field before settling, and that behaviour is preserved.
+     */
+    private PaymentMethod billPaymentMethod;
+
+    private PaymentScheme paymentScheme;
+
+    private Doctor referredBy;
+
+    /**
+     * The surgery batch bill, when settling surgery services - passed straight
+     * to {@code BillBeanController.setSurgeryData(...)}, which returns
+     * immediately when it is null.
+     */
+    private Bill surgeryBatchBill;
+
+    private WebUser loggedUser;
+
+    /** {@code sessionController.getDepartment()} - drives bill numbering. */
+    private Department loggedDepartment;
+
+    /** {@code loggedUser.getDepartment()} - the bill's own department. */
+    private Department creatingDepartment;
+
+    /**
+     * The list the generated bills are appended to, and the list the batch bill
+     * is linked over.
+     *
+     * <p>This is a parameter rather than a fresh list because
+     * {@code BillBhtController.settleBillSurgery()} does not reset its
+     * {@code bills} field before settling, so the batch bill has always been
+     * linked over the controller's whole accumulated list. The hand-driven path
+     * passes {@code getBills()}; the automatic path passes a fresh list.</p>
+     */
+    private List<Bill> billCollector;
+
+    /**
+     * Whether to apply the inward price matrix to the generated fees. False for
+     * automatic admission charges, whose price comes from the configuration and
+     * must not be re-derived - which also suppresses the inward discount matrix,
+     * since {@code InwardBeanController.setBillFeeMargin(...)} applies both.
+     */
+    private boolean applyInwardMargin = true;
+
+    public List<BillEntry> getBillEntries() {
+        return billEntries;
+    }
+
+    public void setBillEntries(List<BillEntry> billEntries) {
+        this.billEntries = billEntries;
+    }
+
+    public PatientEncounter getPatientEncounter() {
+        return patientEncounter;
+    }
+
+    public void setPatientEncounter(PatientEncounter patientEncounter) {
+        this.patientEncounter = patientEncounter;
+    }
+
+    public Department getMatrixDepartment() {
+        return matrixDepartment;
+    }
+
+    public void setMatrixDepartment(Department matrixDepartment) {
+        this.matrixDepartment = matrixDepartment;
+    }
+
+    public PaymentMethod getMarginPaymentMethod() {
+        return marginPaymentMethod;
+    }
+
+    public void setMarginPaymentMethod(PaymentMethod marginPaymentMethod) {
+        this.marginPaymentMethod = marginPaymentMethod;
+    }
+
+    public PaymentMethod getBillPaymentMethod() {
+        return billPaymentMethod;
+    }
+
+    public void setBillPaymentMethod(PaymentMethod billPaymentMethod) {
+        this.billPaymentMethod = billPaymentMethod;
+    }
+
+    public PaymentScheme getPaymentScheme() {
+        return paymentScheme;
+    }
+
+    public void setPaymentScheme(PaymentScheme paymentScheme) {
+        this.paymentScheme = paymentScheme;
+    }
+
+    public Doctor getReferredBy() {
+        return referredBy;
+    }
+
+    public void setReferredBy(Doctor referredBy) {
+        this.referredBy = referredBy;
+    }
+
+    public Bill getSurgeryBatchBill() {
+        return surgeryBatchBill;
+    }
+
+    public void setSurgeryBatchBill(Bill surgeryBatchBill) {
+        this.surgeryBatchBill = surgeryBatchBill;
+    }
+
+    public WebUser getLoggedUser() {
+        return loggedUser;
+    }
+
+    public void setLoggedUser(WebUser loggedUser) {
+        this.loggedUser = loggedUser;
+    }
+
+    public Department getLoggedDepartment() {
+        return loggedDepartment;
+    }
+
+    public void setLoggedDepartment(Department loggedDepartment) {
+        this.loggedDepartment = loggedDepartment;
+    }
+
+    public Department getCreatingDepartment() {
+        return creatingDepartment;
+    }
+
+    public void setCreatingDepartment(Department creatingDepartment) {
+        this.creatingDepartment = creatingDepartment;
+    }
+
+    public List<Bill> getBillCollector() {
+        return billCollector;
+    }
+
+    public void setBillCollector(List<Bill> billCollector) {
+        this.billCollector = billCollector;
+    }
+
+    public boolean isApplyInwardMargin() {
+        return applyInwardMargin;
+    }
+
+    public void setApplyInwardMargin(boolean applyInwardMargin) {
+        this.applyInwardMargin = applyInwardMargin;
+    }
+}

--- a/src/main/java/com/divudi/service/inward/InwardServiceBillRequest.java
+++ b/src/main/java/com/divudi/service/inward/InwardServiceBillRequest.java
@@ -79,6 +79,12 @@ public class InwardServiceBillRequest implements Serializable {
      * {@code bills} field before settling, so the batch bill has always been
      * linked over the controller's whole accumulated list. The hand-driven path
      * passes {@code getBills()}; the automatic path passes a fresh list.</p>
+     *
+     * <p>Bills are appended <b>as they are created</b>, not once the whole run
+     * succeeds. The facades are stateless, so each bill is already committed by
+     * the time the next one is built - a caller that needs to compensate for a
+     * half-finished run reads this list to find what actually reached the
+     * database.</p>
      */
     private List<Bill> billCollector;
 

--- a/src/main/java/com/divudi/service/inward/InwardServiceBillResult.java
+++ b/src/main/java/com/divudi/service/inward/InwardServiceBillResult.java
@@ -1,0 +1,43 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.service.inward;
+
+import com.divudi.core.entity.Bill;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * What {@link InwardServiceBillService} produced: the individual inward service
+ * bills created by this call, and the batch bill they were linked under.
+ *
+ * @author Buddhika
+ */
+public class InwardServiceBillResult implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /** Only the bills created by this call, not the whole collector. */
+    private List<Bill> bills = new ArrayList<>();
+
+    private Bill batchBill;
+
+    public List<Bill> getBills() {
+        return bills;
+    }
+
+    public void setBills(List<Bill> bills) {
+        this.bills = bills;
+    }
+
+    public Bill getBatchBill() {
+        return batchBill;
+    }
+
+    public void setBatchBill(Bill batchBill) {
+        this.batchBill = batchBill;
+    }
+}

--- a/src/main/java/com/divudi/service/inward/InwardServiceBillService.java
+++ b/src/main/java/com/divudi/service/inward/InwardServiceBillService.java
@@ -113,6 +113,11 @@ public class InwardServiceBillService implements Serializable {
         if (billBean.calculateNumberOfBillsPerOrder(request.getBillEntries()) == 1) {
             BilledBill temp = new BilledBill();
             Bill b = saveBill(request.getBillEntries().get(0).getBillItem().getItem().getDepartment(), temp, request);
+            // Collected the moment it exists, not at the end: these facades are
+            // stateless, so the row is already committed and a later failure has
+            // to be able to find it in order to retire it.
+            created.add(b);
+            request.getBillCollector().add(b);
             applyItemRequestReference(b, request.getBillEntries());
 
             List<BillItem> list = saveBillItems(b, request.getBillEntries(), request.getLoggedUser(), request);
@@ -131,12 +136,9 @@ public class InwardServiceBillService implements Serializable {
 
             billFacade.edit(b);
             billBean.calculateBillItems(b, request.getBillEntries());
-            created.add(b);
         } else {
             created.addAll(putToBills(request));
         }
-
-        request.getBillCollector().addAll(created);
 
         result.setBills(created);
         result.setBatchBill(saveBatchBill(request));
@@ -157,6 +159,9 @@ public class InwardServiceBillService implements Serializable {
         for (Department d : billDepts) {
             BilledBill myBill = new BilledBill();
             saveBill(d, myBill, request);
+            // See createServiceBills: collect on creation so a partial run is recoverable.
+            created.add(myBill);
+            request.getBillCollector().add(myBill);
             List<BillEntry> tmp = new ArrayList<>();
             for (BillEntry e : request.getBillEntries()) {
                 if (e.getBillItem().getItem().getDepartment().equals(d)) {
@@ -170,7 +175,6 @@ public class InwardServiceBillService implements Serializable {
             }
             billBean.calculateBillItems(myBill, tmp);
             myBill.setBillItems(tmpBis);
-            created.add(myBill);
         }
 
         return created;

--- a/src/main/java/com/divudi/service/inward/InwardServiceBillService.java
+++ b/src/main/java/com/divudi/service/inward/InwardServiceBillService.java
@@ -1,0 +1,410 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.service.inward;
+
+import com.divudi.bean.common.BillBeanController;
+import com.divudi.bean.common.ConfigOptionApplicationController;
+import com.divudi.bean.common.PriceMatrixController;
+import com.divudi.bean.inward.InwardBeanController;
+import com.divudi.core.data.BillClassType;
+import com.divudi.core.data.BillNumberSuffix;
+import com.divudi.core.data.BillType;
+import com.divudi.core.data.BillTypeAtomic;
+import com.divudi.core.data.FeeType;
+import com.divudi.core.data.inward.SurgeryBillType;
+import com.divudi.core.data.lab.Priority;
+import com.divudi.core.entity.Bill;
+import com.divudi.core.entity.BillEntry;
+import com.divudi.core.entity.BillFee;
+import com.divudi.core.entity.BillItem;
+import com.divudi.core.entity.BilledBill;
+import com.divudi.core.entity.Department;
+import com.divudi.core.entity.PatientEncounter;
+import com.divudi.core.entity.PriceMatrix;
+import com.divudi.core.entity.WebUser;
+import com.divudi.core.entity.inward.RoomCategory;
+import com.divudi.core.facade.BillFacade;
+import com.divudi.core.facade.BillFeeFacade;
+import com.divudi.core.facade.BillItemFacade;
+import com.divudi.ejb.BillNumberGenerator;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import javax.ejb.EJB;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+/**
+ * Turns a list of {@link BillEntry} into inward service bills, bundled by
+ * department and linked under one {@code INWARD_SERVICE_BATCH_BILL}.
+ *
+ * <p>This is the <i>Add Services / Investigations to BHT</i> settle pipeline,
+ * lifted out of {@code BillBhtController} so the automatic admission charges
+ * (issue #23594) run the very same process rather than a lookalike beside it.
+ * Anything that produces bills a different way - one BillItem with no BillFee,
+ * or a bill with no batch bill - cancels and refunds as zero, because both of
+ * those paths read BillFees rather than BillItems.</p>
+ *
+ * <p>Two behaviours of the original are preserved deliberately, because
+ * {@code BillBhtController.settleBillSurgery()} depends on them:</p>
+ * <ul>
+ * <li>the batch bill is linked over the caller's whole
+ * {@link InwardServiceBillRequest#getBillCollector() collector} list, not just
+ * the bills this call created, because {@code settleBillSurgery()} never resets
+ * that list before settling;</li>
+ * <li>the batch bill is returned but must not become the caller's
+ * {@code batchBill} field. The original {@code saveBatchBill()} kept its bill
+ * local, so the surgery path's later {@code saveEncounterComponents(...)} and
+ * {@code updateBatchBill(...)} calls still operate on the <i>surgery</i> bill.</li>
+ * </ul>
+ *
+ * <p>Known wrinkle preserved as-is: {@code calculateNumberOfBillsPerOrder()}
+ * counts distinct {@code item.getTransDepartment()} while {@link #putToBills}
+ * groups by {@code item.getDepartment()}. Where those differ, the count and the
+ * grouping disagree. Changing it would silently alter how existing hand-added
+ * service bills are split.</p>
+ *
+ * @author Buddhika
+ */
+@Named
+@ApplicationScoped
+public class InwardServiceBillService implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Inject
+    private BillBeanController billBean;
+    @Inject
+    private InwardBeanController inwardBean;
+    @Inject
+    private PriceMatrixController priceMatrixController;
+    @Inject
+    private ConfigOptionApplicationController configOptionApplicationController;
+
+    @EJB
+    private BillFacade billFacade;
+    @EJB
+    private BillItemFacade billItemFacade;
+    @EJB
+    private BillFeeFacade billFeeFacade;
+    @EJB
+    private BillNumberGenerator billNumberBean;
+
+    /**
+     * Creates the inward service bills for the given entries and links them
+     * under a new batch bill.
+     *
+     * @return the bills created by this call and the batch bill they sit under
+     */
+    public InwardServiceBillResult createServiceBills(InwardServiceBillRequest request) {
+        InwardServiceBillResult result = new InwardServiceBillResult();
+        List<Bill> created = new ArrayList<>();
+
+        if (billBean.calculateNumberOfBillsPerOrder(request.getBillEntries()) == 1) {
+            BilledBill temp = new BilledBill();
+            Bill b = saveBill(request.getBillEntries().get(0).getBillItem().getItem().getDepartment(), temp, request);
+            applyItemRequestReference(b, request.getBillEntries());
+
+            List<BillItem> list = saveBillItems(b, request.getBillEntries(), request.getLoggedUser(), request);
+            b.setBillItems(list);
+
+            Priority highestPriority = Optional
+                    .ofNullable(list)
+                    .orElse(Collections.emptyList())
+                    .stream()
+                    .filter(bi -> bi.getPriority() != null)
+                    .map(BillItem::getPriority)
+                    .max(Comparator.comparingInt(Priority::getLevel))
+                    .orElse(Priority.NORMAL);
+
+            b.setPriority(highestPriority);
+
+            billFacade.edit(b);
+            billBean.calculateBillItems(b, request.getBillEntries());
+            created.add(b);
+        } else {
+            created.addAll(putToBills(request));
+        }
+
+        request.getBillCollector().addAll(created);
+
+        result.setBills(created);
+        result.setBatchBill(saveBatchBill(request));
+        return result;
+    }
+
+    /**
+     * One bill per distinct {@code item.getDepartment()}, each carrying only
+     * that department's entries.
+     */
+    private List<Bill> putToBills(InwardServiceBillRequest request) {
+        List<Bill> created = new ArrayList<>();
+
+        Set<Department> billDepts = new HashSet<>();
+        for (BillEntry e : request.getBillEntries()) {
+            billDepts.add(e.getBillItem().getItem().getDepartment());
+        }
+        for (Department d : billDepts) {
+            BilledBill myBill = new BilledBill();
+            saveBill(d, myBill, request);
+            List<BillEntry> tmp = new ArrayList<>();
+            for (BillEntry e : request.getBillEntries()) {
+                if (e.getBillItem().getItem().getDepartment().equals(d)) {
+                    tmp.add(e);
+                }
+            }
+            applyItemRequestReference(myBill, tmp);
+            List<BillItem> tmpBis = saveBillItems(myBill, tmp, request.getLoggedUser(), request);
+            for (int i = 0; i < tmpBis.size(); i++) {
+                tmpBis.get(i).setSearialNo(i);
+            }
+            billBean.calculateBillItems(myBill, tmp);
+            myBill.setBillItems(tmpBis);
+            created.add(myBill);
+        }
+
+        return created;
+    }
+
+    /**
+     * If any of the entries being saved onto this bill originated from an
+     * Item/Service Request line (issue #21793 redesign), set the bill's
+     * referenceBill so the request stays traceable to the bill it produced.
+     */
+    private void applyItemRequestReference(Bill bill, List<BillEntry> entries) {
+        for (BillEntry e : entries) {
+            if (e.getSourceRequestBillItem() != null && e.getSourceRequestBillItem().getBill() != null) {
+                bill.setReferenceBill(e.getSourceRequestBillItem().getBill());
+                return;
+            }
+        }
+    }
+
+    /**
+     * The room category of the patient's current room, or null when the patient
+     * is not yet in a room (or the room has no facility charge / category). Used
+     * as the room-category dimension of the inward service-margin matrix lookup
+     * (issue #21977); null means "wildcard row only", preserving legacy behaviour.
+     */
+    private RoomCategory resolveCurrentRoomCategory(PatientEncounter encounter) {
+        if (encounter == null
+                || encounter.getCurrentPatientRoom() == null
+                || encounter.getCurrentPatientRoom().getRoomFacilityCharge() == null) {
+            return null;
+        }
+        return encounter.getCurrentPatientRoom().getRoomFacilityCharge().getRoomCategory();
+    }
+
+    /**
+     * Persists one BillItem and its BillFees onto the bill. Sets
+     * {@code inwardChargeType} from the item when it is null - that is what
+     * gives the interim bill its per-charge-type breakdown.
+     */
+    private BillItem saveBillItem(Bill bill, BillItem billItem, BillEntry billEntry, List<BillFee> billFees, WebUser wu) {
+
+        billItem.setCreatedAt(new Date());
+        billItem.setCreater(wu);
+        billItem.setBill(bill);
+
+        if (billItem.getInwardChargeType() == null && billItem.getItem() != null
+                && billItem.getItem().getInwardChargeType() != null) {
+            billItem.setInwardChargeType(billItem.getItem().getInwardChargeType());
+        }
+
+        if (billEntry != null && billEntry.getSourceRequestBillItem() != null) {
+            billItem.setReferanceBillItem(billEntry.getSourceRequestBillItem());
+        }
+
+        if (billItem.getId() == null) {
+            billItemFacade.create(billItem);
+        }
+
+        billBean.saveBillComponent(billEntry, bill, wu);
+
+        for (BillFee bf : billFees) {
+            inwardBean.saveBillFee(bf, billItem, bill, wu);
+            billItem.getBillFees().add(bf);
+        }
+
+        billBean.updateBillItemByBillFee(billItem);
+
+        return billItem;
+    }
+
+    private List<BillItem> saveBillItems(Bill bill, List<BillEntry> billEntries, WebUser webUser, InwardServiceBillRequest request) {
+        List<BillItem> list = new ArrayList<>();
+        for (BillEntry e : billEntries) {
+            double staffFee = 0.0;
+            double collectingCentreFee = 0.0;
+            double hospitalFee = 0.0;
+            double reagentFee = 0.0;
+            double otherFee = 0.0;
+            double marginFee = 0.0;
+
+            BillItem billItem = saveBillItem(bill, e.getBillItem(), e, e.getLstBillFees(), webUser);
+            billItem.setSearialNo(list.size());
+
+            for (BillFee bf : billItem.getBillFees()) {
+                // Automatic admission charges carry their price in the configuration,
+                // so no inward margin is applied - and therefore no inward discount
+                // matrix either, since setBillFeeMargin(...) applies both. The billed
+                // amount is exactly the configured price. (Issue #23594)
+                if (request.isApplyInwardMargin()) {
+                    PriceMatrix priceMatrix = priceMatrixController.fetchInwardMargin(billItem, bf.getFeeUnitGrossValue() != null ? bf.getFeeUnitGrossValue() : bf.getFeeGrossValue(), request.getMatrixDepartment(), request.getMarginPaymentMethod(), null, bill.getPatientEncounter() != null ? bill.getPatientEncounter().getAdmissionType() : null, resolveCurrentRoomCategory(bill.getPatientEncounter()));
+                    inwardBean.setBillFeeMargin(bf, bf.getBillItem().getItem(), priceMatrix, bill.getPatientEncounter());
+                    billFeeFacade.edit(bf);
+                }
+
+                if (bf.getFee().getFeeType() == FeeType.CollectingCentre) {
+                    collectingCentreFee += bf.getFeeValue();
+                } else if (bf.getFee().getFeeType() == FeeType.Staff) {
+                    staffFee += bf.getFeeValue();
+                } else if (bf.getFee().getFeeType() == FeeType.Chemical) {
+                    reagentFee += bf.getFeeValue();
+                } else if (bf.getFee().getFeeType() == FeeType.Additional) {
+                    otherFee += bf.getFeeValue();
+                } else {
+                    hospitalFee += bf.getFeeValue();
+                }
+
+                marginFee += bf.getFeeMargin();
+            }
+
+            billItem.setHospitalFee(hospitalFee);
+            billItem.setCollectingCentreFee(collectingCentreFee);
+            billItem.setReagentFee(reagentFee);
+            billItem.setOtherFee(otherFee);
+            billItem.setStaffFee(staffFee);
+            billItem.setMarginValue(marginFee);
+
+            billItemFacade.editAndCommit(billItem);
+
+            list.add(billItem);
+
+        }
+
+        billBean.updateBillByBillFee(bill);
+
+        return list;
+    }
+
+    private Bill saveBill(Department bt, BilledBill temp, InwardServiceBillRequest request) {
+        Date now = new Date();
+        temp.setBillType(BillType.InwardBill);
+        temp.setBillTypeAtomic(BillTypeAtomic.INWARD_SERVICE_BILL);
+        temp.setIpOpOrCc("IP");
+        billBean.setSurgeryData(temp, request.getSurgeryBatchBill(), SurgeryBillType.Service);
+
+        temp.setDepartment(request.getCreatingDepartment());
+        temp.setInstitution(request.getCreatingDepartment().getInstitution());
+        temp.setPatient(request.getPatientEncounter().getPatient());
+        temp.setFromDepartment(request.getMatrixDepartment());
+
+        temp.setToDepartment(bt);
+        temp.setToInstitution(bt.getInstitution());
+
+        temp.setPatientEncounter(request.getPatientEncounter());
+        temp.setPaymentScheme(request.getPaymentScheme());
+        temp.setPaymentMethod(request.getBillPaymentMethod());
+        temp.setReferredBy(request.getReferredBy());
+        temp.setCreatedAt(now);
+        temp.setBillDate(now);
+        temp.setBillTime(now);
+        temp.setCreater(request.getLoggedUser());
+
+        boolean inpatientServiceBillNumberGenerateStrategyForFromDepartmentAndToDepartmentCombination
+                = configOptionApplicationController.getBooleanValueByKey(
+                        "InpatientServiceBillNumberGenerateStrategy:FromDepartmentToDepartmentBillTypes", false);
+
+        boolean inpatientServiceBillNumberGenerateStrategySingleNumberForOpdAndInpatientInvestigationsAndServices
+                = configOptionApplicationController.getBooleanValueByKey("OPD Bill Number Generation Strategy - Single Number for OPD and Inpatient Investigations and Services", false);
+
+        boolean inpatientServiceBillNumberGenerateStrategyDefault
+                = configOptionApplicationController.getBooleanValueByKey(
+                        "InpatientServiceBillNumberGenerateStrategy:Default", false);
+
+        String deptId;
+        String insId;
+
+        if (inpatientServiceBillNumberGenerateStrategyForFromDepartmentAndToDepartmentCombination) {
+            deptId = billNumberBean.departmentBillNumberGeneratorYearlyByFromDepartmentAndToDepartment(
+                    bt, request.getLoggedDepartment(), BillTypeAtomic.INWARD_SERVICE_BILL);
+            insId = deptId;
+        } else if (inpatientServiceBillNumberGenerateStrategySingleNumberForOpdAndInpatientInvestigationsAndServices) {
+            List<BillTypeAtomic> opdAndInpatientBills = BillTypeAtomic.findOpdAndInpatientServiceAndInvestigationIndividualBillTypes();
+            deptId = billNumberBean.departmentBillNumberGeneratorYearly(request.getLoggedDepartment(), opdAndInpatientBills);
+            insId = deptId;
+        } else if (inpatientServiceBillNumberGenerateStrategyDefault) {
+            deptId = billNumberBean.departmentBillNumberGeneratorYearly(bt, BillTypeAtomic.INWARD_SERVICE_BILL);
+            insId = deptId;
+        } else {
+            deptId = billNumberBean.departmentBillNumberGenerator(temp.getDepartment(), temp.getToDepartment(), temp.getBillType(), BillClassType.BilledBill);
+            insId = billNumberBean.institutionBillNumberGenerator(temp.getInstitution(), temp.getToDepartment(), temp.getBillType(), BillClassType.BilledBill, BillNumberSuffix.INWSER);
+        }
+
+        temp.setDeptId(deptId);
+        temp.setInsId(insId);
+
+        if (temp.getId() == null) {
+            billFacade.create(temp);
+        } else {
+            billFacade.edit(temp);
+        }
+
+        return temp;
+
+    }
+
+    /**
+     * Creates the INWARD_SERVICE_BATCH_BILL and links it both ways to every bill
+     * in the caller's collector. Without it the batch-cancellation path
+     * (INWARD_SERVICE_BILL_CANCELLATION_DURING_BATCH_BILL_CANCELLATION) has
+     * nothing to work from, which is why this step is not optional.
+     */
+    private Bill saveBatchBill(InwardServiceBillRequest request) {
+        Bill tmp = new BilledBill();
+        tmp.setCreatedAt(new Date());
+        tmp.setCreater(request.getLoggedUser());
+        tmp.setBillTypeAtomic(BillTypeAtomic.INWARD_SERVICE_BATCH_BILL);
+        tmp.setPatient(request.getPatientEncounter().getPatient());
+        boolean opdBillNumberGenerateStrategySingleNumberForOpdAndInpatientInvestigationsAndServices = configOptionApplicationController.getBooleanValueByKey("OpdBillNumberGenerateStrategy:SingleNumberForOpdAndInpatientInvestigationsAndServices", false);
+        String batchBillId;
+
+        if (opdBillNumberGenerateStrategySingleNumberForOpdAndInpatientInvestigationsAndServices) {
+            List<BillTypeAtomic> opdAndInpatientBills = BillTypeAtomic.findOpdAndInpatientServiceAndInvestigationBatchBillTypes();
+            batchBillId = billNumberBean.departmentBatchBillNumberGeneratorYearlyForInpatientAndOpdServices(request.getLoggedDepartment(), opdAndInpatientBills);
+        } else {
+            batchBillId = billNumberBean.departmentBillNumberGeneratorYearly(request.getLoggedDepartment(), BillTypeAtomic.INWARD_SERVICE_BATCH_BILL);
+        }
+
+        tmp.setDeptId(batchBillId);
+        tmp.setInsId(batchBillId);
+
+        if (tmp.getId() == null) {
+            billFacade.create(tmp);
+        }
+
+        for (Bill b : request.getBillCollector()) {
+            b.setBackwardReferenceBill(tmp);
+            billFacade.edit(b);
+        }
+
+        for (Bill b : request.getBillCollector()) {
+            tmp.getForwardReferenceBills().add(b);
+        }
+
+        billFacade.edit(tmp);
+
+        return tmp;
+    }
+}

--- a/src/main/java/com/divudi/ws/common/ApplicationConfig.java
+++ b/src/main/java/com/divudi/ws/common/ApplicationConfig.java
@@ -68,6 +68,7 @@ public class ApplicationConfig extends Application {
         resources.add(com.divudi.ws.investigation.InvestigationFullApi.class);
         resources.add(com.divudi.ws.investigation.InvestigationValidatorApi.class);
         resources.add(com.divudi.ws.investigation.ReportFormatApi.class);
+        resources.add(com.divudi.ws.inward.AdmissionChargeApi.class);
         resources.add(com.divudi.ws.inward.AdmissionNumberApi.class);
         resources.add(com.divudi.ws.inward.AdmissionSearchApi.class);
         resources.add(com.divudi.ws.inward.ApiInward.class);

--- a/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
+++ b/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
@@ -146,6 +146,27 @@ public class CapabilityStatementResource {
                         "Inward patient workflows",
                         "API Key",
                         "GET", "POST"))
+                .add(resource("Admission Charges", "/api/admission-charges",
+                        "Manage AdmissionChargeItem rows — routine charges billed automatically on every "
+                        + "matching admission by AdmissionChargeApplicationBean. Resolution is two-dimensional: "
+                        + "admissionType is the outer filter, paymentMethod (Cash|Credit only; null means both) "
+                        + "the inner one, and null in either column means \"applies to all\" for that dimension. "
+                        + "Because admissionType is a filter rather than a preference, configuring an "
+                        + "admission-type-specific row set for an item completely replaces the null-type rows "
+                        + "for that item — omitting one paymentMethod row for that admission type leaves it with "
+                        + "no charge at all. Only one live row is allowed per (item, admissionType, paymentMethod) "
+                        + "triple. The item must carry a department, an institution, an inwardChargeType, and at "
+                        + "least one live ItemFee. "
+                        + "GET /search filters on itemId, admissionTypeId, paymentMethod, includeRetired, and "
+                        + "pages with limit + offset, returning {items, total, limit, offset}. GET /{id} reads "
+                        + "one row. POST creates; PUT /{id} updates (clearAdmissionType/clearPaymentMethod flags "
+                        + "reset either dimension back to null). DELETE /{id} soft-retires; PATCH /{id}/restore "
+                        + "undoes it (rejected if a live row now conflicts). "
+                        + "Note: AdmissionType.admissionFee is a separate, older mechanism already added to the "
+                        + "bill by InwardBhtChargeAggregationService — configuring both for the same admission "
+                        + "type double-charges it.",
+                        "API Key (Finance header)",
+                        "GET", "POST", "PUT", "PATCH", "DELETE"))
                 .add(resource("Admission Number Counters", "/api/admission-numbers",
                         "View or reset the BHT/OPD-card admission-number sequence counter for an admission type.",
                         "API Key (Finance header)", "GET", "PUT"))

--- a/src/main/java/com/divudi/ws/inward/AdmissionChargeApi.java
+++ b/src/main/java/com/divudi/ws/inward/AdmissionChargeApi.java
@@ -1,0 +1,377 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.ws.inward;
+
+import com.divudi.bean.common.ApiKeyController;
+import com.divudi.core.data.dto.admissioncharge.AdmissionChargeItemCreateRequestDTO;
+import com.divudi.core.data.dto.admissioncharge.AdmissionChargeItemDTO;
+import com.divudi.core.data.dto.admissioncharge.AdmissionChargeItemPageDTO;
+import com.divudi.core.data.dto.admissioncharge.AdmissionChargeItemUpdateRequestDTO;
+import com.divudi.core.entity.ApiKey;
+import com.divudi.core.entity.WebUser;
+import com.divudi.service.inward.AdmissionChargeApiService;
+import com.divudi.service.inward.AdmissionChargeValidationException;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * REST API for Admission Charge Item management (issue #23594).
+ *
+ * <p>Manages {@code AdmissionChargeItem} rows - the routine charges billed
+ * automatically on every matching admission by
+ * {@code AdmissionChargeApplicationBean}. See
+ * {@code developer_docs/api/using-apis/API_ADMISSION_CHARGES.md} for the
+ * two-dimension resolution rule, the configuration trap, and the
+ * double-charge trap with {@code AdmissionType.admissionFee}.
+ *
+ * <p>Authentication: Finance header with a valid API key.
+ *
+ * @author Buddhika
+ */
+@Path("admission-charges")
+@RequestScoped
+public class AdmissionChargeApi {
+
+    @Context
+    private HttpServletRequest requestContext;
+
+    @Context
+    private UriInfo uriInfo;
+
+    @Inject
+    private ApiKeyController apiKeyController;
+
+    @Inject
+    private AdmissionChargeApiService admissionChargeApiService;
+
+    private static final Gson gson = new GsonBuilder()
+            .setDateFormat("yyyy-MM-dd HH:mm:ss")
+            .create();
+
+    public AdmissionChargeApi() {
+    }
+
+    // =========================================================================
+    // Search / Get
+    // =========================================================================
+
+    /**
+     * Search admission charge items.
+     * GET /api/admission-charges/search?itemId=&admissionTypeId=&paymentMethod=&includeRetired=&limit=&offset=
+     */
+    @GET
+    @Path("/search")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response search() {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            Long itemId;
+            Long admissionTypeId;
+            try {
+                itemId = parseLongParam("itemId");
+                admissionTypeId = parseLongParam("admissionTypeId");
+            } catch (NumberFormatException e) {
+                return errorResponse(e.getMessage(), 400);
+            }
+            String paymentMethod = uriInfo.getQueryParameters().getFirst("paymentMethod");
+
+            Boolean includeRetired = parseBooleanParam("includeRetired");
+            if (includeRetired == null) {
+                return errorResponse("Invalid includeRetired value. Use true or false.", 400);
+            }
+
+            int limit = 30;
+            String limitStr = uriInfo.getQueryParameters().getFirst("limit");
+            if (limitStr != null && !limitStr.trim().isEmpty()) {
+                try {
+                    limit = Math.min(Math.max(Integer.parseInt(limitStr.trim()), 1), 100);
+                } catch (NumberFormatException e) {
+                    return errorResponse("Invalid limit format", 400);
+                }
+            }
+
+            int offset = 0;
+            String offsetStr = uriInfo.getQueryParameters().getFirst("offset");
+            if (offsetStr != null && !offsetStr.trim().isEmpty()) {
+                try {
+                    offset = Math.max(Integer.parseInt(offsetStr.trim()), 0);
+                } catch (NumberFormatException e) {
+                    return errorResponse("Invalid offset format", 400);
+                }
+            }
+
+            AdmissionChargeItemPageDTO result = admissionChargeApiService.search(
+                    itemId, admissionTypeId, paymentMethod, includeRetired, limit, offset);
+            return successResponse(result);
+
+        } catch (Exception e) {
+            return mapError(e);
+        }
+    }
+
+    /**
+     * Get an admission charge item by ID.
+     * GET /api/admission-charges/{id}?includeRetired=
+     */
+    @GET
+    @Path("/{id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getById(@PathParam("id") Long id) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            Boolean includeRetired = parseBooleanParam("includeRetired");
+            if (includeRetired == null) {
+                return errorResponse("Invalid includeRetired value. Use true or false.", 400);
+            }
+
+            AdmissionChargeItemDTO result = admissionChargeApiService.findById(id, includeRetired);
+            return successResponse(result);
+
+        } catch (Exception e) {
+            return mapError(e);
+        }
+    }
+
+    // =========================================================================
+    // Create / Update
+    // =========================================================================
+
+    /**
+     * Create a new admission charge item.
+     * POST /api/admission-charges
+     */
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response create(String requestBody) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            AdmissionChargeItemCreateRequestDTO request;
+            try {
+                request = gson.fromJson(requestBody, AdmissionChargeItemCreateRequestDTO.class);
+            } catch (JsonSyntaxException e) {
+                return errorResponse("Invalid JSON format: " + e.getMessage(), 400);
+            }
+            if (request == null) {
+                return errorResponse("Request body is required", 400);
+            }
+
+            AdmissionChargeItemDTO response = admissionChargeApiService.create(request, user);
+            return successResponse(201, response);
+
+        } catch (Exception e) {
+            return mapError(e);
+        }
+    }
+
+    /**
+     * Update an existing admission charge item.
+     * PUT /api/admission-charges/{id}
+     */
+    @PUT
+    @Path("/{id}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response update(@PathParam("id") Long id, String requestBody) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            AdmissionChargeItemUpdateRequestDTO request;
+            try {
+                request = gson.fromJson(requestBody, AdmissionChargeItemUpdateRequestDTO.class);
+            } catch (JsonSyntaxException e) {
+                return errorResponse("Invalid JSON format: " + e.getMessage(), 400);
+            }
+            if (request == null) {
+                return errorResponse("Request body is required", 400);
+            }
+
+            AdmissionChargeItemDTO response = admissionChargeApiService.update(id, request, user);
+            return successResponse(response);
+
+        } catch (Exception e) {
+            return mapError(e);
+        }
+    }
+
+    // =========================================================================
+    // Retire / Restore
+    // =========================================================================
+
+    /**
+     * Retire an admission charge item (soft delete).
+     * DELETE /api/admission-charges/{id}?retireComments=reason
+     */
+    @DELETE
+    @Path("/{id}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response retire(@PathParam("id") Long id) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            String retireComments = uriInfo.getQueryParameters().getFirst("retireComments");
+            AdmissionChargeItemDTO response = admissionChargeApiService.retire(id, retireComments, user);
+            return successResponse(response);
+
+        } catch (Exception e) {
+            return mapError(e);
+        }
+    }
+
+    /**
+     * Un-retire an admission charge item, undoing DELETE /api/admission-charges/{id}.
+     * PATCH /api/admission-charges/{id}/restore
+     */
+    @PATCH
+    @Path("/{id}/restore")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response restore(@PathParam("id") Long id) {
+        try {
+            WebUser user = validateApiKey(requestContext.getHeader("Finance"));
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            AdmissionChargeItemDTO response = admissionChargeApiService.restore(id, user);
+            return successResponse(response);
+
+        } catch (Exception e) {
+            return mapError(e);
+        }
+    }
+
+    // =========================================================================
+    // Private helpers
+    // =========================================================================
+
+    /**
+     * Maps a service-layer exception onto an HTTP status. A broken validation
+     * rule is always the caller's payload, never a server fault - checked by
+     * type so the status does not depend on how the message happens to be
+     * worded.
+     */
+    private Response mapError(Exception e) {
+        String msg = e.getMessage();
+        if (e instanceof AdmissionChargeValidationException) {
+            return errorResponse(msg, 400);
+        }
+        if (msg == null) {
+            return errorResponse("An error occurred: Unknown error", 500);
+        }
+        if (msg.contains("not found")) {
+            return errorResponse(msg, 404);
+        }
+        if (msg.contains("is retired")) {
+            return errorResponse(msg + " — use ?includeRetired=true to read it, "
+                    + "or PATCH the restore endpoint to bring it back.", 404);
+        }
+        if (msg.contains("is not retired")) {
+            return errorResponse(msg, 409);
+        }
+        return errorResponse("An error occurred: " + msg, 500);
+    }
+
+    /**
+     * @return the flag, or null when the caller sent something that is neither true nor
+     *         false - silently treating a typo as false would hide retired rows the
+     *         caller explicitly asked for
+     */
+    private Boolean parseBooleanParam(String name) {
+        String raw = uriInfo.getQueryParameters().getFirst(name);
+        if (raw == null || raw.trim().isEmpty()) {
+            return Boolean.FALSE;
+        }
+        String v = raw.trim().toLowerCase();
+        if ("true".equals(v)) {
+            return Boolean.TRUE;
+        }
+        if ("false".equals(v)) {
+            return Boolean.FALSE;
+        }
+        return null;
+    }
+
+    private Long parseLongParam(String name) {
+        String raw = uriInfo.getQueryParameters().getFirst(name);
+        if (raw == null || raw.trim().isEmpty()) {
+            return null;
+        }
+        try {
+            return Long.parseLong(raw.trim());
+        } catch (NumberFormatException e) {
+            throw new NumberFormatException("Invalid " + name + " format");
+        }
+    }
+
+    private WebUser validateApiKey(String key) {
+        if (key == null || key.trim().isEmpty()) {
+            return null;
+        }
+        ApiKey apiKey = apiKeyController.findApiKey(key);
+        if (apiKey == null) {
+            return null;
+        }
+        WebUser user = apiKey.getWebUser();
+        if (user == null || user.isRetired() || !user.isActivated()) {
+            return null;
+        }
+        if (apiKey.getDateOfExpiary() == null || apiKey.getDateOfExpiary().before(new Date())) {
+            return null;
+        }
+        return user;
+    }
+
+    private Response errorResponse(String message, int code) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("status", "error");
+        response.put("code", code);
+        response.put("message", message);
+        return Response.status(code).entity(gson.toJson(response)).build();
+    }
+
+    private Response successResponse(Object data) {
+        return successResponse(200, data);
+    }
+
+    private Response successResponse(int status, Object data) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("status", "success");
+        response.put("code", status);
+        response.put("data", data);
+        return Response.status(status).entity(gson.toJson(response)).build();
+    }
+}

--- a/src/main/webapp/inward/inward_administration.xhtml
+++ b/src/main/webapp/inward/inward_administration.xhtml
@@ -23,9 +23,9 @@
                                             </p:commandButton>
                                             <p:commandButton
                                                 ajax="false"
-                                                value="Admission Items and Fees"
+                                                value="Automatic Admission Charges"
                                                 class="w-100"
-                                                action="#{admissionTypeController.navigateToManageAdmissionItemsAndFees()}"  ></p:commandButton>
+                                                action="#{admissionChargeItemController.navigateToManageAdmissionCharges()}"  ></p:commandButton>
                                             <p:commandButton
                                                 ajax="false"
                                                 value="BHT Number Management"

--- a/src/main/webapp/inward/inward_admission_charge_item.xhtml
+++ b/src/main/webapp/inward/inward_admission_charge_item.xhtml
@@ -1,0 +1,211 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE composition PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<ui:composition xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+                template="/inward/inward_administration.xhtml"
+                xmlns:h="http://xmlns.jcp.org/jsf/html"
+                xmlns:f="http://xmlns.jcp.org/jsf/core"
+                xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:p="http://primefaces.org/ui"
+                xmlns:na="http://xmlns.jcp.org/jsf/composite/template">
+
+    <ui:define name="subcontent">
+
+        <h:panelGroup rendered="#{not webUserController.hasPrivilege('InwardAdministration')}">
+            <na:not_authorize />
+        </h:panelGroup>
+
+        <h:panelGroup rendered="#{webUserController.hasPrivilege('InwardAdministration')}" layout="block">
+
+            <h:form id="formAdmissionCharges">
+                <p:growl id="growl" showDetail="true"/>
+
+                <p:panel class="mx-1">
+                    <f:facet name="header">
+                        <i class="fa-solid fa-file-invoice-dollar"></i>
+                        <p:outputLabel value="Automatic Admission Charges" class="mx-2"/>
+                    </f:facet>
+
+                    <p:panel class="mb-3" toggleable="true" collapsed="true">
+                        <f:facet name="header">
+                            <i class="fa-solid fa-circle-info"></i>
+                            <p:outputLabel value="How this works" class="mx-2"/>
+                        </f:facet>
+                        <ul class="mb-0">
+                            <li>Each row here is a routine charge that is billed automatically to every matching admission, on top of the room and service charges - these charges are additive, never a replacement for anything else.</li>
+                            <li>Resolution for one item happens in two steps: first by <strong>Admission Type</strong>, then by <strong>Payment Method</strong>. A blank Admission Type means "applies to every admission type"; a blank Payment Method means "applies to both Cash and Credit".</li>
+                            <li><strong>The trap:</strong> as soon as you add one Admission-Type-specific row for an item, the blank ("Any Admission Type") rows stop applying to that admission type entirely. If you configure a charge for, say, Day Case admissions, you must configure it for <em>both</em> Cash and Credit under Day Case, or one of them will silently get no charge at all for this item.</li>
+                            <li>An item used here must already have a Department, an Institution, an Inward Charge Type and a live Fee configured under Item administration - the Save button checks all four before accepting a row.</li>
+                        </ul>
+                    </p:panel>
+
+                    <div class="row">
+                        <!-- Left sidebar: filters -->
+                        <div class="col-12 col-md-3">
+                            <p:panel header="Filters">
+                                <div class="mb-2">
+                                    <p:outputLabel value="Item" for="acFilterItem"/>
+                                    <p:autoComplete id="acFilterItem"
+                                                     value="#{admissionChargeItemController.filterItem}"
+                                                     completeMethod="#{itemController.completeItem}"
+                                                     var="itm" itemLabel="#{itm.name}" itemValue="#{itm}"
+                                                     forceSelection="true" maxResults="20" class="w-100"/>
+                                </div>
+                                <div class="mb-2">
+                                    <p:outputLabel value="Admission Type" for="selFilterAdmissionType"/>
+                                    <p:selectOneMenu id="selFilterAdmissionType"
+                                                      value="#{admissionChargeItemController.filterAdmissionType}"
+                                                      class="w-100">
+                                        <f:selectItem itemLabel="Any Admission Type" itemValue="#{null}"/>
+                                        <f:selectItems value="#{admissionTypeController.items}" var="at" itemValue="#{at}" itemLabel="#{at.name}"/>
+                                    </p:selectOneMenu>
+                                </div>
+                                <div class="mb-3">
+                                    <p:outputLabel value="Payment Method" for="selFilterPaymentMethod"/>
+                                    <p:selectOneMenu id="selFilterPaymentMethod"
+                                                      value="#{admissionChargeItemController.filterPaymentMethod}"
+                                                      class="w-100">
+                                        <f:selectItem itemLabel="Any (Cash and Credit)" itemValue="#{null}"/>
+                                        <f:selectItems value="#{enumController.paymentMethodForAdmission}"/>
+                                    </p:selectOneMenu>
+                                </div>
+                                <div class="d-grid gap-2">
+                                    <p:commandButton id="btnSearch"
+                                                      value="Search"
+                                                      icon="fa fa-search"
+                                                      class="ui-button-info ui-button-outlined w-100"
+                                                      action="#{admissionChargeItemController.search()}"
+                                                      process="acFilterItem selFilterAdmissionType selFilterPaymentMethod"
+                                                      update="tblAdmissionCharges"/>
+                                    <p:commandButton id="btnClear"
+                                                      value="Clear"
+                                                      icon="fa fa-eraser"
+                                                      class="ui-button-secondary w-100"
+                                                      action="#{admissionChargeItemController.clearFilters()}"
+                                                      process="@this"
+                                                      update="acFilterItem selFilterAdmissionType selFilterPaymentMethod tblAdmissionCharges"/>
+                                </div>
+                            </p:panel>
+                        </div>
+
+                        <!-- Main content: list + add/edit -->
+                        <div class="col-12 col-md-9">
+                            <p:dataTable id="tblAdmissionCharges"
+                                         var="row"
+                                         value="#{admissionChargeItemController.items}"
+                                         widgetVar="wTblAdmissionCharges"
+                                         rowKey="#{row.id}"
+                                         styleClass="p-datatable-sm"
+                                         stickyHeader="true"
+                                         emptyMessage="No automatic admission charges configured yet.">
+                                <p:column headerText="Item">#{row.item.name}</p:column>
+                                <p:column headerText="Inward Charge Type">#{row.item.inwardChargeType}</p:column>
+                                <p:column headerText="Department">#{row.item.department.name}</p:column>
+                                <p:column headerText="Admission Type">#{row.admissionType != null ? row.admissionType.name : 'Any'}</p:column>
+                                <p:column headerText="Payment Method">#{row.paymentMethod != null ? row.paymentMethod : 'Any'}</p:column>
+                                <p:column headerText="Price">#{row.price}</p:column>
+                                <p:column headerText="Qty">#{row.qty}</p:column>
+                                <p:column headerText="Order">#{row.orderNo}</p:column>
+                                <p:column headerText="Action">
+                                    <p:commandButton
+                                        id="btnEditCharge"
+                                        title="Edit charge #{row.id}"
+                                        icon="fa fa-pen"
+                                        class="ui-button-info ui-button-outlined"
+                                        actionListener="#{admissionChargeItemController.setCurrent(row)}"
+                                        update=":formAdmissionCharges:gpChargeDetail"
+                                        process="@this">
+                                    </p:commandButton>
+                                </p:column>
+                            </p:dataTable>
+
+                            <p:panel id="gpChargeDetail" class="mt-3">
+                                <f:facet name="header">
+                                    <p:outputLabel value="Add / Edit Charge"/>
+                                    <p:commandButton
+                                        id="btnSaveCharge"
+                                        value="Save"
+                                        icon="fa fa-save"
+                                        class="ui-button-success"
+                                        action="#{admissionChargeItemController.saveSelected()}"
+                                        process="btnSaveCharge gpChargeDetail"
+                                        update="tblAdmissionCharges gpChargeDetail growl"
+                                        style="float: right">
+                                    </p:commandButton>
+                                    <p:commandButton
+                                        id="btnAddCharge"
+                                        value="New"
+                                        icon="fa fa-plus"
+                                        action="#{admissionChargeItemController.prepareAdd()}"
+                                        process="btnAddCharge"
+                                        update="gpChargeDetail"
+                                        style="float: right"
+                                        class="ui-button-info ui-button-outlined mx-2">
+                                    </p:commandButton>
+                                    <p:commandButton
+                                        id="btnDeleteCharge"
+                                        value="Delete"
+                                        icon="fa fa-trash"
+                                        onclick="if (!confirm('Retire this admission charge?')) return false;"
+                                        action="#{admissionChargeItemController.delete()}"
+                                        process="btnDeleteCharge"
+                                        update="tblAdmissionCharges gpChargeDetail growl"
+                                        disabled="#{admissionChargeItemController.current.id == null}"
+                                        style="float: right"
+                                        class="mx-2 ui-button-danger">
+                                    </p:commandButton>
+                                </f:facet>
+
+                                <div class="row">
+                                    <div class="col-12 col-md-6 mb-2">
+                                        <p:outputLabel value="Item" for="acChargeItem"/>
+                                        <p:autoComplete id="acChargeItem"
+                                                         value="#{admissionChargeItemController.current.item}"
+                                                         completeMethod="#{itemController.completeItem}"
+                                                         var="itm" itemLabel="#{itm.name}" itemValue="#{itm}"
+                                                         forceSelection="true" maxResults="20" class="w-100"/>
+                                    </div>
+
+                                    <div class="col-12 col-md-6 mb-2">
+                                        <p:outputLabel value="Admission Type" for="selChargeAdmissionType"/>
+                                        <p:selectOneMenu id="selChargeAdmissionType"
+                                                          value="#{admissionChargeItemController.current.admissionType}"
+                                                          class="w-100">
+                                            <f:selectItem itemLabel="Any Admission Type" itemValue="#{null}"/>
+                                            <f:selectItems value="#{admissionTypeController.items}" var="at" itemValue="#{at}" itemLabel="#{at.name}"/>
+                                        </p:selectOneMenu>
+                                    </div>
+
+                                    <div class="col-12 col-md-6 mb-2">
+                                        <p:outputLabel value="Payment Method" for="selChargePaymentMethod"/>
+                                        <p:selectOneMenu id="selChargePaymentMethod"
+                                                          value="#{admissionChargeItemController.current.paymentMethod}"
+                                                          class="w-100">
+                                            <f:selectItem itemLabel="Any (Cash and Credit)" itemValue="#{null}"/>
+                                            <f:selectItems value="#{enumController.paymentMethodForAdmission}"/>
+                                        </p:selectOneMenu>
+                                    </div>
+
+                                    <div class="col-12 col-md-2 mb-2">
+                                        <p:outputLabel value="Price" for="txtChargePrice"/>
+                                        <p:inputNumber id="txtChargePrice" value="#{admissionChargeItemController.current.price}" class="w-100"/>
+                                    </div>
+
+                                    <div class="col-12 col-md-2 mb-2">
+                                        <p:outputLabel value="Qty" for="txtChargeQty"/>
+                                        <p:inputNumber id="txtChargeQty" value="#{admissionChargeItemController.current.qty}" class="w-100"/>
+                                    </div>
+
+                                    <div class="col-12 col-md-2 mb-2">
+                                        <p:outputLabel value="Order No" for="txtChargeOrderNo"/>
+                                        <p:inputNumber id="txtChargeOrderNo" value="#{admissionChargeItemController.current.orderNo}" decimalPlaces="0" class="w-100"/>
+                                    </div>
+                                </div>
+                            </p:panel>
+                        </div>
+                    </div>
+                </p:panel>
+            </h:form>
+
+        </h:panelGroup>
+    </ui:define>
+</ui:composition>


### PR DESCRIPTION
Closes #23594

Hospitals need a fixed set of routine charges added to **every admission**, priced by admission type and by whether the admission is **Credit or Cash**. Until now that had to be billed by hand on each admission.

## Approach

The core requirement was that admitting a patient produce **exactly what a user would have produced by hand** on *Add Services / Investigations to BHT*. Rather than build a lookalike beside it, the settle pipeline is **extracted out of `BillBhtController` into `InwardServiceBillService`**, and both the manual screen and the new automatic path call it — so the two cannot drift apart.

Two existing behaviours are preserved deliberately, because `settleBillSurgery()` depends on them:

- the batch bill is linked over the caller's **whole accumulated bill list**, not just the bills one call created (`settleBillSurgery()` never resets that list);
- the batch bill is returned but is **not** assigned to the caller's `batchBill` field — the old `saveBatchBill()` kept its bill local, so the surgery path's later `saveEncounterComponents(...)` / `updateBatchBill(...)` still operate on the surgery bill.

The manual path's `null` bill `paymentMethod` is also unchanged; only the automatic path records the encounter's.

**The one intentional divergence is price.** These charges carry their price in the configuration, so the fee is written from that with `overriddenRate` set, and **no inward price-matrix margin — and therefore no inward discount matrix — is applied on top** (`InwardBeanController.setBillFeeMargin(...)` applies both). Each item gets exactly **one `BillFee`**; without it the charge would cancel and refund as zero, since both of those paths read fees rather than bill items.

## Resolution

Per distinct item, admission type is the outer filter and payment method the inner one; `null` in either column means "applies to all". Because the first step is a *filter*, an admission-type-specific row set **completely replaces** the null-type rows for that item — so both the config page and the API warn when such a set covers only one of Cash and Credit.

## Two things the issue did not cover

1. **`AdmissionType.admissionFee` already reaches the bill.** `InwardBhtChargeAggregationService.fetchAdmissionFeeCharges()` adds it under `InwardChargeType.AdmissionFee` without ever persisting a `BillItem`. An admission type with a non-zero `admissionFee` **plus** an admission charge configured here charges the patient twice. Not fixed here — but the config page, the API doc and the wiki all warn about it. (The local `coop` DB's *OPD Card* type already has `admissionFee = 500`, so this is not hypothetical.)
2. **Cancelling an admission was blocked by its own auto-charges.** `BhtEditController.checkPaymentIsMade()` blocks cancelling an admission that has any active bill, so at a hospital using this feature no admission could ever be cancelled. `cancelBillService()`'s contra-bill logic is extracted into `InwardSearch.reverseInwardServiceBill()`, both callers share it, and cancelling an admission now reverses its charges first — stamped `INWARD_SERVICE_BILL_CANCELLATION_DURING_BATCH_BILL_CANCELLATION` (an atomic type reports already read but nothing wrote). A charge bill that genuinely cannot be reversed — checked, already returned, or with a doctor payment against it — still blocks the cancellation and says why.

## Verification

Built, redeployed to local Payara (clean `server.log`), and driven through the real UI with Playwright — every page reached **through the menus**, never by URL.

*Menu → Administration → Manage Inpatient Services → Admission Types → **Automatic Admission Charges***

Configured across **three departments** (Inward, ETU, THEATRE) on the local `coop` DB using existing, already-priced items:

| Item | Dept | Admission Type | Payment Method | Price |
|---|---|---|---|---|
| Admission Charge | Inward | *any* | Cash | 1000 |
| Admission Charge | Inward | *any* | Credit | 1200 |
| Base Nursing Attendant Charges | Inward | *any* | *any* | 2000 |
| ETU Charges Inward | ETU | *any* | *any* | 500 |
| Hemo Clips | THEATRE | **BHT** | *any* | 750 |

| # | Check | Result |
|---|---|---|
| 1 | **Cash BHT admission** (BHT/57815) | 3 bills — THEATRE 750, Inward 3000, ETU 500 — under one batch bill; `billTypeAtomic = INWARD_SERVICE_BILL`, `ipOpOrCc = 'IP'`, `paymentMethod = Cash`, `fromDepartment` = the room's facility-charge dept |
| 2 | **Configured price wins over the item's own fee** | Admission Charge's `ItemFee` is 1500, billed **1000**; Hemo Clips' is 100, billed **750**. `overriddenRate` set, `feeMargin = 0`, `feeDiscount = 0` |
| 3 | **Credit admission** (BHT/57816) | Admission Charge resolved to **1200**; Nursing Care stayed 2000 from its null-payment-method row |
| 4 | **Interim bill** | Admission Fee 1,000 + ETU Charges 500 + Nursing Care 2,000 + Theater Consumables 750 = **4,250**, each under its own charge type; the 2,100 room charge separate and unaffected |
| 5 | **Room-less admission** (CTCARD/38807, `roomChargesAllowed = 0`) | Charged — no `PatientRoom`, priced against the encounter's own department, 2 bills. The BHT-only theatre charge correctly **excluded** |
| 6 | **Cancel a charge bill** | Contra-bill `INWARD_SERVICE_BILL_CANCELLATION`, total −500, **`BillFee` −500** — the check that would expose a missing fee |
| 7 | **Refund a charge bill** | `INWARD_SERVICE_BILL_REFUND` −750 with `BillFee` −750 and `referenceBillFee` linked back to the original |
| 8 | **Cancel the admission** | All 3 charge bills reversed automatically, each contra-bill stamped `..._DURING_BATCH_BILL_CANCELLATION` with fully inverted fees (−750 / −3200 / −500); admission retired |
| 9 | **Regression — hand-added services, multi-department** | 2 bills (Inward 1000, ETU 350) under one batch bill, `ipOpOrCc = 'IP'`, `paymentMethod` **NULL** — i.e. exactly the pre-change behaviour |
| 10 | **Regression — hand-added services, single department** | 1 bill under 1 batch bill, `priority = NORMAL` |
| 11 | **Config validation** | Duplicate `(item, admissionType, paymentMethod)` rejected; both warnings fire (one-sided Cash/Credit coverage, and the `admissionFee` double-charge) |
| 12 | **REST API** | `GET /api/admission-charges/search` returns the standard envelope with all rows; `paymentMethod: "Card"` rejected with 400 |

**Not exercised end-to-end:** the idempotency guard. The `admissionChargeBatchBill` field is confirmed written on every admission, but after a successful admit the UI removes the Admit button, so a duplicate submit is not reachable through the browser to prove the guard short-circuits.

![Automatic Admission Charges configuration page](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23594-automatic-admission-charges-config.png)

![Both configuration warnings firing on save](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23594-automatic-admission-charges-warnings.png)

![Interim bill showing the four automatic charges totalling 4,250](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23594-automatic-admission-charges-interim-bill.png)

## Schema

One new table plus one nullable column on `PATIENTENCOUNTER` (`ADMISSIONCHARGEBATCHBILL_ID`), both generated by `/generate-ddl` and applied via *Add Missing Columns*. **No migration script.**

## Documentation

- **[Admin — Inpatient Automatic Admission Charges](https://github.com/hmislk/hmis/wiki/Admin-Inpatient-Automatic-Admission-Charges)** — new page (resolution rule, both traps, screenshots)
- **[Admin — Inpatient Admission Items and Fees](https://github.com/hmislk/hmis/wiki/Admin-Inpatient-Admission-Items-and-Fees)** — **corrected**: it described automatic billing on admission that the screen never actually performed (it saved `CategoryItem` links no billing code ever read). That button is now retired from the menu.
- Also updated: [Admission Types](https://github.com/hmislk/hmis/wiki/Admin-Inpatient-Admission-Types), [Module Configuration Overview](https://github.com/hmislk/hmis/wiki/Admin-Inpatient-Module-Configuration-Overview), [Manage Inpatient Services](https://github.com/hmislk/hmis/wiki/Manage-Inpatient-Services), [Admit a Patient](https://github.com/hmislk/hmis/wiki/Inpatient-Admit-a-Patient), [Cancel Admission](https://github.com/hmislk/hmis/wiki/Inpatient-Cancel-Admission)
- `developer_docs/api/using-apis/API_ADMISSION_CHARGES.md`, linked from the module index
- `developer_docs/testing/playwright-e2e-workflow.md` §109 — a `p:confirm` dialog is `position: fixed`, so an `offsetParent` visibility probe wrongly reports it closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F5EjQMkgdBq97LToJSpQuE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic admission charge configuration by admission type, payment method, and item.
  * Added administration screens and a Finance-authenticated API to manage charge settings.
  * Admissions now apply matching configured charges automatically, including VAT handling.
  * Added AI assistant support for managing automatic admission charges.

* **Bug Fixes**
  * Automatically reverses generated admission charges when an admission is cancelled.

* **Documentation**
  * Added API documentation and Playwright guidance for confirmation dialogs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->