### PR TITLE
feat(inward): allow privileged view/print of unapproved final bills

### DIFF
--- a/src/main/java/com/divudi/bean/common/UserPrivilageController.java
+++ b/src/main/java/com/divudi/bean/common/UserPrivilageController.java
@@ -322,6 +322,7 @@ public class UserPrivilageController implements Serializable {
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardFinalBillRetire, "Inward Final Bill Retire"), additionalPrivilegesNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardFinalBillEmail, "Inward Final Bill Email"), additionalPrivilegesNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardFinalBillApprove, "Inward Final Bill Approve"), additionalPrivilegesNode);
+        new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardFinalBillViewUnapproved, "Inward Final Bill View / Print Unapproved"), additionalPrivilegesNode);
         new DefaultTreeNode(new PrivilegeHolder(Privileges.InwardSaveProvisionalFinalBill, "Inward Save Provisional Final Bill"), additionalPrivilegesNode);
 
         // Theatre Privileges

--- a/src/main/java/com/divudi/core/data/Privileges.java
+++ b/src/main/java/com/divudi/core/data/Privileges.java
@@ -117,6 +117,7 @@ public enum Privileges {
     InwardFinalBillRetire("Inward Final Bill Retire"),
     InwardFinalBillEmail("Inward Final Bill Email"),
     InwardFinalBillApprove("Inward Final Bill Approve"),
+    InwardFinalBillViewUnapproved("Inward Final Bill View / Print Unapproved"),
     InwardSaveProvisionalFinalBill("Inward Save Provisional Final Bill"),
     InwardReport("Inward Report"),
     // Inpatient Dashboard - Reports Panel individual button privileges (issue: admission_profile.xhtml Reports panel)
@@ -1683,6 +1684,7 @@ public enum Privileges {
             case InwardFinalBillRetire:
             case InwardFinalBillEmail:
             case InwardFinalBillApprove:
+            case InwardFinalBillViewUnapproved:
             case InwardSaveProvisionalFinalBill:
             case InwardLaboratory:
             case InwardLaboratoryBarcodeGeneration:

--- a/src/main/webapp/inward/inward_final_bill_list.xhtml
+++ b/src/main/webapp/inward/inward_final_bill_list.xhtml
@@ -112,11 +112,13 @@
                                     <p:commandButton
                                         ajax="false"
                                         icon="fa fa-print"
-                                        class="ui-button-info me-1"
-                                        value="View / Print"
+                                        class="#{b.approveAt eq null ? 'ui-button-warning me-1' : 'ui-button-info me-1'}"
+                                        value="#{b.approveAt eq null ? 'View / Print (Unapproved)' : 'View / Print'}"
                                         title="View #{b.deptId}"
                                         action="/inward/inward_reprint_bill_final?faces-redirect=true"
-                                        rendered="#{b.approveAt ne null}">
+                                        rendered="#{b.approveAt ne null
+                                                    or webUserController.hasPrivilege('InwardFinalBillViewUnapproved')
+                                                    or webUserController.hasPrivilege('InwardFinalBillApprove')}">
                                         <f:setPropertyActionListener
                                             value="#{b}"
                                             target="#{inwardSearch.bill}">

--- a/src/main/webapp/inward/inward_reprint_bill_final.xhtml
+++ b/src/main/webapp/inward/inward_reprint_bill_final.xhtml
@@ -15,8 +15,23 @@
 
             <ui:define name="content">
                 <h:form>
-                    <p:panel rendered="#{inwardSearch.patient.person ne null and inwardSearch.bill ne null and inwardSearch.bill.approveAt ne null}">
-                        <p:panel styleClass="alignTop" rendered="#{inwardSearch.patient.person ne null and inwardSearch.bill ne null and inwardSearch.bill.approveAt ne null}" class="">
+                    <!--
+                        An unapproved final bill is viewable/printable only by a user holding
+                        InwardFinalBillViewUnapproved, or InwardFinalBillApprove (an approver
+                        already reads the full unapproved bill on inward_final_bill_approve.xhtml).
+                        This page is the single chokepoint for every entry route into final bill
+                        printing - inward_final_bill_list, inward_search_final,
+                        inward_search_final_check and InwardSearch.navigateToFinalBillForAdmission().
+                    -->
+                    <p:panel rendered="#{inwardSearch.patient.person ne null and inwardSearch.bill ne null and (inwardSearch.bill.approveAt ne null or webUserController.hasPrivilege('InwardFinalBillViewUnapproved') or webUserController.hasPrivilege('InwardFinalBillApprove'))}">
+
+                        <p:panel styleClass="mb-3" rendered="#{inwardSearch.bill.approveAt eq null}">
+                            <h:outputText styleClass="fas fa-exclamation-triangle text-danger me-2"></h:outputText>
+                            <h:outputText value="This final bill has NOT been approved. It is shown for reference only and must not be issued to the patient or a credit company as a final bill."
+                                          styleClass="text-danger fw-bold" />
+                        </p:panel>
+
+                        <p:panel styleClass="alignTop" rendered="#{inwardSearch.patient.person ne null and inwardSearch.bill ne null and (inwardSearch.bill.approveAt ne null or webUserController.hasPrivilege('InwardFinalBillViewUnapproved') or webUserController.hasPrivilege('InwardFinalBillApprove'))}" class="">
                             <f:facet name="header">
                                 <div class="d-flex justify-content-between">
                                     <div class="d-flex">
@@ -351,6 +366,7 @@
                                                 </f:facet>
 
                                                 <h:panelGroup id="finalOriginalBillPriview">
+                                                    <bi:unapprovedHeading bill="#{inwardSearch.bill}" />
                                                     <bi:finalBill bill="#{inwardSearch.showOrginalBill ? inwardSearch.bill.referenceBill : inwardSearch.bill}" showProfessional="#{inwardSearch.withProfessionalFee}" /> **Hospital Bill**Original Bill**
                                                 </h:panelGroup>
 
@@ -380,6 +396,7 @@
                                                 </f:facet>
 
                                                 <h:panelGroup id="finalDuplicateBillPriview">
+                                                    <bi:unapprovedHeading bill="#{inwardSearch.bill}" />
                                                     <bi:finalBill bill="#{inwardSearch.showOrginalBill ? inwardSearch.bill.referenceBill : inwardSearch.bill}" duplicate="true" showProfessional="#{inwardSearch.withProfessionalFee}"/>
                                                 </h:panelGroup>
 
@@ -415,6 +432,7 @@
                                                 </f:facet>
 
                                                 <h:panelGroup id="originalHospitalBillPriview">
+                                                    <bi:unapprovedHeading bill="#{inwardSearch.bill}" />
                                                     <bi:finalBill bill="#{inwardSearch.showOrginalBill ? inwardSearch.bill.referenceBill : inwardSearch.bill}" hosCopy="true" showProfessional="#{inwardSearch.withProfessionalFee}" /><!-- **Hospital Bill**Original Bill**-->
                                                 </h:panelGroup>
 
@@ -444,6 +462,7 @@
                                                 </f:facet>
 
                                                 <h:panelGroup id="duplicateHospitalBillPriview">
+                                                    <bi:unapprovedHeading bill="#{inwardSearch.bill}" />
                                                     <bi:finalBill bill="#{inwardSearch.showOrginalBill ? inwardSearch.bill.referenceBill : inwardSearch.bill}" duplicate="true" hosCopy="true" showProfessional="#{inwardSearch.withProfessionalFee}" /><!-- **Hospital Bill**Original Bill**-->
                                                 </h:panelGroup>
 
@@ -472,6 +491,7 @@
                                                 </f:facet>
 
                                                 <h:panelGroup id="originalProfessionalBillBillPriview">
+                                                    <bi:unapprovedHeading bill="#{inwardSearch.bill}" />
                                                     <bi:finalProfessionalBill bill="#{inwardSearch.showOrginalBill ? inwardSearch.bill.referenceBill : inwardSearch.bill}" /><!-- **Professional Bill**Original Bill**-->
                                                 </h:panelGroup>
 
@@ -494,6 +514,7 @@
                                                     </div>
                                                 </f:facet>
                                                 <h:panelGroup id="duplicateProfessionalBillBillPriview">
+                                                    <bi:unapprovedHeading bill="#{inwardSearch.bill}" />
                                                     <bi:finalProfessionalBill bill="#{inwardSearch.showOrginalBill ? inwardSearch.bill.referenceBill : inwardSearch.bill}" duplicate="true" /><!-- Final Bill - **Professional Bill**Duplicate Bill**-->
                                                 </h:panelGroup>
                                             </p:panel>
@@ -528,6 +549,7 @@
                                                     </div>
                                                 </f:facet>
                                                 <h:panelGroup id="OriginalFinalBillSummaryPriview">
+                                                    <bi:unapprovedHeading bill="#{inwardSearch.bill}" />
                                                     <h:panelGroup id="OriginalFinalBillSummarywithoutProfessionalFeePriview" rendered="#{inwardSearch.withProfessionalFee eq false}">
                                                         <bi:finalBillGreenSheet  bill="#{inwardSearch.showOrginalBill ? inwardSearch.bill.referenceBill : inwardSearch.bill}" />
                                                     </h:panelGroup>
@@ -563,6 +585,7 @@
                                                 </f:facet>
 
                                                 <h:panelGroup id="duplicateFinalBillSummaryPriview">
+                                                    <bi:unapprovedHeading bill="#{inwardSearch.bill}" />
                                                     <h:panelGroup id="duplicateFinalBillSummarywithoutProfessionalFeePriview" rendered="#{inwardSearch.withProfessionalFee eq false}">
                                                         <bi:finalBillGreenSheet  bill="#{inwardSearch.showOrginalBill ? inwardSearch.bill.referenceBill : inwardSearch.bill}" duplicate="true"/>
                                                     </h:panelGroup>
@@ -594,6 +617,7 @@
                                         </f:facet>
 
                                         <h:panelGroup id="creditCompanyLetterPriview">
+                                            <bi:unapprovedHeading bill="#{inwardSearch.bill}" />
                                             <bi:credit_company_letter_new bill="#{inwardSearch.bill}"/>
                                         </h:panelGroup>
                                     </p:panel>
@@ -630,6 +654,7 @@
                                                 </f:facet>
 
                                                 <h:panelGroup id="originalCustom2BillPriview">
+                                                    <bi:unapprovedHeading bill="#{inwardSearch.bill}" />
                                                     <bi:finalBillCustom2 bill="#{inwardSearch.showOrginalBill ? inwardSearch.bill.referenceBill : inwardSearch.bill}" duplicate="false"/>
                                                 </h:panelGroup>
 
@@ -653,6 +678,7 @@
                                                 </f:facet>
 
                                                 <h:panelGroup id="duplicateCustom2BillPriview">
+                                                    <bi:unapprovedHeading bill="#{inwardSearch.bill}" />
                                                     <bi:finalBillCustom2 bill="#{inwardSearch.showOrginalBill ? inwardSearch.bill.referenceBill : inwardSearch.bill}" duplicate="true"/>
                                                 </h:panelGroup>
 
@@ -681,6 +707,7 @@
                                                 </f:facet>
 
                                                 <h:panelGroup id="originalCustom3BillPriview">
+                                                    <bi:unapprovedHeading bill="#{inwardSearch.bill}" />
                                                     <bi:finalBillCustom3 bill="#{inwardSearch.showOrginalBill ? inwardSearch.bill.referenceBill : inwardSearch.bill}" duplicate="false"/>
                                                 </h:panelGroup>
 
@@ -704,6 +731,7 @@
                                                 </f:facet>
 
                                                 <h:panelGroup id="duplicateCustom3BillPriview">
+                                                    <bi:unapprovedHeading bill="#{inwardSearch.bill}" />
                                                     <bi:finalBillCustom3 bill="#{inwardSearch.showOrginalBill ? inwardSearch.bill.referenceBill : inwardSearch.bill}" duplicate="true"/>
                                                 </h:panelGroup>
 
@@ -731,6 +759,7 @@
                                                 </f:facet>
 
                                                 <h:panelGroup id="originalCustom4BillPriview">
+                                                    <bi:unapprovedHeading bill="#{inwardSearch.bill}" />
                                                     <bi:finalBillCustom4 bill="#{inwardSearch.showOrginalBill ? inwardSearch.bill.referenceBill : inwardSearch.bill}" duplicate="false" showProfessional="#{inwardSearch.withProfessionalFee}"/>
                                                 </h:panelGroup>
 
@@ -753,6 +782,7 @@
                                                 </f:facet>
 
                                                 <h:panelGroup id="duplicateCustom4BillPriview">
+                                                    <bi:unapprovedHeading bill="#{inwardSearch.bill}" />
                                                     <bi:finalBillCustom4 bill="#{inwardSearch.showOrginalBill ? inwardSearch.bill.referenceBill : inwardSearch.bill}" duplicate="true" showProfessional="#{inwardSearch.withProfessionalFee}"/>
                                                 </h:panelGroup>
 
@@ -781,6 +811,7 @@
                                                 </f:facet>
 
                                                 <h:panelGroup id="originalBundledCustom1BillPriview">
+                                                    <bi:unapprovedHeading bill="#{inwardSearch.bill}" />
                                                     <bi:finalBillBundledCustom1 bill="#{inwardSearch.showOrginalBill ? inwardSearch.bill.referenceBill : inwardSearch.bill}" duplicate="false" showProfessional="#{inwardSearch.withProfessionalFee}"/>
                                                 </h:panelGroup>
 
@@ -804,6 +835,7 @@
                                                 </f:facet>
 
                                                 <h:panelGroup id="duplicateBundledCustom1BillPriview">
+                                                    <bi:unapprovedHeading bill="#{inwardSearch.bill}" />
                                                     <bi:finalBillBundledCustom1 bill="#{inwardSearch.showOrginalBill ? inwardSearch.bill.referenceBill : inwardSearch.bill}" duplicate="true" showProfessional="#{inwardSearch.withProfessionalFee}"/>
                                                 </h:panelGroup>
 
@@ -1100,8 +1132,8 @@
 
                     </p:panel>
 
-                    <p:panel rendered="#{inwardSearch.patient.person ne null and inwardSearch.bill ne null and inwardSearch.bill.approveAt eq null}">
-                        <h:outputText value="This final bill has not been approved yet and cannot be viewed or printed." styleClass="text-danger" />
+                    <p:panel rendered="#{inwardSearch.patient.person ne null and inwardSearch.bill ne null and inwardSearch.bill.approveAt eq null and not webUserController.hasPrivilege('InwardFinalBillViewUnapproved') and not webUserController.hasPrivilege('InwardFinalBillApprove')}">
+                        <h:outputText value="This final bill has not been approved yet, and you do not have permission to view or print unapproved bills." styleClass="text-danger" />
                     </p:panel>
                 </h:form>
             </ui:define>

--- a/src/main/webapp/resources/inward/bill/unapprovedHeading.xhtml
+++ b/src/main/webapp/resources/inward/bill/unapprovedHeading.xhtml
@@ -1,0 +1,43 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:cc="http://xmlns.jcp.org/jsf/composite"
+      xmlns:h="http://xmlns.jcp.org/jsf/html">
+
+    <!--
+        Prints a configurable "UNAPPROVED" heading on top of an inpatient final
+        bill that has not been approved yet (Bill.approveAt == null).
+
+        Must be placed INSIDE each <h:panelGroup id="...Priview"> that a
+        <p:printer target="..."> points at - p:printer only prints the subtree
+        of its target, so a heading placed outside the target never reaches paper.
+
+        Wording comes from the application config option
+        'Inward Final Bill - Unapproved Bill Print Heading' (default "UNAPPROVED").
+        Setting that option to blank suppresses the heading entirely; the
+        on-screen warning on inward_reprint_bill_final.xhtml is independent of
+        this option and always shows.
+    -->
+    <cc:interface>
+        <cc:attribute name="bill" type="com.divudi.core.entity.Bill" required="true"/>
+    </cc:interface>
+
+    <cc:implementation>
+        <h:panelGroup
+            layout="block"
+            rendered="#{cc.attrs.bill ne null
+                        and cc.attrs.bill.approveAt eq null
+                        and not empty configOptionApplicationController.getShortTextValueByKey('Inward Final Bill - Unapproved Bill Print Heading', 'UNAPPROVED')}"
+            style="text-align: center;
+                   font-family: verdana;
+                   font-weight: bold;
+                   font-size: 1.4em;
+                   letter-spacing: 0.3em;
+                   border: 2px solid #000;
+                   padding: 4px;
+                   margin-bottom: 6px;">
+            <h:outputText value="#{configOptionApplicationController.getShortTextValueByKey('Inward Final Bill - Unapproved Bill Print Heading', 'UNAPPROVED')}"/>
+        </h:panelGroup>
+    </cc:implementation>
+
+</html>


