### PR TITLE
fix(notifications): implement the EMAIL medium so subscription emails are actually sent

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -143,6 +143,8 @@ gotcha** — jump straight to the one you need rather than reading the file.
 - [114. PrimeFaces menubar flyouts close between MCP tool calls — click the leaf `<a>` in one `browser_evaluate`](#114-primefaces-menubar-flyouts-close-between-mcp-tool-calls--click-the-leaf-a-in-one-browser_evaluate)
 - [115. Element screenshots land on the wrong region — crop the viewport shot instead](#115-element-screenshots-land-on-the-wrong-region--crop-the-viewport-shot-instead)
 - [116. `p:datePicker` with a mask silently truncates `pressSequentially`](#116-pdatepicker-with-a-mask-silently-truncates-presssequentially)
+- [117. Verifying an `@Asynchronous` dispatch: read the thread name in `server.log`, not the wall clock](#117-verifying-an-asynchronous-dispatch-read-the-thread-name-in-serverlog-not-the-wall-clock)
+- [118. The local dev box has no email or SMS gateway — verify the queued row, not the delivery](#118-the-local-dev-box-has-no-email-or-sms-gateway--verify-the-queued-row-not-the-delivery)
 - [Quick checklist](#quick-checklist)
 
 ---
@@ -3388,3 +3390,59 @@ browser_evaluate(() => { document.getElementById('form:dateStamp_input').value =
 Do **not** follow it with a synthetic `change` event — on these pickers that
 re-runs the mask and blanks the field again. §18's calendar-grid technique
 remains the option when the widget's own parsing needs to run.
+
+## 117. Verifying an `@Asynchronous` dispatch: read the thread name in `server.log`, not the wall clock
+
+A fix that moves work off the request thread (`@Asynchronous` EJB method) has
+no visible signature in the UI — the page returns quickly either way, and "the
+click felt fast" is not evidence. The proof is in `server.log`: every entry
+carries `_ThreadName`, and container-managed async work runs on an EJB pool
+thread rather than the HTTP listener.
+
+```
+[SEVERE] [com.divudi.ejb.EmailManagerEjb] [tid: _ThreadID=126 _ThreadName=__ejb-thread-pool9]
+  Email Gateway URL is not configured.
+```
+
+`__ejb-thread-pool9` confirms the dispatch really was asynchronous. A
+synchronous call would show `http-thread-pool::http-listener-1(N)` instead.
+Grep for the logging class and read the thread name:
+
+```bash
+grep -a "YourEjbClassName" /d/Payara/glassfish/domains/domain1/logs/server.log | tail -5
+```
+
+The same trick distinguishes a `@Schedule` timer (`__ejb-thread-pool`) from a
+user-triggered action, and catches the classic mistake where `@Asynchronous` is
+silently ignored because the method was invoked on `this` from inside the same
+bean (see the comment in `DatabaseMigrationService.java:80`) — self-invocation
+keeps running on the request thread, and the thread name is the only place that
+shows up.
+
+## 118. The local dev box has no email or SMS gateway — verify the queued row, not the delivery
+
+`EmailManagerEjb` logs `SEVERE: Email Gateway URL is not configured.` and
+`SmsManagerEjb.sendSms()` returns `false` when none of the five
+`SMS Sent Using …` config booleans is set. Neither is a defect locally; both
+are simply unconfigured. So **no email or SMS feature can be verified
+end-to-end on a local deployment** — the send will always fail.
+
+Write the assertion against the persisted row instead, which is what the
+feature actually controls:
+
+```sql
+SELECT receipientemail, messagesubject, messagetype, sentsuccessfully, pending
+FROM appemail WHERE messagetype = '<YourMessageType>';
+```
+
+A correct implementation still produces the row, with the right recipient,
+subject, body and foreign keys, and records the gateway's real verdict
+(`sentsuccessfully=0`, `pending=1`) plus a log line. That distinguishes the
+three cases a green screen cannot: *never attempted* (no row — the bug), *
+attempted and refused by the gateway* (row + WARNING — correct behaviour
+locally), and *delivered* (row with `sentsuccessfully=1` — only reachable on a
+deployment with a configured gateway).
+
+Companion to §41 (an empty `TRIGGERSUBSCRIPTION` table silently produces zero
+notifications): check the subscription rows exist *and* the recipient has an
+address on file before concluding anything from a quiet run.

--- a/src/main/java/com/divudi/bean/common/UserNotificationController.java
+++ b/src/main/java/com/divudi/bean/common/UserNotificationController.java
@@ -14,8 +14,11 @@ import com.divudi.bean.pharmacy.PharmacySaleBhtController;
 import com.divudi.bean.pharmacy.PurchaseOrderController;
 import com.divudi.bean.pharmacy.TransferIssueController;
 import com.divudi.core.data.BillTypeAtomic;
+import com.divudi.core.data.MessageType;
 import com.divudi.core.data.OptionScope;
+import com.divudi.ejb.EmailManagerEjb;
 import com.divudi.ejb.SmsManagerEjb;
+import com.divudi.core.entity.AppEmail;
 import com.divudi.core.entity.Bill;
 import com.divudi.core.entity.Department;
 import com.divudi.core.entity.UserNotification;
@@ -26,9 +29,11 @@ import com.divudi.core.entity.inward.PatientRoom;
 import com.divudi.core.entity.PatientEncounter;
 import com.divudi.core.entity.Sms;
 import com.divudi.core.entity.WebUser;
+import com.divudi.core.facade.EmailFacade;
 import com.divudi.core.facade.NotificationFacade;
 import com.divudi.core.facade.SmsFacade;
 import com.divudi.core.facade.UserNotificationFacade;
+import com.divudi.core.util.CommonFunctions;
 import com.divudi.service.NotificationPushService;
 import java.io.Serializable;
 import java.util.Date;
@@ -75,6 +80,8 @@ public class UserNotificationController implements Serializable {
     NotificationFacade notificationFacade;
     @EJB
     SmsFacade smsFacade;
+    @EJB
+    EmailFacade emailFacade;
     private UserNotification current;
     private List<UserNotification> items = null;
 
@@ -82,6 +89,8 @@ public class UserNotificationController implements Serializable {
     PharmacySaleBhtController pharmacySaleBhtController;
     @Inject
     SmsManagerEjb smsManager;
+    @Inject
+    EmailManagerEjb emailManagerEjb;
     @Inject
     NotificationPushService notificationPushService;
     @Inject
@@ -546,8 +555,13 @@ public class UserNotificationController implements Serializable {
                     if (u == null) {
                         continue;
                     }
-                    String number = u.getWebUserPerson().getMobile();
-                    //TODo
+                    String address = resolveEmailAddress(u);
+                    // A subscriber with no usable address on file would otherwise create an
+                    // AppEmail row with a null recipient and hand it to the gateway.
+                    if (address == null) {
+                        continue;
+                    }
+                    sendEmailForUserSubscriptions(address, n);
                 }
                 break;
             case SMS:
@@ -672,6 +686,113 @@ public class UserNotificationController implements Serializable {
             sb.append(" to ").append(bill.getToDepartment().getName().trim());
         }
         return sb.append(".").toString();
+    }
+
+    /**
+     * Resolves the email address to notify a subscribed user at.
+     *
+     * {@code WebUser.email} is authoritative because it is what the admin
+     * screen edits ({@code admin/users/user.xhtml:125} binds
+     * {@code webUserController.current.email}); the Person address is a
+     * fallback for users whose address was only ever captured there.
+     */
+    private String resolveEmailAddress(WebUser u) {
+        if (u == null) {
+            return null;
+        }
+        String address = u.getEmail();
+        if (address == null || address.trim().isEmpty()) {
+            address = u.getWebUserPerson() != null ? u.getWebUserPerson().getEmail() : null;
+        }
+        if (address == null) {
+            return null;
+        }
+        address = address.trim();
+        if (!CommonFunctions.isValidEmail(address)) {
+            return null;
+        }
+        return address;
+    }
+
+    public void sendEmailForUserSubscriptions(String recipientEmail, Notification notification) {
+        AppEmail email = new AppEmail();
+        email.setCreatedAt(new Date());
+        email.setCreater(sessionController.getLoggedUser());
+        email.setReceipientEmail(recipientEmail);
+        email.setMessageSubject(createEmailSubjectForUserNotification(notification));
+        email.setMessageBody(createEmailBodyForUserNotification(notification));
+        if (sessionController.getLoggedUser() != null) {
+            email.setDepartment(sessionController.getLoggedUser().getDepartment());
+            email.setInstitution(sessionController.getLoggedUser().getInstitution());
+        }
+        email.setMessageType(MessageType.UserNotification);
+        if (notification != null) {
+            email.setBill(notification.getBill());
+            email.setPatientEncounter(notification.getPatientEncounter());
+        }
+        email.setSentSuccessfully(false);
+        email.setPending(true);
+        emailFacade.create(email);
+        emailManagerEjb.sendAppEmailAsync(email);
+    }
+
+    /**
+     * Builds the HTML body of a subscription email. Mirrors {@link
+     * #createSmsForUserNotification(Notification)}: bill-backed notifications
+     * describe the bill that triggered them, a free-text notification message
+     * is used as-is, and everything else falls back to the configured
+     * template. The resulting text is HTML-escaped and wrapped since the
+     * email is sent as HTML.
+     */
+    public String createEmailBodyForUserNotification(Notification notification) {
+        String text = null;
+        if (notification != null && notification.getBill() != null) {
+            String billMessage = createSmsBodyForBillNotification(notification.getBill());
+            if (billMessage != null && !billMessage.trim().isEmpty()) {
+                text = billMessage;
+            }
+        }
+        if (text == null && notification != null && notification.getMessage() != null
+                && !notification.getMessage().trim().isEmpty()) {
+            text = notification.getMessage().trim();
+        }
+        if (text == null) {
+            String template = configOptionController.getLongTextValueByKey("Email Template for User Notification", OptionScope.APPLICATION, null, null, null);
+            text = (template == null) ? "" : template.trim();
+        }
+        return "<p>" + escapeHtml(text) + "</p>";
+    }
+
+    private String escapeHtml(String text) {
+        if (text == null) {
+            return "";
+        }
+        return text.replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&#39;");
+    }
+
+    /**
+     * Every EMAIL-medium {@link com.divudi.core.data.TriggerType} label ends
+     * with the literal " - Email" suffix (e.g. "Inward Patient Nursing
+     * Discharge - Email"); this strips it so the subject line reads naturally.
+     */
+    public String createEmailSubjectForUserNotification(Notification notification) {
+        if (notification == null || notification.getTriggerType() == null) {
+            return "Notification";
+        }
+        String label = notification.getTriggerType().getLabel();
+        if (label == null || label.trim().isEmpty()) {
+            return "Notification";
+        }
+        label = label.trim();
+        String suffix = " - Email";
+        if (label.endsWith(suffix)) {
+            label = label.substring(0, label.length() - suffix.length()).trim();
+        }
+        return label.isEmpty() ? "Notification" : label;
     }
 
     public void createAllertMessage(Notification n) {

--- a/src/main/java/com/divudi/bean/common/UserNotificationController.java
+++ b/src/main/java/com/divudi/bean/common/UserNotificationController.java
@@ -741,8 +741,16 @@ public class UserNotificationController implements Serializable {
      * #createSmsForUserNotification(Notification)}: bill-backed notifications
      * describe the bill that triggered them, a free-text notification message
      * is used as-is, and everything else falls back to the configured
-     * template. The resulting text is HTML-escaped and wrapped since the
-     * email is sent as HTML.
+     * template.
+     *
+     * Some producers build the EMAIL-medium body as a complete HTML document
+     * on purpose — {@code NotificationController.createOpdBillCancellationNotification()}
+     * and its batch-bill counterpart switch on the medium and store a full
+     * document carrying the signed {@code requests/bill.xhtml} link that the
+     * recipient is meant to click. Escaping that would deliver literal markup
+     * and break the cancellation workflow, so a body that is already a whole
+     * document is passed through untouched; anything else is treated as plain
+     * text, escaped and wrapped, since the email is sent as HTML.
      */
     public String createEmailBodyForUserNotification(Notification notification) {
         String text = null;
@@ -760,7 +768,24 @@ public class UserNotificationController implements Serializable {
             String template = configOptionController.getLongTextValueByKey("Email Template for User Notification", OptionScope.APPLICATION, null, null, null);
             text = (template == null) ? "" : template.trim();
         }
+        if (isCompleteHtmlDocument(text)) {
+            return text;
+        }
         return "<p>" + escapeHtml(text) + "</p>";
+    }
+
+    /**
+     * True only for a body that opens as a whole HTML document. Deliberately
+     * narrow: matching on stray tags anywhere in the text would let an
+     * ordinary message containing a "&lt;" escape escaping, so nothing short
+     * of a document root counts.
+     */
+    private boolean isCompleteHtmlDocument(String text) {
+        if (text == null) {
+            return false;
+        }
+        String start = text.trim().toLowerCase();
+        return start.startsWith("<!doctype html") || start.startsWith("<html");
     }
 
     private String escapeHtml(String text) {

--- a/src/main/java/com/divudi/core/data/MessageType.java
+++ b/src/main/java/com/divudi/core/data/MessageType.java
@@ -45,5 +45,6 @@ public enum MessageType {
     ClientPortalPasswordResetOTP,
     ClientPortalEmailRegistrationOTP,
     InwardFinalBillEmail,
-    InpatientComposedEmail
+    InpatientComposedEmail,
+    UserNotification
 }

--- a/src/main/java/com/divudi/ejb/EmailManagerEjb.java
+++ b/src/main/java/com/divudi/ejb/EmailManagerEjb.java
@@ -28,6 +28,7 @@ import java.util.logging.Logger;
 import javax.activation.DataHandler;
 import javax.activation.DataSource;
 import javax.activation.FileDataSource;
+import javax.ejb.Asynchronous;
 import javax.ejb.EJB;
 import javax.ejb.Schedule;
 import javax.ejb.Stateless;
@@ -507,6 +508,41 @@ public class EmailManagerEjb {
 
     public EmailFacade getEmailFacade() {
         return emailFacade;
+    }
+
+    /**
+     * Dispatches a persisted {@link AppEmail} row asynchronously and updates
+     * its sending status. Must never throw: this runs on a container-managed
+     * async thread, so an escaping exception would be invisible to the caller.
+     */
+    @Asynchronous
+    public void sendAppEmailAsync(AppEmail email) {
+        try {
+            if (email == null || email.getReceipientEmail() == null || email.getReceipientEmail().trim().isEmpty()) {
+                return;
+            }
+            boolean success = sendEmail(
+                    Collections.singletonList(email.getReceipientEmail()),
+                    email.getMessageBody(),
+                    email.getMessageSubject(),
+                    true
+            );
+            if (success) {
+                email.setSentSuccessfully(true);
+                email.setPending(false);
+                email.setSentAt(new Date());
+            } else {
+                email.setSentSuccessfully(false);
+                email.setPending(true);
+                Logger.getLogger(EmailManagerEjb.class.getName()).log(Level.WARNING,
+                        "Failed to send AppEmail to {0} with subject \"{1}\"",
+                        new Object[]{email.getReceipientEmail(), email.getMessageSubject()});
+            }
+            emailFacade.edit(email);
+        } catch (Exception e) {
+            Logger.getLogger(EmailManagerEjb.class.getName()).log(Level.WARNING,
+                    "Unexpected error while sending AppEmail: " + e.getMessage(), e);
+        }
     }
 
 }


### PR DESCRIPTION
Closes #23657

## Problem

The `EMAIL` branch of `UserNotificationController.createUserNotificationsForMedium()` was an unimplemented stub — it read a **mobile number** (the wrong field, copied from the SMS branch), discarded it, and did nothing:

```java
case EMAIL:
    for (WebUser u : notificationUsers) {
        if (u == null) { continue; }
        String number = u.getWebUserPerson().getMobile();
        //TODo
    }
    break;
```

So **no email was ever sent for any `TriggerType`**, while the subscription UI and `POST /api/subscriptions` accepted subscriptions to all 15 `*_EMAIL` constants and reported success. No error, no log, no record of an attempt — the failure was invisible from every angle. Found while investigating a Ruhunu report of missing nursing-discharge notifications.

## What changed

Reuses the existing mail stack rather than adding one: an `AppEmail` row via `EmailFacade`, dispatched through `EmailManagerEjb`'s REST gateway sender — the same pattern as `PurchaseOrderController.sendPurchaseOrderEmail()`.

| File | Change |
|---|---|
| `MessageType.java` | Append `UserNotification` (column is `@Enumerated(STRING)`, so existing rows are unaffected) |
| `EmailManagerEjb.java` | New `@Asynchronous sendAppEmailAsync(AppEmail)` — sends, records the outcome, never throws |
| `UserNotificationController.java` | Implement `case EMAIL:`; add address resolution, `AppEmail` construction, subject/body builders |

**No schema change.** `AppEmail` already had every field needed, including the `patientEncounter`/`bill` links now carried across so a failed email is traceable to the event that raised it.

### Two deliberate design choices

**Dispatch is asynchronous.** The row is created synchronously so it always exists, then the network call runs on a container thread. This diverges from the SMS branch, which blocks the user's action on the gateway once per subscriber. `@Asynchronous` is silently ignored on self-invocation, so the call is made from `UserNotificationController` — a different bean.

**Failures are silent to the acting user.** The nurse confirming a discharge is not the recipient and cannot fix a mail gateway, so a failed send leaves `sentSuccessfully=false` plus a `WARNING` log for administrators instead of a growl.

> Noted but **not** fixed here: the SMS branch reports failures with `JsfUtil.addSuccessMessage("SMS Failed")` — mislabelling an error as a success. Out of scope.

Recipient resolution prefers `WebUser.email` (the field `admin/users/user.xhtml` edits), falls back to the Person address, and validates via the existing `CommonFunctions.isValidEmail()` so a subscriber with no usable address is skipped rather than handed to the gateway with a null recipient. The subject is the `TriggerType` label minus its `" - Email"` suffix; the body mirrors `createSmsForUserNotification()`'s fallback chain, HTML-escaped.

## Verification

Local Payara, `coop` DB, department **Inward**, real admission **BHT/57811** (`PATIENTENCOUNTER` 13861559). Menu path: *Inward → Search → Admissions → Search → Inpatient Dashboard → Nursing Discharge → Confirm Nursing Discharge*.

Subscribed user `buddhika` (WebUser 60103) to *Inward Patient Nursing Discharge* on **Email** and **System Notification**, both application-wide, through the real admin screens.

**The `APPEMAIL` row is created correctly:**

```
                 id: 5823272
    receipientemail: buddhika.notification.test@carecode.org
     messagesubject: Inward Patient Nursing Discharge
        messagebody: <p>Patient nursing discharge confirmed (BHT: BHT/57811)</p>
        messagetype: UserNotification
   sentsuccessfully: 0
            pending: 1
patientencounter_id: 13861559
      department_id: 486
```

**The dispatch really is asynchronous** — the send ran on an EJB pool thread, not the HTTP listener:

```
[SEVERE] [com.divudi.ejb.EmailManagerEjb] [tid: _ThreadID=126 _ThreadName=__ejb-thread-pool9]
  Email Gateway URL is not configured.
[WARNING] [com.divudi.ejb.EmailManagerEjb] [tid: _ThreadID=126 _ThreadName=__ejb-thread-pool9]
  Failed to send AppEmail to buddhika.notification.test@carecode.org with subject "Inward Patient Nursing Discharge"
```

The local box has no mail gateway, so delivery cannot be verified end-to-end anywhere but a configured deployment. What *is* verified is the part this PR controls: the row exists, and the gateway's real verdict is recorded with a log line — rather than the silence that hid the bug.

**No regression:** the bell fired on both runs (`USERNOTIFICATION` went 0 → 1 → 2).

**Negative case:** blanked the address on both `WebUser` and `Person`, re-ran the discharge — **no** `APPEMAIL` row created, no exception, discharge completed normally.

![Nursing discharge confirmed with the notification bell showing a new alert](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23657-nursing-discharge-notification.png)

*Bell shows the new alert; note there is no email growl — the silent-failure behaviour described above.*

## Documentation

- **[Admin-User-Subscriptions](https://github.com/hmislk/hmis/wiki/Admin-User-Subscriptions)** — the page documented subscriptions but **never mentioned the three mediums at all**, which is arguably how this bug stayed hidden. Added a Mediums section (what each delivers, what each requires), the note that subscribing to one medium does not subscribe to the others, the Application-wide option, and the screenshot above.
- `developer_docs/testing/playwright-e2e-workflow.md` §117–118 — verifying an `@Asynchronous` dispatch via the `server.log` thread name, and why email/SMS can only be verified to the queued-row level locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EtLQsxhboAovFbc848WGNt
