### PR TITLE
fix(dev-tools): make cleanup-branches skill handle pruned remote refs

### DIFF
--- a/.claude/skills/cleanup-branches/SKILL.md
+++ b/.claude/skills/cleanup-branches/SKILL.md
@@ -11,9 +11,11 @@ allowed-tools: Bash
 
 # Cleanup Merged Local Branches
 
-Delete every local branch whose PR has already been merged, then bring
-`development` up to date. Leave `persistence.xml` with local JNDI names
-restored (unstaged) at the end.
+Delete every local branch whose PR has already been merged — plus any branch
+with no PR of its own whose commits are all already on `origin/development`
+(e.g. a `gh pr checkout <N>` review checkout) — then bring `development` up to
+date. Leave `persistence.xml` with local JNDI names restored (unstaged) at the
+end.
 
 ## Step 1 — Stash Local persistence.xml Changes
 
@@ -53,28 +55,34 @@ Check if any PR targeting `development` from this branch is merged:
 gh pr list --head <branch> --base development --state merged --repo hmislk/hmis --json number,title,mergedAt --jq '.[0]'
 ```
 
-- If a merged PR is found → **mark for deletion**, record the PR number and title for the report.
+- If a merged PR is found → **mark for deletion (merged-PR)**, record the PR
+  number and title for the report. No further checks — Step 5 force-deletes it.
 - If no merged PR is found, also check without `--base` filter (in case the base was changed):
 
 ```bash
 gh pr list --head <branch> --state merged --repo hmislk/hmis --json number,title,baseRefName,mergedAt --jq '.[0]'
 ```
 
-- If still no merged PR is found, run a patch-equivalence check before skipping —
-  a `gh pr checkout <N>` review checkout (e.g. `pr-23617`) has no PR with *it*
-  as the head branch, but its commits may already be on `origin/development`
-  (compare against `origin/development`, freshly fetched in Step 2 — local
-  `development` is not fast-forwarded until Step 6):
+- If still no merged PR is found, do **not** delete on merge status alone — run
+  a patch-equivalence check. A `gh pr checkout <N>` review checkout (e.g.
+  `pr-23617`) has no PR with *it* as the head branch, but its commits may
+  already be on `origin/development`. Compare against `origin/development`
+  (freshly fetched in Step 2 — local `development` is not fast-forwarded until
+  Step 6):
 
   ```bash
   git cherry -v origin/development <branch>
   ```
 
   - **Empty output**, or every line starts with `-` → every commit on the branch
-    is already patch-equivalent on `origin/development`. **Mark for deletion**;
-    in the report note it as "content already in development, no PR from this head".
+    is already patch-equivalent on `origin/development`. **Mark for deletion
+    (content-merged)** — reported in its own section, separate from the
+    merged-PR deletions, so a non-standard removal is never silent.
   - **Any line starts with `+`** → the branch has a commit not on
-    `origin/development`. **Skip** (warn the user about the branch).
+    `origin/development` — genuinely unmerged work, *or* a multi-commit branch
+    whose PR was squash-merged (no per-commit equivalent exists). Either way,
+    **skip** and warn; the report line tells the user to check whether it was a
+    squashed PR and delete manually if so.
 
 ### Hotfix branches (end with `-hotfix`)
 
@@ -95,42 +103,29 @@ git checkout development
 
 ## Step 5 — Delete Marked Branches
 
-For each branch marked for deletion, first try the safe delete:
+Every branch that reaches this step was already vetted in Step 3 — it has
+either a **merged PR** or an **empty `git cherry`** against `origin/development`.
+Branches with unmerged work were skipped there and never marked. So Step 5 only
+deletes; it does not re-decide safety.
+
+For each marked branch, try the safe delete first, then force:
 
 ```bash
