### PR TITLE
fix(inward-reports): comment out Balance to Pay column/row on Professional Payment Report (broken layout)

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardReportControllerBht.java
+++ b/src/main/java/com/divudi/bean/inward/InwardReportControllerBht.java
@@ -916,9 +916,11 @@ public class InwardReportControllerBht implements Serializable {
     // UserSettingsController, same "ui.<pageId>.columns.visibility"
     // ConfigOption the xhtml checkboxes write to) instead of a fixed header
     // array, so the exports can never drift from what's checked on screen.
+    // "balanceToPay" temporarily removed - the Balance to Pay column broke the
+    // report layout and is commented out on the xhtml too. TODO: restore.
     private static final List<String> SUMMARY_COLUMN_KEYS_IN_ORDER = Arrays.asList(
             "bhtNo", "admitted", "discharged", "finalBillNo", "consultant",
-            "speciality", "sumAddedFee", "sumPaidFee", "balanceToPay");
+            "speciality", "sumAddedFee", "sumPaidFee");
 
     private static final List<String> DETAILED_COLUMN_KEYS_IN_ORDER = Arrays.asList(
             "bhtNo", "admitted", "discharged", "finalBillNo", "consultant",
@@ -1264,17 +1266,18 @@ public class InwardReportControllerBht implements Serializable {
                             totalPaidCell.setCellStyle(boldMoneyStyle);
                         }
 
-                        Row balanceRow = sheet.createRow(rowIdx++);
-                        if (addedFeeDateCol >= 0) {
-                            Cell balanceLabelCell = balanceRow.createCell(addedFeeDateCol);
-                            balanceLabelCell.setCellValue("Balance to Pay");
-                            balanceLabelCell.setCellStyle(boldStyle);
-                        }
-                        if (addedFeeValueCol >= 0) {
-                            Cell balanceValueCell = balanceRow.createCell(addedFeeValueCol);
-                            balanceValueCell.setCellValue(detail.getSumAddedFee() - detail.getSumPaidFee());
-                            balanceValueCell.setCellStyle(boldMoneyStyle);
-                        }
+                        // Balance to Pay row temporarily commented out - broke the report layout. TODO: restore.
+                        // Row balanceRow = sheet.createRow(rowIdx++);
+                        // if (addedFeeDateCol >= 0) {
+                        //     Cell balanceLabelCell = balanceRow.createCell(addedFeeDateCol);
+                        //     balanceLabelCell.setCellValue("Balance to Pay");
+                        //     balanceLabelCell.setCellStyle(boldStyle);
+                        // }
+                        // if (addedFeeValueCol >= 0) {
+                        //     Cell balanceValueCell = balanceRow.createCell(addedFeeValueCol);
+                        //     balanceValueCell.setCellValue(detail.getSumAddedFee() - detail.getSumPaidFee());
+                        //     balanceValueCell.setCellStyle(boldMoneyStyle);
+                        // }
 
                         if (rowIdx - 1 > consultantStartRow) {
                             if (consultantCol >= 0) {
@@ -1727,26 +1730,27 @@ public class InwardReportControllerBht implements Serializable {
                         table.addCell(totalPaidCell);
                     }
 
-                    if (addedFeeDateVisible) {
-                        table.addCell(new PdfPCell(new Phrase("Balance to Pay", boldFont)));
-                    }
-                    if (addedFeeValueVisible) {
-                        PdfPCell balanceValueCell = new PdfPCell(new Phrase(df.format(detail.getSumAddedFee() - detail.getSumPaidFee()), boldFont));
-                        balanceValueCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
-                        table.addCell(balanceValueCell);
-                    }
-                    if (paidDateVisible) {
-                        table.addCell(new Phrase("", normalFont));
-                    }
-                    if (paidBillNumberVisible) {
-                        table.addCell(new Phrase("", normalFont));
-                    }
-                    if (commentsVisible) {
-                        table.addCell(new Phrase("", normalFont));
-                    }
-                    if (paidFeeValueVisible) {
-                        table.addCell(new Phrase("", normalFont));
-                    }
+                    // Balance to Pay row temporarily commented out - broke the report layout. TODO: restore.
+                    // if (addedFeeDateVisible) {
+                    //     table.addCell(new PdfPCell(new Phrase("Balance to Pay", boldFont)));
+                    // }
+                    // if (addedFeeValueVisible) {
+                    //     PdfPCell balanceValueCell = new PdfPCell(new Phrase(df.format(detail.getSumAddedFee() - detail.getSumPaidFee()), boldFont));
+                    //     balanceValueCell.setHorizontalAlignment(Element.ALIGN_RIGHT);
+                    //     table.addCell(balanceValueCell);
+                    // }
+                    // if (paidDateVisible) {
+                    //     table.addCell(new Phrase("", normalFont));
+                    // }
+                    // if (paidBillNumberVisible) {
+                    //     table.addCell(new Phrase("", normalFont));
+                    // }
+                    // if (commentsVisible) {
+                    //     table.addCell(new Phrase("", normalFont));
+                    // }
+                    // if (paidFeeValueVisible) {
+                    //     table.addCell(new Phrase("", normalFont));
+                    // }
                 }
             }
 

--- a/src/main/webapp/inward/reports/inward_professional_payment_report_dto.xhtml
+++ b/src/main/webapp/inward/reports/inward_professional_payment_report_dto.xhtml
@@ -188,9 +188,11 @@
                                                     <p:selectBooleanCheckbox value="#{userSettingsController.inwardProfessionalPaymentSummarySumPaidFeeVisible}" itemLabel="Sum Paid Fee">
                                                         <p:ajax update="summaryTbl panelSummaryColumnToggler professionalPaymentReportGrowl" />
                                                     </p:selectBooleanCheckbox>
+                                                    <!-- Balance to Pay temporarily commented out - broke the report layout. TODO: restore.
                                                     <p:selectBooleanCheckbox value="#{userSettingsController.inwardProfessionalPaymentSummaryBalanceToPayVisible}" itemLabel="Balance to Pay">
                                                         <p:ajax update="summaryTbl panelSummaryColumnToggler professionalPaymentReportGrowl" />
                                                     </p:selectBooleanCheckbox>
+                                                    -->
                                                 </div>
                                             </p:panel>
                                         </div>
@@ -207,7 +209,9 @@
                                                         <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentSummarySpecialityVisible}"><th>Speciality</th></ui:fragment>
                                                         <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentSummarySumAddedFeeVisible}"><th class="text-end">Sum Added Fee</th></ui:fragment>
                                                         <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentSummarySumPaidFeeVisible}"><th class="text-end">Sum Paid Fee</th></ui:fragment>
