### PR TITLE
fix(inward): correct final bill net total on Manage Final Bills → View / Print (#23652)

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardSearch.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSearch.java
@@ -702,10 +702,7 @@ public class InwardSearch implements Serializable {
         }
 
         if (versions.size() == 1) {
-            bill = versions.get(0);
-            billItems = null;
-            withProfessionalFee = false;
-            return "/inward/inward_reprint_bill_final?faces-redirect=true";
+            return navigateToReprintFinalBill(versions.get(0));
         }
 
         return "/inward/inward_final_bill_list?faces-redirect=true";
@@ -726,6 +723,25 @@ public class InwardSearch implements Serializable {
         }
 
         return "/inward/inward_final_bill_list?faces-redirect=true";
+    }
+
+    /**
+     * Shared reprint navigation into inward_reprint_bill_final.xhtml, used both
+     * by the Manage Final Bills version list ("View / Print") and by the
+     * single-version auto-navigate from {@link #navigateToFinalBillForAdmission()}.
+     * Forces {@link #withProfessionalFee} to true so the Final Bill / Custom Bill
+     * previews render the stored {@code bill.netTotal} rather than the derived
+     * hospital-only figure. Every other route into that page already sets this
+     * flag; these two were leaving it at its stale session value (issue #23652).
+     */
+    public String navigateToReprintFinalBill(Bill b) {
+        if (b == null) {
+            JsfUtil.addErrorMessage("No bill selected");
+            return "";
+        }
+        setBill(b);
+        withProfessionalFee = true;
+        return "/inward/inward_reprint_bill_final?faces-redirect=true";
     }
 
     /**

--- a/src/main/webapp/inward/inward_final_bill_list.xhtml
+++ b/src/main/webapp/inward/inward_final_bill_list.xhtml
@@ -115,14 +115,10 @@
                                         class="#{b.approveAt eq null ? 'ui-button-warning me-1' : 'ui-button-info me-1'}"
                                         value="#{b.approveAt eq null ? 'View / Print (Unapproved)' : 'View / Print'}"
                                         title="View #{b.deptId}"
-                                        action="/inward/inward_reprint_bill_final?faces-redirect=true"
+                                        action="#{inwardSearch.navigateToReprintFinalBill(b)}"
                                         rendered="#{b.approveAt ne null
                                                     or webUserController.hasPrivilege('InwardFinalBillViewUnapproved')
                                                     or webUserController.hasPrivilege('InwardFinalBillApprove')}">
-                                        <f:setPropertyActionListener
-                                            value="#{b}"
-                                            target="#{inwardSearch.bill}">
-                                        </f:setPropertyActionListener>
                                     </p:commandButton>
 
                                     <p:commandButton


### PR DESCRIPTION
## Problem

The inward final bill's **Net Total** shown on **Inpatient Dashboard → Manage Final Bills → View / Print** differed from the value shown elsewhere (settle preview, Final Bill Search, the versions-list Net Total column). On that route the **Final Bill** tab and **Custom Bill** tabs opened showing a figure lower than the real net total; ticking **With Professional Fee** made it correct. Reported as "net total differs from time to time". (Closes #23652)

## Root cause

`inward_reprint_bill_final.xhtml` passes `showProfessional="#{inwardSearch.withProfessionalFee}"` into the `finalBill` / `finalBillCustom4` / `finalBillBundledCustom1` preview components. Those render:

- `showProfessional == true`  → `bill.netTotal` (the stored, correct value)
- `showProfessional == false` → `bill.hospitalFee - bill.discount` (a derived hospital-only figure, lower than the real net total by roughly the professional-fee amount)

`withProfessionalFee` is a mutable field on the **`@SessionScoped`** `InwardSearch` bean, default `false`. Every route into that page sets it before navigating **except**:

1. The **"View / Print"** button on `inward_final_bill_list.xhtml` — a bare `action="/inward/inward_reprint_bill_final?faces-redirect=true"` plus `setPropertyActionListener` for the bill only.
2. The single-version branch of `navigateToFinalBillForAdmission()` — which set it to `false`.

So those two paths rendered whatever stale value the session bean last held. Final Bill Search always looked right because `refreshFinalBillBackwordReferenceBills()` forces `withProfessionalFee = true`; the settle preview always looked right because it hard-codes `showProfessional="true"`.

## Change

- **`InwardSearch.navigateToReprintFinalBill(Bill)`** (new) — sets the bill via `setBill()` (which refreshes it from the facade and clears the view model) and forces `withProfessionalFee = true`, matching every other entry point into the page.
- **`inward_final_bill_list.xhtml`** — the "View / Print" button now calls `navigateToReprintFinalBill(b)` instead of the bare navigation string + `setPropertyActionListener`.
- **`navigateToFinalBillForAdmission()`** — the single-version branch now routes through `navigateToReprintFinalBill(...)` too, so both entry points share one preparation path (removes the duplication a self-review flagged).

No entity, schema, privilege, or constructor changes. JSF/Java only.

## Decisions made without approval

- **Default value = `true`.** Chosen because it is the established value on every working route (`refreshFinalBillBackwordReferenceBills()` → `true`; settle preview → `showProfessional="true"`; the `finalBill`/`finalBillCustom4`/`finalBillBundledCustom1` composites all default `showProfessional` to `true`) and it makes the tab Net Total match the **Bill Details** card on the same page. Not treated as ambiguous.
- **Fix at the navigation layer, not in `setBill()`.** `setBill()` is invoked from many unrelated pages via `setPropertyActionListener target="#{inwardSearch.bill}"` (provisional bills, cancellations); forcing the flag there would leak into those flows. Rejected.
- **Did not change the `showProfessional == false` branch** in `finalBill.xhtml` (`hospitalFee - discount`). That is a deliberate "hospital copy without professional fees" display mode with its own config key and checkbox; reworking what it computes is a separate concern, out of scope for this issue.
- **Self-review finding folded in, not deferred:** unifying the single-version branch through the shared method (see third bullet under Change). Rebuilt and re-verified after this change.
- **Implementation not delegated to a subagent** — 3-line flip + one 8-line method mirroring an existing sibling + one attribute swap; reviewed via `/code-review high` (no correctness findings) instead.

## Verification (local Payara + MySQL, Playwright)

**Menu path:** Menu → Inward → Search → Admissions → search BHT → **Inpatient Dashboard** → **Manage Final Bills** → **View / Print**.

Test record: final bill `Inward/INWFINAL/189/1` — `netTotal` 223,587.9663, `hospitalFee` 103,587.9663, `discount` 0, `professionalFee` 120,000. Pre-fix the tabs showed `hospitalFee - discount` = **103,587.97**; expected **223,587.97**.

After the fix, on a fresh session:

- **Manage Final Bills → View / Print** — page opens with **With Professional Fee** ticked; **Net Total 223,587.97** in the **Final Bill** tab and in all three **Custom Bills** formats (Custom Bill 2 / Custom Bill 3 / Bundled Custom 1), matching `bill.netTotal`, the versions-list Net Total column, and the Bill Details card.
- **Admission Profile → Final Bill** button (single-version auto-navigate) — same: ticked on open, Net Total 223,587.97.
- DB re-checked read-only after each view; values unchanged.

![Final Bill tab on open](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23652-01-final-bill-tab-net-total-correct.png)

![Custom Bills tab on open](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23652-02-custom-bills-tab-net-total-correct.png)

## Documentation

Wiki — **[Inpatient — Final Bill Versions](https://github.com/hmislk/hmis/wiki/Inpatient-Final-Bill-Versions)**: added a "Viewing / Printing a Version" section covering the format tabs and the **With Professional Fee** toggle (now defaulting ticked on every route), with both screenshots above, and a note on the prior behaviour on this route. Committed with the images in `hmis.wiki`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved the **View / Print** action for final bill versions with more consistent navigation to the final bill reprint screen.
  - Final bill reprints now consistently include professional fee details when applicable.
  - Selecting a bill version now directly opens the corresponding reprint view for a smoother workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->