-git branch -d <branch>
+git branch -d <branch> || git branch -D <branch>
 ```
 
-`-d` refuses whenever the branch tip is not reachable from local `development` —
-the normal case here, both because the PR was squash- or rebase-merged and
-because local `development` is not fast-forwarded until Step 6. Before
-force-deleting, confirm the branch has no unmerged work.
+`-d` succeeds only when the branch tip is reachable from local `development`.
+It normally **refuses** here — the PR was merged with a merge commit or a
+squash, and local `development` is not fast-forwarded until Step 6, so the tip
+is not yet an ancestor. That refusal is expected, not a warning sign; the
+`|| git branch -D` completes the delete.
 
-Do **not** use `git log origin/<branch>..<branch>` for this: Step 2's
-`git fetch --prune` deletes `origin/<branch>` as soon as the PR is merged and
-GitHub removes the remote branch, so that command errors with
-`unknown revision or path not in the working tree` instead of returning empty.
-
-Compare against `origin/development` (freshly fetched in Step 2) instead:
-
-```bash
-git cherry -v origin/development <branch>
-```
-
-- **Empty output**, or every line starts with `-` — every commit is already
-  patch-equivalent on `origin/development`. Safe to force-delete:
-
-  ```bash
-  git branch -D <branch>
-  ```
-
-- **Any line starts with `+`** — that commit is not on `origin/development`; the
-  branch has work that was never merged. **Skip this branch** and warn the user
-  instead of deleting:
-
-  ```
-  ⚠ Skipped <branch>: has commit(s) not in development — delete manually after review.
-  ```
+Do **not** add a `git log origin/<branch>..<branch>` guard: Step 2's
+`git fetch --prune` deletes the `origin/<branch>` upstream as soon as the PR is
+merged and GitHub removes the remote branch, so that command errors with
+`unknown revision or path not in the working tree` rather than returning empty.
+`git branch -D` still prints the deleted SHA (`Deleted branch X (was 906d5ebbb4)`)
+and the reflog retains it, so an over-eager delete is recoverable.
 
 ## Step 6 — Fast-Forward development to origin/development
 
@@ -164,21 +159,25 @@ If no stash was created, leave `persistence.xml` as-is.
 Print a summary:
 
 ```
