### PR TITLE
fix(inward): appointment/admission fixes (#23618-#23622)

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -3152,6 +3152,72 @@ paper types the page checks, such as "POS Paper". This does not validate
 
 Found while fixing issue #23571.
 
+## 111. The local `coop` DB can have **zero** vacant rooms — free some by SQL before testing any admission flow
+
+The admission form's Room autocomplete (`roomFacilityChargeController.completeRoom`)
+only returns a room when **no** `PATIENTROOM` row exists for it with
+`RETIRED=0 AND DISCHARGED=0`, and the room's `CATEGORY.FILLED` is not `1`.
+`InwardBeanController.isRoomFilled(room)` applies the same
+`discharged=false` test. Restored production-shaped `coop` data is often at
+or near full occupancy, so the Room autocomplete legitimately returns **no
+suggestions** for any query — an admission simply cannot be completed, and
+this looks like a broken autocomplete rather than a data state.
+
+`Room` is `Room extends Category`, so room rows live in `CATEGORY` (`DTYPE='Room'`),
+not a `ROOM` table. To free rooms on the **local** DB (disposable — see the
+`dev-issue-unattended` hard limits), mark their active `PATIENTROOM` discharged
+and clear any stuck `FILLED`:
+
+```sql
+UPDATE PATIENTROOM PR
+JOIN ROOMFACILITYCHARGE RFC ON PR.ROOMFACILITYCHARGE_ID = RFC.ID
+JOIN CATEGORY C ON RFC.ROOM_ID = C.ID
+SET PR.DISCHARGED = 1
+WHERE PR.RETIRED = 0 AND PR.DISCHARGED = 0
+  AND C.NAME IN ('Room 100','Room 101','Room 102','Room 103','Room 104', ...);
+
+UPDATE CATEGORY SET FILLED = 0
+WHERE NAME IN ('Room 100','Room 101','Room 102','Room 103','Room 104', ...);
+```
+
+Verify with:
+
+```sql
+SELECT C.NAME FROM ROOMFACILITYCHARGE RFC JOIN CATEGORY C ON RFC.ROOM_ID = C.ID
+WHERE RFC.RETIRED = 0 AND (C.FILLED IS NULL OR C.FILLED <> 1)
+  AND C.ID NOT IN (
+    SELECT RFC2.ROOM_ID FROM PATIENTROOM PR
+    JOIN ROOMFACILITYCHARGE RFC2 ON PR.ROOMFACILITYCHARGE_ID = RFC2.ID
+    WHERE PR.RETIRED = 0 AND PR.DISCHARGED = 0)
+ORDER BY C.NAME;
+```
+
+(A room name repeats once per `ROOMFACILITYCHARGE` fee tier — that is normal.)
+This is a local-only shortcut; never run it against a tunnelled/remote DB.
+The proper app path is a Physical Discharge, but that is a long workflow just
+to reclaim a bed for a test.
+
+Found while verifying #23618-#23622 (admission + appointment-deposit-conversion
+flows) — every `completeRoom` query returned nothing until rooms were freed.
+
+## 112. Relaxing a "required" validation? Audit every downstream reader of that field for null-safety
+
+#23618 removed the `settleBill()` guard that forced `reservedToDate` to be
+non-null for a Room Admission appointment. That guard was also the de-facto
+protection for code that read the value unconditionally later:
+`updateChangesReservation()` did `reservedToDate.before(...)` (NPE), and both
+that method and `settleBill()` did `sdf.format(res.getReservedTo())` when
+reporting a room conflict (NPE if the *conflicting* reservation was itself
+saved with a null end). None of these are in the diff of the validation
+change, so a review that only looks at changed lines misses them — CodeRabbit
+flagged it on PR #23628.
+
+When a change makes a previously-guaranteed field nullable (or merely more
+often null), grep the whole class (and callers) for every read of that
+field — `.before(`, `.after(`, `.format(`, `.getTime()`, arithmetic — and
+guard or apply the same fallback the new code uses (here: treat a missing
+end as the start instant).
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.
@@ -3177,4 +3243,5 @@ Found while fixing issue #23571.
 - [ ] For a guard fix: asserted the **action actually executed** (expected message in the response) before treating unchanged DB state as proof — a JSF-disabled button skips its action entirely — and ran the negative test (clean record still succeeds), reverting it through the app.
 - [ ] For a menu item nested three levels deep, fired the anchor's own `onclick` (which submits the menu form, so the navigation method still runs) instead of falling back to typing the page URL — scoping the lookup to its own submenu, since labels repeat within one menu.
 - [ ] Before writing "did not reproduce", checked every `getBooleanValueByKey(...)` branch in the code path and flipped any option whose local value differs from the reporter's likely setting (§107) — and, when verifying a fix, exercised **both** settings of any option gating the changed code.
