### PR TITLE
fix(inward): name the other patient in a room overlap warning

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -14,7 +14,7 @@ waste a session.
 
 ## Contents
 
-111 sections. **The workflow is §0-§8; everything from §9 on is an independent
+118 sections. **The workflow is §0-§8; everything from §9 on is an independent
 gotcha** — jump straight to the one you need rather than reading the file.
 
 **Workflow**
@@ -3217,6 +3217,49 @@ often null), grep the whole class (and callers) for every read of that
 field — `.before(`, `.after(`, `.format(`, `.getTime()`, arithmetic — and
 guard or apply the same fallback the new code uses (here: treat a missing
 end as the start instant).
+
+## 113. `p:tag` silently drops `title` — a tooltip on a tag needs `p:tooltip`
+
+`inward_patient_room_details.xhtml` carried a room-conflict explanation as
+
+```xhtml
+<p:tag value="Overlap" severity="danger" title="#{bean.overlapDescription(rm)}"/>
+```
+
+and the text had **never once reached a user**: `p:tag` has no `title`
+passthrough, so the rendered markup is just
+
+```html
+<span class="ui-tag ui-widget ui-tag-danger">…Overlap</span>
+```
+
+with no `title` attribute at all. There is no warning at build or render time
+— the page looks right, the EL is even evaluated, and the string is thrown
+away. Found on #23641 only because the E2E check read the attribute back:
+
+```js
+() => { const t = [...document.querySelectorAll('.ui-tag')]
+          .find(e => e.textContent.trim() === 'Overlap');
+        return t && t.getAttribute('title'); }   // → null
+```
+
+Use the component the codebase already uses elsewhere
+(`admin/lims/investigation_format_multiple.xhtml`):
+
+```xhtml
+<p:tag id="roomOverlapTag" value="Overlap" severity="danger"/>
+<p:tooltip for="roomOverlapTag" position="top" showDelay="150"
+           value="#{bean.overlapDescription(rm)}"/>
+```
+
+Inside a `p:dataTable` the plain `for="roomOverlapTag"` resolves per row —
+no need to build the full row client id.
+
+**Testing rule:** a `title` tooltip is invisible to a screenshot, so
+"the page rendered" is not evidence it works. Assert the attribute (or the
+`.ui-tooltip` text after a `browser_hover`) explicitly. The same blind spot
+applies to any attribute a component may not support — verify the *rendered
+DOM*, not the source.
 
 ## Quick checklist
 