+                                                        <!-- Balance to Pay temporarily commented out - broke the report layout. TODO: restore.
                                                         <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentSummaryBalanceToPayVisible}"><th class="text-end">Balance to Pay</th></ui:fragment>
+                                                        -->
                                                     </tr>
                                                 </thead>
                                                 <tbody>
@@ -273,6 +277,7 @@
                                                                         </h:outputText>
                                                                     </td>
                                                                 </ui:fragment>
+                                                                <!-- Balance to Pay temporarily commented out - broke the report layout. TODO: restore.
                                                                 <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentSummaryBalanceToPayVisible}">
                                                                     <td class="text-end">
                                                                         <h:outputText value="#{detail.sumAddedFee - detail.sumPaidFee}">
@@ -280,6 +285,7 @@
                                                                         </h:outputText>
                                                                     </td>
                                                                 </ui:fragment>
+                                                                -->
                                                             </tr>
                                                         </ui:repeat>
                                                     </ui:repeat>
@@ -366,9 +372,11 @@
                                                     <p:selectBooleanCheckbox value="#{userSettingsController.inwardProfessionalPaymentDetailedPaidFeeValueVisible}" itemLabel="Paid Fee Value">
                                                         <p:ajax update="detailedTbl panelDetailedColumnToggler professionalPaymentReportGrowl" />
                                                     </p:selectBooleanCheckbox>
