### PR TITLE
fix(inward): recheck refundable balance fresh at refund-submit time (follow-up to #23659)

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardRefundController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardRefundController.java
@@ -207,7 +207,11 @@ public class InwardRefundController implements Serializable {
             return true;
         }
 
-        double remaining = getRemainingRefundableAmount(getOriginalBillToRefund());
+        // Read fresh from the DB, not remainingRefundableAmountCache: this
+        // guard runs at click time, and on a @SessionScoped bean the cache
+        // can hold a balance from before another cashier refunded the same
+        // bill. A stale value here would let this refund exceed what is left.
+        double remaining = calculateFreshRemainingRefundableAmount(getOriginalBillToRefund());
 
         if (Math.abs(remaining) < getCurrent().getTotal()) {
             double different = Math.abs(Math.abs(remaining) - Math.abs(getCurrent().getTotal()));

--- a/src/main/java/com/divudi/bean/inward/PostFinalBillInwardPaymentController.java
+++ b/src/main/java/com/divudi/bean/inward/PostFinalBillInwardPaymentController.java
@@ -999,7 +999,11 @@ public class PostFinalBillInwardPaymentController implements Serializable, Contr
             return true;
         }
 
-        double remaining = getRemainingRefundableAmount(getOriginalBillToRefund());
+        // Read fresh from the DB, not remainingRefundableAmountCache: this
+        // guard runs at click time, and on a @SessionScoped bean the cache
+        // can hold a balance from before another cashier refunded the same
+        // bill. A stale value here would let this refund exceed what is left.
+        double remaining = calculateFreshRemainingRefundableAmount(getOriginalBillToRefund());
 
         if (Math.abs(remaining) < getRefundCurrent().getTotal()) {
             double different = Math.abs(Math.abs(remaining) - Math.abs(getRefundCurrent().getTotal()));


### PR DESCRIPTION
## Follow-up to #23659 — CodeRabbit review point

CodeRabbit flagged that `InwardRefundController.errorCheck()` and
`PostFinalBillInwardPaymentController.errorCheckForRefund()` validate the
requested refund amount against `getRemainingRefundableAmount()`, which reads
`remainingRefundableAmountCache` first. That cache is populated when the BHT is
selected; on a `@SessionScoped` controller a cashier who opened the screen
*before* another cashier refunded the same bill would pass the guard against a
**stale balance** and over-refund it.

## Change

Both guards now call `calculateFreshRemainingRefundableAmount()` (the
cache-bypassing DB read added in #23659) immediately before the refund is
written — a two-line change per controller.

```diff
-        double remaining = getRemainingRefundableAmount(getOriginalBillToRefund());
+        // Read fresh from the DB, not remainingRefundableAmountCache: this
+        // guard runs at click time ...
+        double remaining = calculateFreshRemainingRefundableAmount(getOriginalBillToRefund());
```

**Out of scope:** a genuine simultaneous double-submit within one request window
still needs row-level locking on the original bill — a broader transactional
change, not attempted here.

## Verification (local Payara, `coop` DB)

*Menu → Inpatient → Billing → Interim Bill → BHT/57819 → Deposits & Payments → View Bill → Deposit Reprint → Refund.*

Partial refund of Rs. 1,000 against the Rs. 1,500 deposit `Inward//26/050556`:
- refund succeeds, receipt shows −1,000.00
- Refund button stays enabled (Rs. 500 remaining), To Cancel disabled
- DB: `BILL 14080266  INWARD_DEPOSIT_REFUND  netTotal -1000  referenceBill=14080248` — one linked refund, guard used the fresh read.

## Merge order

Stacked on #23659 (needs `calculateFreshRemainingRefundableAmount`). Once #23659
merges, this PR's diff reduces to the two guard lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ML6GGHFHHndgjmCBrZhJv
