### PR TITLE
fix(inward): reflect running timed services' live accrued amount in the interim bill balance

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -5154,6 +5154,8 @@ public class BhtSummeryController implements Serializable {
 
             setGrossMarginVatBreakdown();
 
+            addRunningTimedServiceLiveTopUp();
+
         }
 
         setNetAdjustValue();
@@ -5167,6 +5169,87 @@ public class BhtSummeryController implements Serializable {
             }
         }
 
+    }
+
+    /**
+     * Tops up the charge-type totals with the amount every still-running timed
+     * service ({@code toTime IS NULL}) would bill if it stopped right now.
+     * <p>
+     * The persisted-value queries behind {@link #setTimedServiceTotCategoryWise()}
+     * and {@link #setGrossMarginVatBreakdown()} only ever contributed each
+     * running service's add-time snapshot ({@code PatientItem.serviceValue} /
+     * the mirrored {@code BillItem.grossValue}) — {@code save()} prices a timed
+     * service once when it is added and it does not grow with elapsed time. The
+     * Timed Service Charges tab, on the other hand, recomputes the live figure in
+     * memory ({@link #createPatientItems()}), so tab and balance diverge the
+     * longer a service runs (issue #23607 / #23606).
+     * <p>
+     * Here we re-price each running service as of "now" ({@code toTime} null →
+     * current time, the same convention {@code calCount} already uses) with
+     * {@link InwardBeanController#calTotalTimedChargeForItem} — the tiered-fee,
+     * foreigner-rate path a manual stop or the discharge auto-close uses — and
+     * add only the difference from the persisted value onto the matching
+     * {@link ChargeItemTotal}'s {@code total} and {@code gross}. A running
+     * service accrues gross only, so margin/VAT are left untouched.
+     * <p>
+     * Nothing is persisted: {@code toTime} stays null, the service is still
+     * genuinely running and can be stopped/edited/removed normally, and merely
+     * viewing or recalculating the interim bill writes nothing to the database.
+     */
+    private void addRunningTimedServiceLiveTopUp() {
+        List<PatientItem> running = getInwardBean()
+                .fetchRunningTimedPatientItems(getPatientEncounter(), childPatientEncouters);
+        if (running == null || running.isEmpty()) {
+            return;
+        }
+
+        Date now = new Date();
+        Map<InwardChargeType, Double> topUpByChargeType = new HashMap<>();
+
+        for (PatientItem pi : running) {
+            if (pi.getItem() == null || !(pi.getItem() instanceof TimedItem)) {
+                continue;
+            }
+            // Package-locked services keep their fixed price - skip, same as the
+            // discharge-time close (finalizeRunningTimedServices).
+            if (pi.getBillItem() != null && pi.getBillItem().isFromPackage()) {
+                continue;
+            }
+            // A start time in the future has not accrued anything yet.
+            if (pi.getFromTime() == null || now.before(pi.getFromTime())) {
+                continue;
+            }
+            // No configured fee -> would price at zero; leave the persisted value
+            // alone rather than zero it out.
+            if (getInwardBean().getAllTimedItemFees((TimedItem) pi.getItem()).isEmpty()) {
+                continue;
+            }
+
+            PatientEncounter owner = pi.getPatientEncounter() != null
+                    ? pi.getPatientEncounter() : getPatientEncounter();
+            double liveValue = getInwardBean().calTotalTimedChargeForItem(
+                    (TimedItem) pi.getItem(), pi.getFromTime(), now, owner.isForiegner());
+            double persistedValue = pi.getServiceValue() != null ? pi.getServiceValue() : 0.0;
+            double delta = liveValue - persistedValue;
+            if (delta == 0.0) {
+                continue;
+            }
+
+            InwardChargeType chargeType = pi.getItem().getInwardChargeType();
+            topUpByChargeType.merge(chargeType, delta, Double::sum);
+        }
+
+        if (topUpByChargeType.isEmpty()) {
+            return;
+        }
+
+        for (ChargeItemTotal cit : chargeItemTotals) {
+            Double delta = topUpByChargeType.get(cit.getInwardChargeType());
+            if (delta != null && delta != 0.0) {
+                cit.setTotal(cit.getTotal() + delta);
+                cit.setGross(cit.getGross() + delta);
+            }
+        }
     }
 
     private void restoreChargeItemComments() {

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -5231,7 +5231,13 @@ public class BhtSummeryController implements Serializable {
                     (TimedItem) pi.getItem(), pi.getFromTime(), now, owner.isForiegner());
             double persistedValue = pi.getServiceValue() != null ? pi.getServiceValue() : 0.0;
             double delta = liveValue - persistedValue;
-            if (delta == 0.0) {
+            // Only ever add positive accrual. A running service can only have run
+            // longer since it was priced, so the live value should never be below
+            // the persisted one; if it is (e.g. the fee config was changed after
+            // the service was added), pulling the charge-type total down here
+            // would understate the balance against a figure the bill has not
+            // actually recorded. Leave those to the explicit stop/recalc path.
+            if (delta <= 0.0) {
                 continue;
             }
 
@@ -5245,7 +5251,7 @@ public class BhtSummeryController implements Serializable {
 
         for (ChargeItemTotal cit : chargeItemTotals) {
             Double delta = topUpByChargeType.get(cit.getInwardChargeType());
-            if (delta != null && delta != 0.0) {
+            if (delta != null && delta > 0.0) {
                 cit.setTotal(cit.getTotal() + delta);
                 cit.setGross(cit.getGross() + delta);
             }


### PR DESCRIPTION
## Issue

Closes #23607 · Closes #23606

Issue #23607 ("Running service issues", Ruhunu) bundles four sub-items about inward **Time Services** that are still running (Stopped Time not set):

| Sub-item | Ask | Status |
|---|---|---|
| **1** | Stop Time column empty while a service runs | ✅ already done by **#23630** (`InwardTimedItemController.save()` no longer auto-fills `toTime`) |
| **3** | Nursing Discharge must not proceed while a Time Service runs | ✅ already done by **#23638** — nursing discharge is **blocked** until staff stop every running service by hand. This is the intended behaviour; the system must **not** auto-stop anything. |
| **2 / 4** | Interim Bill must include a running service's accrued amount in the **charge-type totals and patient balance**, not just the tab (#23606) | ❌ **this PR** |

## The gap

`inward_bill_intrim.xhtml`'s **Timed Service Charges tab** already shows the live accrued amount per row — `BhtSummeryController.createPatientItems()` recomputes each timed `PatientItem.serviceValue` in memory as `calCount(fee, fromTime, toTime==null → now) * fee`.

But the **charge-type totals** that feed **Total Charges** and the patient **Due** use `InwardBeanController.getTimedItemFeeTotalByInwardChargeTypeBulk()` (`SUM(serviceValue)` where `billItem is null`) plus the BillItem-side bulk sums (`bi.grossValue`) — both read the **persisted** value, which `save()` prices **once** at add time and never grows. So for a still-running service the tab and the balance diverged, and the balance under-stated what the patient owed the longer the service ran.

## Change

One method, `BhtSummeryController.addRunningTimedServiceLiveTopUp()`, called at the end of `createChargeItemTotals()`:

- For each running timed `PatientItem` (`fetchRunningTimedPatientItems`, `toTime IS NULL`), re-price as of **now** with `calTotalTimedChargeForItem(...)` — the tiered-fee, foreigner-rate path used by the manual stop and the discharge auto-close.
- Add **only the difference** from the persisted value onto the matching `ChargeItemTotal`'s `total` and `gross` (margin/VAT untouched — a running service accrues gross only).
- Skips the same items `finalizeRunningTimedServices` skips: package-locked, `fromTime` in the future, no configured fee.

**Nothing is persisted.** `toTime` stays null, the service is still genuinely running and can be stopped/edited/removed normally, and opening or recalculating the interim bill writes nothing to the database. The Timed Service Charges tab is unchanged; it simply now agrees with the totals.

## Verification (local Payara, coop DB)

1. Created a per-minute `TimedItem` (Rs 10/min) + fee via the **Timed Item API** (`POST /api/timed-items`, `POST /api/timed-items/{id}/fees`).
2. Via the **Add Timed Services** page (Menu → Inward → Add Timed Services), added a running instance of it to a live Galle Co-op admission **BHT/57813**, Start Time backdated 60 min, Stopped Time left blank.
   - Row rendered with **Stopped Time empty** — sub-item 1 regression check ✅
   - DB: `PatientItem` `serviceValue = 600`, `toTime = NULL`, linked `BillItem.grossValue = 600`, `Bill.netTotal = 600`
3. Menu → Inward → Interim Bill → searched BHT/57813 → **Continue**:
   - **Oxygen Charges** charge-type total, **Total Charges**, **Due** all showed **610** (live ≈ 61 min)
   - DB still `600` / `600` / `600` — no write
4. Clicked **Recalculate** ~5 min later:
   - All three UI figures moved to **660** (+50 = 5 min × Rs 10)
   - DB still `600` / `600` / `600` — no write
5. Regression: a stopped timed service (`toTime` set) contributes an identical figure before and after — the top-up only applies to running items.
6. Test data removed afterwards.

![Interim Bill Summary and Charges with a running per-minute timed service reflected at its live amount, matching between the Timed Service Charges tab and the Oxygen Charges row that feeds Total Charges and Due](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23607-interim-bill-running-timed-service-live-total.png)

## Documentation

Updated the wiki page for the screen this changes:
**[Intrim Bill](https://github.com/hmislk/hmis/wiki/Intrim-Bill)** → new section *"Running Timed Services Are Counted in the Balance at Their Live Amount"* with the screenshot above and a note that this is a display-time calculation only (no stop, no write) and that nursing discharge still blocks on running services.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159PRDiWz158pPE29cpQuUW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Running timed services now have their charges updated in real time as time elapses.
  - Charge summaries now include only the additional amount accrued since the service was started, preventing duplicate charges.
  - Services that are not yet started, locked, or missing a configured fee continue to be excluded from live updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->