-✓ Deleted branches:
+✓ Deleted branches (merged PR):
   - <branch>  (PR #NNN merged → <base-branch>)
-  - <branch>  (content already in development, no PR from this head)
+  ...
+
+✓ Deleted branches (no PR, but all commits already in development):
+  - <branch>
   ...
 
 ⚠ Skipped branches:
-  - <branch>  (has commit(s) not in development)
+  - <branch>  (has commit(s) not in development — if its PR was squash-merged,
+    delete manually after confirming)
   ...
 
 ✓ development is now at <short-sha> (<commit subject>)
 ✓ persistence.xml restored to local JNDI settings (unstaged)
 ```
 
-If all branches were deleted (nothing skipped), omit the skipped section.
-If nothing was stashed, replace the last line with:
+Omit any of the three branch sections that has no entries. If nothing was
+stashed, replace the last line with:
 `✓ persistence.xml unchanged (no local changes were present)`
 
 ## Notes

--- a/.claude/skills/cleanup-branches/SKILL.md
+++ b/.claude/skills/cleanup-branches/SKILL.md
@@ -58,56 +58,70 @@ warning icon.
 
 ### Feature branches (do NOT end with `-hotfix`)
 
-Check if any PR targeting `development` from this branch is merged:
+The comparison base is `origin/development`. Look for a merged PR from this head:
 
 ```bash
 gh pr list --head <branch> --base development --state merged --repo hmislk/hmis --json number,title,mergedAt --jq '.[0]'
-```
-
-- If a merged PR is found → **mark for deletion (merged-PR)**, record the PR
-  number and title for the report. No further checks — Step 5 force-deletes it.
-- If no merged PR is found, also check without `--base` filter (in case the base was changed):
-
-```bash
+# if that is empty, retry without --base — the PR's base may have been changed:
 gh pr list --head <branch> --state merged --repo hmislk/hmis --json number,title,baseRefName,mergedAt --jq '.[0]'
 ```
 
-- If still no merged PR is found, do **not** delete on merge status alone — run
-  a patch-equivalence check. A `gh pr checkout <N>` review checkout (e.g.
-  `pr-23617`) has no PR with *it* as the head branch, but its commits may
-  already be on `origin/development`. Compare against `origin/development`
-  (freshly fetched in Step 2 — local `development` is not fast-forwarded until
-  Step 6):
-
-  ```bash
-  git cherry -v origin/development <branch>
-  git rev-list --merges --count origin/development..<branch>
-  ```
-
-  - **`git cherry` empty or all `-`, AND the merge count is `0`** → every commit
-    on the branch is already patch-equivalent on `origin/development`. **Mark
-    for deletion (content-merged)** — reported in its own section, separate from
-    the merged-PR deletions, so a non-standard removal is never silent.
-  - **Merge count is not `0`** → the branch carries merge commits, which
-    `git cherry` does not inspect; conflict-resolution content in a merge commit
-    can be absent from `origin/development` while every non-merge commit still
-    shows `-`. Do **not** trust the `git cherry` result here — **skip** and warn.
-  - **Any `git cherry` line starts with `+`** → the branch has a non-merge
-    commit not on `origin/development` — genuinely unmerged work, *or* a
-    multi-commit branch whose PR was squash-merged (no per-commit equivalent
-    exists). Either way, **skip** and warn; the report line tells the user to
-    check whether it was a squashed PR and delete manually if so.
+Record the PR number/title if found. If the second query returns a PR with a
+`baseRefName` other than `development`, the comparison base is
+`origin/<that baseRefName>`, not `origin/development`. Whether or not a PR is
+found, continue to **Vet the branch tip** — a merged PR does not by itself
+prove the local branch is safe to force-delete (it may carry post-merge
+commits, or have been reused).
 
 ### Hotfix branches (end with `-hotfix`)
 
-Hotfix PRs target a production branch, not `development`. Check for any merged PR:
+Hotfix PRs target a production branch. Look for a merged PR:
 
 ```bash
 gh pr list --head <branch> --state merged --repo hmislk/hmis --json number,title,baseRefName,mergedAt --jq '.[0]'
 ```
 
-- If a merged PR is found → **mark for deletion**, record PR number, title, and the production branch it targeted.
-- If no merged PR → **skip** (warn the user).
+- **No merged PR** → **skip** (warn the user). A hotfix branch is never vetted
+  by patch-equivalence against `development`; its commits legitimately are not
+  there.
+- **Merged PR found** → record the PR number/title and its `baseRefName`, then
+  **Vet the branch tip** with the comparison base `origin/<baseRefName>`.
+
+### Vet the branch tip (both branch kinds)
+
+Let `<base>` be the comparison base decided above — `origin/development` for a
+feature branch (or a no-PR review checkout), `origin/<prod>` for a merged
+hotfix.
+
+```bash
+git merge-base --is-ancestor <branch> <base> && echo CONTAINED || echo AHEAD
+```
+
+- **CONTAINED** — the branch tip is already reachable from `<base>`; it holds
+  nothing unmerged and no post-merge commits. **Mark for deletion** — labelled
+  "merged-PR" if a PR was found, else "content-merged".
+- **AHEAD** — the tip is not reachable from `<base>`. Normal for a squash- or
+  rebase-merged PR, but also how a branch with genuine post-merge commits (or a
+  reused branch) looks. Disambiguate:
+
+  ```bash
+  git cherry -v <base> <branch>
+  git rev-list --merges --count <base>..<branch>
+  ```
+
+  - **`git cherry` empty or every line starts with `-`, AND the merge count is
+    `0`** → every non-merge commit is patch-equivalent to something already on
+    `<base>` (a clean squash/rebase merge, or a fully-absorbed no-PR checkout
+    such as `pr-23617`). **Mark for deletion** — "content-merged"; reported in
+    its own section so a non-fast-forward deletion is never silent.
+  - **any `+` line, or a non-zero merge count** → the branch has a non-merge
+    commit not on `<base>`, or a merge commit `git cherry` cannot inspect
+    (conflict-resolution content can be absent from `<base>` while every
+    non-merge commit still shows `-`). Could be post-merge work, a reused
+    branch, or a multi-commit squash whose combined diff no longer matches
+    commit-for-commit. **Skip** and warn: "PR #<n> is merged but <branch> is
+    ahead of <base> — if you squash/rebase-merged it, delete manually with
+    `git branch -D <branch>`; otherwise inspect it for unmerged work first."
 
 ## Step 4 — Switch to development
 
@@ -117,30 +131,26 @@ git checkout development
 
 ## Step 5 — Delete Marked Branches
 
-Every branch that reaches this step was already vetted in Step 3 — it has
-either a **merged PR**, or a clean patch-equivalence result (`git cherry` empty
-/ all `-` *and* zero merge commits) against `origin/development`. Branches with
-unmerged work, or merge commits `git cherry` can't see through, were skipped
-there and never marked. So Step 5 only deletes; it does not re-decide safety.
-
-For each marked branch, try the safe delete first, then force:
+Step 3's **Vet the branch tip** fully decided every marked branch — each is
+either CONTAINED in its comparison base, or AHEAD but proven patch-equivalent
+(no `+` commits, no merge commits). Branches with post-merge or unmerged work
+were skipped there. Step 5 only deletes; it does not re-decide safety.
 
 ```bash
 git branch -d <branch> || git branch -D <branch>
 ```
 
-`-d` succeeds only when the branch tip is reachable from local `development`.
-It normally **refuses** here — the PR was merged with a merge commit or a
-squash, and local `development` is not fast-forwarded until Step 6, so the tip
-is not yet an ancestor. That refusal is expected, not a warning sign; the
-`|| git branch -D` completes the delete.
+`git branch -d` refuses when the tip is not reachable from *local* `development`
+— normal here, because a squash/rebase merge leaves the tip off `development`
+and local `development` is not fast-forwarded until Step 6. The `|| git branch
+-D` completes the delete; Step 3 already established the branch is safe to drop.
+`git branch -D` prints the deleted SHA (`Deleted branch X (was 906d5ebbb4)`) and
+the reflog keeps it ~30 days, so a mistaken delete is still recoverable.
 
-Do **not** add a `git log origin/<branch>..<branch>` guard: Step 2's
-`git fetch --prune` deletes the `origin/<branch>` upstream as soon as the PR is
-merged and GitHub removes the remote branch, so that command errors with
-`unknown revision or path not in the working tree` rather than returning empty.
-`git branch -D` still prints the deleted SHA (`Deleted branch X (was 906d5ebbb4)`)
-and the reflog retains it, so an over-eager delete is recoverable.
+Do **not** re-check with `git log origin/<branch>..<branch>`: Step 2's
+`git fetch --prune` has already removed the `origin/<branch>` upstream, so that
+command errors with `unknown revision or path not in the working tree` instead
+of returning empty.
 
 ## Step 6 — Fast-Forward development to origin/development
 

--- a/.claude/skills/cleanup-branches/SKILL.md
+++ b/.claude/skills/cleanup-branches/SKILL.md
@@ -12,10 +12,10 @@ allowed-tools: Bash
 # Cleanup Merged Local Branches
 
 Delete every local branch whose PR has already been merged — plus any branch
-with no PR of its own whose commits are all already on `origin/development`
-(e.g. a `gh pr checkout <N>` review checkout) — then bring `development` up to
-date. Leave `persistence.xml` with local JNDI names restored (unstaged) at the
-end.
+with no PR of its own whose changes are all already represented on
+`origin/development` (e.g. a `gh pr checkout <N>` review checkout) — then bring
+`development` up to date. Leave `persistence.xml` with local JNDI names restored
+(unstaged) at the end.
 
 ## Step 1 — Stash Local persistence.xml Changes
 
@@ -103,26 +103,33 @@ git merge-base --is-ancestor <branch> <base> && echo CONTAINED || echo AHEAD
   nothing unmerged and no post-merge commits. **Mark for deletion.**
 - **AHEAD** — the tip is not reachable from `<base>`. Normal for a squash- or
   rebase-merged PR, but also how a branch with genuine post-merge commits (or a
-  reused branch) looks. Disambiguate:
+  reused branch) looks. Decide with a **final-tree guard**: are `<branch>`'s
+  versions of the files it touched already identical to `<base>`?
 
   ```bash
-  git cherry -v <base> <branch>
-  git rev-list --merges --count <base>..<branch>
+  mb=$(git merge-base <base> <branch>)
+  git diff --quiet <base> <branch> -- $(git diff --name-only "$mb" <branch>)
   ```
 
-  - **`git cherry` empty or every line starts with `-`, AND the merge count is
-    `0`** → every non-merge commit is patch-equivalent to something already on
-    `<base>` (a clean squash/rebase merge, or a fully-absorbed no-PR checkout
-    such as `pr-23617`). **Mark for deletion.**
-  - **any `+` line, or a non-zero merge count** → the branch has a non-merge
-    commit not on `<base>`, or a merge commit `git cherry` cannot inspect
-    (conflict-resolution content can be absent from `<base>` while every
-    non-merge commit still shows `-`). Could be post-merge work, a reused
-    branch, or a multi-commit squash whose combined diff no longer matches
-    commit-for-commit. **Skip** and warn, quoting the branch's real
-    `<base>` and its PR reference (or noting it has none): "*ahead of `<base>`
-    — if PR #`<n>` was squash/rebase-merged, `git branch -D <branch>`
-    manually; otherwise inspect for unmerged work first*".
+  This compares final content, not per-commit patches, so it is correct where
+  `git cherry` is not: a clean multi-commit squash-merge (no per-commit
+  equivalent) passes; a branch whose change was applied to `<base>` and later
+  reverted there fails; a merge commit that carried unique content in fails.
+
+  - **exit `0`** — every file the branch touched already matches `<base>`;
+    deleting the branch loses nothing (a clean squash/rebase merge, or a
+    fully-absorbed no-PR checkout such as `pr-23617`). **Mark for deletion.**
+  - **exit `1`** — some file the branch touched differs from `<base>`: genuine
+    post-merge work, a reused branch, conflict-resolution content, or a
+    squash/rebase that did not land identical content. **Skip** and warn,
+    quoting the branch's real `<base>` and its PR reference (or noting it has
+    none): "*ahead of `<base>` — if PR #`<n>` was squash/rebase-merged,
+    `git branch -D <branch>` manually; otherwise inspect for unmerged work
+    first*".
+
+  (If the touched-file list is empty — the branch's commits change nothing —
+  the command degrades to a full-tree diff and will exit `1`; skip and warn,
+  which is the safe outcome for that oddity.)
 
 ## Step 4 — Switch to development
 
@@ -133,9 +140,10 @@ git checkout development
 ## Step 5 — Delete Marked Branches
 
 Step 3's **Vet the branch tip** fully decided every marked branch — each is
-either CONTAINED in its comparison base, or AHEAD but proven patch-equivalent
-(no `+` commits, no merge commits). Branches with post-merge or unmerged work
-were skipped there. Step 5 only deletes; it does not re-decide safety.
+either CONTAINED in its comparison base, or AHEAD but proven fully absorbed (the
+final-tree guard found every file it touched already identical to `<base>`).
+Branches with post-merge or unmerged work were skipped there. Step 5 only
+deletes; it does not re-decide safety.
 
 ```bash
 git branch -d <branch> || git branch -D <branch>
@@ -187,7 +195,7 @@ Print a summary:
 ```text
 ✓ Deleted branches:
   - <branch>  (PR #NNN merged → <base-branch>)
-  - <branch>  (no PR; all commits already on <base-branch>)
+  - <branch>  (no PR; all changes already represented on <base-branch>)
   ...
 
 ⚠ Skipped branches:
@@ -204,10 +212,11 @@ Print a summary:
 ✓ persistence.xml restored to local JNDI settings (unstaged)
 ```
 
-Each deleted / skipped line carries the branch's real PR reference (or "no PR")
-and its real comparison base — never assume a PR exists or that the base is
-`development`. Omit any section with no entries. If nothing was stashed, replace
-the last line with:
+Each *vetted* deleted / skipped line carries the branch's real PR reference (or
+"no PR") and its real comparison base — never assume a PR exists or that the
+base is `development`. The unvetted "hotfix, no merged PR found" line is the one
+exception: it is skipped before any base is chosen, so it carries neither. Omit
+any section with no entries. If nothing was stashed, replace the last line with:
 `✓ persistence.xml unchanged (no local changes were present)`
 
 ## Notes

