### PR TITLE
feat(inward-reports): add column-visibility toggle for Balance to Pay in professional payment detailed report

### DIFF
--- a/src/main/java/com/divudi/bean/common/UserSettingsController.java
+++ b/src/main/java/com/divudi/bean/common/UserSettingsController.java
@@ -3509,10 +3509,15 @@ public class UserSettingsController implements Serializable {
 
     // Issue #23515 review (CodeRabbit) - same "at least one column stays
     // visible" guard as the Summary block above.
+    // balanceToPay is deliberately excluded - it's a summary total row, not a
+    // detail column, so it must not count toward "at least one column visible"
+    // (CodeRabbit #23611: including it let every real column be hidden while
+    // the guard still saw balanceToPay's default-true isColumnVisible() read
+    // as "something is visible", leaving an empty table).
     private static final java.util.List<String> INWARD_PROFESSIONAL_PAYMENT_DETAILED_COLUMN_KEYS = java.util.Arrays.asList(
             "bhtNo", "admitted", "discharged", "finalBillNo", "consultant",
             "speciality", "addedFeeDate", "addedFeeValue", "paidDate",
-            "paidBillNumber", "comments", "paidFeeValue", "balanceToPay");
+            "paidBillNumber", "comments", "paidFeeValue");
 
     private void setProfessionalPaymentDetailedColumnVisible(String columnId, boolean visible) {
         ColumnVisibilitySettings settings = getColumnVisibility("inward_professional_payment_detailed");

--- a/src/main/java/com/divudi/bean/common/UserSettingsController.java
+++ b/src/main/java/com/divudi/bean/common/UserSettingsController.java
@@ -3512,7 +3512,7 @@ public class UserSettingsController implements Serializable {
     private static final java.util.List<String> INWARD_PROFESSIONAL_PAYMENT_DETAILED_COLUMN_KEYS = java.util.Arrays.asList(
             "bhtNo", "admitted", "discharged", "finalBillNo", "consultant",
             "speciality", "addedFeeDate", "addedFeeValue", "paidDate",
-            "paidBillNumber", "comments", "paidFeeValue");
+            "paidBillNumber", "comments", "paidFeeValue", "balanceToPay");
 
     private void setProfessionalPaymentDetailedColumnVisible(String columnId, boolean visible) {
         ColumnVisibilitySettings settings = getColumnVisibility("inward_professional_payment_detailed");
@@ -3623,6 +3623,18 @@ public class UserSettingsController implements Serializable {
 
     public void setInwardProfessionalPaymentDetailedPaidFeeValueVisible(boolean visible) {
         setProfessionalPaymentDetailedColumnVisible("paidFeeValue", visible);
+    }
+
+    // Defaults to hidden (unlike every other column above, which defaults to
+    // visible via isColumnVisible's getOrDefault(key, true)) - requested as a
+    // temporary hide of this row; users who want it back can re-check it.
+    public boolean isInwardProfessionalPaymentDetailedBalanceToPayVisible() {
+        return getColumnVisibility("inward_professional_payment_detailed")
+                .getColumnVisible().getOrDefault("balanceToPay", false);
+    }
+
+    public void setInwardProfessionalPaymentDetailedBalanceToPayVisible(boolean visible) {
+        setProfessionalPaymentDetailedColumnVisible("balanceToPay", visible);
     }
 
     /**

--- a/src/main/webapp/inward/reports/inward_professional_payment_report_dto.xhtml
+++ b/src/main/webapp/inward/reports/inward_professional_payment_report_dto.xhtml
@@ -366,6 +366,9 @@
                                                     <p:selectBooleanCheckbox value="#{userSettingsController.inwardProfessionalPaymentDetailedPaidFeeValueVisible}" itemLabel="Paid Fee Value">
                                                         <p:ajax update="detailedTbl panelDetailedColumnToggler professionalPaymentReportGrowl" />
                                                     </p:selectBooleanCheckbox>
+                                                    <p:selectBooleanCheckbox value="#{userSettingsController.inwardProfessionalPaymentDetailedBalanceToPayVisible}" itemLabel="Balance to Pay">
+                                                        <p:ajax update="detailedTbl panelDetailedColumnToggler professionalPaymentReportGrowl" />
+                                                    </p:selectBooleanCheckbox>
                                                 </div>
                                             </p:panel>
                                         </div>
@@ -500,10 +503,9 @@
                                                                     </td>
                                                                 </ui:fragment>
                                                             </tr>
-                                                            <!-- Temporarily hidden - #23515 follow-up: revert to a proper column-visibility toggle.
-                                                                 rendered is not a recognized attribute on a plain <tr> (no xmlns:jsf pass-through
-                                                                 in this file), so the whole row is wrapped in ui:fragment instead. -->
-                                                            <ui:fragment rendered="false">
+                                                            <!-- tr is not a JSF component, so rendered on it directly is inert
+                                                                 (no xmlns:jsf pass-through namespace in this file) - wrap in ui:fragment. -->
+                                                            <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedBalanceToPayVisible}">
                                                             <tr style="font-weight: bold;">
                                                                 <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedAddedFeeDateVisible}"><td>Balance to Pay</td></ui:fragment>
                                                                 <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedAddedFeeValueVisible}">


### PR DESCRIPTION
## Summary
- Adds a proper `UserSettingsController` column-visibility toggle for the "Balance to Pay" summary row on the Detailed tab of the Inpatient Professional Payment Report, following `developer_docs/ui/user-settings-implementation-guide.md`.
- New checkbox in the "Configure Columns" panel; the row's `rendered` attribute now checks this same property (checkbox/column property binding matched, per the guide's "Critical Synchronization Check").
- Unlike every other column on this page (default visible), this one **defaults to hidden** — it was hardcoded off in #23610 at the user's request, and this PR replaces that hardcode with a real per-user toggle instead of forcing it back on for everyone.
- Does not touch the Summary tab's existing "Balance to Pay" toggle (`inwardProfessionalPaymentSummaryBalanceToPayVisible`), which already works correctly and defaults to visible.
- No changes to Excel/PDF export for the Detailed report — that export never included this row (confirmed by inspecting `downloadProfessionalPaymentDetailedExcel()`/`downloadProfessionalPaymentDetailedPdf()`), so on-screen and export behavior stay consistent.

## Relationship to #23610
This PR should be merged after #23610 (or independently — it doesn't conflict, since it's branched from clean `development` and fully replaces the hardcoded `rendered="false"` with the new toggle-backed expression).

## Test plan
- [x] `mvn compile` succeeds
- [ ] Load the Detailed tab: Balance to Pay row is hidden by default
- [ ] Check the "Balance to Pay" box in Configure Columns: row appears immediately via AJAX
- [ ] Refresh the page: preference persists
- [ ] Uncheck it again: row disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a **Balance to Pay** column option to the detailed inward professional payment report.
  - Users can show or hide the column through the report’s column settings.
  - **Balance to Pay** totals are displayed only when the column is visible.
  - The column is hidden by default, while other detailed columns remain subject to the requirement that at least one stays visible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->