### PR TITLE
fix(inward): keep Refund button live while a refundable balance remains (#23646)

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -3388,3 +3388,26 @@ browser_evaluate(() => { document.getElementById('form:dateStamp_input').value =
 Do **not** follow it with a synthetic `change` event — on these pickers that
 re-runs the mask and blanks the field again. §18's calendar-grid technique
 remains the option when the widget's own parsing needs to run.
+
+## 117. `p:tabView` renders every tab's markup — a text-matched `browser_evaluate` click hits a hidden tab's copy
+
+`inward_bill_intrim.xhtml` has a "View Bill" `p:commandButton` in **six**
+different tabs (Room Charges, Professional Fees, Deposits & Payments, …). A
+`p:tabView` keeps all inactive panels in the DOM (just `display:none`), so
+`[...document.querySelectorAll('button')].find(b => b.textContent.trim() === 'View Bill')`
+returns the **first in document order** — a hidden tab's button — and clicking it
+fires that tab's action (it navigated to `inward_reprint_bill_service.xhtml` for
+a bill that did not exist, "No records found").
+
+Scope the query to the active panel by its server id before matching text:
+
+```js
+browser_evaluate(() => {
+  const panel = document.querySelector('[id="pageForm:tvPt:tabP"]');   // the Deposits & Payments panel
+  const row = [...panel.querySelectorAll('tr')].find(r => /050558/.test(r.textContent)); // the exact bill row
+  row.querySelector('button').click();
+});
+```
+
+Matching on a stable substring of the row (bill number) also guards against
+clicking the wrong row once the table has several entries.

--- a/src/main/java/com/divudi/bean/inward/InwardRefundController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardRefundController.java
@@ -439,15 +439,35 @@ public class InwardRefundController implements Serializable {
      * so it never reflects referenceBill-linked refunds.
      */
     private double computeRemainingRefundableAmount(Bill originalBill) {
-        String sql = "select sum(b.netTotal) from Bill b where b.referenceBill=:orig and b.retired=false";
-        HashMap hm = new HashMap();
-        hm.put("orig", originalBill);
-        double refundedSoFar = getBillFacade().findDoubleByJpql(sql, hm);
-        double remaining = originalBill.getNetTotal() + refundedSoFar;
-        if (remainingRefundableAmountCache != null && originalBill.getId() != null) {
+        double remaining = calculateFreshRemainingRefundableAmount(originalBill);
+        if (remainingRefundableAmountCache != null && originalBill != null && originalBill.getId() != null) {
             remainingRefundableAmountCache.put(originalBill.getId(), remaining);
         }
         return remaining;
+    }
+
+    /**
+     * Fresh (uncached, cache-bypassing) remaining refundable amount for a
+     * payment/deposit bill: the bill's own netTotal plus the SUM of netTotal
+     * of every RefundBill linked to it by referenceBill (each &lt;= 0). A
+     * positive result means that much is still refundable.
+     *
+     * Used by the Payment / Deposit Reprint pages to decide whether the
+     * "Refund" button is still live after one or more partial refunds
+     * (issue #23646). Deliberately does NOT read or write
+     * remainingRefundableAmountCache - that cache belongs to the bill-picker
+     * render loop and, on a @SessionScoped bean, can still hold a value from
+     * an earlier visit to the refund page.
+     */
+    public double calculateFreshRemainingRefundableAmount(Bill originalBill) {
+        if (originalBill == null || originalBill.getId() == null) {
+            return 0.0;
+        }
+        String sql = "select sum(b.netTotal) from Bill b where b.referenceBill=:orig and b.retired=false";
+        Map<String, Object> hm = new HashMap<>();
+        hm.put("orig", originalBill);
+        double refundedSoFar = getBillFacade().findDoubleByJpql(sql, hm, true);
+        return originalBill.getNetTotal() + refundedSoFar;
     }
 
     public void selectBillToRefundListener() {

--- a/src/main/java/com/divudi/bean/inward/PostFinalBillInwardPaymentController.java
+++ b/src/main/java/com/divudi/bean/inward/PostFinalBillInwardPaymentController.java
@@ -907,15 +907,35 @@ public class PostFinalBillInwardPaymentController implements Serializable, Contr
      * populates, so it never reflects referenceBill-linked refunds.
      */
     private double computeRemainingRefundableAmount(Bill originalBill) {
-        String sql = "select sum(b.netTotal) from Bill b where b.referenceBill=:orig and b.retired=false";
-        HashMap hm = new HashMap();
-        hm.put("orig", originalBill);
-        double refundedSoFar = getBillFacade().findDoubleByJpql(sql, hm);
-        double remaining = originalBill.getNetTotal() + refundedSoFar;
-        if (remainingRefundableAmountCache != null && originalBill.getId() != null) {
+        double remaining = calculateFreshRemainingRefundableAmount(originalBill);
+        if (remainingRefundableAmountCache != null && originalBill != null && originalBill.getId() != null) {
             remainingRefundableAmountCache.put(originalBill.getId(), remaining);
         }
         return remaining;
+    }
+
+    /**
+     * Fresh (uncached, cache-bypassing) remaining refundable amount for a
+     * post-final payment bill: the bill's own netTotal plus the SUM of
+     * netTotal of every RefundBill linked to it by referenceBill (each
+     * &lt;= 0). A positive result means that much is still refundable.
+     *
+     * Used by the Post Final Payment Reprint page to decide whether the
+     * "Refund" button is still live after one or more partial refunds
+     * (issue #23646). Deliberately does NOT read or write
+     * remainingRefundableAmountCache - that cache belongs to the bill-picker
+     * render loop and, on a @SessionScoped bean, can still hold a value from
+     * an earlier visit to the refund page.
+     */
+    public double calculateFreshRemainingRefundableAmount(Bill originalBill) {
+        if (originalBill == null || originalBill.getId() == null) {
+            return 0.0;
+        }
+        String sql = "select sum(b.netTotal) from Bill b where b.referenceBill=:orig and b.retired=false";
+        Map<String, Object> hm = new HashMap<>();
+        hm.put("orig", originalBill);
+        double refundedSoFar = getBillFacade().findDoubleByJpql(sql, hm, true);
+        return originalBill.getNetTotal() + refundedSoFar;
     }
 
     public void selectBillToRefundListener() {

--- a/src/main/webapp/inward/inward_reprint_bill_deposit.xhtml
+++ b/src/main/webapp/inward/inward_reprint_bill_deposit.xhtml
@@ -37,7 +37,7 @@
                                         class="ui-button-warning"
                                         icon="fa fa-money-bill-transfer"
                                         action="#{inwardRefundController.navigateToRefundFromDepositBill(inwardSearch.bill)}"
-                                        disabled="#{inwardSearch.bill.cancelled or inwardSearch.bill.refunded}"  >
+                                        disabled="#{inwardSearch.bill.cancelled or inwardRefundController.calculateFreshRemainingRefundableAmount(inwardSearch.bill) le 0.01}"  >
                                     </p:commandButton>
 
                                     <p:commandButton

--- a/src/main/webapp/inward/inward_reprint_bill_payment.xhtml
+++ b/src/main/webapp/inward/inward_reprint_bill_payment.xhtml
@@ -37,7 +37,7 @@
                                         class="ui-button-warning"
                                         icon="fa fa-money-bill-transfer"
                                         action="#{inwardRefundController.navigateToRefundFromPaymentBill(inwardSearch.bill)}"
-                                        disabled="#{inwardSearch.bill.cancelled or inwardSearch.bill.refunded}"  >
+                                        disabled="#{inwardSearch.bill.cancelled or inwardRefundController.calculateFreshRemainingRefundableAmount(inwardSearch.bill) le 0.01}"  >
                                     </p:commandButton>
 
                                     <p:commandButton

--- a/src/main/webapp/inward/inward_reprint_bill_post_final_payment.xhtml
+++ b/src/main/webapp/inward/inward_reprint_bill_post_final_payment.xhtml
@@ -37,7 +37,7 @@
                                         class="ui-button-warning"
                                         icon="fa fa-money-bill-transfer"
                                         action="#{postFinalBillInwardPaymentController.navigateToRefundFromPostFinalPaymentBill(postFinalBillInwardPaymentController.current)}"
-                                        disabled="#{postFinalBillInwardPaymentController.current.cancelled or postFinalBillInwardPaymentController.current.refunded}"  >
+                                        disabled="#{postFinalBillInwardPaymentController.current.cancelled or postFinalBillInwardPaymentController.calculateFreshRemainingRefundableAmount(postFinalBillInwardPaymentController.current) le 0.01}"  >
                                     </p:commandButton>
 
                                     <p:commandButton


### PR DESCRIPTION
## Problem

Closes #23646.

A patient paid Rs. 500 as an inward payment; after a Rs. 400 refund the **Refund** button on the Payment Reprint page went permanently disabled, so the remaining Rs. 100 could never be refunded from that screen.

**Root cause:** `InwardRefundController.pay()` sets `originalBill.setRefunded(true)` after *any* refund, partial or not. The Refund shortcut button (added in #22820) on the Payment / Deposit / Post-Final Payment Reprint pages was gated on that binary flag:

```xhtml
disabled="#{inwardSearch.bill.cancelled or inwardSearch.bill.refunded}"
```

so the first partial refund killed it. Partial refunds are otherwise fully supported — `InwardRefundController` already tracks the remaining refundable amount (`bill.netTotal + SUM(netTotal of RefundBills linked by referenceBill)`), and the manual BHT-search refund path filters on that, not on the flag.

## Change

| File | Change |
|---|---|
| `InwardRefundController.java` | New public `calculateFreshRemainingRefundableAmount(Bill)` — the SUM read **cache-bypassing** so a refund raised earlier in the same `@SessionScoped` conversation is counted. Private `computeRemainingRefundableAmount()` now delegates to it then caches (its picker column also stops showing a stale figure right after a refund). |
| `PostFinalBillInwardPaymentController.java` | Same helper + delegation. |
| `inward_reprint_bill_payment.xhtml`, `inward_reprint_bill_deposit.xhtml`, `inward_reprint_bill_post_final_payment.xhtml` | Refund button `disabled` now = `cancelled or calculateFreshRemainingRefundableAmount(...) le 0.01`. |
| `developer_docs/testing/playwright-e2e-workflow.md` | New gotcha #117 (`p:tabView` renders every tab's markup — a text-matched `browser_evaluate` click can hit a hidden tab's button). |

**Not changed:** `To Cancel` stays keyed on `bill.refunded` — a partially-refunded bill must not be whole-bill cancellable. `pay()` still sets `refunded=true` / `refundedBill` on a partial refund; the cancel guard and channel reports rely on that signal. No constructor changes; JPQL only.

## Verification (local Payara, `coop` DB)

Menu path: *Menu → Inpatient → Billing → Interim Bill → find BHT → Deposits & Payments tab → **View Bill** → Deposit Reprint*.

Deposit `Inward//26/050558` on **BHT/57821**, Rs. 2,000:

| Step | Remaining refundable | Refund button |
|---|---|---|
| Before any refund | 2,000.00 | enabled |
| After refunding 1,500 | 500.00 | **enabled** — was disabled before this fix |
| After refunding the last 500 | 0.00 | disabled |

`To Cancel` disabled from the first partial refund onward (unchanged). DB after the run:

```
BILL 14080255  Inward//26/050558  INWARD_DEPOSIT         netTotal 2000  refunded=1
BILL 14080264  Inward//26/050559  INWARD_DEPOSIT_REFUND  netTotal -1500  referenceBill=14080255
BILL 14080265  Inward//26/050560  INWARD_DEPOSIT_REFUND  netTotal  -500  referenceBill=14080255
SUM(referenceBill-linked) = -2000  →  remaining 0  →  button disabled ✔
```

![Refund still enabled after partial refund](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23646-partial-refund-button-still-enabled.png)
*After refunding 1,500 of 2,000 — Refund still enabled, To Cancel greyed.*

![Refund disabled once fully refunded](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23646-full-refund-button-disabled.png)
*Full 2,000 refunded across two bills — Refund disabled.*

![Deposit with its two partial refunds](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23646-deposit-with-two-partial-refunds.png)

The post-final payment reprint change is the identical one-line edit and was code-inspected + build-checked (no local post-final-payment test data).

## Documentation

Wiki updated — **[Inpatient Bill Refunds → Partial Refunds](https://github.com/hmislk/hmis/wiki/Finance-Inpatient-Bill-Refunds#partial-refunds)**: new section explaining that payments/deposits can be refunded in parts, that the Refund button stays live until the balance reaches zero, and that To Cancel is disabled once any refund exists. Screenshots embedded; the "Refunding a Deposit" paragraph reconciled with this behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ML6GGHFHHndgjmCBrZhJv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Refund availability now reflects the bill’s current remaining refundable amount across inward bill and payment reprint screens.
  * Added fresh calculations that account for linked refunds and prevent refunds when no refundable balance remains.

* **Documentation**
  * Added guidance for reliably interacting with visible buttons in PrimeFaces tab views during end-to-end testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->