--- a/.claude/skills/cleanup-branches/SKILL.md
+++ b/.claude/skills/cleanup-branches/SKILL.md
@@ -45,7 +45,16 @@ List every local branch except `development`:
 git branch --format='%(refname:short)' | grep -v '^development$'
 ```
 
-For each branch, determine whether it is safe to delete:
+For each branch, determine whether it is safe to delete.
+
+### Protected branches — never delete, never classify
+
+Before the feature/hotfix split, skip any branch that is `master` or ends with
+`-prod` (the local mirrors of admin-managed / production branches — see Notes
+for the full list). They diverge from `development` by design, so a naïve
+patch-equivalence check could still misfire on them; the explicit skip is the
+guarantee. Report them under a separate "Protected — not touched" line, no
+warning icon.
 
 ### Feature branches (do NOT end with `-hotfix`)
 
@@ -72,17 +81,22 @@ gh pr list --head <branch> --state merged --repo hmislk/hmis --json number,title
 
   ```bash
   git cherry -v origin/development <branch>
+  git rev-list --merges --count origin/development..<branch>
   ```
 
-  - **Empty output**, or every line starts with `-` → every commit on the branch
-    is already patch-equivalent on `origin/development`. **Mark for deletion
-    (content-merged)** — reported in its own section, separate from the
-    merged-PR deletions, so a non-standard removal is never silent.
-  - **Any line starts with `+`** → the branch has a commit not on
-    `origin/development` — genuinely unmerged work, *or* a multi-commit branch
-    whose PR was squash-merged (no per-commit equivalent exists). Either way,
-    **skip** and warn; the report line tells the user to check whether it was a
-    squashed PR and delete manually if so.
+  - **`git cherry` empty or all `-`, AND the merge count is `0`** → every commit
+    on the branch is already patch-equivalent on `origin/development`. **Mark
+    for deletion (content-merged)** — reported in its own section, separate from
+    the merged-PR deletions, so a non-standard removal is never silent.
+  - **Merge count is not `0`** → the branch carries merge commits, which
+    `git cherry` does not inspect; conflict-resolution content in a merge commit
+    can be absent from `origin/development` while every non-merge commit still
+    shows `-`. Do **not** trust the `git cherry` result here — **skip** and warn.
+  - **Any `git cherry` line starts with `+`** → the branch has a non-merge
+    commit not on `origin/development` — genuinely unmerged work, *or* a
+    multi-commit branch whose PR was squash-merged (no per-commit equivalent
+    exists). Either way, **skip** and warn; the report line tells the user to
+    check whether it was a squashed PR and delete manually if so.
 
 ### Hotfix branches (end with `-hotfix`)
 
@@ -104,9 +118,10 @@ git checkout development
 ## Step 5 — Delete Marked Branches
 
 Every branch that reaches this step was already vetted in Step 3 — it has
-either a **merged PR** or an **empty `git cherry`** against `origin/development`.
-Branches with unmerged work were skipped there and never marked. So Step 5 only
-deletes; it does not re-decide safety.
+either a **merged PR**, or a clean patch-equivalence result (`git cherry` empty
+/ all `-` *and* zero merge commits) against `origin/development`. Branches with
+unmerged work, or merge commits `git cherry` can't see through, were skipped
+there and never marked. So Step 5 only deletes; it does not re-decide safety.
 
 For each marked branch, try the safe delete first, then force:
 
@@ -158,7 +173,7 @@ If no stash was created, leave `persistence.xml` as-is.
 
 Print a summary:
 
-```
+```text
 ✓ Deleted branches (merged PR):
   - <branch>  (PR #NNN merged → <base-branch>)
   ...
@@ -170,14 +185,18 @@ Print a summary:
 ⚠ Skipped branches:
   - <branch>  (has commit(s) not in development — if its PR was squash-merged,
     delete manually after confirming)
+  - <branch>  (carries merge commits — verify manually before deleting)
   ...
+
+• Protected — not touched:
+  - master, <name>-prod  (never deleted by this skill)
 
 ✓ development is now at <short-sha> (<commit subject>)
 ✓ persistence.xml restored to local JNDI settings (unstaged)
 ```
 
