### PR TITLE
fix(inward-reports): temporarily hide Balance to Pay row in professional payment detailed report

### DIFF
--- a/src/main/webapp/inward/reports/inward_professional_payment_report_dto.xhtml
+++ b/src/main/webapp/inward/reports/inward_professional_payment_report_dto.xhtml
@@ -500,7 +500,8 @@
                                                                     </td>
                                                                 </ui:fragment>
                                                             </tr>
-                                                            <tr style="font-weight: bold;">
+                                                            <!-- Temporarily hidden - #23515 follow-up: revert to a proper column-visibility toggle -->
+                                                            <tr style="font-weight: bold;" rendered="false">
                                                                 <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedAddedFeeDateVisible}"><td>Balance to Pay</td></ui:fragment>
                                                                 <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedAddedFeeValueVisible}">
                                                                     <td class="text-end">

--- a/src/main/webapp/inward/reports/inward_professional_payment_report_dto.xhtml
+++ b/src/main/webapp/inward/reports/inward_professional_payment_report_dto.xhtml
@@ -500,8 +500,11 @@
                                                                     </td>
                                                                 </ui:fragment>
                                                             </tr>
-                                                            <!-- Temporarily hidden - #23515 follow-up: revert to a proper column-visibility toggle -->
-                                                            <tr style="font-weight: bold;" rendered="false">
+                                                            <!-- Temporarily hidden - #23515 follow-up: revert to a proper column-visibility toggle.
+                                                                 rendered is not a recognized attribute on a plain <tr> (no xmlns:jsf pass-through
+                                                                 in this file), so the whole row is wrapped in ui:fragment instead. -->
+                                                            <ui:fragment rendered="false">
+                                                            <tr style="font-weight: bold;">
                                                                 <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedAddedFeeDateVisible}"><td>Balance to Pay</td></ui:fragment>
                                                                 <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedAddedFeeValueVisible}">
                                                                     <td class="text-end">
@@ -515,6 +518,7 @@
                                                                 <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedCommentsVisible}"><td></td></ui:fragment>
                                                                 <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedPaidFeeValueVisible}"><td></td></ui:fragment>
                                                             </tr>
+                                                            </ui:fragment>
                                                         </ui:repeat>
                                                     </ui:repeat>
                                                 </tbody>


### PR DESCRIPTION
## Summary
- The Detailed tab of the Inpatient Professional Payment Report (`inward_professional_payment_report_dto.xhtml`) shows a per-admission "Balance to Pay" summary row that has no dedicated column-visibility toggle — it piggybacks on other columns' flags.
- Per user request, hides this row for now via `rendered="false"` on the `<tr>`.
- XHTML-only change, no Java touched.

## Follow-up
A separate PR adds a proper column-visibility toggle for this row (checkbox + `ColumnVisibilitySettings` persistence), following `developer_docs/ui/user-settings-implementation-guide.md`, and will replace this hardcoded hide.

## Test plan
- [x] JSF-only change — no compilation/testing required per project convention
- [ ] Visually confirm the Balance to Pay row no longer renders on the Detailed tab after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Hid the “Balance to Pay” total row in the detailed professional payment report.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->