### PR TITLE
feat(inward): honour Final Bill Group bundling on standard + Custom Final Bill prints (#23651)

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -3264,6 +3264,27 @@ no need to build the full row client id.
 applies to any attribute a component may not support — verify the *rendered
 DOM*, not the source.
 
+## 114. To make a SQL-inserted `ConfigOption` visible without a redeploy, click **Reload Config** on the Application Options page
+
+Verifying a *new* toggle (one the code reads via `getBooleanValueByKeyReadOnly`,
+which by design never creates the row) has a chicken-and-egg problem: the
+Application Options admin page (*Administration → Manage Institutions →
+Application Options*) only lets you Edit/Delete rows that already exist, so a
+key with no row can't be set there. `INSERT` the row directly
+(`OPTIONKEY`, `OPTIONVALUE`, `RETIRED=0`, `SCOPE='APPLICATION'`,
+`VALUETYPE='BOOLEAN'`) — but per §26/§48 that write is invisible to the
+running app because `ConfigOptionApplicationController` caches the whole table
+at load. Instead of restarting the domain (§97), click the **Reload Config**
+button on that same Application Options page: it re-runs `loadApplicationOptions()`
+and the new value takes effect immediately. Used on #23651 to flip
+`Inward Final Bill - Bundle Grouped Charge Types` between runs.
+
+Note the department-scoped-key-first resolution (`feedback_config_option_scope_resolution`):
+`getBooleanValueByKeyReadOnly("X", …)` with a department selected looks up
+`"<Dept> - X"` before the plain `"X"`, so an admin who saved the toggle from a
+department context produces a `"Inward - X"` row, not `"X"`. Insert whichever
+one matches how it will really be set (the plain global key is usually right).
+
 ## Quick checklist
 
 - [ ] Confirmed environment + URL with the developer; credentials kept out of the repo.

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -536,47 +536,77 @@ public class BhtSummeryController implements Serializable {
      * Charges grouped by inward charge type (excluding Professional Charge,
      * which is printed separately on the Professional Bill section),
      * alphabetical by display name, for the Custom2 "Final Bill" totals-only
-     * section.
+     * section. When {@link #isBundleGroupedChargeTypesOnFinalBill()} is enabled,
+     * charge types sharing a group text print as one summed line (see
+     * {@link #foldInwardCategoryTotals(Bill)}); otherwise behaviour is
+     * unchanged.
      */
     public List<Map.Entry<String, Double>> getCustom2CategoryTotals(Bill bill) {
-        Map<String, Double> totals = new TreeMap<>();
-        if (bill == null || bill.getBillItems() == null) {
-            return new ArrayList<>(totals.entrySet());
-        }
-        for (BillItem bi : bill.getBillItems()) {
-            if (bi.getInwardChargeType() == InwardChargeType.ProfessionalCharge) {
-                continue;
-            }
-            if (bi.getAdjustedValue() == 0.0) {
-                continue;
-            }
-            String label = getChargeTypeLabel(bi.getInwardChargeType());
-            totals.merge(label, bi.getAdjustedValue(), Double::sum);
-        }
-        return new ArrayList<>(totals.entrySet());
+        return foldInwardCategoryTotals(bill);
     }
 
     /**
      * Charges grouped by inward charge type (excluding Professional Charge,
      * which is now listed as individual per-doctor fee lines), alphabetical
      * by display name, for the Custom3 5x5 impact-printer bill ("Custom Bill
-     * 2" in the UI).
+     * 2" in the UI). When {@link #isBundleGroupedChargeTypesOnFinalBill()} is
+     * enabled, charge types sharing a group text print as one summed line (see
+     * {@link #foldInwardCategoryTotals(Bill)}); otherwise behaviour is
+     * unchanged.
      */
     public List<Map.Entry<String, Double>> getCustom3CategoryTotals(Bill bill) {
+        return foldInwardCategoryTotals(bill);
+    }
+
+    /**
+     * Shared implementation for {@link #getCustom2CategoryTotals(Bill)} and
+     * {@link #getCustom3CategoryTotals(Bill)}: charges summed by inward charge
+     * type keyed on the display label, Professional Charge excluded,
+     * DoctorAndNurses kept, alphabetical (TreeMap) by key.
+     *
+     * When {@link #isBundleGroupedChargeTypesOnFinalBill()} is false the result
+     * is byte-identical to the pre-grouping logic (returned early, before any
+     * group lookup). When it is true, any charge type whose
+     * "Inward Charge Type Final Bill Group - X" value is non-blank (after trim)
+     * is folded under that group text instead of its own label, matching the
+     * "Bundled Custom 1" behaviour. The per-type group reads are wrapped in
+     * {@code configOptionApplicationController.seedInBatch(...)} — the same
+     * helper {@code InwardChargeTypeLabelController.init()} uses — so a batch of
+     * missing rows triggers at most one synchronized cache reload, after the
+     * loop, instead of one per lazily created row.
+     */
+    private List<Map.Entry<String, Double>> foldInwardCategoryTotals(Bill bill) {
         Map<String, Double> totals = new TreeMap<>();
         if (bill == null || bill.getBillItems() == null) {
             return new ArrayList<>(totals.entrySet());
         }
-        for (BillItem bi : bill.getBillItems()) {
-            if (bi.getInwardChargeType() == InwardChargeType.ProfessionalCharge) {
-                continue;
+        if (!isBundleGroupedChargeTypesOnFinalBill()) {
+            for (BillItem bi : bill.getBillItems()) {
+                InwardChargeType type = bi.getInwardChargeType();
+                if (type == InwardChargeType.ProfessionalCharge) {
+                    continue;
+                }
+                if (bi.getAdjustedValue() == 0.0) {
+                    continue;
+                }
+                totals.merge(getChargeTypeLabel(type), bi.getAdjustedValue(), Double::sum);
             }
-            if (bi.getAdjustedValue() == 0.0) {
-                continue;
-            }
-            String label = getChargeTypeLabel(bi.getInwardChargeType());
-            totals.merge(label, bi.getAdjustedValue(), Double::sum);
+            return new ArrayList<>(totals.entrySet());
         }
+        configOptionApplicationController.seedInBatch(() -> {
+            for (BillItem bi : bill.getBillItems()) {
+                InwardChargeType type = bi.getInwardChargeType();
+                if (type == InwardChargeType.ProfessionalCharge) {
+                    continue;
+                }
+                if (bi.getAdjustedValue() == 0.0) {
+                    continue;
+                }
+                String group = configOptionApplicationController.getInwardChargeTypeFinalBillGroup(type);
+                String label = (group != null && !group.trim().isEmpty()) ? group.trim() : getChargeTypeLabel(type);
+                totals.merge(label, bi.getAdjustedValue(), Double::sum);
+            }
+        });
         return new ArrayList<>(totals.entrySet());
     }
 
@@ -5424,6 +5454,19 @@ public class BhtSummeryController implements Serializable {
 
     public String getChargeTypeLabel(com.divudi.core.data.inward.InwardChargeType type) {
         return configOptionApplicationController.getInwardChargeTypeLabel(type);
+    }
+
+    /**
+     * Opt-in toggle for folding grouped charge types into one summed line on the
+     * standard Final Bill totals sections (Custom2 / Custom3). Uses the same
+     * read-only getter and injected bean as {@code showBundledCustom1Format}
+     * (see {@link #loadCustomBillFormatVisibility()}); the key auto-creates on
+     * first read, so no migration is needed. Off by default: a hospital that
+     * only set Final Bill Group values for the #23382 "Bundled Custom 1" feature
+     * is unaffected until it explicitly enables this.
+     */
+    public boolean isBundleGroupedChargeTypesOnFinalBill() {
+        return configOptionController.getBooleanValueByKeyReadOnly("Inward Final Bill - Bundle Grouped Charge Types", false);
     }
 
     public List<ChargeItemTotal> getChargeItemTotals() {

--- a/src/main/webapp/resources/inward/bill/finalBill.xhtml
+++ b/src/main/webapp/resources/inward/bill/finalBill.xhtml
@@ -219,6 +219,13 @@
                                     <h:outputLabel value="Charge (Rs.)" />
                                 </td>
                             </tr>
+
+                            <!-- Charge-type bundling OFF (default): render the existing flat /
+                                 organized charge-type ladders unchanged. When the
+                                 'Inward Final Bill - Bundle Grouped Charge Types' ConfigOption is
+                                 on, this whole block is skipped in favour of the grouped block
+                                 below (charge types sharing a Final Bill Group print as one line). -->
+                            <h:panelGroup rendered="#{!bhtSummeryController.bundleGroupedChargeTypesOnFinalBill}">
                             <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip" rendered="#{!configOptionApplicationController.getBooleanValueByKey('Organized Final Bill Charge Types',false)}" >
                                 <h:panelGroup rendered="#{(bip.adjustedValue!=0 and  bip.inwardChargeType ne 'ProfessionalCharge' )
                                                           or
@@ -712,6 +719,147 @@
                                     </ui:repeat>
                                 </h:panelGroup>
 
+                            </h:panelGroup>
+                            </h:panelGroup>
+
+                            <!-- Charge-type bundling ON: same-group inward charge types are
+                                 summed into a single printed line (getBundledFinalBillRows already
+                                 excludes ProfessionalCharge + DoctorAndNurses, drops zero rows and
+                                 sorts by Final Bill Order), then Doctor/Professional fees are
+                                 itemised per staff member exactly as on finalBillBundledCustom1. -->
+                            <h:panelGroup rendered="#{bhtSummeryController.bundleGroupedChargeTypesOnFinalBill}">
+                                <!-- Every non-Professional/DoctorAndNurses charge type, individually or
+                                     summed into its configured group — see
+                                     BhtSummeryController#getBundledFinalBillRows. -->
+                                <ui:repeat value="#{bhtSummeryController.getBundledFinalBillRows(cc.attrs.bill)}" var="row">
+                                    <tr style="width: 100%; font-weight: 400; line-height: 18px;">
+                                        <td style="text-align: left;font-size: 13px!important; margin-top: -10px;">
+                                            <h:outputLabel value="#{row.label}" />
+                                        </td>
+                                        <td style="margin-top: -10px;">
+                                            &nbsp;
+                                        </td>
+                                        <td  style="width: 30%;text-align: right;font-size: 13px!important;">
+                                            <h:outputLabel  value="#{row.amount}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                        </td>
+                                    </tr>
+                                </ui:repeat>
+
+                                <h:panelGroup rendered="#{!configOptionApplicationController.getBooleanValueByKey('Display All Doctor Chargers as a One and Show Sum Value of a Doctor',false)}">
+                                    <!-- Doctor and Nurse assisting charges: always shown individually with
+                                         their per-staff fee breakdown, never folded into a group. -->
+                                    <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
+                                        <h:panelGroup rendered="#{bip.inwardChargeType eq 'DoctorAndNurses' and bip.adjustedValue != 0}" style="font-size: 12px;">
+                                            <tr style="width: 100%; font-weight: 400; line-height: 18px;">
+                                                <td style="text-align: left; font-size: 13px!important; margin-top: -10px;">
+                                                    <h:outputLabel value="#{configOptionApplicationController.getInwardChargeTypeLabel(bip.inwardChargeType)}" />
+                                                </td>
+                                                <td style="margin-top: -10px;">
+                                                    <table>
+                                                        <ui:repeat value="#{bip.billFees}" var="fe" rendered="#{!configOptionApplicationController.getBooleanValueByKey('Hide Doctor and Nurse Charges Details in Final Bill', false)}">
+                                                            <h:panelGroup>
+                                                                <tr>
+                                                                    <td>
+                                                                        <h:outputLabel value="#{fe.referencePatientRoom.name}" style="text-align: center; font-size: 9px!important;" />
+                                                                    </td>
+                                                                </tr>
+                                                            </h:panelGroup>
+                                                        </ui:repeat>
+                                                    </table>
+                                                </td>
+                                                <td style="width: 30%; text-align: right; font-size: 13px!important;">
+                                                    <h:outputLabel value="#{bip.adjustedValue}">
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputLabel>
+                                                </td>
+                                            </tr>
+                                        </h:panelGroup>
+                                    </ui:repeat>
+
+                                    <!-- Professional Charge: same, per-staff breakdown, only when
+                                         showProfessional is true (Hospital Copy without professional
+                                         fees passes showProfessional=false). -->
+                                    <h:panelGroup rendered="#{cc.attrs.showProfessional}">
+                                        <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
+                                            <h:panelGroup rendered="#{bip.inwardChargeType eq 'ProfessionalCharge' and bip.adjustedValue != 0}" style="font-size: 12px;">
+                                                <tr style="width: 100%; font-weight: 400; line-height: 18px;">
+                                                    <td style="text-align: left; font-size: 13px!important; margin-top: -10px;">
+                                                        <h:outputLabel value="#{configOptionApplicationController.getInwardChargeTypeLabel(bip.inwardChargeType)}" />
+                                                    </td>
+                                                    <td style="margin-top: -10px;">
+                                                        <table>
+                                                            <ui:repeat value="#{bip.proFees}" var="fe">
+                                                                <h:panelGroup rendered="#{fe.feeAdjusted ne 0 and fe.bill.cancelled eq false and fe.bill.billClass eq 'class com.divudi.core.entity.BilledBill'}">
+                                                                    <tr>
+                                                                        <td style="text-align: left; font-size: 10px!important;">
+                                                                            <h:panelGroup>#{fe.staff.person.nameWithTitle}<h:outputText value=" (#{fe.staff.speciality.name})" rendered="#{fe.staff.speciality ne null}"/></h:panelGroup>
+                                                                        </td>
+                                                                        <td style="text-align: right; font-size: 10px!important; padding-left: 25px;">
+                                                                            <h:outputLabel value="#{fe.feeAdjusted}">
+                                                                                <f:convertNumber pattern="#,##0.00" />
+                                                                            </h:outputLabel>
+                                                                        </td>
+                                                                    </tr>
+                                                                </h:panelGroup>
+                                                            </ui:repeat>
+                                                        </table>
+                                                    </td>
+                                                    <td style="width: 30%; text-align: right; font-size: 13px!important;">
+                                                        <h:outputLabel value="#{bip.adjustedValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputLabel>
+                                                    </td>
+                                                </tr>
+                                            </h:panelGroup>
+                                        </ui:repeat>
+                                    </h:panelGroup>
+                                </h:panelGroup>
+
+                                <!-- Alternate rendering when the hospital wants every doctor's fees
+                                     (DoctorAndNurses + ProfessionalCharge) summed into one row per
+                                     doctor instead of one row per fee. Passes showProfessional through
+                                     so the Hospital Copy (showProfessional=false) excludes
+                                     ProfessionalCharge from the aggregate — its printed Total uses
+                                     bill.hospitalFee, which itself excludes ProfessionalCharge; without
+                                     this the printed rows would sum to more than the printed Total
+                                     (found in review). DoctorAndNurses is always included regardless. -->
+                                <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Display All Doctor Chargers as a One and Show Sum Value of a Doctor',false)}">
+                                    <ui:repeat value="#{bhtSummeryController.getSummaryOfDoctorChargers(cc.attrs.bill.billItems,cc.attrs.bill.patientEncounter,cc.attrs.showProfessional)}" var="bip">
+                                        <h:panelGroup rendered="#{(bip.inwardChargeType eq 'ProfessionalCharge' or bip.inwardChargeType eq 'DoctorAndNurses') and bip.adjustedValue != 0}" style="font-size: 12px;">
+                                            <tr style="width: 100%; font-weight: 400; line-height: 18px;">
+                                                <td style="text-align: left; font-size: 13px!important; margin-top: -10px;">
+                                                    <h:outputLabel value="#{configOptionApplicationController.getInwardChargeTypeLabel(bip.inwardChargeType)}" />
+                                                </td>
+                                                <td style="margin-top: -10px;">
+                                                    <table>
+                                                        <ui:repeat value="#{bip.proFees}" var="fe">
+                                                            <h:panelGroup rendered="#{fe.feeAdjusted gt 0 or fe.feeValue gt 0}">
+                                                                <tr>
+                                                                    <td style="text-align: left; font-size: 10px!important;">
+                                                                        <h:panelGroup>#{fe.staff.person.nameWithTitle}<h:outputText value=" (#{fe.staff.speciality.name})" rendered="#{fe.staff.speciality ne null}"/></h:panelGroup>
+                                                                    </td>
+                                                                    <td>&emsp;</td>
+                                                                    <td style="text-align: right; font-size: 10px!important;">
+                                                                        <h:outputLabel value="#{fe.feeAdjusted ne 0 ? fe.feeAdjusted : fe.feeValue}">
+                                                                            <f:convertNumber pattern="#,##0.00" />
+                                                                        </h:outputLabel>
+                                                                    </td>
+                                                                </tr>
+                                                            </h:panelGroup>
+                                                        </ui:repeat>
+                                                    </table>
+                                                </td>
+                                                <td style="width: 30%; text-align: right; font-size: 13px!important;">
+                                                    <h:outputLabel value="#{bip.adjustedValue}">
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputLabel>
+                                                </td>
+                                            </tr>
+                                        </h:panelGroup>
+                                    </ui:repeat>
+                                </h:panelGroup>
                             </h:panelGroup>
 
 

--- a/src/main/webapp/resources/inward/bill/finalBill.xhtml
+++ b/src/main/webapp/resources/inward/bill/finalBill.xhtml
@@ -764,6 +764,22 @@
                                                                     <td>
                                                                         <h:outputLabel value="#{fe.referencePatientRoom.name}" style="text-align: center; font-size: 9px!important;" />
                                                                     </td>
+                                                                    <td>
+                                                                        <h:outputLabel value=" || " style="text-align: center; font-size: 9px!important; width: 10px; text-align: left;" />
+                                                                    </td>
+                                                                    <td>
+                                                                        <h:outputLabel value="#{fe.referencePatientRoom.printAdmittedAt}" style="text-align: center; font-size: 9px!important;">
+                                                                            <f:convertDateTime pattern="dd/MM/yyyy hh mm a" />
+                                                                        </h:outputLabel>
+                                                                    </td>
+                                                                    <td>
+                                                                        <h:outputLabel value=" || " style="text-align: center; font-size: 9px!important; width: 20px; text-align: center;" />
+                                                                    </td>
+                                                                    <td>
+                                                                        <h:outputLabel value="#{fe.referencePatientRoom.printDischargeAt}" style="text-align: center; font-size: 9px!important;">
+                                                                            <f:convertDateTime pattern="dd/MM/yyyy hh mm a" />
+                                                                        </h:outputLabel>
+                                                                    </td>
                                                                 </tr>
                                                             </h:panelGroup>
                                                         </ui:repeat>

--- a/src/main/webapp/resources/inward/bill/finalBillCustom4.xhtml
+++ b/src/main/webapp/resources/inward/bill/finalBillCustom4.xhtml
@@ -196,6 +196,13 @@
                                     <h:outputLabel value="Charge (Rs.)" />
                                 </td>
                             </tr>
+
+                            <!-- Charge-type bundling OFF (default): render the existing flat /
+                                 organized charge-type ladders unchanged. When the
+                                 'Inward Final Bill - Bundle Grouped Charge Types' ConfigOption is
+                                 on, this whole block is skipped in favour of the grouped block
+                                 below (charge types sharing a Final Bill Group print as one line). -->
+                            <h:panelGroup rendered="#{!bhtSummeryController.bundleGroupedChargeTypesOnFinalBill}">
                             <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip" rendered="#{!configOptionApplicationController.getBooleanValueByKey('Organized Final Bill Charge Types',false)}" >
                                 <h:panelGroup rendered="#{(bip.adjustedValue!=0 and  bip.inwardChargeType ne 'ProfessionalCharge' )
                                                           or
@@ -689,6 +696,147 @@
                                     </ui:repeat>
                                 </h:panelGroup>
 
+                            </h:panelGroup>
+                            </h:panelGroup>
+
+                            <!-- Charge-type bundling ON: same-group inward charge types are
+                                 summed into a single printed line (getBundledFinalBillRows already
+                                 excludes ProfessionalCharge + DoctorAndNurses, drops zero rows and
+                                 sorts by Final Bill Order), then Doctor/Professional fees are
+                                 itemised per staff member exactly as on finalBillBundledCustom1. -->
+                            <h:panelGroup rendered="#{bhtSummeryController.bundleGroupedChargeTypesOnFinalBill}">
+                                <!-- Every non-Professional/DoctorAndNurses charge type, individually or
+                                     summed into its configured group — see
+                                     BhtSummeryController#getBundledFinalBillRows. -->
+                                <ui:repeat value="#{bhtSummeryController.getBundledFinalBillRows(cc.attrs.bill)}" var="row">
+                                    <tr style="width: 100%; font-weight: 400; line-height: 18px;">
+                                        <td style="text-align: left;font-size: 13px!important; margin-top: -10px;">
+                                            <h:outputLabel value="#{row.label}" />
+                                        </td>
+                                        <td style="margin-top: -10px;">
+                                            &nbsp;
+                                        </td>
+                                        <td  style="width: 30%;text-align: right;font-size: 13px!important;">
+                                            <h:outputLabel  value="#{row.amount}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                        </td>
+                                    </tr>
+                                </ui:repeat>
+
+                                <h:panelGroup rendered="#{!configOptionApplicationController.getBooleanValueByKey('Display All Doctor Chargers as a One and Show Sum Value of a Doctor',false)}">
+                                    <!-- Doctor and Nurse assisting charges: always shown individually with
+                                         their per-staff fee breakdown, never folded into a group. -->
+                                    <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
+                                        <h:panelGroup rendered="#{bip.inwardChargeType eq 'DoctorAndNurses' and bip.adjustedValue != 0}" style="font-size: 12px;">
+                                            <tr style="width: 100%; font-weight: 400; line-height: 18px;">
+                                                <td style="text-align: left; font-size: 13px!important; margin-top: -10px;">
+                                                    <h:outputLabel value="#{configOptionApplicationController.getInwardChargeTypeLabel(bip.inwardChargeType)}" />
+                                                </td>
+                                                <td style="margin-top: -10px;">
+                                                    <table>
+                                                        <ui:repeat value="#{bip.billFees}" var="fe" rendered="#{!configOptionApplicationController.getBooleanValueByKey('Hide Doctor and Nurse Charges Details in Final Bill', false)}">
+                                                            <h:panelGroup>
+                                                                <tr>
+                                                                    <td>
+                                                                        <h:outputLabel value="#{fe.referencePatientRoom.name}" style="text-align: center; font-size: 9px!important;" />
+                                                                    </td>
+                                                                </tr>
+                                                            </h:panelGroup>
+                                                        </ui:repeat>
+                                                    </table>
+                                                </td>
+                                                <td style="width: 30%; text-align: right; font-size: 13px!important;">
+                                                    <h:outputLabel value="#{bip.adjustedValue}">
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputLabel>
+                                                </td>
+                                            </tr>
+                                        </h:panelGroup>
+                                    </ui:repeat>
+
+                                    <!-- Professional Charge: same, per-staff breakdown, only when
+                                         showProfessional is true (Hospital Copy without professional
+                                         fees passes showProfessional=false). -->
+                                    <h:panelGroup rendered="#{cc.attrs.showProfessional}">
+                                        <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
+                                            <h:panelGroup rendered="#{bip.inwardChargeType eq 'ProfessionalCharge' and bip.adjustedValue != 0}" style="font-size: 12px;">
+                                                <tr style="width: 100%; font-weight: 400; line-height: 18px;">
+                                                    <td style="text-align: left; font-size: 13px!important; margin-top: -10px;">
+                                                        <h:outputLabel value="#{configOptionApplicationController.getInwardChargeTypeLabel(bip.inwardChargeType)}" />
+                                                    </td>
+                                                    <td style="margin-top: -10px;">
+                                                        <table>
+                                                            <ui:repeat value="#{bip.proFees}" var="fe">
+                                                                <h:panelGroup rendered="#{fe.feeAdjusted ne 0 and fe.bill.cancelled eq false and fe.bill.billClass eq 'class com.divudi.core.entity.BilledBill'}">
+                                                                    <tr>
+                                                                        <td style="text-align: left; font-size: 10px!important;">
+                                                                            <h:panelGroup>#{fe.staff.person.nameWithTitle}<h:outputText value=" (#{fe.staff.speciality.name})" rendered="#{fe.staff.speciality ne null}"/></h:panelGroup>
+                                                                        </td>
+                                                                        <td style="text-align: right; font-size: 10px!important; padding-left: 25px;">
+                                                                            <h:outputLabel value="#{fe.feeAdjusted}">
+                                                                                <f:convertNumber pattern="#,##0.00" />
+                                                                            </h:outputLabel>
+                                                                        </td>
+                                                                    </tr>
+                                                                </h:panelGroup>
+                                                            </ui:repeat>
+                                                        </table>
+                                                    </td>
+                                                    <td style="width: 30%; text-align: right; font-size: 13px!important;">
+                                                        <h:outputLabel value="#{bip.adjustedValue}">
+                                                            <f:convertNumber pattern="#,##0.00" />
+                                                        </h:outputLabel>
+                                                    </td>
+                                                </tr>
+                                            </h:panelGroup>
+                                        </ui:repeat>
+                                    </h:panelGroup>
+                                </h:panelGroup>
+
+                                <!-- Alternate rendering when the hospital wants every doctor's fees
+                                     (DoctorAndNurses + ProfessionalCharge) summed into one row per
+                                     doctor instead of one row per fee. Passes showProfessional through
+                                     so the Hospital Copy (showProfessional=false) excludes
+                                     ProfessionalCharge from the aggregate — its printed Total uses
+                                     bill.hospitalFee, which itself excludes ProfessionalCharge; without
+                                     this the printed rows would sum to more than the printed Total
+                                     (found in review). DoctorAndNurses is always included regardless. -->
+                                <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Display All Doctor Chargers as a One and Show Sum Value of a Doctor',false)}">
+                                    <ui:repeat value="#{bhtSummeryController.getSummaryOfDoctorChargers(cc.attrs.bill.billItems,cc.attrs.bill.patientEncounter,cc.attrs.showProfessional)}" var="bip">
+                                        <h:panelGroup rendered="#{(bip.inwardChargeType eq 'ProfessionalCharge' or bip.inwardChargeType eq 'DoctorAndNurses') and bip.adjustedValue != 0}" style="font-size: 12px;">
+                                            <tr style="width: 100%; font-weight: 400; line-height: 18px;">
+                                                <td style="text-align: left; font-size: 13px!important; margin-top: -10px;">
+                                                    <h:outputLabel value="#{configOptionApplicationController.getInwardChargeTypeLabel(bip.inwardChargeType)}" />
+                                                </td>
+                                                <td style="margin-top: -10px;">
+                                                    <table>
+                                                        <ui:repeat value="#{bip.proFees}" var="fe">
+                                                            <h:panelGroup rendered="#{fe.feeAdjusted gt 0 or fe.feeValue gt 0}">
+                                                                <tr>
+                                                                    <td style="text-align: left; font-size: 10px!important;">
+                                                                        <h:panelGroup>#{fe.staff.person.nameWithTitle}<h:outputText value=" (#{fe.staff.speciality.name})" rendered="#{fe.staff.speciality ne null}"/></h:panelGroup>
+                                                                    </td>
+                                                                    <td>&emsp;</td>
+                                                                    <td style="text-align: right; font-size: 10px!important;">
+                                                                        <h:outputLabel value="#{fe.feeAdjusted ne 0 ? fe.feeAdjusted : fe.feeValue}">
+                                                                            <f:convertNumber pattern="#,##0.00" />
+                                                                        </h:outputLabel>
+                                                                    </td>
+                                                                </tr>
+                                                            </h:panelGroup>
+                                                        </ui:repeat>
+                                                    </table>
+                                                </td>
+                                                <td style="width: 30%; text-align: right; font-size: 13px!important;">
+                                                    <h:outputLabel value="#{bip.adjustedValue}">
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputLabel>
+                                                </td>
+                                            </tr>
+                                        </h:panelGroup>
+                                    </ui:repeat>
+                                </h:panelGroup>
                             </h:panelGroup>
 
 

--- a/src/main/webapp/resources/inward/bill/finalBillCustom4.xhtml
+++ b/src/main/webapp/resources/inward/bill/finalBillCustom4.xhtml
@@ -741,6 +741,22 @@
                                                                     <td>
                                                                         <h:outputLabel value="#{fe.referencePatientRoom.name}" style="text-align: center; font-size: 9px!important;" />
                                                                     </td>
+                                                                    <td>
+                                                                        <h:outputLabel value=" || " style="text-align: center; font-size: 9px!important; width: 10px; text-align: left;" />
+                                                                    </td>
+                                                                    <td>
+                                                                        <h:outputLabel value="#{fe.referencePatientRoom.printAdmittedAt}" style="text-align: center; font-size: 9px!important;">
+                                                                            <f:convertDateTime pattern="dd/MM/yyyy hh mm a" />
+                                                                        </h:outputLabel>
+                                                                    </td>
+                                                                    <td>
+                                                                        <h:outputLabel value=" || " style="text-align: center; font-size: 9px!important; width: 20px; text-align: center;" />
+                                                                    </td>
+                                                                    <td>
+                                                                        <h:outputLabel value="#{fe.referencePatientRoom.printDischargeAt}" style="text-align: center; font-size: 9px!important;">
+                                                                            <f:convertDateTime pattern="dd/MM/yyyy hh mm a" />
+                                                                        </h:outputLabel>
+                                                                    </td>
                                                                 </tr>
                                                             </h:panelGroup>
                                                         </ui:repeat>


### PR DESCRIPTION
## What & why

`#23340` / `#23382` added an admin-configurable **Final Bill Group** column (*Charge Type Labels* page) that folds several inward charge types into one summed line on the Final Bill — but only on the opt-in **Bundled Custom 1** print format. `#23651` asks for the same on the standard Final Bill and the other Custom formats.

This PR extends the grouping to:

| Format | Composite |
|---|---|
| standard Final Bill (post-generation + reprint *Final Bill* tab, also embedded by the approve / provisional-edit screens) | `resources/inward/bill/finalBill.xhtml` |
| Custom Bill | `resources/inward/bill/finalBillCustom2.xhtml` (via `getCustom2CategoryTotals`) |
| Custom Bill 2 | `resources/inward/bill/finalBillCustom3.xhtml` (via `getCustom3CategoryTotals`) |
| Custom Bill 3 (Letterhead) | `resources/inward/bill/finalBillCustom4.xhtml` |

**Bundled Custom 1 is unchanged.**

## Decisions made without approval (unattended run)

1. **Dedicated opt-in toggle instead of "any group value set".** The approved plan gated the new behaviour on *any* `Inward Charge Type Final Bill Group - *` value being non-blank. `/code-review` flagged that a hospital which set group values purely for the opt-in Bundled Custom 1 feature (#23382) would then have its **standard** Final Bill silently switch to the bundled layout on deploy — losing the "Organized Final Bill Charge Types" per-room detail with no admin action. Changed to a new boolean ConfigOption **`Inward Final Bill - Bundle Grouped Charge Types`** (default `false`), read the same way as `showBundledCustom1Format`. Now the change is fully inert until explicitly enabled, and there's no per-render ConfigOption map scan.
2. **`foldInwardCategoryTotals` keeps its own semantics for Custom 2 / Custom 3** rather than reusing `buildBundledRows`: it keeps `DoctorAndNurses` in the totals (those two formats have no separate per-staff D&N block, so excluding it would drop the charge) and keeps their existing alphabetical order. `buildBundledRows` (used by finalBill / finalBillCustom4 / bundledCustom1) excludes D&N and sorts by Final Bill Order. The divergence is inherent to the formats' structure — documented in code, not "fixed".
3. Per-type group reads in `foldInwardCategoryTotals` are wrapped in `configOptionApplicationController.seedInBatch(...)` (the helper `InwardChargeTypeLabelController.init()` uses) so a batch of not-yet-created ConfigOption rows triggers at most one cache reload, not one per row (also a `/code-review` finding).
4. `/code-review` also noted the standard-Final-Bill regression risk (finding 4) — resolved by decision 1. No other findings were actioned; one low-confidence semantic-divergence note is decision 2.

## Implementation

- **`BhtSummeryController`**
  - `isBundleGroupedChargeTypesOnFinalBill()` → `configOptionController.getBooleanValueByKeyReadOnly("Inward Final Bill - Bundle Grouped Charge Types", false)`.
  - `getCustom2CategoryTotals` / `getCustom3CategoryTotals` delegate to a new `private foldInwardCategoryTotals(Bill)` — byte-identical to the old logic when the toggle is off (early return before any group lookup); when on, folds same-group charge types under the group text.
- **`finalBill.xhtml` / `finalBillCustom4.xhtml`** — the existing flat + "Organized" ladders are wrapped in `rendered="#{!bhtSummeryController.bundleGroupedChargeTypesOnFinalBill}"`; a sibling block (`rendered` on the positive) renders `getBundledFinalBillRows(bill)` as one row per (possibly grouped) charge type, then the DoctorAndNurses / ProfessionalCharge per-staff blocks — all copied verbatim from `finalBillBundledCustom1.xhtml`.
- No entity / schema / migration change. The ConfigOption key auto-creates on first read.

## Verification (local Payara, `INWARD_FINAL_BILL` — BHT/57601)

RoomCharges 5,800.00 + MealCharges 1,006.25 both set to Final Bill Group `Room & Board`, exercised through the real UI (Charge Type Labels page → save; Application Options → set toggle → Reload Config; Final Bill Search → open bill → Final Bill tab + Custom Bills tab):

| Format | Toggle OFF | Toggle ON |
|---|---|---|
| Final Bill | Room Charges 5,800.00 + Extra Meal Charges 1,006.25 (separate) | **Room & Board 6,806.25** |
| Custom Bill | separate | **Room & Board 6,806.25** |
| Custom Bill 2 | separate | **Room & Board 6,806.25** |
| Custom Bill 3 (Letterhead) | separate | **Room & Board 6,806.25** |
| Bundled Custom 1 | Room & Board 6,806.25 | Room & Board 6,806.25 |

- Every format's printed **Total = 223,587.97** in both states (Custom Bill hospital-total 103,587.97 + professional 120,000.00 also unchanged).
- Toggle OFF **with the group values already in the DB** → all four gated formats print unchanged → confirms inert-by-default.
- DB reconcile: `6,806.25 = 5,800.00 + 1,006.25`.

![Standard Final Bill, toggle ON — Room Charges + Meal Charges merged into one Room & Board line (names redacted)](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23651-final-bill-group-standard-print.png)

## Documentation

- [Admin — Inpatient Charge Type Labels](https://github.com/hmislk/hmis/wiki/Admin-Inpatient-Charge-Type-Labels#bundling-charge-types-on-the-final-bill) — corrected the "standard Final Bill is never affected" / "only Bundled Custom 1" wording; documented the new toggle.
- [Finance — Inpatient Final Bill](https://github.com/hmislk/hmis/wiki/Finance-Inpatient-Final-Bill#custom-bills--bundled-charge-types) — same correction; added the redacted standard-Final-Bill screenshot.
- `developer_docs/testing/playwright-e2e-workflow.md` §114 — how to make a SQL-inserted ConfigOption visible via the **Reload Config** button (learned this run).

Closes #23651

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ML6GGHFHHndgjmCBrZhJv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Final bills can now display charge types in configurable grouped sections.
  - Doctor, nurse, and professional charges can be shown separately by staff member or combined according to billing settings.
  - Professional-charge visibility is respected in final bill summaries and hospital copies.
  - Updated category totals support configured final-bill groupings while preserving alphabetical ordering.

- **Documentation**
  - Added guidance for reloading application options so newly configured billing settings take effect immediately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->