-Omit any of the three branch sections that has no entries. If nothing was
-stashed, replace the last line with:
+Omit any branch section that has no entries. If nothing was stashed, replace
+the last line with:
 `✓ persistence.xml unchanged (no local changes were present)`
 
 ## Notes

--- a/.claude/skills/cleanup-branches/SKILL.md
+++ b/.claude/skills/cleanup-branches/SKILL.md
@@ -53,8 +53,8 @@ Before the feature/hotfix split, skip any branch that is `master` or ends with
 `-prod` (the local mirrors of admin-managed / production branches — see Notes
 for the full list). They diverge from `development` by design, so a naïve
 patch-equivalence check could still misfire on them; the explicit skip is the
-guarantee. Report them under a separate "Protected — not touched" line, no
-warning icon.
+guarantee. List them in the report under their own "Protected — not touched"
+heading (they are expected, not a problem to flag).
 
 ### Feature branches (do NOT end with `-hotfix`)
 
@@ -89,17 +89,18 @@ gh pr list --head <branch> --state merged --repo hmislk/hmis --json number,title
 
 ### Vet the branch tip (both branch kinds)
 
-Let `<base>` be the comparison base decided above — `origin/development` for a
-feature branch (or a no-PR review checkout), `origin/<prod>` for a merged
-hotfix.
+Carry two facts forward for each branch: its **PR reference** — either
+`#<n> → <base-branch>` (from the `gh pr list` step) or *none* (a no-PR review
+checkout) — and its comparison base `<base>`: `origin/development` for a feature
+branch or a no-PR checkout, `origin/<baseRefName>` for a feature PR whose base
+was changed, `origin/<prod>` for a merged hotfix.
 
 ```bash
 git merge-base --is-ancestor <branch> <base> && echo CONTAINED || echo AHEAD
 ```
 
 - **CONTAINED** — the branch tip is already reachable from `<base>`; it holds
