### PR TITLE
fix(inward): admit reservations within a configurable window, not just today (#23615)

### DIFF
--- a/src/main/java/com/divudi/bean/common/AppointmentController.java
+++ b/src/main/java/com/divudi/bean/common/AppointmentController.java
@@ -128,6 +128,8 @@ public class AppointmentController implements Serializable, ControllerWithPatien
     @Inject
     ConfigOptionApplicationController configOptionApplicationController;
     @Inject
+    ConfigOptionController configOptionController;
+    @Inject
     SessionController sessionController;
     @Inject
     private PaymentSchemeController paymentSchemeController;
@@ -190,14 +192,18 @@ public class AppointmentController implements Serializable, ControllerWithPatien
         return "/inward/view_appointment?faces-redirect=true";
     }
 
+    /** ~10 years, in hours — larger admission-window offsets are treated as misconfiguration. */
+    private static final long MAX_ADMISSION_WINDOW_HOURS = 24L * 366L * 10L;
+
     /**
-     * Returns {@code hours} when it is a usable non-negative value, otherwise
-     * {@code defaultHours}. Guards against a blank or corrupted {@code CONFIGOPTION}
-     * row: {@link ConfigOptionApplicationController#getLongValueByKey(String, Long)}
-     * returns {@code null} when the stored value cannot be parsed to a {@code Long}.
+     * Returns {@code hours} when it is a usable value, otherwise {@code defaultHours}.
+     * Guards against a blank or corrupted {@code CONFIGOPTION} row
+     * ({@code getLongValueByKey} returns {@code null} when the stored value cannot be
+     * parsed to a {@code Long}), a negative value, and an absurdly large value that
+     * would overflow the {@code hours * 3_600_000} millisecond conversion at the call site.
      */
     private long safeHours(Long hours, long defaultHours) {
-        if (hours == null || hours < 0L) {
+        if (hours == null || hours < 0L || hours > MAX_ADMISSION_WINDOW_HOURS) {
             return defaultHours;
         }
         return hours;
@@ -225,9 +231,10 @@ public class AppointmentController implements Serializable, ControllerWithPatien
         // valid reservation, so fall back to reservedFrom as the effective end here.
         Date effectiveEnd = (resTo != null) ? resTo : resFrom;
 
-        long earlyHours = safeHours(configOptionApplicationController.getLongValueByKey(
+        // Resolved per-department-first (falls back to the application-scoped row, then 24).
+        long earlyHours = safeHours(configOptionController.getLongValueByKey(
                 "Inward - Reservation Admission Early Window (Hours)", 24L), 24L);
-        long graceHours = safeHours(configOptionApplicationController.getLongValueByKey(
+        long graceHours = safeHours(configOptionController.getLongValueByKey(
                 "Inward - Reservation Admission Grace Period (Hours)", 24L), 24L);
 
         Date now = CommonFunctions.getCurrentDateTime();

--- a/src/main/java/com/divudi/bean/common/AppointmentController.java
+++ b/src/main/java/com/divudi/bean/common/AppointmentController.java
@@ -190,30 +190,17 @@ public class AppointmentController implements Serializable, ControllerWithPatien
         return "/inward/view_appointment?faces-redirect=true";
     }
 
-    public boolean isReservationWithinToday(Date resFrom, Date resTo, Date currentStartDate, Date currentEndDate) {
-        if (resFrom == null || resTo == null || currentStartDate == null || currentEndDate == null) {
-            return false;
+    /**
+     * Returns {@code hours} when it is a usable non-negative value, otherwise
+     * {@code defaultHours}. Guards against a blank or corrupted {@code CONFIGOPTION}
+     * row: {@link ConfigOptionApplicationController#getLongValueByKey(String, Long)}
+     * returns {@code null} when the stored value cannot be parsed to a {@code Long}.
+     */
+    private long safeHours(Long hours, long defaultHours) {
+        if (hours == null || hours < 0L) {
+            return defaultHours;
         }
-
-        // Check if the entire reservation interval is within today
-        return (resFrom.compareTo(currentStartDate) >= 0 && resTo.compareTo(currentEndDate) <= 0);
-    }
-
-    public boolean doesReservationOverlapWithToday(Date resFrom, Date resTo, Date currentStartDate, Date currentEndDate) {
-        if (resFrom == null || resTo == null || currentStartDate == null || currentEndDate == null) {
-            return false;
-        }
-
-        int fromDateComparison  = resFrom.compareTo(currentEndDate);
-        int toDateComparison  = resTo.compareTo(currentStartDate);
-        
-        if(fromDateComparison <= 0 && toDateComparison  <= 0){
-            return false;
-        }else if(fromDateComparison <= 0 && toDateComparison  >= 0){
-            return true;
-        }else{
-            return true;
-        }
+        return hours;
     }
 
     public String navigatePatientAdmit() {
@@ -228,12 +215,30 @@ public class AppointmentController implements Serializable, ControllerWithPatien
         }
 
         Date resFrom = reservation.getReservedFrom();
+        if (resFrom == null) {
+            JsfUtil.addErrorMessage("Reservation Expired");
+            return "";
+        }
         Date resTo = reservation.getReservedTo();
+        // reservedTo is nullable and is null for reservations made through the normal
+        // booking flow; the calendar feed treats a null reservedTo as an open, still
+        // valid reservation, so fall back to reservedFrom as the effective end here.
+        Date effectiveEnd = (resTo != null) ? resTo : resFrom;
 
-        Date currentStartDate = CommonFunctions.getStartOfDay();
-        Date currentEndDate = CommonFunctions.getEndOfDay();
+        long earlyHours = safeHours(configOptionApplicationController.getLongValueByKey(
+                "Inward - Reservation Admission Early Window (Hours)", 24L), 24L);
+        long graceHours = safeHours(configOptionApplicationController.getLongValueByKey(
+                "Inward - Reservation Admission Grace Period (Hours)", 24L), 24L);
 
-        if (!doesReservationOverlapWithToday(resFrom, resTo, currentStartDate, currentEndDate)) {
+        Date now = CommonFunctions.getCurrentDateTime();
+        Date windowStart = new Date(resFrom.getTime() - earlyHours * 3_600_000L);
+        Date windowEnd = new Date(effectiveEnd.getTime() + graceHours * 3_600_000L);
+
+        if (now.before(windowStart)) {
+            JsfUtil.addErrorMessage("Reservation not yet open for admission");
+            return "";
+        }
+        if (now.after(windowEnd)) {
             JsfUtil.addErrorMessage("Reservation Expired");
             return "";
         }

--- a/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
+++ b/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
@@ -173,6 +173,7 @@ public class ConfigOptionApplicationController implements Serializable {
             loadAiChatConfigurationDefaults();
             loadStockHistoryArchiveConfigurationDefaults();
             loadSapIntegrationConfigurationDefaults();
+            loadInwardConfigurationDefaults();
             enumController.resetPaymentMethods();
         } finally {
             isLoadingApplicationOptions = false;
@@ -182,6 +183,14 @@ public class ConfigOptionApplicationController implements Serializable {
     private void loadOpdBillingConfigurationDefaults() {
         // Feature toggle: whether all departments share the same OPD payment methods
         getBooleanValueByKey("All Departments Use Same Payment Methods for OPD Billing", true);
+    }
+
+    private void loadInwardConfigurationDefaults() {
+        // Reservation admission window: admission is allowed from this many hours before
+        // reservedFrom until this many hours after the reservation end (reservedTo, or
+        // reservedFrom when reservedTo is null). Consumed by AppointmentController.navigatePatientAdmit().
+        getLongValueByKey("Inward - Reservation Admission Early Window (Hours)", 24L);
+        getLongValueByKey("Inward - Reservation Admission Grace Period (Hours)", 24L);
     }
 
     private void loadPettyCashBillingConfigurationDefaults() {

--- a/src/main/java/com/divudi/bean/common/ConfigOptionController.java
+++ b/src/main/java/com/divudi/bean/common/ConfigOptionController.java
@@ -220,6 +220,33 @@ public class ConfigOptionController implements Serializable {
         return configOptionApplicationController.getBooleanValueByKeyReadOnly(deptKey, defaultValue);
     }
 
+    public Long getLongValueByKey(String key) {
+        return getLongValueByKey(key, 0L);
+    }
+
+    /**
+     * Department-scoped-key-first lookup for a LONG option, mirroring
+     * {@link #getBooleanValueByKey(String, boolean)}: resolves
+     * {@code "<Department name> - <key>"} first and only falls back to the plain
+     * application-scoped key (and finally {@code defaultValue}) when no
+     * department override exists. Use this so an admin can tune a per-department
+     * value from Department Options without a code change.
+     */
+    public Long getLongValueByKey(String key, Long defaultValue) {
+        String departmentName;
+        if (sessionController.getDepartment() != null) {
+            departmentName = sessionController.getDepartment().getName();
+        } else {
+            return configOptionApplicationController.getLongValueByKey(key, defaultValue);
+        }
+        String deptKey = departmentName + " - " + key;
+        ConfigOption appOption = configOptionApplicationController.getApplicationOption(deptKey);
+        if (appOption == null || appOption.getValueType() != OptionValueType.LONG) {
+            defaultValue = configOptionApplicationController.getLongValueByKey(key, defaultValue);
+        }
+        return configOptionApplicationController.getLongValueByKey(deptKey, defaultValue);
+    }
+
     public String navigateToDepartmentOptions() {
         institution = null;
         department = sessionController.getDepartment();

--- a/src/main/java/com/divudi/bean/common/ConfigOptionController.java
+++ b/src/main/java/com/divudi/bean/common/ConfigOptionController.java
@@ -240,9 +240,11 @@ public class ConfigOptionController implements Serializable {
             return configOptionApplicationController.getLongValueByKey(key, defaultValue);
         }
         String deptKey = departmentName + " - " + key;
-        ConfigOption appOption = configOptionApplicationController.getApplicationOption(deptKey);
-        if (appOption == null || appOption.getValueType() != OptionValueType.LONG) {
-            defaultValue = configOptionApplicationController.getLongValueByKey(key, defaultValue);
+        ConfigOption deptOption = configOptionApplicationController.getApplicationOption(deptKey);
+        if (deptOption == null || deptOption.getValueType() != OptionValueType.LONG) {
+            // No department override — return the plain application value without
+            // letting getLongValueByKey(deptKey, ...) persist a spurious department row.
+            return configOptionApplicationController.getLongValueByKey(key, defaultValue);
         }
         return configOptionApplicationController.getLongValueByKey(deptKey, defaultValue);
     }


### PR DESCRIPTION
## What & why

Fixes #23615 — on the Reservation Calendar, clicking **Admit** on a *Pending* reservation always failed with the growl **"Reservation Expired"**, even for a reservation whose `Reserve From` is today or in the future.

`AppointmentController.navigatePatientAdmit()` gated admission on `doesReservationOverlapWithToday(resFrom, resTo, startOfDay, endOfDay)`, whose null-guard returns `false` the moment `Reservation.reservedTo` is `null`. Every reservation created through the normal booking flow has `reservedTo = null` (verified on local `coop`: all `RESERVATION` rows are `RESERVEDTO IS NULL`), and the calendar's own feed query treats a null `reservedTo` as an *open, still-valid* reservation — so the same reservation was **listed as active but rejected on Admit**, for every reservation, not an edge case.

## Changes

**`AppointmentController.java`**
- `navigatePatientAdmit()` replaces the "overlaps the current calendar day" gate with an explicit window check:
  - `effectiveEnd = reservedTo`, or `reservedFrom` when `reservedTo` is `null`
  - admission allowed from `reservedFrom − earlyHours` to `effectiveEnd + graceHours`
  - `now < windowStart` → **"Reservation not yet open for admission"**
  - `now > windowEnd` → **"Reservation Expired"**
  - a `null reservedFrom` is rejected defensively
- `safeHours(Long, long)` helper falls back to the default when the ConfigOption row is blank/unparseable (`getLongValueByKey` returns `null` on `NumberFormatException`).
- Removed the now-unused `doesReservationOverlapWithToday()` / `isReservationWithinToday()` helpers — no other callers anywhere in `src/`.

**`ConfigOptionApplicationController.java`**
- New `loadInwardConfigurationDefaults()` (same pattern as the other `load*ConfigurationDefaults()` seeders) registers two `LONG` keys, default **24** each, so they are discoverable in **Administration → Manage Institutions → Preferences → Application Options**:
  - `Inward - Reservation Admission Early Window (Hours)`
  - `Inward - Reservation Admission Grace Period (Hours)`

Application-scoped, matching the existing `Inward - Appoiment Lookup Duration (Days)` precedent in the same bean.

**No schema change** — ConfigOption rows only, created by the existing seed mechanism. No migration / DDL regeneration.

## Verification (local Payara `rh`, DB `coop`, Inward department)

Menu path: **Inward (bed icon) → Appointment → Room Reservations → click a calendar block → Reservations Details → Admit**

| Check | Result |
|---|---|
| Admit reservation `IPA/COOP/26/000005` — `RESERVEDFROM 2026-09-08 23:00`, `RESERVEDTO NULL`, status *Pending* | Navigates to `/inward/inward_admission` with the reserved patient loaded (**was** "Reservation Expired") |
| Config keys after deploy | `SELECT` shows two `LONG` rows = 24, `APPLICATION` scope; visible & editable in Application Options |
| Window still enforced — Grace Period set to `0`, Admit reservation `IPA/COOP/26/000001` (`RESERVEDFROM 13:00`, ~10 h past) | Blocked with "Reservation Expired", stays on calendar; value restored to 24 |
| DB after runs | Config back to 24/24; no stray `PATIENTENCOUNTER` (`DTYPE='Admission'`); `RESERVATION` rows unchanged |

### Screenshots

Admit from the Reservations Details dialog (identifiers blacked out):
![](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23615-reservation-details-admit.png)

Admission screen opens after Admit — the fixed behaviour:
![](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23615-admission-screen-after-admit.png)

Both ConfigOption rows seeded / editable:
![](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23615-admission-window-config-options.png)

Window still enforced (Grace Period = 0):
![](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23615-admission-window-expired.png)

## Documentation

Wiki updated: [Inpatient — Room Reservations](https://github.com/hmislk/hmis/wiki/Inpatient-Room-Reservations) — rewrote *Converting a Reservation to an Admission* to cover the calendar-driven **Admit** route, and added an *Admission Window* subsection documenting the two new config keys and the "not yet open" / "Expired" messages. Screenshots embedded on the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012RbyKxQkUTSLbuFHy4sQeT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reservation admissions now use configurable early-admission and grace-period windows.
  * Added application settings for the early window and grace period, each defaulting to 24 hours.
  * Departments can override these admission timing settings with department-specific values.
* **Bug Fixes**
  * Improved handling of reservations with missing end times.
  * Reservations without a start time, or outside the configured admission window, are now correctly prevented from admission.
  * Invalid timing values are safely handled using sensible defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Review-loop updates (CodeRabbit)

- **`90aa8204ea`** — the two window keys are now read via a new `ConfigOptionController.getLongValueByKey(key, default)` that resolves `"<Department> - <key>"` first (application row → 24 as fallback), mirroring the existing `getBooleanValueByKey`. `safeHours()` also rejects offsets above ~10 years so a nonsense value can't overflow the `hours × 3_600_000` ms conversion. Re-verified: with a department-scoped grace period of 0 (app row 24) a past-window reservation is blocked, confirming the override wins.
- **`21a8de734f`** — kept that per-department fallback **read-only**: when no override row exists it returns the application value directly instead of calling `getLongValueByKey(deptKey, …)`, which would have persisted a spurious `"<Department> - <key>"` row on a plain lookup. Re-verified: an Admit lookup with no override now creates zero department rows (was two).

All three CodeRabbit findings addressed and acknowledged; CI green (`validate-compilation`, `validate-jdbc-data-sources`).