### PR TITLE
fix(inward): block nursing discharge/timed-service edits/surgery validation while a timed service is running

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardTimedItemController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardTimedItemController.java
@@ -657,11 +657,6 @@ public class InwardTimedItemController implements Serializable {
         if (isLockedForChanges(getCurrent().getPatientEncounter())) {
             return true;
         }
-        if (getCurrent().getPatientEncounter().isNursingDischarged()
-                && !webUserController.hasPrivilege("InwardAddChargesAfterNursingDischarge")) {
-            JsfUtil.addErrorMessage("Cannot add charges: nursing discharge has been confirmed for this patient.");
-            return true;
-        }
         return false;
     }
 
@@ -680,6 +675,10 @@ public class InwardTimedItemController implements Serializable {
         }
         if (pe.isDischarged()) {
             JsfUtil.addErrorMessage("This patient has been discharged. Timed services can no longer be changed.");
+            return true;
+        }
+        if (pe.isNursingDischarged() && !webUserController.hasPrivilege("InwardAddChargesAfterNursingDischarge")) {
+            JsfUtil.addErrorMessage("Cannot change timed services: nursing discharge has been confirmed for this patient.");
             return true;
         }
         return false;

--- a/src/main/java/com/divudi/bean/inward/NursingDischargeController.java
+++ b/src/main/java/com/divudi/bean/inward/NursingDischargeController.java
@@ -6,6 +6,7 @@ import com.divudi.core.data.BillTypeAtomic;
 import com.divudi.core.data.dto.PendingLabInvestigationDTO;
 import com.divudi.core.data.dto.PendingPharmacyItemDTO;
 import com.divudi.core.entity.PatientEncounter;
+import com.divudi.core.entity.PatientItem;
 import com.divudi.core.facade.BillFacade;
 import com.divudi.core.facade.PatientEncounterFacade;
 import com.divudi.core.facade.PatientInvestigationFacade;
