### PR TITLE
fix(inward): pin locale for receipt date/time formatting to fix CI test flake

### DIFF
--- a/src/main/java/com/divudi/core/util/InwardReceiptTextRenderer.java
+++ b/src/main/java/com/divudi/core/util/InwardReceiptTextRenderer.java
@@ -8,6 +8,7 @@ import java.text.DecimalFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.TimeZone;
 
 /**
@@ -89,9 +90,9 @@ public final class InwardReceiptTextRenderer {
         String bht = pe != null ? safe(pe.getBhtNo()) : "";
 
         DecimalFormat money = new DecimalFormat("#,##0.00");
-        SimpleDateFormat dfDate = new SimpleDateFormat("dd/MMM/yyyy");
+        SimpleDateFormat dfDate = new SimpleDateFormat("dd/MMM/yyyy", Locale.ENGLISH);
         dfDate.setTimeZone(COLOMBO);
-        SimpleDateFormat dfTime = new SimpleDateFormat("hh:mm a");
+        SimpleDateFormat dfTime = new SimpleDateFormat("hh:mm a", Locale.ENGLISH);
         dfTime.setTimeZone(COLOMBO);
         Date created = bill.getCreatedAt();
 
@@ -103,7 +104,7 @@ public final class InwardReceiptTextRenderer {
         field(sb, "BHT No", bht);
         field(sb, "Bill No", safe(bill.getDeptId()));
         field(sb, "Bill Date", created == null ? "" : dfDate.format(created));
-        field(sb, "Bill Time", created == null ? "" : dfTime.format(created));
+        field(sb, "Bill Time", created == null ? "" : dfTime.format(created).toLowerCase(Locale.ROOT));
         field(sb, "Payment", bill.getPaymentMethod() == null ? ""
                 : bill.getPaymentMethod().toString());
 


### PR DESCRIPTION
## Problem
All 5 QA/staging deploy builds (`hims-qa1-4-migrated`, `rh-local-staging`) were failing on the full `mvn test` run with:

```
InwardReceiptTextRendererTest.dateAndTimeAreFormattedInColomboTimeRegardlessOfDefaultTimeZone
expected the Colombo-local time, not the JVM-default-zone time ==> expected: <true> but was: <false>
```

This is a pre-existing regression on `development` from 85c8415fea, not something introduced by the QA sync PRs — it only surfaces in workflows that run the full Maven test suite (the Branch Merge Validation check does not run tests).

## Root cause
`InwardReceiptTextRenderer` formats the receipt time with `new SimpleDateFormat("hh:mm a")` — no explicit `Locale`. The `a" (AM/PM) marker is locale-dependent: it renders lowercase `"pm"` under `en_GB` (what most dev machines here default to) but uppercase `"PM"` under the `en_US`-like default locale on the GitHub Actions runner. The test hardcodes an explicit `TimeZone` to catch JVM-environment dependence, but missed that `Locale` has the same problem for the AM/PM text.

Verified locally:
- `en_GB` default locale → `11:45 pm` (test passes by accident)
- `en_US` default locale (simulated via `-Duser.language=en -Duser.country=US`, matching CI) → `11:45 PM` (test fails, reproducing the CI failure exactly)

## Fix
- Pin both `SimpleDateFormat` instances (date and time) to `Locale.ENGLISH`, matching the existing explicit `Asia/Colombo` `TimeZone` pin.
- Explicitly lowercase the formatted AM/PM marker (`Locale.ROOT`) so the printed receipt text is deterministic regardless of the runner's default locale — `Locale.ENGLISH` alone still yields uppercase `"PM"`.

## Verification
- `mvn -Dtest=InwardReceiptTextRendererTest test` — 10/10 pass, including the previously-failing test, under both the local `en_GB` default and a simulated `en_US` default (`-Duser.language=en -Duser.country=US`).
- Full suite (`mvn test`) under simulated `en_US`: 286/286 pass, no regressions.

Unblocks `deploy-qa all` for all 5 QA/staging environments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized receipt date and time formatting across locales.
  * Ensured bill times are rendered consistently in lowercase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->