### PR TITLE
fix(pharmacy): fall back to institution email on PO approval receipt

### DIFF
--- a/src/main/webapp/resources/pharmacy/po_custom_1.xhtml
+++ b/src/main/webapp/resources/pharmacy/po_custom_1.xhtml
@@ -32,7 +32,7 @@
                 </div>
                 <div >
                     <h:outputLabel value="Email : &nbsp;"/>
-                    <h:outputLabel value="#{cc.attrs.bill.referenceBill.creater.department.email}"/>                                                 
+                    <h:outputLabel value="#{not empty cc.attrs.bill.referenceBill.creater.department.email ? cc.attrs.bill.referenceBill.creater.department.email : cc.attrs.bill.referenceBill.creater.institution.email}"/>
                 </div>
             </div>
 

--- a/src/main/webapp/resources/pharmacy/po_custom_2.xhtml
+++ b/src/main/webapp/resources/pharmacy/po_custom_2.xhtml
@@ -32,7 +32,7 @@
                 </div>
                 <div >
                     <h:outputLabel value="Email : &nbsp;"/>
-                    <h:outputLabel value="#{cc.attrs.bill.referenceBill.creater.department.email}"/>                                                 
+                    <h:outputLabel value="#{not empty cc.attrs.bill.referenceBill.creater.department.email ? cc.attrs.bill.referenceBill.creater.department.email : cc.attrs.bill.referenceBill.creater.institution.email}"/>
                 </div>
             </div>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Purchase orders now display the institution’s email address when the department email is unavailable.
  - Updated both purchase order header and print views for consistent email display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->