### PR DESCRIPTION
Closes #23639

## What this does

Since #23173, an inpatient final bill version cannot be viewed or printed at all until it is approved. This relaxes **view/print only**, behind a new privilege, and marks every printed copy so a draft cannot pass as a real final bill.

**Email and Set-as-Confirmed stay approval-gated** — email is outward-facing, and confirming an unapproved version is a data-integrity problem. Their server-side guards in `InwardSearch` are untouched.

## Changes

| File | Change |
|---|---|
| `Privileges.java` | new `InwardFinalBillViewUnapproved("Inward Final Bill View / Print Unapproved")` + its `getCategory()` case in the Inward group |
| `UserPrivilageController.java` | tree node under **Inward → Additional Privileges** — without it the privilege can never be granted |
| `resources/inward/bill/unapprovedHeading.xhtml` *(new)* | composite rendering a boxed heading when `bill.approveAt == null` and the config text is non-blank |
| `inward_reprint_bill_final.xhtml` | guards accept the new privilege; persistent on-screen warning strip; heading inserted into all 17 `<p:printer>` targets |
| `inward_final_bill_list.xhtml` | View/Print renders for unapproved versions to privileged users, labelled *View / Print (Unapproved)* in amber |

### Config option

`Inward Final Bill - Unapproved Bill Print Heading` — SHORT_TEXT, default `UNAPPROVED`. Blank suppresses the **printed** heading while the on-screen warning remains. Auto-creates on first read, so **no migration and no registration code**.