@@ -54,6 +55,9 @@ public class NursingDischargeController implements Serializable {
 
     @Inject
     private NotificationController notificationController;
+
+    @Inject
+    private InwardBeanController inwardBean;
 
     private PatientEncounter currentEncounter;
     private List<PendingPharmacyItemDTO> pendingPharmacyItems = new ArrayList<>();
@@ -268,6 +272,14 @@ public class NursingDischargeController implements Serializable {
             JsfUtil.addErrorMessage("Cannot confirm nursing discharge: "
                     + pendingLabInvestigations.size()
                     + " lab investigation(s) must be sent to lab first.");
+            return;
+        }
+        List<PatientEncounter> cpts = inwardBean.fetchChildPatientEncounter(currentEncounter);
+        List<PatientItem> runningTimedServices = inwardBean.fetchRunningTimedPatientItems(currentEncounter, cpts);
+        if (!runningTimedServices.isEmpty()) {
+            JsfUtil.addErrorMessage("Cannot confirm nursing discharge: "
+                    + runningTimedServices.size()
+                    + " timed service(s) are still running and must be stopped first.");
             return;
         }
         Map<String, Object> before = nursingDischargeStateMap();

--- a/src/main/java/com/divudi/bean/inward/SurgeryBillController.java
+++ b/src/main/java/com/divudi/bean/inward/SurgeryBillController.java
@@ -1096,6 +1096,38 @@ public class SurgeryBillController implements Serializable {
         return getBillFacade().findLongByJpql(jpql, hm);
     }
 
+    /**
+     * Counts still-running ({@code toTime IS NULL}) timed services scoped to
+     * this surgery specifically, not the whole admission - a patient can have
+     * more than one surgery per admission. Every timed-service PatientItem
+     * for a surgery is billed on the single TimedService Bill found via
+     * {@code fetchByForwardBill}, the same lookup
+     * {@code InwardTimedItemController.selectSurgeryBillListener()} uses.
+     * <p>
+     * Joined through {@code EncounterComponent} rather than
+     * {@code PatientItem.billItem} - the surgery Add flow
+     * ({@code InwardTimedItemController.saveTimeServiceBill()}) links a
+     * timed service's BillItem onto its {@code EncounterComponent}, never
+     * onto the {@code PatientItem} itself, so {@code PatientItem.billItem}
+     * is always null here.
+     */
+    public long getRunningTimedServiceCount() {
+        if (getSurgeryBill().getId() == null) {
+            return 0;
+        }
+        Bill timedServiceBill = getBillBean().fetchByForwardBill(getSurgeryBill(), SurgeryBillType.TimedService);
+        if (timedServiceBill == null) {
+            return 0;
+        }
+        String jpql = "SELECT COUNT(ec) FROM EncounterComponent ec"
+                + " WHERE ec.retired = false"
+                + " AND ec.billItem.bill = :bill"
+                + " AND ec.billFee.patientItem.toTime IS NULL";
+        HashMap<String, Object> hm = new HashMap<>();
+        hm.put("bill", timedServiceBill);
+        return getEncounterComponentFacade().findLongByJpql(jpql, hm);
+    }
+
     public void validateSurgery() {
         if (getSurgeryBill().getId() == null) {
             JsfUtil.addErrorMessage("Select Surgery");
@@ -1108,6 +1140,12 @@ public class SurgeryBillController implements Serializable {
         if (!isAllSurgeryBillsChecked()) {
             JsfUtil.addErrorMessage("Cannot validate: " + getUncheckedSurgeryBillCount()
                     + " bill(s) under this surgery are not yet checked.");
+            return;
+        }
+        long runningTimedServices = getRunningTimedServiceCount();
+        if (runningTimedServices > 0) {
+            JsfUtil.addErrorMessage("Cannot validate: " + runningTimedServices
+                    + " timed service(s) under this surgery are still running. Stop them first.");
             return;
         }
         Map<String, Object> before = new LinkedHashMap<>();

--- a/src/main/java/com/divudi/bean/inward/SurgeryBillController.java
+++ b/src/main/java/com/divudi/bean/inward/SurgeryBillController.java
@@ -1110,6 +1110,13 @@ public class SurgeryBillController implements Serializable {
      * timed service's BillItem onto its {@code EncounterComponent}, never
      * onto the {@code PatientItem} itself, so {@code PatientItem.billItem}
      * is always null here.
+     * <p>
+     * Filters on {@code patientItem.retired} in addition to
+     * {@code ec.retired} - {@link #removeTimeService(PatientItem)} (the
+     * Remove action on the Surgery Dashboard's Timed Services tab) only
+     * retires the {@code PatientItem}, not its {@code EncounterComponent},
+     * so a removed-but-never-stopped service would otherwise still count as
+     * running here and permanently block validation.
      */
     public long getRunningTimedServiceCount() {
         if (getSurgeryBill().getId() == null) {
@@ -1122,6 +1129,7 @@ public class SurgeryBillController implements Serializable {
         String jpql = "SELECT COUNT(ec) FROM EncounterComponent ec"
                 + " WHERE ec.retired = false"
                 + " AND ec.billItem.bill = :bill"
+                + " AND ec.billFee.patientItem.retired = false"
                 + " AND ec.billFee.patientItem.toTime IS NULL";
         HashMap<String, Object> hm = new HashMap<>();
         hm.put("bill", timedServiceBill);


### PR DESCRIPTION
## Summary

Fixes three related gaps in timed-service locking discovered while shipping #23623 (merged as PR #23630): several checkpoints assumed a running timed service (`toTime IS NULL`) would always be stopped before discharge/validation, but nothing actually enforced it.

- **Closes #23631** — Nursing discharge now blocks while any timed service on the admission (or a child encounter) is still running.
- **Closes #23632** — Inward timed-service **Update** and **Remove** are now locked after nursing discharge, the same as **Add** already was.
- **Closes #23633** — Surgery validation now blocks while any timed service under that specific surgery is still running.

## Changes

- `NursingDischargeController.confirmNursingDischarge()` — added a running-timed-service check, reusing `InwardBeanController.fetchRunningTimedPatientItems()` (the same query `BhtSummeryController` already uses to auto-close running services at *physical* discharge — a later, different-purpose safety net, not reused here since nursing discharge is meant to be an explicit staff checkpoint, matching the existing pending-pharmacy/pending-lab checks' hard-block style in the same method).
- `InwardTimedItemController.isLockedForChanges()` — folded in the nursing-discharge + `InwardAddChargesAfterNursingDischarge` privilege check (previously only present in `errorCheck()` for Add), so `finalizeService()` (Update) and `removePatientItem()` (Remove) are now covered by the same guard. Removed the now-redundant duplicate check from `errorCheck()`.
- `SurgeryBillController` — added `getRunningTimedServiceCount()` and a call to it in `validateSurgery()`. Scoped to the specific surgery (a patient can have more than one), joined through `EncounterComponent` rather than `PatientItem.billItem` — a surgery-added timed service's `BillItem` is linked on its `EncounterComponent`, never on the `PatientItem` itself (confirmed live: an initial `PatientItem.billItem`-based query silently matched nothing).

### Design notes (self-review)

- The nursing-discharge check is a **hard block**, not an auto-stop-and-reprice like physical discharge's `finalizeRunningTimedServices()`. This is intentional — nursing discharge is meant to be an explicit staff checkpoint (mirrors the pending-pharmacy/pending-lab hard blocks already in the same method), whereas physical discharge's auto-close is a later, best-effort safety net for whatever's still open by then.
- Reusing `InwardAddChargesAfterNursingDischarge` (rather than a new, narrower privilege) for Update/Remove is intentional — it's the codebase's existing "can manage charges after nursing discharge" override, and Update/Remove are exactly the actions a holder of that override should still have.

## Verification (local Payara, local `coop` DB)

All three verified live via Playwright, menu-driven navigation, as user `buddhika` (who holds `InwardAddChargesAfterNursingDischarge` — see caveat below):

**#23631** — BHT/57821 (clean test admission, room discharged): added a running timed service via *Inward → Add Timed Services*, attempted Nursing Discharge → blocked: `"Cannot confirm nursing discharge: 1 timed service(s) are still running and must be stopped first."` Stopped the service (Update), retried → `"Nursing discharge confirmed."` DB confirmed `NURSINGDISCHARGED=1`.

![Nursing discharge confirmed](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23631-nursing-discharge-confirmed.png)

**#23632** — Verified via the shared guard: `isLockedForChanges()` is the single method now called by all three of `errorCheck()` (Add), `finalizeService()` (Update), `removePatientItem()` (Remove) — confirmed by direct grep of the diff, all three call sites unchanged apart from the guard itself. **Caveat**: live-clicking Update/Remove as `buddhika` still succeeds, because this account holds the `InwardAddChargesAfterNursingDischarge` override privilege by design (same reason Add already succeeded for this account before this fix) — this is expected, not a gap. Did not attempt to strip that privilege from a real account for this local test.

**#23633** — BHT/57817, surgery "Appendicectomy" (bill #14080222): added a running timed service via the surgery's *Add Timed Services* tab, marked the pending service bill checked, attempted **Validate Surgery** → blocked (`Pending Validation` status unchanged, DB `COMPLETED=0`; growl read via accessibility snapshot: `"Cannot validate: 1 timed service(s) under this surgery are still running. Stop them first."`). Stopped the service (Update, End Time set), retried → succeeded (DB `COMPLETED=1`).

![Surgery validation blocked while running](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23633-surgery-validate-blocked-running-timed-service.png)
![Surgery validated after stopping](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23633-surgery-validate-succeeds-after-stop.png)

## Documentation

- [Inpatient — Nursing Discharge](https://github.com/hmislk/hmis/wiki/Inpatient-Nursing-Discharge) — added the running-timed-services prerequisite and a new "Effect on Timed Services" section.
- [Theatre — Surgery Bill Summary / Validate](https://github.com/hmislk/hmis/wiki/Theatre-Surgery-Bill-Validation) — added the running-timed-service validation block, before/after screenshots.

## Not in scope

- `SurgeryBillController.generalChecking()`'s own, separately-implemented nursing-discharge check for the surgery Add/Update/Remove flow was **not** consolidated with `InwardTimedItemController.isLockedForChanges()` — this duplication predates this PR (both existed independently before this change) and unifying them is a larger refactor than these three bug fixes warrant. Tracked as follow-up: #23642.
- #23629 (duplicate/overlapping same timed service) — confirmed intentional behavior by the reporter, closed as not-planned in the prior batch. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017dxdmNUTJsxo1MLSQgJ46V


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Nursing discharge is blocked when running timed services remain for the encounter or its related encounters.
  * Surgery completion is prevented while timed services are still running.
  * Timed-service changes, removals, and finalization are restricted after nursing discharge unless the required permission is available.
  * Removed timed services are excluded from running-service checks, preventing incorrect discharge or surgery blocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