+- [ ] For any admission flow: confirmed the local DB actually has a vacant room (`completeRoom` returns suggestions); if not, freed some by SQL (§111) before concluding the Room autocomplete is broken.
 - [ ] Before trying to reproduce a same-session state-change race (item A staged, then a dependency of A is invalidated by a legitimate app action before A is submitted), checked whether a `@SessionScoped` controller's already-held entity reference would even observe the change (§96) rather than assuming any in-app mutation propagates live.

--- a/src/main/java/com/divudi/bean/common/AppointmentController.java
+++ b/src/main/java/com/divudi/bean/common/AppointmentController.java
@@ -690,8 +690,15 @@ public class AppointmentController implements Serializable, ControllerWithPatien
         }
 
         if (currentAppointment.getAppointmentDate() == null) {
-            JsfUtil.addErrorMessage("Appointment Date is Missing.");
-            return;
+            // For a room appointment the reservation start date is the effective
+            // appointment date - derive it here instead of blocking the save.
+            // (#23619)
+            if (appointmentCategory.needsRoom() && getReservedFromDate() != null) {
+                currentAppointment.setAppointmentDate(getReservedFromDate());
+            } else {
+                JsfUtil.addErrorMessage("Appointment Date is Missing.");
+                return;
+            }
         }
 
         if (currentBill.getReferredBy() == null) {
@@ -1506,9 +1513,17 @@ public class AppointmentController implements Serializable, ControllerWithPatien
     }
 
     public Reservation checkRoomAvailability() {
-        if (reservedRoom == null || reservedFromDate == null || reservedToDate == null) {
-            JsfUtil.addErrorMessage("Reservation, room, and dates must not be null");
+        if (reservedRoom == null || reservedFromDate == null) {
+            JsfUtil.addErrorMessage("A room and a reservation start date are required.");
+            return null;
         }
+
+        // "Reserve To" is optional in the booking flow and is legitimately left
+        // blank. Treat a missing end as a point in time at reservedFrom for the
+        // overlap check (the same fallback navigatePatientAdmit() uses) instead
+        // of adding a spurious "must not be null" error and then saving the
+        // appointment anyway. (#23618)
+        Date effectiveReservedTo = (reservedToDate != null) ? reservedToDate : reservedFromDate;
 
         Map<String, Object> parameters = new HashMap<>();
 
@@ -1531,7 +1546,7 @@ public class AppointmentController implements Serializable, ControllerWithPatien
         parameters.put("room", reservedRoom);
         parameters.put("status", AppointmentStatus.PENDING);
         parameters.put("reservedFrom", reservedFromDate);
-        parameters.put("reservedTo", reservedToDate);
+        parameters.put("reservedTo", effectiveReservedTo);
 
         Reservation r = reservationFacade.findFirstByJpql(jpql, parameters, TemporalType.TIMESTAMP);
 
@@ -1599,6 +1614,25 @@ public class AppointmentController implements Serializable, ControllerWithPatien
 
     public InwardAppointmentCategory[] getAppointmentCategories() {
         return InwardAppointmentCategory.values();
+    }
+
+    /**
+     * When the reservation "Reserve From" date changes and the user has not yet
+     * set an Appointment Date, mirror the reservation date into the Appointment
+     * Date field so it never has to be re-keyed. Does nothing once the user has
+     * entered their own Appointment Date. (#23619)
+     *
+     * Only used for room categories (the "Reserve From" picker is not rendered
+     * for the others), and the schedule-slot lookup does not apply to them, so
+     * it is deliberately not invoked here.
+     */
+    public void onReservedFromDateChanged() {
+        if (currentAppointment == null || reservedFromDate == null) {
+            return;
+        }
+        if (currentAppointment.getAppointmentDate() == null) {
+            currentAppointment.setAppointmentDate(reservedFromDate);
+        }
     }
 
     public void onScheduleFilterChanged() {

--- a/src/main/java/com/divudi/bean/common/AppointmentController.java
+++ b/src/main/java/com/divudi/bean/common/AppointmentController.java
@@ -327,7 +327,8 @@ public class AppointmentController implements Serializable, ControllerWithPatien
             return;
         }
 
-        if (reservedToDate.before(reservedFromDate)) {
+        // reservedToDate is optional (#23618) - only validate it when set.
+        if (reservedToDate != null && reservedToDate.before(reservedFromDate)) {
             JsfUtil.addErrorMessage("Reserved To Date not Valid");
             return;
         }
@@ -347,7 +348,9 @@ public class AppointmentController implements Serializable, ControllerWithPatien
         if (res != null) {
             SimpleDateFormat sdf = new SimpleDateFormat("yyyy.MM.dd hh:mm a");
             String fDate = sdf.format(res.getReservedFrom());
-            String tDate = sdf.format(res.getReservedTo());
+            // A conflicting reservation may itself have a null reservedTo (#23618).
+            Date resTo = (res.getReservedTo() != null) ? res.getReservedTo() : res.getReservedFrom();
+            String tDate = sdf.format(resTo);
             JsfUtil.addErrorMessage("This room is already booked from " + fDate + " to " + tDate + ".");
             return;
         }
@@ -723,7 +726,9 @@ public class AppointmentController implements Serializable, ControllerWithPatien
             if (res != null) {
                 SimpleDateFormat sdf = new SimpleDateFormat("yyyy.MM.dd hh:mm a");
                 String fDate = sdf.format(res.getReservedFrom());
-                String tDate = sdf.format(res.getReservedTo());
+                // A conflicting reservation may itself have a null reservedTo (#23618).
+                Date resTo = (res.getReservedTo() != null) ? res.getReservedTo() : res.getReservedFrom();
+                String tDate = sdf.format(resTo);
                 JsfUtil.addErrorMessage("This room is already booked from " + fDate + " to " + tDate + ".");
                 return;
             }

--- a/src/main/java/com/divudi/bean/inward/AdmissionController.java
+++ b/src/main/java/com/divudi/bean/inward/AdmissionController.java
@@ -74,6 +74,7 @@ import com.divudi.core.entity.clinical.ClinicalFindingValue;
 import com.divudi.core.entity.inward.AdmissionType;
 import com.divudi.core.entity.PaymentScheme;
 import com.divudi.core.entity.inward.Reservation;
+import com.divudi.core.entity.inward.RoomFacilityCharge;
 import com.divudi.core.facade.ClinicalFindingValueFacade;
 import com.divudi.core.facade.ReservationFacade;
 import com.divudi.core.util.CommonFunctions;
@@ -174,6 +175,8 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
     ClinicalFindingValueController clinicalFindingValueController;
     @Inject
     AppointmentController appointmentController;
+    @Inject
+    AdmissionTypeController admissionTypeController;
     @Inject
     BillSearch billSearch;
     @Inject
@@ -2660,6 +2663,65 @@ public class AdmissionController implements Serializable, ControllerWithPatient 
             return;
         }
         setPatient(ap.getPatient());
+        prefillAdmissionFromAppointment(ap);
+    }
+
+    /**
+     * Pre-fills the admission form from the appointment being admitted so staff
+     * do not have to re-key what the appointment already captured. (#23620)
+     *
+     * <ul>
+     *   <li>Consultant &larr; the appointment bill's referring doctor.</li>
+     *   <li>Room &larr; the reservation's room, when the reservation is a room
+     *       reservation and that room is still vacant.</li>
+     *   <li>Admission Type &larr; the single {@link AdmissionType} whose fixed
+     *       {@code roomFacilityCharge} is that room, and only when exactly one
+     *       matches - otherwise it is left for staff to choose.</li>
+     * </ul>
+     *
+     * Every field is only set when it is currently empty, so this never
+     * overrides a value staff have already entered.
+     */
+    private void prefillAdmissionFromAppointment(Bill appointmentBill) {
+        if (getCurrent() == null) {
+            return;
+        }
+        if (getCurrent().getReferringConsultant() == null && appointmentBill.getReferredBy() != null) {
+            getCurrent().setReferringConsultant(appointmentBill.getReferredBy());
+        }
+        Reservation res = getCurrentReservation();
+        // currentReservation is @SessionScoped and is NOT set by every caller of
+        // this listener (the admission form's own "Appointment" search tab calls
+        // it without a reservation). Only trust it for the room / admission-type
+        // prefill when it actually belongs to the appointment being admitted -
+        // otherwise a stale reservation from an earlier, abandoned calendar
+        // "To Admit" click would apply the wrong room. (#23620)
+        if (res == null || res.getRoom() == null
+                || res.getAppointment() == null || res.getAppointment().getBill() == null
+                || !res.getAppointment().getBill().equals(appointmentBill)) {
+            return;
+        }
+        RoomFacilityCharge reservedRoom = res.getRoom();
+        if (reservedRoom.getRoom() != null && getInwardBean().isRoomFilled(reservedRoom.getRoom())) {
+            // Reserved room has since been taken - leave selection to staff.
+            return;
+        }
+        if (getPatientRoom() != null && getPatientRoom().getRoomFacilityCharge() == null) {
+            getPatientRoom().setRoomFacilityCharge(reservedRoom);
+        }
+        if (getCurrent().getAdmissionType() == null) {
+            AdmissionType matchedType = null;
+            int matchCount = 0;
+            for (AdmissionType at : admissionTypeController.getItems()) {
+                if (reservedRoom.equals(at.getRoomFacilityCharge())) {
+                    matchedType = at;
+                    matchCount++;
+                }
+            }
+            if (matchCount == 1) {
+                getCurrent().setAdmissionType(matchedType);
+            }
+        }
     }
 
     @Inject

--- a/src/main/java/com/divudi/core/data/dto/InwardBillReceiptDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/InwardBillReceiptDTO.java
@@ -190,6 +190,13 @@ public class InwardBillReceiptDTO implements Serializable {
         return patientTitle;
     }
 
+    // Setters for title / dob / sex exist so BillFacade.findInwardBillReceiptDTO
+    // can backfill them from the bill's own patient when the bill has no
+    // encounter (e.g. an appointment-deposit cancel bill). (#23622)
+    public void setPatientTitle(Title patientTitle) {
+        this.patientTitle = patientTitle;
+    }
+
     public String getPatientName() {
         return patientName;
     }
@@ -198,8 +205,16 @@ public class InwardBillReceiptDTO implements Serializable {
         return patientDob;
     }
 
+    public void setPatientDob(Date patientDob) {
+        this.patientDob = patientDob;
+    }
+
     public Sex getPatientSex() {
         return patientSex;
+    }
+
+    public void setPatientSex(Sex patientSex) {
+        this.patientSex = patientSex;
     }
 
     public String getAdmissionTypeName() {

--- a/src/main/java/com/divudi/core/data/dto/ReservationDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/ReservationDTO.java
@@ -4,6 +4,9 @@ import com.divudi.bean.lab.LaboratoryCommonController;
 import com.divudi.core.data.AppointmentStatus;
 import com.divudi.core.data.Title;
 import java.io.Serializable;
+import java.time.LocalDate;
+import java.time.Period;
+import java.time.ZoneId;
 import java.util.Date;
 
 public class ReservationDTO implements Serializable {
@@ -148,6 +151,36 @@ public class ReservationDTO implements Serializable {
 
     public void setPatientAge(String patientAge) {
         this.patientAge = patientAge;
+    }
+
+    /**
+     * Compact age for dense grids: "86Y", "3M20D", "12D". The long-form
+     * {@link #getPatientAge()} is unchanged and is still used elsewhere. (#23621)
+     */
+    public String getPatientAgeShort() {
+        if (patientDob == null) {
+            return "";
+        }
+        Date ref = (createdAt != null) ? createdAt : new Date();
+        LocalDate birth = patientDob.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+        LocalDate on = ref.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+        if (birth.isAfter(on)) {
+            return "";
+        }
+        Period p = Period.between(birth, on);
+        int years = p.getYears();
+        int months = p.getMonths();
+        int days = p.getDays();
+        if (years >= 5) {
+            return years + "Y";
+        }
+        if (years >= 1) {
+            return (months > 0) ? years + "Y" + months + "M" : years + "Y";
+        }
+        if (months >= 1) {
+            return (days > 0) ? months + "M" + days + "D" : months + "M";
+        }
+        return days + "D";
     }
 
     public String getPatientNameWithTitle() {

--- a/src/main/java/com/divudi/core/facade/BillFacade.java
+++ b/src/main/java/com/divudi/core/facade/BillFacade.java
@@ -52,14 +52,15 @@ public class BillFacade extends AbstractFacade<Bill> {
      * bills) and via {@code Bill.patient} directly (the only path populated
      * on appointment bills, per {@code AppointmentController.saveBill()} —
      * without this fallback, appointment-bill receipts render "Name: null").
-     * Title/DOB/sex are read only from the encounter-based path (EclipseLink
-     * fails the DTO constructor's reflective binding with
-     * "argument type mismatch" when an enum- or Date-typed field is wrapped
-     * in COALESCE across two different join paths in the same SELECT NEW —
-     * confirmed by temporarily logging the swallowed exception from
-     * findLightsByJpql's catch block) — so on an appointment bill's receipt,
-     * name resolves correctly but Age/Sex render blank, same as fields the
-     * bill genuinely has no data for (Admission Type, BHT No).
+     * Title/DOB/sex cannot be COALESCEd the same way: EclipseLink fails the DTO
+     * constructor's reflective binding with a ConversionException
+     * ("The object [Mrs] ... could not be converted to ... Title") when an enum-
+     * or Date-typed field is wrapped in COALESCE/CASE across two join paths in
+     * the same SELECT NEW. So they are still read from the encounter path in the
+     * main query, and when the bill has no encounter (title/dob/sex all null) a
+     * second lightweight query backfills them from {@code Bill.patient} directly.
+     * Admission Type and BHT No stay blank on such a receipt — the bill genuinely
+     * has no encounter to source them from. (#23622)
      *
      * Bill.netTotal is a primitive double and is projected directly (not
      * COALESCEd) to avoid EclipseLink DTO-constructor binding mismatches.
@@ -100,7 +101,28 @@ public class BillFacade extends AbstractFacade<Bill> {
         if (results == null || results.isEmpty()) {
             return null;
         }
-        return (InwardBillReceiptDTO) results.get(0);
+        InwardBillReceiptDTO dto = (InwardBillReceiptDTO) results.get(0);
+
+        // The demographics above come from the bill's patient ENCOUNTER. A bill
+        // with no encounter - e.g. the appointment-deposit cancel bill produced by
+        // the Convert-to-Inward-Deposit flow - therefore shows a blank title / age
+        // / sex on its receipt even though the bill's own patient has them.
+        // EclipseLink cannot COALESCE/CASE over an @Enumerated path in a
+        // constructor query (ConversionException), so fall back with a second
+        // lightweight query instead. (#23622)
+        if (dto.getPatientDob() == null && dto.getPatientSex() == null && dto.getPatientTitle() == null) {
+            List<?> fb = findLightsByJpql(
+                    "SELECT p.title, p.dob, p.sex "
+                    + "FROM Bill b JOIN b.patient pt JOIN pt.person p WHERE b.id = :billId",
+                    params);
+            if (fb != null && !fb.isEmpty() && fb.get(0) instanceof Object[]) {
+                Object[] row = (Object[]) fb.get(0);
+                dto.setPatientTitle((com.divudi.core.data.Title) row[0]);
+                dto.setPatientDob((java.util.Date) row[1]);
+                dto.setPatientSex((com.divudi.core.data.Sex) row[2]);
+            }
+        }
+        return dto;
     }
 
     /**

--- a/src/main/webapp/inward/inward_appointment.xhtml
+++ b/src/main/webapp/inward/inward_appointment.xhtml
@@ -277,7 +277,12 @@
                                                             timeInput="true"
                                                             showTime="true"
                                                             showButtonBar="true"
-                                                            class="my-2"/>
+                                                            class="my-2">
+                                                            <p:ajax event="dateSelect"
+                                                                    listener="#{appointmentController.onReservedFromDateChanged()}"
+                                                                    update="appointmentDate"
+                                                                    process="@this" />
+                                                        </p:datePicker>
 
                                                         <h:outputLabel
                                                             for="reserveToTimeStamp"

--- a/src/main/webapp/inward/inward_reservations_schedule_calendar.xhtml
+++ b/src/main/webapp/inward/inward_reservations_schedule_calendar.xhtml
@@ -165,7 +165,7 @@
                             <p:commandButton
                                 icon="fa fa-check-circle"
                                 ajax="false"
-                                value="Admit"
+                                value="To Admit"
                                 style="width: 250px;"
                                 rendered="#{webUserController.hasPrivilege('InwardAppointmentAdmission')}"
                                 disabled="#{inwardReservationController.currentReservationDTO.status eq 'CANCEL' or inwardReservationController.currentReservationDTO.status eq 'COMPLETE'}"

--- a/src/main/webapp/inward/view_appointment.xhtml
+++ b/src/main/webapp/inward/view_appointment.xhtml
@@ -150,26 +150,23 @@
                                     </p:column>
 
                                     <p:column headerText="Patient" style="padding: 8px;">
-                                        <i class="fas fa-user text-primary" style="width: 27px;"></i> <!-- Name Icon -->
                                         <h:outputLabel value="#{r.patientNameWithTitle}" />
                                     </p:column>
 
-                                    <p:column headerText="Age / Gender"  width="17em;" style="padding: 8px;">
-                                        <i class="fas fa-birthday-cake text-info" style="width: 27px;"></i> <!-- Age Icon -->
-                                        <h:outputLabel value="#{r.patientAge}" />
-                                        <h:outputLabel value="/" class="text-center" style="width: 25px;"/>
-                                        <i class="fas fa-venus-mars text-danger" style="width: 27px;"></i> <!-- Sex Icon -->
-                                        <h:outputLabel value="#{r.patientGender}" />
+                                    <p:column headerText="Age / Gender" width="9em;" style="padding: 8px;">
+                                        <h:outputLabel value="#{r.patientAgeShort}" />
+                                        <h:outputText value=" / " />
+                                        <h:outputText styleClass="fas fa-mars text-primary" title="Male"
+                                                      rendered="#{r.patientGender eq 'Male'}" />
+                                        <h:outputText styleClass="fas fa-venus text-danger" title="Female"
+                                                      rendered="#{r.patientGender eq 'Female'}" />
+                                        <h:outputText styleClass="fas fa-genderless text-muted" title="#{r.patientGender}"
+                                                      rendered="#{r.patientGender ne 'Male' and r.patientGender ne 'Female'}" />
                                     </p:column>
 
                                     <p:column headerText="Mobile"  width="10em;" style="padding: 8px;">
-                                        <h:panelGroup rendered="#{not empty r.patientMobile.blank}">
-                                            <i class="fas fa-mobile-alt text-warning" style="width: 27px;"></i> <!-- Mobile Icon -->
-                                            <h:outputLabel value="#{r.patientMobile}" />
-                                        </h:panelGroup>
-                                        <h:panelGroup rendered="#{empty r.patientMobile}">
-                                            <h:outputLabel value="N/A" />
-                                        </h:panelGroup>
+                                        <h:outputLabel value="#{r.patientMobile}" rendered="#{not empty r.patientMobile}" />
+                                        <h:outputLabel value="N/A" rendered="#{empty r.patientMobile}" />
                                     </p:column>
 
                                     <p:column headerText="Status" width="8em;" style="padding: 8px;">
@@ -178,12 +175,12 @@
                                         <p:badge rendered="#{r.status eq'CANCEL'}" severity="danger" value="#{r.status.name}"></p:badge>
                                     </p:column>
 
-                                    <p:column headerText="Actions" width="220px;" style="padding: 8px;" >
+                                    <p:column headerText="Actions" width="260px;" style="padding: 8px;" >
                                         <div class="d-flex gap-2">
                                             <p:commandButton
                                                 icon="fa fa-check-circle"
                                                 ajax="false"
-                                                value="Admit"
+                                                value="To Admit"
                                                 rendered="#{webUserController.hasPrivilege('InwardAppointmentAdmission')}"
                                                 disabled="#{r.status eq 'CANCEL' or r.status eq 'COMPLETE'}"
                                                 action="#{appointmentController.navigatePatientAdmit(r.id)}"


### PR DESCRIPTION
## Summary

Bundles five related Inward appointment/admission fixes found in one
`demonstrate-issues` session. Closes #23618, #23619, #23620, #23621, #23622.

| Issue | Change |
|---|---|
| #23618 | No more spurious *"Reservation, room, and dates must not be null"* toast on a successful Make Appointment when **Reserve To** is left blank |
| #23619 | Appointment Date derived from the reservation — auto-filled on save, mirrored when Reserve From changes, never overrides a staff-entered value |
| #23620 | Appointment → Admit now pre-fills **Consultant** (and, best-effort, Room / Admission Type); the navigation buttons read **"To Admit"**; the Appointment Search Actions column widened |
| #23621 | Appointment Search grid: short age (`86Y`, `3M20D`), sex-specific gender icon, no Patient/Mobile row icons, broken mobile render-guard fixed |
| #23622 | Appointment Deposit **Cancellation** receipt no longer shows blank Age/Sex (backfilled from the bill's own patient when there is no encounter) |

## Decisions made without approval

- **One combined PR for all five issues** — requested by the user; they overlap
  heavily (#23618/#23619 both in `AppointmentController.settleBill`,
  #23620/#23621 both in `view_appointment.xhtml`), so a single branch was lower
  risk than five parallel ones.
- **#23620 Room / Admission Type carry-over is best-effort.** The existing
  `AdmissionController.bhtNumberCalculation()` (fired when staff pick an
  Admission Type) overwrites `patientRoom.roomFacilityCharge` with the selected
  type's own (usually `null`) room. So the **Consultant** carries reliably, but
  the **Room** only sticks when an Admission Type whose fixed room matches the
  reservation is also auto-selected (exactly one match). `bhtNumberCalculation()`
  was left unchanged to avoid altering the existing "switching Admission Type
  resets the Room" behaviour — a follow-up if full room carry-over is wanted.
- **#23620 stale-reservation guard.** `listnerForAppoimentSelect()` has a second
  caller (the admission form's own *Appointment* search tab) that never sets
  `currentReservation`. The prefill now only trusts `currentReservation` for the
  room/type when it actually belongs to the appointment being admitted, so a
  stale reservation from an earlier abandoned "To Admit" cannot apply the wrong
  room.
- **#23622 fix approach.** The obvious `COALESCE(per.title, per2.title)` fails —
  EclipseLink throws `ConversionException` COALESCE/CASE-ing an `@Enumerated`
  path in a `SELECT NEW` (this was already documented in the method's Javadoc as
  a known limitation, and confirmed live in the server log during this work). So
  a second lightweight query backfills title/dob/sex from the bill's own patient
  when all three come back null. Admission Type / BHT stay blank — a
  no-encounter bill has nothing to source them from.

## Self-review (`/code-review high`)

Ran before the first push. Three findings, all in this PR's own new code, all
fixed and re-verified:

1. The new `p:ajax` on the Reserve From picker referenced `pnlScheduleInfo`,
   which is rendered only for *non-room* categories — mutually exclusive with the
   picker. Reduced `update` to just `appointmentDate`.
2. `prefillAdmissionFromAppointment()` trusted `getCurrentReservation()` without
   checking it belongs to the appointment — added the ownership guard above.
3. `onReservedFromDateChanged()` called `onScheduleFilterChanged()`, a wasted
   schedule-slot query for room categories — removed.

## Testing

Local Payara, `coop` DB, department Inward, reached through the menus
(*Menu → Inward → Appointment → Add Appointment* / *Manage Appointment*;
*Manage Appointment → row → To Admit*).

- **#23618 + #23619 (save):** Made a Room Admission appointment with **Reserve To
  blank** and **Appointment Date blank** → no error toast, only *"Bill Saved"*;
  appointment `IPA/COOP/26/000008` created. DB: `RESERVATION.RESERVEDTO = NULL`,
  `PATIENTENCOUNTER.APPOINTMENTDATE = 2026-09-09 09:00` (derived from Reserve
  From).
- **#23619 (mirror-on-change):** Changed Reserve From via the calendar → empty
  Appointment Date auto-populated to the same value, no ajax error; a second
  Reserve From change left the now-set Appointment Date untouched.
- **#23620:** Row/dialog buttons read **"To Admit"**; clicking it lands on the
  admission form with **Consultant = the appointment's referring doctor**
  pre-filled (was blank before). Patient + allergies carry as before.
- **#23621:** Appointment Search grid shows `3M20D / ♀` and `86Y / ♂` with
  sex-specific icons and no text label; Patient and Mobile cells have no leading
  icon.
- **#23622:** Root cause reproduced in the server log
  (`ConversionException: The object [Mrs] ... could not be converted to ...
  Title`) from the first COALESCE attempt, then reverted. DB confirms
  `INWARD_APPOINTMENT_CANCEL_BILL` rows have `PATIENTENCOUNTER_ID = NULL` but a
  `PATIENT` → `PERSON` with populated `TITLE` / `DOB` / `SEX`, which the new
  fallback query reads. **A final screenshot of a populated cancellation receipt
  was not captured** — after the earlier test admissions the admission form's
  room autocomplete returned no vacant rooms, so a fresh end-to-end conversion
  could not be completed in this session. The fallback query uses the same
  bare-column enum projection the working `per.title` / `per.sex` path uses, so
  the `ConversionException` does not apply to it.

## Documentation

No wiki page is factually contradicted by these changes (they are additive
behaviour + display tweaks). The Appointment Search list screenshot on
`Inward-Manage-Appointments` and the receipt notes on
`Appointment-Deposit-Conversion-Receipts-and-Payment-Reports` are now slightly
out of date (short age, gender icon, "To Admit" label; populated cancellation
receipt) — flagged for a docs follow-up rather than updated here, since the
`#23622` screenshot could not be produced this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ML6GGHFHHndgjmCBrZhJv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Reservation dates now automatically populate missing appointment dates.
  - Admission details can be prefilled from appointment information when applicable.
  - Reservation and receipt views now support compact patient age and fallback demographic details.

- **Bug Fixes**
  - Room availability checks handle reservations without an end time.
  - Receipt demographic information is recovered when encounter details are unavailable.

- **UI Updates**
  - Updated appointment lists with clearer age, gender, and mobile information.
  - Renamed admission actions to “To Admit” and adjusted action-column sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->