### PR TITLE
fix(inward): stop auto-filling Stopped Time when adding a timed service

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardTimedItemController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardTimedItemController.java
@@ -715,22 +715,27 @@ public class InwardTimedItemController implements Serializable {
         if (errorCheck()) {
             return;
         }
-        if (getCurrent().getToTime() == null) {
-            getCurrent().setToTime(new Date());
+        if (getCurrent().getFromTime() == null) {
+            getCurrent().setFromTime(new Date());
         }
+        // Stopped Time is intentionally left null when not entered - the
+        // service is still running. calTotalTimedChargeForItem/calCount
+        // already treats a null end time as "now" for interim pricing without
+        // persisting it (see fetchRunningTimedPatientItems, which queries
+        // toTime is null to find services still in progress), and the row's
+        // Update button (finalizeService) is how a real stop time gets
+        // recorded later.
         // Price from the Start Time the user entered on this page, not from the
         // date of admission. Both are stored on the item, but only fromTime is
         // what the service actually ran for — and it is what the row's Update
         // button (finalizeService) re-prices against, so pricing from the
         // admission date made Add and Update disagree. A per-minute service made
         // that glaring: a six-minute run on a two-week-old admission billed every
-        // minute since admission.
-        Date chargeFrom = getCurrent().getFromTime() != null
-                ? getCurrent().getFromTime()
-                : getCurrent().getPatientEncounter().getDateOfAdmission();
+        // minute since admission. fromTime is always set by now (see above), so
+        // there is no admission-date fallback to fall back to.
         double value = getInwardBean().calTotalTimedChargeForItem(
                 (TimedItem) getCurrent().getItem(),
-                chargeFrom,
+                getCurrent().getFromTime(),
                 getCurrent().getToTime(),
                 getCurrent().getPatientEncounter().isForiegner());
         getCurrent().setServiceValue(value);


### PR DESCRIPTION
## Decisions made without approval
- Scoped the fix to `InwardTimedItemController.save()` only (the shared Add-service path for the Inward "Manage Inward Timed Services" page). The separate surgery/theatre "Add Timed Services" flow (`addTimedService()`/`saveSurgeryTimedService()`) was already correct and untouched.
- Removed the now-dead admission-date pricing fallback ternary in the same method — a self-review finding (see below) directly caused by this diff, not a scope expansion.
- Filed the "no duplicate-running-service guard" self-review finding as a separate follow-up issue (#23629) rather than expanding this PR, since it's a pre-existing gap already reachable via the surgery page, not something this fix introduces.
- No wiki update: verified `Theatre-Timed-Services.md` and `Admin-Inpatient-Timed-Services.md` already correctly document Stopped Time as "blank if not yet finalised" — this fix restores that documented behavior rather than contradicting or extending existing docs.

## Summary
- `save()` unconditionally set `toTime` to `new Date()` whenever it was null, so every newly added timed service looked already-stopped even though it had just started.
- This also silently broke the app's existing "running service" model: `fetchRunningTimedPatientItems()` queries `toTime is null` to find services still in progress (used by `BhtSummeryController` to auto-close them at discharge), and `calTotalTimedChargeForItem`/`calCount` already treats a null end time as "now" for interim pricing without persisting it. The row-level **Update** button (`finalizeService()`) already correctly handles `toTime == null` as the "give it a stop time later" mechanism — `save()` just never let that state exist.
- Fixed by defaulting `fromTime` to now instead when blank (mirroring `getCurrent()`'s own lazy-init default, which the post-save reset didn't replicate for the second and later adds in a session), and no longer touching `toTime` at all.

## Root cause
`src/main/java/com/divudi/bean/inward/InwardTimedItemController.java`, `save()`:
- Old: `if (getCurrent().getToTime() == null) { getCurrent().setToTime(new Date()); }`
- New: `if (getCurrent().getFromTime() == null) { getCurrent().setFromTime(new Date()); }` — `toTime` is left untouched.

## Test plan
- [x] Rebuilt (`mvn clean package -DskipTests`) and redeployed locally (Payara `domain1`, `rh-3.0.0` on `/rh`)
- [x] Reached the page only via menus (never by URL): **Inpatient Dashboard → Services → Add Timed Services**, for a real local test admission
- [x] Added a timed service with no Stopped Time entered — confirmed in the UI grid and via direct DB query (`PATIENTITEM` table) that the new row has `fromTime` set to the add time and `toTime = NULL`
- [x] Confirmed the Interim Bill page's "Timed Service Charges" tab renders the running (null-Stopped-Time) row correctly with no errors
- [x] Checked server log — no exceptions during any of the above
- [x] Self-review pass (`/code-review high`) run against the diff before this push; both findings triaged (one fixed in this commit, one filed as #23629)
- [x] Re-verified end-to-end after the dead-code cleanup from the self-review pass

## Documentation
No wiki update needed — `Theatre-Timed-Services.md` and `Admin-Inpatient-Timed-Services.md` already correctly document the intended null-until-stopped behavior this fix restores.

Fixes #23623

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017dxdmNUTJsxo1MLSQgJ46V


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Timed services with no recorded start time now default to the current time.
  - Ongoing services without a stop time remain active and are priced through the current time for interim billing.
  - Time-based charges now use the service’s recorded start time for more accurate billing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->