+                                                    <!-- Balance to Pay temporarily commented out - broke the report layout. TODO: restore.
                                                     <p:selectBooleanCheckbox value="#{userSettingsController.inwardProfessionalPaymentDetailedBalanceToPayVisible}" itemLabel="Balance to Pay">
                                                         <p:ajax update="detailedTbl panelDetailedColumnToggler professionalPaymentReportGrowl" />
                                                     </p:selectBooleanCheckbox>
+                                                    -->
                                                 </div>
                                             </p:panel>
                                         </div>
@@ -503,8 +511,9 @@
                                                                     </td>
                                                                 </ui:fragment>
                                                             </tr>
-                                                            <!-- tr is not a JSF component, so rendered on it directly is inert
-                                                                 (no xmlns:jsf pass-through namespace in this file) - wrap in ui:fragment. -->
+                                                            <!-- Balance to Pay row temporarily commented out - broke the report layout. TODO: restore.
+                                                                 tr is not a JSF component, so rendered on it directly is inert
+                                                                 (no xmlns:jsf pass-through namespace in this file) - wrap in ui:fragment.
                                                             <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedBalanceToPayVisible}">
                                                             <tr style="font-weight: bold;">
                                                                 <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedAddedFeeDateVisible}"><td>Balance to Pay</td></ui:fragment>
@@ -521,6 +530,7 @@
                                                                 <ui:fragment rendered="#{userSettingsController.inwardProfessionalPaymentDetailedPaidFeeValueVisible}"><td></td></ui:fragment>
                                                             </tr>
                                                             </ui:fragment>
+                                                            -->
                                                         </ui:repeat>
                                                     </ui:repeat>
                                                 </tbody>


### PR DESCRIPTION
## Summary

The **Balance to Pay** column (Summary tab) and **Balance to Pay** summary row (Detailed tab) on the *Inpatient Professional Payment Report* broke the report layout after PRs #23610 / #23611. This PR comments them out for now, on-screen and in the Excel/PDF exports.

The per-user toggle infrastructure in `UserSettingsController` is left intact, so restoring is just un-commenting the marked blocks (`TODO: restore`).

## Changes

**`inward_professional_payment_report_dto.xhtml`**
- Summary tab: commented out the "Balance to Pay" Configure-Columns checkbox, `<th>`, and `<td>`.
- Detailed tab: commented out the "Balance to Pay" checkbox and the whole "Balance to Pay" summary row.

**`InwardReportControllerBht.java`**
- Removed `"balanceToPay"` from `SUMMARY_COLUMN_KEYS_IN_ORDER` — drops it from the Summary Excel **and** Summary PDF in one place (both driven by `visibleSummaryColumnKeys()`).
- Commented out the unconditional "Balance to Pay" row block in `downloadProfessionalPaymentDetailedExcel()`.
- Commented out the unconditional "Balance to Pay" row block in `downloadProfessionalPaymentDetailedPdf()`.

## Test plan

- [ ] Menu → Inpatient → Reports → Inpatient Professional Payment Report → **Summary**: table renders correctly, no Balance to Pay column
- [ ] Same, **Detailed**: table renders correctly, no Balance to Pay row
- [ ] Summary Excel / Summary PDF: no Balance to Pay column
- [ ] Detailed Excel / Detailed PDF: no Balance to Pay row
- [ ] "Configure Columns" panel on both tabs: no "Balance to Pay" checkbox, other toggles still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Report Updates**
  - The “Balance to Pay” column is no longer displayed in professional payment report summary and detailed views.
  - Separate “Balance to Pay” rows have been removed from detailed Excel and PDF exports.
  - Related column-visibility controls and balance calculations are no longer included in these reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->