-  nothing unmerged and no post-merge commits. **Mark for deletion** — labelled
-  "merged-PR" if a PR was found, else "content-merged".
+  nothing unmerged and no post-merge commits. **Mark for deletion.**
 - **AHEAD** — the tip is not reachable from `<base>`. Normal for a squash- or
   rebase-merged PR, but also how a branch with genuine post-merge commits (or a
   reused branch) looks. Disambiguate:
@@ -112,16 +113,16 @@ git merge-base --is-ancestor <branch> <base> && echo CONTAINED || echo AHEAD
   - **`git cherry` empty or every line starts with `-`, AND the merge count is
     `0`** → every non-merge commit is patch-equivalent to something already on
     `<base>` (a clean squash/rebase merge, or a fully-absorbed no-PR checkout
-    such as `pr-23617`). **Mark for deletion** — "content-merged"; reported in
-    its own section so a non-fast-forward deletion is never silent.
+    such as `pr-23617`). **Mark for deletion.**
   - **any `+` line, or a non-zero merge count** → the branch has a non-merge
     commit not on `<base>`, or a merge commit `git cherry` cannot inspect
     (conflict-resolution content can be absent from `<base>` while every
     non-merge commit still shows `-`). Could be post-merge work, a reused
     branch, or a multi-commit squash whose combined diff no longer matches
