### PR TITLE
Timed service checking on the Interim Bill, and the final-bill gate that was missing it

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -14,7 +14,7 @@ waste a session.
 
 ## Contents
 
-118 sections. **The workflow is §0-§8; everything from §9 on is an independent
+121 sections. **The workflow is §0-§8; everything from §9 on is an independent
 gotcha** — jump straight to the one you need rather than reading the file.
 
 **Workflow**
@@ -140,6 +140,9 @@ gotcha** — jump straight to the one you need rather than reading the file.
 - [111. The local `coop` DB can have **zero** vacant rooms — free some by SQL before testing any admission flow](#111-the-local-coop-db-can-have-zero-vacant-rooms--free-some-by-sql-before-testing-any-admission-flow)
 - [112. Relaxing a "required" validation? Audit every downstream reader of that field for null-safety](#112-relaxing-a-required-validation-audit-every-downstream-reader-of-that-field-for-null-safety)
 - [113. `p:tag` silently drops `title` — a tooltip on a tag needs `p:tooltip`](#113-ptag-silently-drops-title--a-tooltip-on-a-tag-needs-ptooltip)
+- [114. PrimeFaces menubar flyouts close between MCP tool calls — click the leaf `<a>` in one `browser_evaluate`](#114-primefaces-menubar-flyouts-close-between-mcp-tool-calls--click-the-leaf-a-in-one-browser_evaluate)
+- [115. Element screenshots land on the wrong region — crop the viewport shot instead](#115-element-screenshots-land-on-the-wrong-region--crop-the-viewport-shot-instead)
+- [116. `p:datePicker` with a mask silently truncates `pressSequentially`](#116-pdatepicker-with-a-mask-silently-truncates-presssequentially)
 - [Quick checklist](#quick-checklist)
 
 ---
@@ -3291,3 +3294,76 @@ DOM*, not the source.
 - [ ] Before writing "did not reproduce", checked every `getBooleanValueByKey(...)` branch in the code path and flipped any option whose local value differs from the reporter's likely setting (§107) — and, when verifying a fix, exercised **both** settings of any option gating the changed code.
 - [ ] For any admission flow: confirmed the local DB actually has a vacant room (`completeRoom` returns suggestions); if not, freed some by SQL (§111) before concluding the Room autocomplete is broken.
 - [ ] Before trying to reproduce a same-session state-change race (item A staged, then a dependency of A is invalidated by a legitimate app action before A is submitted), checked whether a `@SessionScoped` controller's already-held entity reference would even observe the change (§96) rather than assuming any in-app mutation propagates live.
+## 114. PrimeFaces menubar flyouts close between MCP tool calls — click the leaf `<a>` in one `browser_evaluate`
+
+The main menu's nested submenus (e.g. *Inpatient → Services & Items → Add Timed
+Services*) are `autoDisplay="false"`, so they open on **click**, not hover —
+`browser_hover` leaves the parent `ui-menuitem-active` but the child list stays
+`display: none`. Worse, each Playwright tool call is a fresh round trip, and the
+flyout collapses in between: opening the top level in one call and reaching for
+the leaf in the next always fails with *"element is not visible"*, and clicking
+the parent again just toggles it shut.
+
+Driving it click-by-click is not worth the fight. Invoke the leaf item's own
+handler in a single call:
+
+```js
+browser_evaluate(() => {
+  Array.from(document.querySelectorAll('.ui-menubar a'))
+    .find(a => a.textContent.trim() === 'Add Timed Services')
+    .click();
+});
+```
+
+This is **not** the same as URL navigation and does not violate §2: the anchor's
+`onclick` is `PrimeFaces.addSubmitParam(...).submit('menuForm')`, so the menu
+form posts exactly as it would for a user and the `@SessionScoped` navigation
+method runs normally. You are reproducing the click, not skipping it. Still
+record the human menu path in the issue/PR.
+
+Related: menubar items are icon-only with no accessible name, so
+`browser_snapshot` shows a wall of anonymous `menuitem` nodes. To map them,
+read the submenu text rather than guessing:
+
+```js
+browser_evaluate(() => Array.from(document.querySelectorAll('.ui-menubar > .ui-menu-list > li'))
+  .map((li, i) => i + ': ' + Array.from(li.querySelectorAll('.ui-menu-child a'))
+    .slice(0, 4).map(a => a.textContent.trim()).join(' / ')).join('\n'));
+```
+
+## 115. Element screenshots land on the wrong region — crop the viewport shot instead
+
+`browser_take_screenshot` with an `element`/`target` repeatedly captured the
+wrong band of the page on inward billing screens (blank, or the footer instead
+of the table). The pages have a sticky header and the browser runs at a device
+pixel ratio > 1, and the element-clip path does not agree with the rendered
+offsets.
+
+What works reliably: size the viewport wide enough for the whole table, scroll
+the target into view, take a plain **viewport** screenshot, then crop it:
+
+```python
+from PIL import Image
+im = Image.open('tmp/<issue>/_full.png')
+im.crop((0, top, im.size[0], bottom)).save('tmp/<issue>/<name>.png')
+```
+
+Cropping is also how you strip patient identifiers before anything reaches the
+wiki — a full-page inward screenshot carries name, DOB, phone, NIC and
+consultant in the Patient Details panel, none of which may be published.
+
+## 116. `p:datePicker` with a mask silently truncates `pressSequentially`
+
+Typing `10 Sep 2026 04:00:00` into a masked `p:datePicker` character by
+character produced `'10 Sep 2026 04:'` and a JSF conversion error
+(*"could not be understood as a date and time"*) — the mask consumed part of
+the input mid-type. Setting the value in one assignment works, because JSF reads
+the submitted string on the full form post:
+
+```js
+browser_evaluate(() => { document.getElementById('form:dateStamp_input').value = '10 Sep 2026 04:00:00'; });
+```
+
+Do **not** follow it with a synthetic `change` event — on these pickers that
+re-runs the mask and blanks the field again. §18's calendar-grid technique
+remains the option when the widget's own parsing needs to run.

--- a/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
+++ b/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
@@ -191,6 +191,12 @@ public class ConfigOptionApplicationController implements Serializable {
         // reservedFrom when reservedTo is null). Consumed by AppointmentController.navigatePatientAdmit().
         getLongValueByKey("Inward - Reservation Admission Early Window (Hours)", 24L);
         getLongValueByKey("Inward - Reservation Admission Grace Period (Hours)", 24L);
+        // Settlement gate: unchecked inward service / professional / pharmacy /
+        // store / payment bills block the final bill. Seeded here so an admin
+        // can find and toggle it without first having to settle a bill.
+        // Replaces "Need to check inward bills before discharge", which was read
+        // inverted - see BhtSummeryController.INWARD_BILL_CHECKING_REQUIRED.
+        getBooleanValueByKey("Inward bills must be checked before the final bill is settled", true);
     }
 
     private void loadPettyCashBillingConfigurationDefaults() {

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -1984,6 +1984,90 @@ public class BhtSummeryController implements Serializable {
     }
 
     /**
+     * Marks a timed service's own bill as checked from the Interim Bill, so
+     * timed services can be verified where they are listed instead of only from
+     * Search &rarr; Service Bill.
+     * <p>
+     * Deliberately the same two fields, and the same "not once the payment is
+     * finalized" refusal, as {@code InwardSearch#markAsChecked()} — a timed
+     * service checked here has to be indistinguishable from one checked there,
+     * because the settlement gate reads {@code Bill.checkedBy} and does not care
+     * which screen set it.
+     */
+    public void markTimedServiceAsChecked(PatientItem patientItem) {
+        Bill b = billOfTimedService(patientItem);
+        if (b == null) {
+            return;
+        }
+        if (b.getCheckedBy() != null) {
+            JsfUtil.addErrorMessage("This timed service has already been checked.");
+            return;
+        }
+        // A running service has no final amount yet - its charge keeps growing,
+        // and the discharge closes it and reprices it (see
+        // finalizeRunningTimedServices). Checking one would stamp a verification
+        // on a figure the system itself is about to change, which is exactly
+        // what the checked-is-frozen rule exists to prevent. Verify a finished
+        // charge, not a growing one.
+        if (patientItem.getToTime() == null) {
+            JsfUtil.addErrorMessage("This timed service is still running. Enter a Stopped Time and press Update before checking it.");
+            return;
+        }
+        b.setCheckeAt(new Date());
+        b.setCheckedBy(getSessionController().getLoggedUser());
+        getBillFacade().edit(b);
+
+        patientItems = null;
+        JsfUtil.addSuccessMessage("Timed service checked.");
+    }
+
+    /**
+     * Reverses {@link #markTimedServiceAsChecked}. This is what reopens a
+     * checked timed service for editing — see
+     * {@code InwardTimedItemController#isCheckedAndLocked} — which is why it
+     * sits behind its own {@code InwardUnCheck} privilege on the page.
+     */
+    public void markTimedServiceAsUnChecked(PatientItem patientItem) {
+        Bill b = billOfTimedService(patientItem);
+        if (b == null) {
+            return;
+        }
+        if (b.getCheckedBy() == null) {
+            JsfUtil.addErrorMessage("This timed service has not been checked.");
+            return;
+        }
+        b.setCheckeAt(null);
+        b.setCheckedBy(null);
+        getBillFacade().edit(b);
+
+        patientItems = null;
+        JsfUtil.addSuccessMessage("Timed service unchecked.");
+    }
+
+    /**
+     * The bill a timed service can be checked on, or null with the reason
+     * reported to the user. Only ward timed services own a bill; a
+     * surgery-added or pre-redesign one is charged through the PatientItem
+     * itself and has no bill of its own for a cashier to check.
+     */
+    private Bill billOfTimedService(PatientItem patientItem) {
+        if (patientItem == null || patientItem.getBill() == null) {
+            JsfUtil.addErrorMessage("This timed service has no bill of its own and cannot be checked.");
+            return null;
+        }
+        Bill b = patientItem.getBill();
+        if (b.isRetired() || b.isCancelled()) {
+            JsfUtil.addErrorMessage("This timed service's bill has been removed or cancelled.");
+            return null;
+        }
+        if (b.getPatientEncounter() != null && b.getPatientEncounter().isPaymentFinalized()) {
+            JsfUtil.addErrorMessage("Final payment has been settled for this admission. Bills can no longer be checked or unchecked.");
+            return null;
+        }
+        return b;
+    }
+
+    /**
      * Entry point for the "Save Changes" button. If the room's current
      * admitted/discharged times overlap another (non-Guardian/Theatre) room
      * period for the same patient or bed, ask for confirmation before saving
@@ -3446,11 +3530,21 @@ public class BhtSummeryController implements Serializable {
     }
 
     public boolean checkBill() {
-        if (configOptionApplicationController.getBooleanValueByKey("Need to check inward bills before discharge")) {
+        if (!isInwardBillCheckingEnforced()) {
             return false;
         }
 
         if (getInwardBean().checkByBillFee(getPatientEncounter(), new BilledBill(), BillType.InwardBill)) {
+            JsfUtil.addErrorMessage("Some Inward Service Bills Are Not Checked ");
+            return true;
+        }
+
+        // BillFee-side only catches inward service bills that carry fees. Timed
+        // services get a bill with a BillItem and no BillFee at all
+        // (InwardTimedItemController#createBillForTimedService), so an unchecked
+        // timed service used to walk straight past this gate. The BillItem side
+        // is a superset: every unchecked InwardBill BilledBill, fees or not.
+        if (getInwardBean().checkByBillItem(getPatientEncounter(), new BilledBill(), BillType.InwardBill)) {
             JsfUtil.addErrorMessage("Some Inward Service Bills Are Not Checked ");
             return true;
         }
@@ -3510,8 +3604,38 @@ public class BhtSummeryController implements Serializable {
         return false;
     }
 
+    /**
+     * Whether unchecked inward bills should block settlement.
+     * <p>
+     * This replaces the old {@code "Need to check inward bills before
+     * discharge"} option, which was read inverted: switching it ON turned all
+     * bill checking OFF, the opposite of what it says, so a hospital that
+     * enabled it silently lost the gate entirely.
+     * <p>
+     * The fix is a new key rather than flipping how the old one is read. The
+     * old key was consulted through the single-argument
+     * {@code getBooleanValueByKey}, which <em>creates</em> the option row set to
+     * {@code "false"} the first time it is read — so by now every deployment
+     * that has ever settled an inward bill has it stored as {@code false},
+     * meaning "enforce" under the old reading. Re-reading that same stored
+     * {@code false} as "do not enforce" would have switched the gate off for
+     * every hospital at once. A new key defaults to {@code true} everywhere and
+     * means exactly what it says.
+     * <p>
+     * A hospital that had deliberately turned the old option on to bypass
+     * checking must now turn this one off instead.
+     */
+    public static final String INWARD_BILL_CHECKING_REQUIRED
+            = "Inward bills must be checked before the final bill is settled";
+
+    private boolean isInwardBillCheckingEnforced() {
+        return configOptionApplicationController.getBooleanValueByKey(
+                INWARD_BILL_CHECKING_REQUIRED, true);
+    }
+
     private boolean hasAnyUncheckedInwardBills() {
         return getInwardBean().checkByBillFee(getPatientEncounter(), new BilledBill(), BillType.InwardBill)
+                || getInwardBean().checkByBillItem(getPatientEncounter(), new BilledBill(), BillType.InwardBill)
                 || getInwardBean().checkByBillFee(getPatientEncounter(), new BilledBill(), BillType.InwardProfessional)
                 || getInwardBean().checkByBillItem(getPatientEncounter(), new PreBill(), BillType.PharmacyBhtPre)
                 || getInwardBean().checkByBillItem(getPatientEncounter(), new RefundBill(), BillType.PharmacyBhtPre)
@@ -3545,7 +3669,7 @@ public class BhtSummeryController implements Serializable {
 
         System.out.println("Privilege = " + getWebUserController().hasPrivilege("InwardBillSettleWithoutCheck"));
 
-        System.out.println("Option = " + configOptionApplicationController.getBooleanValueByKey("Need to check inward bills before discharge"));
+        System.out.println("Bill checking enforced = " + isInwardBillCheckingEnforced());
 
         System.out.println("Starting Bills Checking Process.... ");
         if (getPatientEncounter().getAdmissionType().getAdmissionTypeEnum() == AdmissionTypeEnum.Admission) {
@@ -3554,7 +3678,7 @@ public class BhtSummeryController implements Serializable {
                 if (checkBill()) {
                     return "";
                 }
-            } else if (!configOptionApplicationController.getBooleanValueByKey("Need to check inward bills before discharge")
+            } else if (isInwardBillCheckingEnforced()
                     && hasAnyUncheckedInwardBills()) {
                 JsfUtil.addWarningMessage("Settling with unchecked Inward Service / Professional / Pharmacy / Store / Payment bills. "
                         + "Proceeding because you hold the 'Inward Bill Settle Without Check' privilege.");

--- a/src/main/java/com/divudi/bean/inward/InwardTimedItemController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardTimedItemController.java
@@ -407,6 +407,9 @@ public class InwardTimedItemController implements Serializable {
         if (patientItem != null && isLockedForChanges(patientItem.getPatientEncounter())) {
             return;
         }
+        if (isCheckedAndLocked(patientItem)) {
+            return;
+        }
         if (patientItem != null) {
             patientItem.setRetirer(getSessionController().getLoggedUser());
             patientItem.setRetiredAt(new Date());
@@ -424,8 +427,12 @@ public class InwardTimedItemController implements Serializable {
      * Retires the BillItem and Bill behind a removed timed service. Without
      * this the charge would survive the removal, since the inward totals are
      * summed from the BillItem side.
+     * <p>
+     * Public because the Interim Bill's own Remove button removes timed
+     * services through {@code SurgeryBillController#removeTimeService}, which
+     * has to retire the same bill rather than duplicate this.
      */
-    private void retireTimedServiceBill(PatientItem patientItem) {
+    public void retireTimedServiceBill(PatientItem patientItem) {
         BillItem bi = patientItem.getBillItem();
         if (bi == null || bi.isFromPackage()) {
             return;
@@ -685,6 +692,29 @@ public class InwardTimedItemController implements Serializable {
     }
 
     /**
+     * A timed service whose bill a cashier has already checked is frozen —
+     * times cannot be edited and the service cannot be removed. Checking is a
+     * verification that the charge is correct, so letting the charge change
+     * afterwards would make the check meaningless. Reopening one is a
+     * deliberate, privileged act: uncheck the bill (needs
+     * {@code InwardUnCheck}) and the row is editable again.
+     * <p>
+     * Only ward timed services carry a bill of their own (see
+     * {@link #createBillForTimedService}); a surgery-added or pre-redesign
+     * service has none and is not locked by this.
+     */
+    public boolean isCheckedAndLocked(PatientItem pi) {
+        if (pi == null || pi.getBill() == null) {
+            return false;
+        }
+        if (pi.getBill().getCheckedBy() == null) {
+            return false;
+        }
+        JsfUtil.addErrorMessage("This timed service's bill has been checked. Uncheck it before changing the times.");
+        return true;
+    }
+
+    /**
      * Department the service was physically delivered in. Defaults to the
      * service item's own department and can be overridden by the user before
      * adding, since the same service may be given in a different ward or unit.
@@ -871,6 +901,9 @@ public class InwardTimedItemController implements Serializable {
             return;
         }
         if (pic != null && isLockedForChanges(pic.getPatientEncounter())) {
+            return;
+        }
+        if (isCheckedAndLocked(pic)) {
             return;
         }
         PatientItem temPi;

--- a/src/main/java/com/divudi/bean/inward/SurgeryBillController.java
+++ b/src/main/java/com/divudi/bean/inward/SurgeryBillController.java
@@ -402,10 +402,21 @@ public class SurgeryBillController implements Serializable {
             JsfUtil.addErrorMessage("This surgery has been validated and is locked. Revert validation to make changes.");
             return;
         }
+        if (inwardTimedItemController.isCheckedAndLocked(patientItem)) {
+            return;
+        }
         patientItem.setRetirer(getSessionController().getLoggedUser());
         patientItem.setRetiredAt(new Date());
         patientItem.setRetired(true);
         getPatientItemFacade().edit(patientItem);
+        // Retiring only the PatientItem hid the row but kept the charge: the
+        // inward totals are summed from the BillItem side
+        // (InwardBeanController#calServiceBillItemsTotalByInwardChargeTypeBulk),
+        // so a removed ward timed service went on billing - and, once unchecked
+        // service bills block the final bill, would have blocked it from a bill
+        // no screen still listed. No-ops for surgery-added services, whose
+        // PatientItem carries no BillItem of its own.
+        inwardTimedItemController.retireTimedServiceBill(patientItem);
         refreshTimedEncounterComponents();
     }
 

--- a/src/main/webapp/inward/inward_bill_intrim.xhtml
+++ b/src/main/webapp/inward/inward_bill_intrim.xhtml
@@ -617,21 +617,32 @@
                                         <p:column headerText="Service Name" styleClass="text-start">
                                             <h:outputLabel value="#{pt.item.name}"/>
                                         </p:column>
+                                        <!--
+                                            #23606 - a checked bill is frozen. The times go
+                                            read-only and Update/Remove are disabled until
+                                            someone with InwardUnCheck unchecks it, so the
+                                            charge a cashier verified cannot then change
+                                            underneath the verification. The same rule is
+                                            enforced server-side in
+                                            InwardTimedItemController.isCheckedAndLocked.
+                                        -->
                                         <p:column headerText="Start Time" styleClass="text-start">
-                                            <p:datePicker 
+                                            <p:datePicker
                                                 showTime="true"
                                                 timeInput="true"
                                                 id="serviceStartTimeStamp"
                                                 value="#{pt.fromTime}"
+                                                disabled="#{pt.bill.checkedBy ne null}"
                                                 pattern="dd/MM/yyyy  hh:mm:ss a" >
                                             </p:datePicker>
                                         </p:column>
                                         <p:column headerText="Stopped Time" styleClass="text-start">
-                                            <p:datePicker 
+                                            <p:datePicker
                                                 showTime="true"
                                                 timeInput="true"
                                                 id="serviceStoppedTimeStamp"
                                                 value="#{pt.toTime}"
+                                                disabled="#{pt.bill.checkedBy ne null}"
                                                 pattern="dd/MM/yyyy  hh:mm:ss a" >
                                             </p:datePicker>
                                         </p:column>
@@ -643,30 +654,99 @@
                                         <p:column headerText="Creator" styleClass="text-start" >
                                             <h:outputLabel value="#{pt.creater.webUserPerson.name}"/>
                                             <br/>
-                                            <h:panelGroup rendered="#{ti.retired}" >
+                                            <h:panelGroup rendered="#{pt.retired}" >
                                                 <h:outputLabel style="color: red;" value="Deleted By " />
                                                 <h:outputLabel style="color: red;"  value="#{pt.retirer.webUserPerson.name}" >
                                                 </h:outputLabel>
                                             </h:panelGroup>
                                         </p:column>
+                                        <!--
+                                            #23606 - timed services are billed one BilledBill each
+                                            (InwardTimedItemController.createBillForTimedService), so
+                                            they carry the same Checked By / Checked At verification
+                                            as every other charge tab. Rows with no bill are surgery-
+                                            added or pre-redesign services, charged through the
+                                            PatientItem itself, with no bill of their own to check.
+                                        -->
+                                        <p:column headerText="Bill No" styleClass="text-start">
+                                            <h:outputLabel value="#{pt.bill.deptId}"/>
+                                            <h:outputLabel value="—" rendered="#{pt.bill eq null}" styleClass="text-muted"/>
+                                        </p:column>
+                                        <p:column headerText="Status" styleClass="text-start">
+                                            <h:outputLabel styleClass="badge bg-success"
+                                                           value="Checked"
+                                                           rendered="#{pt.bill ne null and pt.bill.checkedBy ne null}"/>
+                                            <h:outputLabel styleClass="badge bg-warning text-dark"
+                                                           value="Pending Check"
+                                                           rendered="#{pt.bill ne null and pt.bill.checkedBy eq null}"/>
+                                            <h:outputLabel styleClass="badge bg-secondary"
+                                                           value="No Separate Bill"
+                                                           rendered="#{pt.bill eq null}"/>
+                                        </p:column>
+                                        <p:column headerText="Checked By" styleClass="text-start">
+                                            <h:outputLabel value="#{pt.bill.checkedBy.webUserPerson.name}"/>
+                                        </p:column>
+                                        <p:column headerText="Checked At" styleClass="text-start">
+                                            <h:outputLabel value="#{pt.bill.checkeAt}">
+                                                <f:convertDateTime timeZone="Asia/Colombo"
+                                                                   pattern="#{sessionController.applicationPreference.longDateTimeFormat}"/>
+                                            </h:outputLabel>
+                                        </p:column>
                                         <p:column headerText="Inward Charge Type" styleClass="text-start">
                                             <h:outputLabel value="#{pt.item.inwardChargeType}"/>
                                         </p:column>
-                                        <p:column headerText="Action" width="14em;" class="text-center">
-                                            <div class="d-flex gap-2 justify-content-center">
-                                                <p:commandButton 
-                                                    ajax="false" 
+                                        <p:column headerText="Action" width="26em;" class="text-center">
+                                            <div class="d-flex gap-2 justify-content-center flex-wrap">
+                                                <p:commandButton
+                                                    ajax="false"
                                                     value="Update"
                                                     class="ui-button-warning"
                                                     icon="fa fa-refresh"
+                                                    disabled="#{pt.bill.checkedBy ne null}"
                                                     action="#{bhtSummeryController.updatePatientItem(pt)}" >
                                                 </p:commandButton>
-                                                <p:commandButton 
-                                                    ajax="false" 
+                                                <p:commandButton
+                                                    ajax="false"
                                                     icon="fa fa-times"
                                                     class="ui-button-danger"
                                                     value="Remove "
+                                                    disabled="#{pt.bill.checkedBy ne null}"
                                                     action="#{surgeryBillController.removeTimeService(pt)}" >
+                                                </p:commandButton>
+                                                <!--
+                                                    A service still running has no final amount to
+                                                    verify - the discharge will close and re-price it -
+                                                    so Check stays disabled until a Stopped Time is
+                                                    recorded, with the reason in the tooltip rather
+                                                    than only after a failed click.
+                                                -->
+                                                <p:commandButton
+                                                    ajax="false"
+                                                    icon="fa fa-check-square"
+                                                    class="ui-button-success"
+                                                    value="Check"
+                                                    rendered="#{pt.bill ne null and pt.bill.checkedBy eq null}"
+                                                    disabled="#{pt.toTime eq null or not webUserController.hasPrivilege('InwardCheck')}"
+                                                    title="#{pt.toTime eq null ? 'Enter a Stopped Time and press Update before checking this service.' : 'Mark this timed service bill as checked'}"
+                                                    action="#{bhtSummeryController.markTimedServiceAsChecked(pt)}" >
+                                                </p:commandButton>
+                                                <p:commandButton
+                                                    ajax="false"
+                                                    icon="fa fa-square"
+                                                    class="ui-button-warning"
+                                                    value="Uncheck"
+                                                    rendered="#{pt.bill ne null and pt.bill.checkedBy ne null}"
+                                                    disabled="#{not webUserController.hasPrivilege('InwardUnCheck')}"
+                                                    action="#{bhtSummeryController.markTimedServiceAsUnChecked(pt)}" >
+                                                </p:commandButton>
+                                                <p:commandButton
+                                                    ajax="false"
+                                                    icon="fa fa-file-invoice"
+                                                    class="ui-button-info ui-button-outlined"
+                                                    value="View Bill"
+                                                    rendered="#{pt.bill ne null}"
+                                                    action="inward_reprint_bill_service?faces-redirect=true" >
+                                                    <f:setPropertyActionListener value="#{pt.bill}" target="#{inwardSearch.bill}"/>
                                                 </p:commandButton>
                                             </div>
 

--- a/src/main/webapp/inward/inward_timed_service_consume.xhtml
+++ b/src/main/webapp/inward/inward_timed_service_consume.xhtml
@@ -299,7 +299,7 @@
                                 showTime="true"
                                 timeInput="true"
                                 value="#{ti.fromTime}"
-                                disabled="#{ti.billItem.fromPackage}"
+                                disabled="#{ti.billItem.fromPackage or ti.bill.checkedBy ne null}"
                                 pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  >
                             </p:datePicker>
                         </p:column>
@@ -309,7 +309,7 @@
                                 showTime="true"
                                 timeInput="true"
                                 value="#{ti.toTime}"
-                                disabled="#{ti.billItem.fromPackage}"
+                                disabled="#{ti.billItem.fromPackage or ti.bill.checkedBy ne null}"
                                 pattern="#{sessionController.applicationPreference.longDateTimeFormat}"  >
                             </p:datePicker>
                         </p:column>
@@ -339,6 +339,7 @@
                                     icon="fa fa-pencil"
                                     ajax="false"
                                     action="#{inwardTimedItemController.finalizeService(ti)}"
+                                    disabled="#{ti.bill.checkedBy ne null}"
                                     rendered="#{not ti.billItem.fromPackage}" >
                                 </p:commandButton>
                                 <p:commandButton
@@ -347,7 +348,7 @@
                                     ajax="false"
                                     value="Remove"
                                     action="#{inwardTimedItemController.removePatientItem(ti)}"
-                                    disabled="#{inwardTimedItemController.current.patientEncounter.paymentFinalized}"
+                                    disabled="#{inwardTimedItemController.current.patientEncounter.paymentFinalized or ti.bill.checkedBy ne null}"
                                     rendered="#{not ti.billItem.fromPackage}" >
                                 </p:commandButton>
                             </div>


### PR DESCRIPTION
Closes #23606

## What was reported

> The Time Service checking option is not available in the Interim Bill.

Every charge tab on the Interim Bill carries the bill-**checking** (cashier
verification) state — Service & Investigation has `Checked Count` / `Pending
Check Count` / `Checked By` / `Checked At` (#21983), Medicine, Professional
Fees and Deposits all show `Checked By` / `Checked At`. **Timed Service Charges
was the one tab with none of it**, and no way to check from there.

## Root cause

A ward timed service is billed on its own `BilledBill` carrying **only a
BillItem and no BillFee** (`InwardTimedItemController#createBillForTimedService`),
while the settlement gate (`BhtSummeryController#checkBill`) looked for
unchecked inward bills through `checkByBillFee`, which joins `BillFee`. So an
unchecked timed service was invisible to the gate and **reached the final bill
unverified**.

Timed items are also excluded from the Service & Investigation tab
(`InwardBeanController#getToDepartmentItems`, `Type(b.item)!=TimedItem`), which
is why #21983's check columns never reached them.

Verified on the test admission below: the 4 ordinary inward service bills carry
1–2 BillFees each; the two timed-service bills carry **0**.

## What changed

1. **Interim Bill — Timed Service Charges tab** gains `Bill No`, `Status`,
   `Checked By`, `Checked At` columns and **Check / Uncheck / View Bill** row
   actions. Privileges gate with `disabled` (not `rendered`) using the existing
   `InwardCheck` / `InwardUnCheck`. **View Bill** reuses the
   `inward_reprint_bill_service` navigation, which already has *Back To Interim*.
2. **A checked timed service is frozen** — times read-only, `Update` and
   `Remove` refused server-side (`InwardTimedItemController#isCheckedAndLocked`,
   so it holds from *Add Timed Services* too) and disabled in the UI. Uncheck
   reopens it.
3. **Check is refused while a service is still running.** The discharge closes
   and re-prices running services, so checking one would stamp a verification on
   a figure the system is about to change. Found during testing — see below.
4. **The gate now looks at the BillItem side too**, so an unchecked timed
   service blocks the final bill like every other bill type.
5. **Config option fixed.** `checkBill()` returned "nothing to block" when
   `Need to check inward bills before discharge` was **true** — turning that
   option ON switched all bill checking OFF. Replaced with **`Inward bills must
   be checked before the final bill is settled`**, defaulting to on.
6. **Remove leak fixed.** `SurgeryBillController#removeTimeService` retired only
   the `PatientItem`; the totals sum the BillItem side
   (`calServiceBillItemsTotalByInwardChargeTypeBulk`), so **Remove hid the row
   but kept charging** — and once the gate exists it would have left an
   unchecked, invisible bill blocking the final bill permanently.

### Why a new config key rather than flipping the old one

The old key was read through the single-argument `getBooleanValueByKey`, which
**creates the option row set to `"false"`** on first read. Every deployment that
has ever settled an inward bill therefore already stores it as `false`, meaning
"enforce" under the old inverted reading. Re-reading that same stored `false` as
"do not enforce" would have silently switched the gate off for **every
hospital**. A new key defaults to `true` everywhere and means what it says.

**Behaviour change to flag:** a hospital that had deliberately turned the old
option ON to bypass checking must now turn the new one OFF instead.

## Verification (local Payara, `coop`)

Menu path used throughout — no URL navigation:
*Menu → Inpatient → Billing → Interim Bill → search BHT → Continue → **Timed
Service Charges***. Test data created through the app:
*Administration → Manage Inpatient Services → Services → Time-based Service
Categories / Services / Charges* (`Oxygen Therapy 23606`, Rs 100/hour), then
*Inpatient → Services & Items → Add Timed Services*.

**Admission BHT/57815**, timed-service bills `Inward/INWSER/583` and `/584`.

| Step | Result |
|---|---|
| Both services listed | `Status = Pending Check`, empty Checked By/At |
| **Check** row 1 | `Status = Checked`, Checked By `Buddhika`; DB: `bill.checkedBy_id=60103`, `checkeAt=2026-09-10 03:59:36` |
| Row 1 after checking | Start/Stop pickers, `Update`, `Remove` all disabled; only `Uncheck` + `View Bill` remain |
| **Uncheck** | `checkedBy_id` and `checkeAt` both back to `NULL`; row editable again |
| Check while running | Button disabled with a tooltip; server refuses too |
| **Create Final Bill**, both unchecked | Blocked, stays on the interim bill |
| Isolation: every *other* inward bill checked, leaving **only** the two fee-less timed bills | **Still blocked** — proving the new BillItem-side check is what catches them; the old BillFee-only gate could not |
| Check both → **Create Final Bill** | Proceeds to `inward_bill_final.xhtml`, no error |
| **Remove** a timed service (BHT/57818, `Inward/INWSER/585`) | DB: `patientitem.retired=1`, `bill.retired=1`, `billitem.retired=1` — previously only the first |

The block was verified with the `InwardBillSettleWithoutCheck` privilege
temporarily removed (it bypasses the gate by design, and the signed-in user
holds it); the privilege rows were restored afterwards.

![Timed Service Charges tab showing a checked row and a pending row](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23606-timed-service-checking.png)

*Top row checked — times and Update/Remove greyed out, only Uncheck remains. Bottom row still pending.*

![Final bill blocked because inward service bills are unchecked](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23606-final-bill-blocked.png)

## Not in scope

Surgery-added timed services (`saveTimeServiceBill`) link through a BillFee and
leave `PatientItem.bill` null, so they appear on the same tab with **No Separate
Bill** and no check actions. They are charged through the PatientItem path, not
the bill path, so there is no separate bill for a cashier to check.

## Documentation

- [Inpatient Interim Bills](https://github.com/hmislk/hmis/wiki/Finance-Inpatient-Interim-Bills) — new *Timed Service Charges — Checking* section (columns, the three actions, the checked-is-frozen rule, and the final-bill gate), with both screenshots.
- [Add Timed Services – Inward](https://github.com/hmislk/hmis/wiki/Add-TImed-Services-%E2%80%90-Inward) — added the stop-the-service step and the checked-is-locked note; also corrected the menu path, which read *"Add Estimated Professional Fee"*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EtLQsxhboAovFbc848WGNt


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a setting requiring inward bills to be checked before final settlement.
  - Added Check, Uncheck, and View Bill actions for eligible timed services.
  - Timed services now display bill details, check status, checker, and check time.
- **Bug Fixes**
  - Timed-service bills are now consistently included in settlement checks.
  - Removing a timed service also removes its associated bill charge.
- **Workflow Updates**
  - Checked timed-service bills can no longer be edited, updated, or removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->