--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -137,6 +137,9 @@ gotcha** — jump straight to the one you need rather than reading the file.
 - [107. A bug that "does not reproduce" locally may be gated by a `ConfigOption` whose default hides it — flip the option before concluding the report is wrong](#107-a-bug-that-does-not-reproduce-locally-may-be-gated-by-a-configoption-whose-default-hides-it--flip-the-option-before-concluding-the-report-is-wrong)
 - [109. A `p:confirm` dialog is `position: fixed`, so an `offsetParent` visibility probe wrongly reports it hidden — the click did work](#109-a-pconfirm-dialog-is-position-fixed-so-an-offsetparent-visibility-probe-wrongly-reports-it-hidden--the-click-did-work)
 - [110. A print receipt rendering completely blank can mean the department's paper-type preference isn't one the page checks — not a broken query](#110-a-print-receipt-rendering-completely-blank-can-mean-the-departments-paper-type-preference-isnt-one-the-page-checks--not-a-broken-query)
+- [111. The local `coop` DB can have **zero** vacant rooms — free some by SQL before testing any admission flow](#111-the-local-coop-db-can-have-zero-vacant-rooms--free-some-by-sql-before-testing-any-admission-flow)
+- [112. Relaxing a "required" validation? Audit every downstream reader of that field for null-safety](#112-relaxing-a-required-validation-audit-every-downstream-reader-of-that-field-for-null-safety)
+- [113. `p:tag` silently drops `title` — a tooltip on a tag needs `p:tooltip`](#113-ptag-silently-drops-title--a-tooltip-on-a-tag-needs-ptooltip)
 - [Quick checklist](#quick-checklist)
 
 ---

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -82,6 +82,7 @@ import com.divudi.core.util.CommonFunctions;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
+import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -92,6 +93,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
 import javax.ejb.EJB;
@@ -197,6 +199,8 @@ public class BhtSummeryController implements Serializable {
     private List<ChargeItemTotal> chargeItemTotals;
     List<PatientRoom> patientRooms;
     private PatientRoom pendingOverlapRoom;
+    /** Fallback when no shortDateTimeFormat preference is resolvable. */
+    private static final String DEFAULT_STAY_WINDOW_PATTERN = "dd MMM yyyy HH:mm";
     private List<CreditCompanyAllocation> creditCompanyAllocations;
     private EncounterCreditCompany newEncounterCreditCompany;
     private boolean creatingNewVersion;
@@ -2018,6 +2022,13 @@ public class BhtSummeryController implements Serializable {
         if (patientRoom == null || patientRoom.getAdmittedAt() == null || patientRoom.getPatientEncounter() == null) {
             return new ArrayList<>();
         }
+        // A retired stay is a room record that was withdrawn - it never occupied the
+        // bed, so it can neither have nor cause a conflict. The JPQL below already
+        // keeps retired rows out of the candidate side; this guards the subject side,
+        // which a caller can still reach with a stale in-memory row (Issue #23641).
+        if (patientRoom.isRetired()) {
+            return new ArrayList<>();
+        }
         if (patientRoom.getDischargedAt() != null && patientRoom.getDischargedAt().before(patientRoom.getAdmittedAt())) {
             return new ArrayList<>();
         }
@@ -2052,7 +2063,73 @@ public class BhtSummeryController implements Serializable {
         // midnight, so two stays merely sharing a calendar day were reported as
         // overlapping even when the times did not actually conflict.
         List<PatientRoom> overlaps = getPatientRoomFacade().findByJpql(jpql.toString(), params, TemporalType.TIMESTAMP);
-        return overlaps != null ? overlaps : new ArrayList<>();
+        if (overlaps == null) {
+            return new ArrayList<>();
+        }
+        // Re-assert every condition in memory. The query already applies them, but
+        // repeating the rule here keeps it enforced when a row arrives from a stale
+        // persistence context, and makes it unit testable without a database.
+        List<PatientRoom> conflicts = new ArrayList<>();
+        for (PatientRoom candidate : overlaps) {
+            if (isOverlapConflict(patientRoom, candidate)) {
+                conflicts.add(candidate);
+            }
+        }
+        return conflicts;
+    }
+
+    /**
+     * True when {@code candidate} is a genuine room-time conflict for
+     * {@code subject}: both are live (non-retired) ward stays, they belong either to
+     * the same encounter or to the same bed, and their occupied time ranges
+     * intersect. Mirrors the predicate in {@link #getOverlappingRooms(PatientRoom)}
+     * exactly. Static and facade-free so the rules - above all "a retired stay never
+     * counts, on either side" - are unit testable without a database (Issue #23641).
+     */
+    static boolean isOverlapConflict(PatientRoom subject, PatientRoom candidate) {
+        if (subject == null || candidate == null || subject == candidate) {
+            return false;
+        }
+        if (subject.getId() != null && subject.getId().equals(candidate.getId())) {
+            return false;
+        }
+        if (subject.isRetired() || candidate.isRetired()) {
+            return false;
+        }
+        if (isGuardianOrTheatreRoom(subject) || isGuardianOrTheatreRoom(candidate)) {
+            return false;
+        }
+        Date from = subject.getAdmittedAt();
+        Date to = subject.getDischargedAt();
+        if (from == null || candidate.getAdmittedAt() == null) {
+            return false;
+        }
+        if (to != null && to.before(from)) {
+            return false;
+        }
+        if (!isSameEncounter(subject, candidate) && !isSameBed(subject, candidate)) {
+            return false;
+        }
+        if (to != null && !candidate.getAdmittedAt().before(to)) {
+            return false;
+        }
+        return candidate.getDischargedAt() == null || candidate.getDischargedAt().after(from);
+    }
+
+    private static boolean isGuardianOrTheatreRoom(PatientRoom patientRoom) {
+        return patientRoom instanceof GuardianRoom || patientRoom instanceof TheatreRoom;
+    }
+
+    private static boolean isSameEncounter(PatientRoom a, PatientRoom b) {
+        return a.getPatientEncounter() != null
+                && b.getPatientEncounter() != null
+                && a.getPatientEncounter().equals(b.getPatientEncounter());
+    }
+
+    private static boolean isSameBed(PatientRoom a, PatientRoom b) {
+        return a.getRoomFacilityCharge() != null
+                && b.getRoomFacilityCharge() != null
+                && a.getRoomFacilityCharge().equals(b.getRoomFacilityCharge());
     }
 
     /**
@@ -2073,21 +2150,97 @@ public class BhtSummeryController implements Serializable {
      * are 3+ open (non-discharged) room stays.
      */
     public String getOverlapDescription(PatientRoom patientRoom) {
-        List<PatientRoom> overlaps = getOverlappingRooms(patientRoom);
-        if (overlaps.isEmpty()) {
+        return describeOverlaps(patientRoom, getOverlappingRooms(patientRoom), resolveStayWindowPattern());
+    }
+
+    /**
+     * The date/time pattern the row's own Admitted At / Discharged At pickers are
+     * rendered with. The conflict description sits beside those fields and is read
+     * against them, so a different format there would have staff comparing
+     * "19:19" with "07:19 PM" on the one screen meant to resolve the conflict.
+     */
+    private String resolveStayWindowPattern() {
+        if (sessionController != null && sessionController.getApplicationPreference() != null) {
+            return sessionController.getApplicationPreference().getShortDateTimeFormat();
+        }
+        return DEFAULT_STAY_WINDOW_PATTERN;
+    }
+
+    /**
+     * Formats the conflicts found for {@code subject}. A conflict on the same
+     * encounter needs only the room name - the user can see the other row on the
+     * same screen. A conflict with a DIFFERENT patient is named in full, because
+     * the room name alone renders as "Room 90 overlaps with Room 90", which reads
+     * as a false alarm and gives ward staff nothing to act on: the bed is held by
+     * someone else and they cannot tell who from this page (Issue #23641).
+     */
+    static String describeOverlaps(PatientRoom subject, List<PatientRoom> overlaps, String dateTimePattern) {
+        if (overlaps == null || overlaps.isEmpty()) {
             return "";
         }
         StringBuilder sb = new StringBuilder("Overlaps with ");
         for (int i = 0; i < overlaps.size(); i++) {
-            PatientRoom pr2 = overlaps.get(i);
             if (i > 0) {
-                sb.append(", ");
+                sb.append("; ");
             }
-            String roomName = pr2.getRoomFacilityCharge() != null && pr2.getRoomFacilityCharge().getName() != null
-                    ? pr2.getRoomFacilityCharge().getName() : "an unnamed room";
-            sb.append(roomName).append(pr2.getDischargedAt() == null ? " (Active)" : " (Left)");
+            sb.append(describeOverlap(subject, overlaps.get(i), dateTimePattern));
         }
         return sb.toString();
+    }
+
+    private static String describeOverlap(PatientRoom subject, PatientRoom other, String dateTimePattern) {
+        String roomName = other.getRoomFacilityCharge() != null && other.getRoomFacilityCharge().getName() != null
+                ? other.getRoomFacilityCharge().getName() : "an unnamed room";
+        if (subject != null && isSameEncounter(subject, other)) {
+            return roomName + (other.getDischargedAt() == null ? " (Active)" : " (Left)");
+        }
+        StringBuilder sb = new StringBuilder(roomName);
+        sb.append(" - held by ").append(bhtLabelOf(other));
+        String patientName = patientNameOf(other);
+        if (patientName != null && !patientName.trim().isEmpty()) {
+            sb.append(" (").append(patientName.trim()).append(")");
+        }
+        sb.append(", ").append(stayWindowOf(other, dateTimePattern));
+        return sb.toString();
+    }
+
+    private static String bhtLabelOf(PatientRoom patientRoom) {
+        PatientEncounter pe = patientRoom.getPatientEncounter();
+        String bhtNo = pe != null ? pe.getBhtNo() : null;
+        return bhtNo == null || bhtNo.trim().isEmpty() ? "another patient" : bhtNo.trim();
+    }
+
+    /**
+     * The conflicting patient's name. Ward staff already see the occupant of every
+     * bed - BHT number and patient name - on the Room Occupancy screen, so naming
+     * them here discloses nothing that page does not.
+     */
+    private static String patientNameOf(PatientRoom patientRoom) {
+        PatientEncounter pe = patientRoom.getPatientEncounter();
+        if (pe == null || pe.getPatient() == null || pe.getPatient().getPerson() == null) {
+            return null;
+        }
+        return pe.getPatient().getPerson().getName();
+    }
+
+    /**
+     * Locale.ENGLISH rather than the JVM default: the rest of this UI is English,
+     * and a default-locale month name would make the rendered text depend on the
+     * server's locale (and make any assertion on it environment-dependent).
+     */
+    private static String stayWindowOf(PatientRoom patientRoom, String dateTimePattern) {
+        String pattern = dateTimePattern == null || dateTimePattern.trim().isEmpty()
+                ? DEFAULT_STAY_WINDOW_PATTERN : dateTimePattern;
+        SimpleDateFormat formatter;
+        try {
+            formatter = new SimpleDateFormat(pattern, Locale.ENGLISH);
+        } catch (IllegalArgumentException e) {
+            // A malformed preference must not take the whole room table down.
+            formatter = new SimpleDateFormat(DEFAULT_STAY_WINDOW_PATTERN, Locale.ENGLISH);
+        }
+        String from = patientRoom.getAdmittedAt() == null ? "unknown" : formatter.format(patientRoom.getAdmittedAt());
+        String to = patientRoom.getDischargedAt() == null ? "still in room" : formatter.format(patientRoom.getDischargedAt());
+        return from + " to " + to;
     }
 
     public boolean isAnyRoomOverlapping() {
@@ -2095,6 +2248,9 @@ public class BhtSummeryController implements Serializable {
             return false;
         }
         for (PatientRoom pr : patientRooms) {
+            if (pr == null || pr.isRetired()) {
+                continue;
+            }
             if (hasOverlap(pr)) {
                 return true;
             }

--- a/src/main/webapp/inward/inward_patient_room_details.xhtml
+++ b/src/main/webapp/inward/inward_patient_room_details.xhtml
@@ -38,10 +38,11 @@
                     </p:confirmDialog>
 
                     <p:dialog id="dlgRoomOverlapConfirm" widgetVar="dlgRoomOverlapConfirm" header="&#9888; Room Time Overlap Warning"
-                              modal="true" resizable="false" closable="true" style="width:480px">
+                              modal="true" resizable="false" closable="true" style="width:560px">
                         <div style="padding:12px">
                             <p style="color:#b71c1c; font-weight:bold; font-size:1.1em;">
-                                &#9888; WARNING: This room's time range overlaps another room period for this patient or bed.
+                                &#9888; WARNING: This room's time range overlaps another room stay - either another
+                                stay for this patient, or another patient recorded in the same bed.
                             </p>
                             <p style="color:#b71c1c;">
                                 <h:outputText value="#{bhtSummeryController.pendingOverlapDescription}"/>
@@ -160,8 +161,12 @@
                                                     <p:badge value="Active" severity="warning"/>
                                                 </h:panelGroup>
                                                 <h:panelGroup rendered="#{bhtSummeryController.hasOverlap(rm)}">
-                                                    <p:tag value="Overlap" icon="fa fa-exclamation-triangle" severity="danger"
-                                                           title="#{bhtSummeryController.getOverlapDescription(rm)}"/>
+                                                    <!-- p:tag drops a plain title attribute, so the conflict details need
+                                                         p:tooltip to reach the screen at all (Issue #23641). -->
+                                                    <p:tag id="roomOverlapTag" value="Overlap"
+                                                           icon="fa fa-exclamation-triangle" severity="danger"/>
+                                                    <p:tooltip for="roomOverlapTag" position="top" showDelay="150"
+                                                               value="#{bhtSummeryController.getOverlapDescription(rm)}"/>
                                                 </h:panelGroup>
                                             </div>
                                         </p:column>

--- a/src/test/java/com/divudi/bean/inward/BhtSummeryControllerRoomOverlapTest.java
+++ b/src/test/java/com/divudi/bean/inward/BhtSummeryControllerRoomOverlapTest.java
@@ -1,0 +1,279 @@
+package com.divudi.bean.inward;
+
+import com.divudi.core.entity.Patient;
+import com.divudi.core.entity.PatientEncounter;
+import com.divudi.core.entity.Person;
+import com.divudi.core.entity.inward.GuardianRoom;
+import com.divudi.core.entity.inward.PatientRoom;
+import com.divudi.core.entity.inward.RoomFacilityCharge;
+import org.junit.jupiter.api.Test;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Room-stay overlap detection on the Patient Room Details screen (Issue #23641).
+ *
+ * <p>Reproduces the Coop case that prompted the issue: a patient moved from one
+ * room to another with no gap in their own stays, while a different patient was
+ * still recorded in the first room's bed. The warning was correct but described
+ * only the room, so it read as "Room 90 overlaps with Room 90".
+ */
+class BhtSummeryControllerRoomOverlapTest {
+
+    /** Mirrors the default shortDateTimeFormat preference. */
+    private static final String PATTERN = "dd MMM yyyy HH:mm";
+
+    private static Date at(String yyyyMMddHHmm) {
+        try {
+            return new SimpleDateFormat("yyyy-MM-dd HH:mm").parse(yyyyMMddHHmm);
+        } catch (ParseException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    private static RoomFacilityCharge bed(long id, String name) {
+        RoomFacilityCharge bed = new RoomFacilityCharge();
+        bed.setId(id);
+        bed.setName(name);
+        return bed;
+    }
+
+    private static PatientEncounter encounter(long id, String bhtNo, String patientName) {
+        PatientEncounter pe = new PatientEncounter();
+        pe.setId(id);
+        pe.setBhtNo(bhtNo);
+        Person person = new Person();
+        person.setName(patientName);
+        Patient patient = new Patient();
+        patient.setPerson(person);
+        pe.setPatient(patient);
+        return pe;
+    }
+
+    private static PatientRoom stay(long id, PatientEncounter pe, RoomFacilityCharge bed, String from, String to) {
+        PatientRoom pr = new PatientRoom();
+        pr.setId(id);
+        pr.setPatientEncounter(pe);
+        pr.setRoomFacilityCharge(bed);
+        pr.setAdmittedAt(at(from));
+        if (to != null) {
+            pr.setDischargedAt(at(to));
+        }
+        return pr;
+    }
+
+    // ---------------------------------------------------------------- retired
+
+    @Test
+    void retiredCandidateIsNeverAConflict() {
+        PatientEncounter pe = encounter(1L, "BHT/1", "A Patient");
+        RoomFacilityCharge room90 = bed(90L, "Room 90 wm");
+
+        PatientRoom live = stay(200L, pe, room90, "2026-09-08 15:17", "2026-09-08 19:19");
+        // A withdrawn correction that squarely overlaps the live row.
+        PatientRoom retired = stay(201L, pe, room90, "2026-09-08 15:01", "2026-09-08 19:16");
+        retired.setRetired(true);
+
+        assertFalse(BhtSummeryController.isOverlapConflict(live, retired),
+                "a retired stay was withdrawn and must never raise an overlap");
+    }
+
+    @Test
+    void retiredSubjectNeverHasAConflict() {
+        PatientEncounter pe = encounter(1L, "BHT/1", "A Patient");
+        RoomFacilityCharge room90 = bed(90L, "Room 90 wm");
+
+        PatientRoom retired = stay(201L, pe, room90, "2026-09-08 15:01", "2026-09-08 19:16");
+        retired.setRetired(true);
+        PatientRoom live = stay(200L, pe, room90, "2026-09-08 15:17", "2026-09-08 19:19");
+
+        assertFalse(BhtSummeryController.isOverlapConflict(retired, live),
+                "a retired stay cannot be in conflict with anything either");
+    }
+
+    // ------------------------------------------------------- non-overlapping
+
+    @Test
+    void backToBackStaysForTheSamePatientDoNotConflict() {
+        PatientEncounter pe = encounter(1L, "BHT/57914", "A Patient");
+
+        PatientRoom first = stay(200L, pe, bed(90L, "Room 90 wm"), "2026-09-08 15:17", "2026-09-08 19:19");
+        PatientRoom second = stay(202L, pe, bed(511L, "Room 511 wm"), "2026-09-08 19:20", null);
+
+        assertFalse(BhtSummeryController.isOverlapConflict(first, second));
+        assertFalse(BhtSummeryController.isOverlapConflict(second, first));
+    }
+
+    @Test
+    void guardianRoomIsExcluded() {
+        PatientEncounter pe = encounter(1L, "BHT/1", "A Patient");
+        RoomFacilityCharge room90 = bed(90L, "Room 90 wm");
+
+        PatientRoom ward = stay(200L, pe, room90, "2026-09-08 15:17", "2026-09-08 19:19");
+        GuardianRoom guardian = new GuardianRoom();
+        guardian.setId(203L);
+        guardian.setPatientEncounter(pe);
+        guardian.setRoomFacilityCharge(room90);
+        guardian.setAdmittedAt(at("2026-09-08 15:17"));
+
+        assertFalse(BhtSummeryController.isOverlapConflict(ward, guardian));
+        assertFalse(BhtSummeryController.isOverlapConflict(guardian, ward));
+    }
+
+    @Test
+    void differentPatientsInDifferentBedsDoNotConflict() {
+        PatientRoom mine = stay(200L, encounter(1L, "BHT/57914", "A Patient"),
+                bed(90L, "Room 90 wm"), "2026-09-08 15:17", "2026-09-08 19:19");
+        PatientRoom theirs = stay(300L, encounter(2L, "BHT/57843", "B Patient"),
+                bed(511L, "Room 511 wm"), "2026-09-05 00:48", null);
+
+        assertFalse(BhtSummeryController.isOverlapConflict(mine, theirs));
+    }
+
+    // ------------------------------------------------------ cross-patient bed
+
+    @Test
+    void anotherPatientStillInTheSameBedIsAConflict() {
+        PatientRoom mine = stay(200L, encounter(1L, "BHT/57914", "A Patient"),
+                bed(90L, "Room 90 wm"), "2026-09-08 15:17", "2026-09-08 19:19");
+        PatientRoom theirs = stay(300L, encounter(2L, "BHT/57843", "B Patient"),
+                bed(90L, "Room 90 wm"), "2026-09-05 00:48", null);
+
+        assertTrue(BhtSummeryController.isOverlapConflict(mine, theirs));
+    }
+
+    @Test
+    void crossPatientConflictNamesTheOtherBhtPatientAndWindow() {
+        PatientRoom mine = stay(200L, encounter(1L, "BHT/57914", "A Patient"),
+                bed(90L, "Room 90 wm"), "2026-09-08 15:17", "2026-09-08 19:19");
+        PatientRoom theirs = stay(300L, encounter(2L, "BHT/57843", "B Patient"),
+                bed(90L, "Room 90 wm"), "2026-09-05 00:48", null);
+
+        String description = BhtSummeryController.describeOverlaps(mine, Collections.singletonList(theirs), PATTERN);
+
+        assertTrue(description.contains("Room 90 wm"), description);
+        assertTrue(description.contains("BHT/57843"), description);
+        assertTrue(description.contains("B Patient"), description);
+        assertTrue(description.contains("05 Sep 2026 00:48"), description);
+        assertTrue(description.contains("still in room"), description);
+    }
+
+    @Test
+    void crossPatientConflictShowsTheOtherStaysDischargeTimeWhenItHasOne() {
+        PatientRoom mine = stay(200L, encounter(1L, "BHT/57914", "A Patient"),
+                bed(90L, "Room 90 wm"), "2026-09-08 15:17", "2026-09-08 19:19");
+        PatientRoom theirs = stay(300L, encounter(2L, "BHT/57843", "B Patient"),
+                bed(90L, "Room 90 wm"), "2026-09-05 00:48", "2026-09-09 11:11");
+
+        String description = BhtSummeryController.describeOverlaps(mine, Collections.singletonList(theirs), PATTERN);
+
+        assertTrue(description.contains("09 Sep 2026 11:11"), description);
+        assertFalse(description.contains("still in room"), description);
+    }
+
+    /**
+     * The description sits next to the row's own Admitted At / Discharged At
+     * pickers, which render with the deployment's shortDateTimeFormat. Rendering
+     * the conflict in a different format would have staff comparing "19:19" with
+     * "07:19 PM" on the one screen meant to resolve the conflict.
+     */
+    @Test
+    void stayWindowUsesTheSuppliedDateTimePattern() {
+        PatientRoom mine = stay(200L, encounter(1L, "BHT/57914", "A Patient"),
+                bed(90L, "Room 90 wm"), "2026-09-08 15:17", "2026-09-08 19:19");
+        PatientRoom theirs = stay(300L, encounter(2L, "BHT/57843", "B Patient"),
+                bed(90L, "Room 90 wm"), "2026-09-05 00:48", "2026-09-09 23:11");
+
+        String description = BhtSummeryController.describeOverlaps(
+                mine, Collections.singletonList(theirs), "dd/MM/yyyy hh:mm a");
+
+        assertTrue(description.contains("05/09/2026 12:48 AM"), description);
+        assertTrue(description.contains("09/09/2026 11:11 PM"), description);
+    }
+
+    /** A blank or malformed preference must not blank the row or throw. */
+    @Test
+    void stayWindowFallsBackWhenThePatternIsUnusable() {
+        PatientRoom mine = stay(200L, encounter(1L, "BHT/57914", "A Patient"),
+                bed(90L, "Room 90 wm"), "2026-09-08 15:17", "2026-09-08 19:19");
+        PatientRoom theirs = stay(300L, encounter(2L, "BHT/57843", "B Patient"),
+                bed(90L, "Room 90 wm"), "2026-09-05 00:48", null);
+
+        for (String pattern : new String[]{null, "   ", "dd 'unterminated"}) {
+            String description = BhtSummeryController.describeOverlaps(
+                    mine, Collections.singletonList(theirs), pattern);
+            assertTrue(description.contains("05 Sep 2026 00:48"),
+                    "pattern " + pattern + " -> " + description);
+        }
+    }
+
+    @Test
+    void crossPatientConflictFallsBackWhenTheOtherEncounterHasNoBht() {
+        PatientEncounter noBht = encounter(2L, null, null);
+        PatientRoom mine = stay(200L, encounter(1L, "BHT/57914", "A Patient"),
+                bed(90L, "Room 90 wm"), "2026-09-08 15:17", "2026-09-08 19:19");
+        PatientRoom theirs = stay(300L, noBht, bed(90L, "Room 90 wm"), "2026-09-05 00:48", null);
+
+        String description = BhtSummeryController.describeOverlaps(mine, Collections.singletonList(theirs), PATTERN);
+
+        assertTrue(description.contains("another patient"), description);
+    }
+
+    // ---------------------------------------------------- same-patient wording
+
+    @Test
+    void sameEncounterConflictKeepsTheShortWording() {
+        PatientEncounter pe = encounter(1L, "BHT/57914", "A Patient");
+        PatientRoom mine = stay(200L, pe, bed(90L, "Room 90 wm"), "2026-09-08 15:17", "2026-09-08 19:19");
+        PatientRoom otherRoomSamePatient = stay(202L, pe, bed(511L, "Room 511 wm"), "2026-09-08 18:00", null);
+
+        String description = BhtSummeryController.describeOverlaps(mine, Collections.singletonList(otherRoomSamePatient), PATTERN);
+
+        assertEquals("Overlaps with Room 511 wm (Active)", description);
+    }
+
+    @Test
+    void sameEncounterConflictThatHasLeftIsMarkedLeft() {
+        PatientEncounter pe = encounter(1L, "BHT/57914", "A Patient");
+        PatientRoom mine = stay(200L, pe, bed(90L, "Room 90 wm"), "2026-09-08 15:17", "2026-09-08 19:19");
+        PatientRoom otherRoomSamePatient = stay(202L, pe, bed(511L, "Room 511 wm"), "2026-09-08 18:00", "2026-09-08 18:30");
+
+        String description = BhtSummeryController.describeOverlaps(mine, Collections.singletonList(otherRoomSamePatient), PATTERN);
+
+        assertEquals("Overlaps with Room 511 wm (Left)", description);
+    }
+
+    @Test
+    void multipleConflictsAreAllListed() {
+        PatientEncounter pe = encounter(1L, "BHT/57914", "A Patient");
+        PatientRoom mine = stay(200L, pe, bed(90L, "Room 90 wm"), "2026-09-08 15:17", "2026-09-08 19:19");
+        PatientRoom sameEncounter = stay(202L, pe, bed(511L, "Room 511 wm"), "2026-09-08 18:00", null);
+        PatientRoom otherPatient = stay(300L, encounter(2L, "BHT/57843", "B Patient"),
+                bed(90L, "Room 90 wm"), "2026-09-05 00:48", null);
+
+        List<PatientRoom> conflicts = Arrays.asList(sameEncounter, otherPatient);
+        String description = BhtSummeryController.describeOverlaps(mine, conflicts, PATTERN);
+
+        assertTrue(description.contains("Room 511 wm (Active)"), description);
+        assertTrue(description.contains("BHT/57843"), description);
+        assertTrue(description.contains(";"), "multiple conflicts should be separated: " + description);
+    }
+
+    @Test
+    void noConflictsProducesNoDescription() {
+        PatientRoom mine = stay(200L, encounter(1L, "BHT/57914", "A Patient"),
+                bed(90L, "Room 90 wm"), "2026-09-08 15:17", "2026-09-08 19:19");
+
+        assertEquals("", BhtSummeryController.describeOverlaps(mine, Collections.<PatientRoom>emptyList(), PATTERN));
+        assertEquals("", BhtSummeryController.describeOverlaps(mine, null, PATTERN));
+    }
+}


### PR DESCRIPTION
Closes #23641

## Decisions made without approval

Run unattended (`dev-issue-unattended`), so every judgment call is listed here for the reviewer to scan first.

1. **The other patient's name is shown, not just their BHT number.** `inward/inward_room_occupancy.xhtml` already lists BHT number *and* `patientEncounter.patient.person.name` for every occupied room, to the same inward staff — so this discloses nothing that screen does not. One-line revert in `patientNameOf(...)` if that is wrong. ([reasoning on the issue](https://github.com/hmislk/hmis/issues/23641#issuecomment-5598237991))
2. **Scope grew by one item: the tooltip never rendered at all.** `p:tag` has no `title` passthrough, so `<p:tag … title="#{…getOverlapDescription(rm)}"/>` produced a DOM node with no `title` — that description has never reached a user on any build. Fixing only the string could not have met the issue's tooltip acceptance criterion, so `p:tooltip` was added (the pattern already used in `admin/lims/investigation_format_multiple.xhtml`).
3. **Multiple conflicts are separated by `;` instead of `,`** — a cross-patient entry contains commas of its own, so a comma separator became ambiguous.
4. **No caching added**, though `hasOverlap` + the tooltip value re-query per row per phase. A memoised result that outlives a row edit would leave an Overlap tag on a conflict the user just fixed — worse than the extra queries, and not something to land unattended. Filed as **#23644** instead, with the staleness trap written up.
5. **Implemented directly rather than dispatched to `java-backend-developer` / `jsf-frontend-dev`** — one controller, one facelet, one new test; delegation would have cost more than it saved.
6. **Wiki prose extended, not rewritten.** The existing "Identifying Room Overlaps" paragraph is untouched; a new section documents the tag/banner/tooltip/dialog and the two conflict kinds. Nothing existing was contradicted or deleted.

### Self-review pass (`/code-review high`, before first push)

Run on the working tree pre-commit; it raised five findings.

| Finding | Bucket | Action |
|---|---|---|
| Stay window hardcoded `dd MMM yyyy HH:mm` + default locale, while the row's own date pickers use `shortDateTimeFormat` | in-scope bug | **Fixed** — see "Formatting" below, plus 2 new tests |
| The new retired guards are unreachable from any current production path | no change | Correct, and deliberate — see "On the retired guards" |
| Tooltip adds a second overlap query per conflicting row | out of scope | **Filed as #23644** |
| Cross-encounter PHI on a single-patient screen; suggested a `ConfigOption` gate | no change | This is what the issue asks for. Gating PHI is an access-control change, which this workflow will not make unattended — flagged for the reviewer instead |
| `persistence.xml` must not be committed | process | Left unstaged; the commit carries the CI placeholders |

## Problem

`getOverlappingRooms()` matches other stays on **the same encounter OR the same bed**, so a conflict is often a *different admission* still holding the room. The message named only the room, so that case rendered as *"Room 90 overlaps with Room 90 (Active)"* — reading as a false alarm, with no way to find the other admission from this page. In the reported case that led to the other patient's room stay being closed by hand to silence the warning, leaving an in-house patient with no open room stay and their room charges no longer accruing.

## Changes

**`BhtSummeryController`**
- `isOverlapConflict(subject, candidate)` — new `static`, facade-free predicate mirroring the JPQL clause-for-clause. Retired excluded on **both** sides.
- `getOverlappingRooms()` — early return when the *subject* row is retired; query results re-checked through the predicate above.
- `describeOverlaps(subject, overlaps, pattern)` — new `static` formatter. Same-encounter conflicts keep the terse wording; a different-patient conflict is named in full: room, BHT, patient, and that stay's window.
- `isAnyRoomOverlapping()` — skips retired entries.

**Formatting** — the window now renders with `sessionController.applicationPreference.shortDateTimeFormat`, the same preference the row's `rmAdmittedAt` / `rmDischargedAt` pickers use, under `Locale.ENGLISH`, falling back to a default if the preference is unusable. Previously a deployment on `dd/MM/yyyy hh:mm a` showed the conflict as `19:19` beside a field reading `07:19 PM`.

**`inward_patient_room_details.xhtml`** — row tag: dropped the non-functional `title`, added `p:tooltip`. Save-confirmation wording now says the conflict may be *another patient recorded in the same bed*; dialog widened for the longer message.

**`BhtSummeryControllerRoomOverlapTest`** — 15 tests: retired candidate ignored, retired subject ignored, back-to-back stays, Guardian excluded, different beds, cross-patient same-bed detected, full cross-patient wording, discharged-window wording, missing-BHT fallback, same-encounter Active/Left wording, multiple conflicts, empty/null, configured pattern honoured, unusable pattern falls back.

### On the retired guards

Worth being explicit, since the review flagged it: **retired stays were already excluded** before this PR — `InwardBeanController.fetchPatientRoomAll` filters `pr.retired = false`, and the overlap JPQL opens with `pr2.retired = false`. Confirmed live: a retired stay in the test bed, whose times overlap all three live stays, raised no warning on `development` either. So the guards are a rule made total and locked in by tests, not a behaviour fix — the issue asks for the former. The one genuinely new guard is on the *subject* row, which `hasOverlap(pr)` will accept from any caller.

## Testing

**Menu path:** *Menu → Inward → Search → Admissions → (BHT No filter) → Search → Inpatient Dashboard → Room Management → Room Details*

`mvn clean package` — **276 tests, 0 failures** (15 new).

End-to-end against local Payara + local `coop` DB. The conflict was created **through the app** (room autocomplete → Save Changes → Yes, Save Anyway), not by SQL, so the save path was exercised too. The bed ended up holding four stays — three live, one retired — making every branch observable at once:

- Page banner **Room Time Overlap Detected** renders.
- Row tooltip renders and names the conflicting admission with BHT, patient and window — previously it rendered nothing at all.
- The **retired** stay in the same bed, overlapping all three live stays, is absent from the description.
- A live stay that ended one minute before the subject began is correctly **not** reported.
- **Save Changes** raises the confirmation carrying the same text; **Yes, Save Anyway** persists (verified in the DB).
- After the formatting fix, tooltip `08 Sep 26 15:39` matches the row's own field `08 Sep 26 17:52` — same preference, same rendering.

![Overlap tag with hover text naming the other admission](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23641-room-overlap-tooltip.png)

*Patient identifiers are replaced in both screenshots.*

## Documentation

Wiki — **[Inpatient — Patient Room Details](https://github.com/hmislk/hmis/wiki/Inpatient-Patient-Room-Details)**: new *Room Time Overlap Warnings* section covering the banner, the row tag, the two kinds of conflict with the wording for each, that withdrawn room records are ignored, and that the save warning does not block the save. Both screenshots embedded with visible captions.

`developer_docs/testing/playwright-e2e-workflow.md` §113 — `p:tag` silently drops `title`; how to spot it, and to assert the rendered DOM rather than trusting the source.

## Follow-up

- **#23644** — the overlap check re-queries per row, per phase, on this page.

## Not changed

Cancellation/return behaviour, room charge calculation, and the overlap query's own predicate. The warning remains advisory and still does not block discharge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXjDBhnANtPG3GDuJ9uvay


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved room-overlap detection by excluding retired rooms and validating conflicts more reliably.
  - Clarified warnings for overlaps involving the same patient versus another patient.
  - Conflict details now display patient, BHT, and stay-time information using the configured date format.
  - Room-overlap dialogs provide clearer, more spacious warnings.
  - Room-overlap tooltips now display consistently, including within data tables.

- **Documentation**
  - Added guidance for implementing and testing room-overlap tooltips.

- **Tests**
  - Expanded coverage for overlap detection, conflict descriptions, date formats, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->