-    commit-for-commit. **Skip** and warn: "PR #<n> is merged but <branch> is
-    ahead of <base> — if you squash/rebase-merged it, delete manually with
-    `git branch -D <branch>`; otherwise inspect it for unmerged work first."
+    commit-for-commit. **Skip** and warn, quoting the branch's real
+    `<base>` and its PR reference (or noting it has none): "*ahead of `<base>`
+    — if PR #`<n>` was squash/rebase-merged, `git branch -D <branch>`
+    manually; otherwise inspect for unmerged work first*".
 
 ## Step 4 — Switch to development
 
@@ -184,28 +185,28 @@ If no stash was created, leave `persistence.xml` as-is.
 Print a summary:
 
 ```text
-✓ Deleted branches (merged PR):
+✓ Deleted branches:
   - <branch>  (PR #NNN merged → <base-branch>)
-  ...
-
-✓ Deleted branches (no PR, but all commits already in development):
-  - <branch>
+  - <branch>  (no PR; all commits already on <base-branch>)
   ...
 
 ⚠ Skipped branches:
-  - <branch>  (has commit(s) not in development — if its PR was squash-merged,
-    delete manually after confirming)
-  - <branch>  (carries merge commits — verify manually before deleting)
+  - <branch>  (PR #NNN merged → <base-branch>, but tip is ahead of it —
+    squash/rebase merge? `git branch -D` manually; else inspect for unmerged work)
+  - <branch>  (no PR; tip has commit(s) not on <base-branch>)
+  - <branch>  (hotfix, no merged PR found)
   ...
 
 • Protected — not touched:
-  - master, <name>-prod  (never deleted by this skill)
+  - master, <name>-prod
 
 ✓ development is now at <short-sha> (<commit subject>)
 ✓ persistence.xml restored to local JNDI settings (unstaged)
 ```
 
-Omit any branch section that has no entries. If nothing was stashed, replace
+Each deleted / skipped line carries the branch's real PR reference (or "no PR")
+and its real comparison base — never assume a PR exists or that the base is
+`development`. Omit any section with no entries. If nothing was stashed, replace
 the last line with:
 `✓ persistence.xml unchanged (no local changes were present)`
 

--- a/.claude/skills/cleanup-branches/SKILL.md
+++ b/.claude/skills/cleanup-branches/SKILL.md
@@ -60,7 +60,21 @@ gh pr list --head <branch> --base development --state merged --repo hmislk/hmis 
 gh pr list --head <branch> --state merged --repo hmislk/hmis --json number,title,baseRefName,mergedAt --jq '.[0]'
 ```
 
-- If still no merged PR → **skip** (warn the user about the branch).
+- If still no merged PR is found, run a patch-equivalence check before skipping —
+  a `gh pr checkout <N>` review checkout (e.g. `pr-23617`) has no PR with *it*
+  as the head branch, but its commits may already be on `origin/development`
+  (compare against `origin/development`, freshly fetched in Step 2 — local
+  `development` is not fast-forwarded until Step 6):
+
+  ```bash
+  git cherry -v origin/development <branch>
+  ```
+
+  - **Empty output**, or every line starts with `-` → every commit on the branch
+    is already patch-equivalent on `origin/development`. **Mark for deletion**;
+    in the report note it as "content already in development, no PR from this head".
+  - **Any line starts with `+`** → the branch has a commit not on
+    `origin/development`. **Skip** (warn the user about the branch).
 
 ### Hotfix branches (end with `-hotfix`)
 
@@ -87,26 +101,35 @@ For each branch marked for deletion, first try the safe delete:
 git branch -d <branch>
 ```
 