### Design notes

- The heading must sit **inside** each `<p:printer>` target — `p:printer` prints only its target's subtree, so a heading placed outside would never reach paper. Hence 17 identical one-line insertions rather than one banner at the top of the page.
- `InwardFinalBillApprove` is OR'd into the conditions because its holders already read the full unapproved bill on `inward_final_bill_approve.xhtml` by design. Without it, an approver would see no View/Print button for the very bill they are about to open and read in full one click later.
- The reprint page is the single chokepoint for every entry route into final bill printing (`inward_final_bill_list`, `inward_search_final`, `inward_search_final_check`, `navigateToFinalBillForAdmission()`), so relaxing the guard there covers them all.

## Testing

Verified end-to-end on a local Payara deployment against the `coop` database, admission **BHT/56284**, bill `Inward/INWFINAL/190/1`.

Menu path: *Menu → Inpatient → Search → Admissions → Inpatient Dashboard → Manage Final Bills*

- Button renders beside the *Pending Approval* tag; page opens; warning strip and boxed `UNAPPROVED` heading both show.
- Heading confirmed present in **all 11 rendered print targets** — the other 6 are the Custom3/Custom4/BundledCustom1 formats that deployment disables by config.
- Changed the option to `DRAFT - NOT FOR PAYMENT` via *Administration → Manage Institutions → Application Options* → heading followed. Set it blank → printed heading gone, on-screen warning still shown.
- **Privilege isolation:** revoked `InwardFinalBillApprove` for the Inward department and re-logged in → View/Print button gone entirely. Granted **only** `InwardFinalBillViewUnapproved` → button back, page renders, and no Approve button — confirming the new privilege alone carries the access, independent of the approver path. The tree node read and wrote the correct `webuserprivilege` rows.
- Local test state restored afterwards.

## ⚠️ Deployment note

This ships **inert**: no user holds the new privilege until a hospital admin grants it at *Administration → Manage Users → (user) → Manage Privileges → select department → List Privileges → Inward → Additional Privileges → **Inward Final Bill View / Print Unapproved***. Worth calling out in the release note, otherwise expect "the feature doesn't work" tickets.

No wiki page for the new config option yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXjDBhnANtPG3GDuJ9uvay