-If `-d` refuses, check whether the local branch has commits that are not on
-the remote (i.e. local-only work added after the PR was merged):
+`-d` refuses whenever the branch tip is not reachable from local `development` —
+the normal case here, both because the PR was squash- or rebase-merged and
+because local `development` is not fast-forwarded until Step 6. Before
+force-deleting, confirm the branch has no unmerged work.
+
+Do **not** use `git log origin/<branch>..<branch>` for this: Step 2's
+`git fetch --prune` deletes `origin/<branch>` as soon as the PR is merged and
+GitHub removes the remote branch, so that command errors with
+`unknown revision or path not in the working tree` instead of returning empty.
+
+Compare against `origin/development` (freshly fetched in Step 2) instead:
 
 ```bash
-git log origin/<branch>..<branch> --oneline
+git cherry -v origin/development <branch>
 ```
 
-- If the output is **empty** — the local tip matches the remote; the refusal
-  is just because the merge commit was squashed/rebased and git cannot trace
-  it locally. It is safe to force-delete:
+- **Empty output**, or every line starts with `-` — every commit is already
+  patch-equivalent on `origin/development`. Safe to force-delete:
 
   ```bash
   git branch -D <branch>
   ```
 
-- If the output shows **local-only commits** — the branch has work that was
-  never pushed. **Skip this branch** and warn the user instead of deleting:
+- **Any line starts with `+`** — that commit is not on `origin/development`; the
+  branch has work that was never merged. **Skip this branch** and warn the user
+  instead of deleting:
 
   ```
-  ⚠ Skipped <branch>: has local commits not present on origin — delete manually after review.
+  ⚠ Skipped <branch>: has commit(s) not in development — delete manually after review.
   ```
 
 ## Step 6 — Fast-Forward development to origin/development
@@ -143,10 +166,11 @@ Print a summary:
 ```
 ✓ Deleted branches:
   - <branch>  (PR #NNN merged → <base-branch>)
+  - <branch>  (content already in development, no PR from this head)
   ...
 
-⚠ Skipped branches (no merged PR found):
-  - <branch>
+⚠ Skipped branches:
+  - <branch>  (has commit(s) not in development)
   ...
 
 ✓ development is now at <short-sha> (<commit subject>)


### PR DESCRIPTION
## Summary

The `/cleanup-branches` skill's Step 5 unmerged-work check used
`git log origin/<branch>..<branch>`. That command **errors** with
`unknown revision or path not in the working tree` in the exact situation the
skill runs in: `git fetch --prune` (Step 2) has already deleted
`origin/<branch>` because the PR merged and GitHub removed the branch. The
skill's "empty output = safe to delete" branch was therefore unreachable, and
the run just observed earlier only got through because the check was done by
hand.

### Changes

- **Step 5**: replace `git log origin/<branch>..<branch>` with
  `git cherry -v origin/development <branch>`, which reports patch-equivalent
  commits regardless of whether the remote ref still exists. Compare against
  `origin/development` (freshly fetched in Step 2) because local `development`
  is not fast-forwarded until Step 6.
- **Step 3**: add the same `git cherry` patch-equivalence check before skipping
  a feature branch with no merged PR from its head. A `gh pr checkout <N>`
  review checkout (e.g. `pr-23617`) has no PR pointing at it, but its commits
  are already on `origin/development` — it should be deleted, not skipped.
- **Step 8**: report template updated for the "content already in development,
  no PR from this head" deletion reason and the reworded skip reason.

Docs/skill-only change (Markdown) — no compilation or tests required.

## Test plan

- [ ] Run `/cleanup-branches` after merging a PR whose remote branch GitHub
      auto-deleted; confirm the local branch is deleted (not skipped) with no
      `unknown revision` error.
- [ ] With a `gh pr checkout <N>` local branch whose PR merged from a different
      head, confirm the skill deletes it and reports "content already in
      development, no PR from this head".
- [ ] With a local branch carrying a genuinely unpushed commit, confirm the
      skill still skips it and warns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified cleanup guidance for branches whose commits are already included in development.
  - Documented protections for `master` and production branches, which are never deleted.
  - Added checks to preserve branches containing merge commits.
  - Clarified handling of feature and hotfix branches associated with merged or missing pull requests.
  - Updated deletion steps and reporting to show pull request status, comparison bases, protected branches, and skip reasons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->