### PR TITLE
fix(inward): Custom Bill 3 print layout fixes

### DIFF
--- a/src/main/webapp/inward/inward_final_bill_approve.xhtml
+++ b/src/main/webapp/inward/inward_final_bill_approve.xhtml
@@ -20,7 +20,7 @@
                             <div class="d-flex justify-content-between">
                                 <div class="d-flex">
                                     <h:outputText styleClass="fas fa-gavel"></h:outputText>
-                                    <h:outputLabel value="Approve Final Bill" class="mx-4"></h:outputLabel>
+                                    <h:outputLabel value="Approve Final Bill (Read Only)" class="mx-4"></h:outputLabel>
                                     <h:outputLabel value="#{inwardSearch.bill.deptId}" styleClass="text-muted"></h:outputLabel>
                                 </div>
                                 <div class="d-flex gap-2">
@@ -35,25 +35,12 @@
                                 </div>
                             </div>
                         </f:facet>
-
-                        <p:panel rendered="#{inwardSearch.bill.approveAt ne null}" class="mb-3">
-                            <h:outputText value="This bill has already been approved." styleClass="text-success" />
-                        </p:panel>
-
-                        <p:panel class="mt-3">
-                            <f:facet name="header">
-                                <h:outputLabel value="Final Bill (Read Only)"></h:outputLabel>
-                            </f:facet>
-
-                            <bi:finalBill bill="#{inwardSearch.bill}" />
-
-                        </p:panel>
-
-                        <div class="d-flex gap-2 mt-3">
+                        
+                        <div class="d-flex  justify-content-end gap-2 mt-3">
                             <p:commandButton
                                 ajax="false"
                                 icon="fa fa-gavel"
-                                class="ui-button-primary"
+                                class="ui-button-warning"
                                 value="Approve"
                                 title="Approve #{inwardSearch.bill.deptId}"
                                 actionListener="#{inwardSearch.approveFinalBillVersion(inwardSearch.bill)}"
@@ -71,6 +58,14 @@
                                 title="Back to Final Bills">
                             </p:commandButton>
                         </div>
+
+                        <p:panel rendered="#{inwardSearch.bill.approveAt ne null}" class="mb-3">
+                            <h:outputText value="This bill has already been approved." styleClass="text-success" />
+                        </p:panel>
+
+                        <h:panelGroup class="mt-3">
+                            <bi:finalBill bill="#{inwardSearch.bill}" />
+                        </h:panelGroup>
 
                     </p:panel>
 

--- a/src/main/webapp/inward/inward_reprint_bill_final.xhtml
+++ b/src/main/webapp/inward/inward_reprint_bill_final.xhtml
@@ -757,9 +757,10 @@
                                                         </div>
                                                     </div>
                                                 </f:facet>
+                                                
+                                                <bi:unapprovedHeading bill="#{inwardSearch.bill}" />
 
                                                 <h:panelGroup id="originalCustom4BillPriview">
-                                                    <bi:unapprovedHeading bill="#{inwardSearch.bill}" />
                                                     <bi:finalBillCustom4 bill="#{inwardSearch.showOrginalBill ? inwardSearch.bill.referenceBill : inwardSearch.bill}" duplicate="false" showProfessional="#{inwardSearch.withProfessionalFee}"/>
                                                 </h:panelGroup>
 
@@ -780,9 +781,10 @@
                                                         </div>
                                                     </div>
                                                 </f:facet>
+                                                
+                                                <bi:unapprovedHeading bill="#{inwardSearch.bill}" />
 
                                                 <h:panelGroup id="duplicateCustom4BillPriview">
-                                                    <bi:unapprovedHeading bill="#{inwardSearch.bill}" />
                                                     <bi:finalBillCustom4 bill="#{inwardSearch.showOrginalBill ? inwardSearch.bill.referenceBill : inwardSearch.bill}" duplicate="true" showProfessional="#{inwardSearch.withProfessionalFee}"/>
                                                 </h:panelGroup>
 

--- a/src/main/webapp/resources/css/final_bill_custom4_letterhead.css
+++ b/src/main/webapp/resources/css/final_bill_custom4_letterhead.css
@@ -51,52 +51,14 @@
     margin-bottom: 1cm;
     margin-left: 0;
     margin-right: 0;
-
-    /* Page number, top-right of every page, "Page X of Y" format - only
-       rendered by Paged.js, not by native browser printing.
-       @top-right is right-aligned by default. margin-right on @page is 0,
-       so its right edge is literally the page's physical right edge - the
-       text was sitting flush in the corner with no breathing room.
-       padding-right/padding-top nudge it inward instead; padding-right is
-       larger than the theoretical 0.55cm content-edge match (see note
-       below) because that value clipped too close to the physically
-       unprintable edge on a real print. */
-    @top-right {
-        content: "Page " counter(page) " of " counter(pages);
-        font-size: 11px;
-        padding-top: 3.0cm;
-        /* Started from the content's own right inset - .container-fluid is
-           a fixed 214mm (21.4cm) wide, centered on the 22.5cm page via
-           margin:auto, which leaves (22.5 - 21.4) / 2 = 0.55cm on each
-           side - then increased to 1.5cm after a real print showed 0.55cm
-           printing too close to the paper's physically unprintable edge. */
-        padding-right: 1.5cm;
-    }
 }
 
 /* Page 1's header space mostly comes from finalBillCustom4.xhtml's own inline
    top-margin div (config key "Inward Final Bill Header Margin-Top Space",
    default "4cm") - so this is NOT the full 4cm from the general @page rule
-   above (that would double-reserve it). It is not 0 either, unlike before:
-   margin boxes like @top-right only render inside the page's OWN margin area,
-   not inside an ordinary content div, so page 1 needs a small margin-top of
-   its own for the page number to have anywhere to sit - this adds a little
-   under 1cm of extra top space on page 1 only (~4.8cm total instead of 4cm)
-   purely to make room for that single line of text. */
+   above (that would double-reserve it). */
 @page :first {
     margin-top: 0.8cm;
-
-    /* The general @top-right above has padding-top: 3.0cm, which fits the
-       4cm margin-top most pages get - but this page's margin-top is only
-       0.8cm, so that padding alone would overflow/clip the page-number text.
-       Override with a padding that actually fits this page's smaller margin
-       box; keep padding-right the same since the page width doesn't change. */
-    @top-right {
-        content: "Page " counter(page) " of " counter(pages);
-        font-size: 11px;
-        padding-top: 0.1cm;
-        padding-right: 1.5cm;
-    }
 }
 
 [id$="originalCustom4BillPriview"] .container-fluid,

--- a/src/main/webapp/resources/inward/bill/finalBillCustom4.xhtml
+++ b/src/main/webapp/resources/inward/bill/finalBillCustom4.xhtml
@@ -81,21 +81,21 @@
                             </div>
 
                             <!-- Patient Name -->
-                            <div class="col-6 d-flex mb-1">
+                            <div class="col-12 d-flex mb-1">
                                 <span style="width: 130px;">Patient Name</span>
                                 <span style="width: 12px; text-align: center;">:</span>
-                                <span class="flex-fill ps-2">
+                                <span class="flex-fill ps-2" style="min-width: 0; white-space: normal; word-break: break-word;">
                                     <h:outputLabel value="#{cc.attrs.bill.patientEncounter.patient.person.nameWithTitle}"/>
                                 </span>
                             </div>
 
                             <!-- Address -->
-                            <h:panelGroup layout="block" styleClass="col-6 d-flex mb-1"
+                            <h:panelGroup layout="block" styleClass="col-12 d-flex mb-1"
                                           rendered="#{bhtSummeryController.custom4ShowAddress}">
                                 <span style="width: 130px;">Address</span>
                                 <span style="width: 12px; text-align: center;">:</span>
-                                <span class="flex-fill ps-2">
-                                    <h:outputLabel value="#{cc.attrs.bill.patientEncounter.patient.person.address}"/>
+                                <span class="flex-fill ps-2" style="min-width: 0; white-space: normal; word-break: break-word;">
+                                    <h:outputLabel value="#{cc.attrs.bill.patientEncounter.patient.person.address ne null and !cc.attrs.bill.patientEncounter.patient.person.address.equals('') ? cc.attrs.bill.patientEncounter.patient.person.address : 'N/A'}"/>
                                 </span>
                             </h:panelGroup>
 
@@ -125,7 +125,17 @@
                                 <span style="width: 130px;">Phone No</span>
                                 <span style="width: 12px; text-align: center;">:</span>
                                 <span class="flex-fill ps-2">
-                                    <h:outputLabel value="#{cc.attrs.bill.patientEncounter.patient.person.mobile}"/>
+                                    <h:outputLabel value="#{cc.attrs.bill.patientEncounter.patient.person.mobile ne null and !cc.attrs.bill.patientEncounter.patient.person.mobile.equals('') ? cc.attrs.bill.patientEncounter.patient.person.mobile : 'N/A'}"/>
+                                </span>
+                            </h:panelGroup>
+
+                            <!-- Guardian -->
+                            <h:panelGroup layout="block" styleClass="col-6 d-flex mb-1"
+                                          rendered="#{bhtSummeryController.custom4ShowGuardian}">
+                                <span style="width: 130px;">Guardian</span>
+                                <span style="width: 12px; text-align: center;">:</span>
+                                <span class="flex-fill ps-2">
+                                    <h:outputLabel value="#{cc.attrs.bill.patientEncounter.guardian ne null and cc.attrs.bill.patientEncounter.guardian.name ne null and !cc.attrs.bill.patientEncounter.guardian.name.equals('') ? cc.attrs.bill.patientEncounter.guardian.nameWithTitle : 'N/A'}" />
                                 </span>
                             </h:panelGroup>
 
@@ -151,15 +161,7 @@
                                 </span>
                             </div>
 
-                            <!-- Guardian -->
-                            <h:panelGroup layout="block" styleClass="col-6 d-flex mb-1"
-                                          rendered="#{bhtSummeryController.custom4ShowGuardian}">
-                                <span style="width: 130px;">Guardian</span>
-                                <span style="width: 12px; text-align: center;">:</span>
-                                <span class="flex-fill ps-2">
-                                    <h:outputLabel value="#{cc.attrs.bill.patientEncounter.guardian.nameWithTitle}" />
-                                </span>
-                            </h:panelGroup>
+
 
                             <!-- Room -->
                             <div class="col-6 d-flex mb-1">

--- a/src/main/webapp/resources/inward/bill/finalBillCustom4.xhtml
+++ b/src/main/webapp/resources/inward/bill/finalBillCustom4.xhtml
@@ -40,7 +40,7 @@
                         </h:panelGroup>
                     </h:panelGroup>
 
-                    <table class="headingPrinting" >
+                    <table class="headingPrinting" style="line-height: 1.1;">
 
                         <tr>
                             <td colspan="4">
@@ -58,7 +58,7 @@
 
 
                     <!-- ===== A4 Bill Header (BHT, Name, ...) - auto-wrapping 2-column grid ===== -->
-                    <div style="font-size: 13px; width: 90%; margin-left: 5%; margin-right: 5%; line-height: 1.2;" class="mt-4 mb-4">
+                    <div style="font-size: 13px; width: 90%; margin-left: 5%; margin-right: 5%; line-height: 1.2;" class="mt-3 mb-2">
                         <div class="row gx-0 custom4-header-details-row">
 
                             <!-- BHT No -->
@@ -185,8 +185,8 @@
                     </div>
 
                     <div style="width: 90%; margin-left: 5%; margin-right: 5%">
-                        <table class=" w-100"  >
-                            <tr style="t">
+                        <table class=" w-100" style="line-height: 1.05;"  >
+                            <tr style="t" class="mb-2">
                                 <td style="text-align: left; font-weight: bold; font-size: 14px;">
                                     <h:outputLabel value="Description" />
                                 </td>
@@ -646,7 +646,7 @@
                                                         <h:panelGroup rendered="#{bip.inwardChargeType eq 'ProfessionalCharge'}">
                                                             <table>
                                                                 <ui:repeat value="#{bip.proFees}" var="fe">
-                                                                    <h:panelGroup rendered="#{fe.feeAdjusted ne 0 and fe.bill.cancelled eq false and fe.bill.billClass eq 'class com.divudi.core.entity.BilledBill'}">
+                                                                    <h:panelGroup style="line-height: 1.0;" rendered="#{fe.feeAdjusted ne 0 and fe.bill.cancelled eq false and fe.bill.billClass eq 'class com.divudi.core.entity.BilledBill'}">
                                                                         <tr>
                                                                             <td style="text-align: left; font-size: 10px!important;">
                                                                                 <h:panelGroup>#{fe.staff.person.nameWithTitle}<h:outputText value=" (#{fe.staff.speciality.name})" rendered="#{fe.staff.speciality ne null}"/></h:panelGroup>
@@ -810,7 +810,7 @@
                                         <td>
                                             <table>
                                                 <ui:repeat value="#{cc.attrs.bill.patientEncounter.finalBill ne null ? cc.attrs.bill.patientEncounter.finalBill.backwardReferenceBills : cc.attrs.bill.backwardReferenceBills}" var="b">
-                                                    <h:panelGroup rendered="#{(b.netTotal ne 0 )
+                                                    <h:panelGroup style="line-height: 1.05;" rendered="#{(b.netTotal ne 0 )
                                                                               and
                                                                               ((b.cancelled eq false
                                                                               and b.billClass eq 'class com.divudi.core.entity.BilledBill')

--- a/src/main/webapp/resources/inward/bill/finalBillCustom4.xhtml
+++ b/src/main/webapp/resources/inward/bill/finalBillCustom4.xhtml
@@ -818,14 +818,20 @@
                                                                               (b.cancelled eq false
                                                                               and b.refundedBill eq null
                                                                               and b.billClass eq 'class com.divudi.core.entity.RefundBill')) and b.billTypeAtomic ne 'INPATIENT_CREDIT_COMPANY_PAYMENT_RECEIVED'}">
+
                                                         <div class="d-flex gap-3" style="font-size: 11px;">
-                                                            <h:outputLabel value="#{b.deptId}"/>
-                                                            <h:outputLabel value="#{b.paymentMethod}" rendered="#{configOptionApplicationController.getBooleanValueByKey('Show Payment Method on Payments on Final Bill On Final Bill Print',false)}"/>
-                                                            <h:outputLabel value="#{b.netTotal}"
-                                                                           style="text-align: right;">
+                                                            <h:outputLabel value="#{b.deptId}" style="width: 110px;"/>
+
+                                                            <h:outputLabel value="#{b.paymentMethod}"  style="width: 40px;" rendered="#{configOptionApplicationController.getBooleanValueByKey('Show Payment Method on Payments on Final Bill On Final Bill Print',false)}"/>
+
+                                                            <h:outputLabel value="#{b.netTotal}" style="text-align: right;">
                                                                 <f:convertNumber pattern="#,##0.00"/>
                                                             </h:outputLabel>
-                                                            <h:outputLabel value="(#{b.comments})" rendered="#{configOptionApplicationController.getBooleanValueByKey('Show Comments of Payments on Final Bill On Final Bill Print',false) and b.comments ne null and b.comments ne ''}"/>
+
+                                                            <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Show Payment Type on Final Bill On Final Bill Print',false)}">
+                                                                <h:outputLabel value="(#{b.billTypeAtomic.label})" rendered="#{configOptionApplicationController.getBooleanValueByKey('Show Inward Deposit label on Final Bill Print',false) and b.billTypeAtomic eq 'INWARD_DEPOSIT'}" style="max-width: 100px; white-space: nowrap;overflow: visible; text-overflow: ellipsis;"/>
+                                                                <h:outputLabel value="(#{b.billTypeAtomic.label})" rendered="#{configOptionApplicationController.getBooleanValueByKey('Show Inward Payment label on Final Bill Print',false) and b.billTypeAtomic eq 'INWARD_PAYMENT'}" style="max-width: 100px; white-space: nowrap;overflow: visible; text-overflow: ellipsis;"/>
+                                                            </h:panelGroup>
 
                                                         </div>
 

--- a/src/main/webapp/resources/inward/bill/finalBillCustom4.xhtml
+++ b/src/main/webapp/resources/inward/bill/finalBillCustom4.xhtml
@@ -911,7 +911,6 @@
                                             </h:outputLabel>
                                         </td>
                                     </tr>
-
                                 </h:panelGroup>
 
                                 <h:panelGroup >
@@ -928,30 +927,22 @@
                                             </h:outputLabel>
                                         </td>
                                     </tr>
-
-
                                 </h:panelGroup>
+                                
                             </h:panelGroup>
 
                         </table>
                     </div>
 
-                    <p:spacer></p:spacer>
-
-                    <div class="row mt-4" style="font-size: 12px;">
-                        <div class="col-4">
+                    <div class="row mt-4" style="font-size: 11px;">
+                        <div class="col-5">
                             <div class="d-grid justify-content-center">
                                 <h:outputLabel value="-----------------------------" />
                                 <h:outputLabel value="Patient/Guardian" class="w-100 d-flex justify-content-center"/>
                             </div>
                         </div>
-                        <div class="col-4">
-                            <div class="d-grid justify-content-center">
-                                <h:outputLabel value="-----------------------------" />
-                                <h:outputLabel value="Prepared by : #{cc.attrs.bill.creater.name}"  class="w-100 d-flex justify-content-center"/>
-                            </div>
-                        </div>
-                        <div class="col-4">
+                        <div class="col-2"></div>
+                        <div class="col-5">
                             <div class="d-grid justify-content-center">
                                 <h:outputLabel value="-----------------------------" />
                                 <h:outputLabel value="Cashier"  class="w-100 d-flex justify-content-center"/>

--- a/src/main/webapp/resources/inward/bill/finalBillCustom4.xhtml
+++ b/src/main/webapp/resources/inward/bill/finalBillCustom4.xhtml
@@ -203,11 +203,12 @@
                                                           (bip.adjustedValue!=0 and cc.attrs.showProfessional eq true and bip.inwardChargeType eq 'ProfessionalCharge')}"
                                               style="font-size: 12px;">
                                     <tr style="width: 100%; font-weight: 400; line-height: 18px;" >
-                                        <td style="text-align: left;font-size: 13px!important; margin-top: -10px;">
-                                            <h:outputLabel   value="#{bip.inwardChargeType.name}" >
-                                            </h:outputLabel>
+                                        <td style="text-align: left; font-size: 13px !important;
+                                                    max-width: 150px; white-space: nowrap;
+                                                    overflow: visible; text-overflow: ellipsis;">
+                                            <h:outputLabel value="#{bip.inwardChargeType.name}"/>
                                         </td>
-                                        <td style="margin-top: -10px;">
+                                        <td style="margin-top: 10px;">
                                             <h:panelGroup style="font-size: 10px;" >
                                                 <h:panelGroup rendered="#{!(bip.inwardChargeType eq 'ProfessionalCharge'
                                                                           and bip.inwardChargeType eq 'RoomCharges' )}">
@@ -293,9 +294,11 @@
                                 <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
                                     <h:panelGroup rendered="#{bip.inwardChargeType eq 'AdmissionFee' and bip.adjustedValue != 0}" style="font-size: 12px;">
                                         <tr style="width: 100%; font-weight: 400; line-height: 18px;">
-                                            <td style="text-align: left; font-size: 13px!important; margin-top: -10px;">
-                                                <h:outputLabel value="#{bip.inwardChargeType.name}" />
-                                            </td>
+                                            <td style="text-align: left; font-size: 13px !important;
+                                                    max-width: 150px; white-space: nowrap;
+                                                    overflow: visible; text-overflow: ellipsis;">
+                                                    <h:outputLabel value="#{bip.inwardChargeType.name}"/>
+                                                </td>
                                             <td style="margin-top: -10px;">
                                             </td>
                                             <td style="width: 30%; text-align: right; font-size: 13px!important;">
@@ -311,9 +314,11 @@
                                 <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
                                     <h:panelGroup rendered="#{bip.inwardChargeType eq 'RoomCharges' and bip.adjustedValue != 0}" style="font-size: 12px;">
                                         <tr style="width: 100%; font-weight: 400; line-height: 18px;">
-                                            <td style="text-align: left; font-size: 13px!important; margin-top: -10px;">
-                                                <h:outputLabel value="#{bip.inwardChargeType.name}" />
-                                            </td>
+                                            <td style="text-align: left; font-size: 13px !important;
+                                                    max-width: 150px; white-space: nowrap;
+                                                    overflow: visible; text-overflow: ellipsis;">
+                                                    <h:outputLabel value="#{bip.inwardChargeType.name}"/>
+                                                </td>
                                             <td style="margin-top: -10px;">
                                                 <h:panelGroup style="font-size: 10px;">
                                                     <h:panelGroup rendered="#{!(bip.inwardChargeType eq 'ProfessionalCharge' and bip.inwardChargeType eq 'RoomCharges')}">
@@ -369,8 +374,10 @@
                                     <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
                                         <h:panelGroup rendered="#{bip.inwardChargeType eq 'NursingCharges' and bip.adjustedValue != 0}" style="font-size: 12px;">
                                             <tr style="width: 100%; font-weight: 400; line-height: 18px;">
-                                                <td style="text-align: left; font-size: 13px!important; margin-top: -10px;">
-                                                    <h:outputLabel value="#{bip.inwardChargeType.name}" />
+                                                <td style="text-align: left; font-size: 13px !important;
+                                                    max-width: 150px; white-space: nowrap;
+                                                    overflow: visible; text-overflow: ellipsis;">
+                                                    <h:outputLabel value="#{bip.inwardChargeType.name}"/>
                                                 </td>
                                                 <td style="margin-top: -10px;">
                                                 </td>
@@ -387,8 +394,10 @@
                                     <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
                                         <h:panelGroup rendered="#{bip.inwardChargeType eq 'MOCharges' and bip.adjustedValue != 0}" style="font-size: 12px;">
                                             <tr style="width: 100%; font-weight: 400; line-height: 18px;">
-                                                <td style="text-align: left; font-size: 13px!important; margin-top: -10px;">
-                                                    <h:outputLabel value="#{bip.inwardChargeType.name}" />
+                                                <td style="text-align: left; font-size: 13px !important;
+                                                    max-width: 150px; white-space: nowrap;
+                                                    overflow: visible; text-overflow: ellipsis;">
+                                                    <h:outputLabel value="#{bip.inwardChargeType.name}"/>
                                                 </td>
                                                 <td style="margin-top: -10px;">
                                                 </td>
@@ -405,8 +414,10 @@
                                     <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
                                         <h:panelGroup rendered="#{bip.inwardChargeType eq 'LinenCharges' and bip.adjustedValue != 0}" style="font-size: 12px;">
                                             <tr style="width: 100%; font-weight: 400; line-height: 18px;">
-                                                <td style="text-align: left; font-size: 13px!important; margin-top: -10px;">
-                                                    <h:outputLabel value="#{bip.inwardChargeType.name}" />
+                                                <td style="text-align: left; font-size: 13px !important;
+                                                    max-width: 150px; white-space: nowrap;
+                                                    overflow: visible; text-overflow: ellipsis;">
+                                                    <h:outputLabel value="#{bip.inwardChargeType.name}"/>
                                                 </td>
                                                 <td style="margin-top: -10px;">
                                                 </td>
@@ -423,8 +434,10 @@
                                     <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
                                         <h:panelGroup rendered="#{bip.inwardChargeType eq 'MedicalCareICU' and bip.adjustedValue != 0}" style="font-size: 12px;">
                                             <tr style="width: 100%; font-weight: 400; line-height: 18px;">
-                                                <td style="text-align: left; font-size: 13px!important; margin-top: -10px;">
-                                                    <h:outputLabel value="#{bip.inwardChargeType.name}" />
+                                                <td style="text-align: left; font-size: 13px !important;
+                                                    max-width: 150px; white-space: nowrap;
+                                                    overflow: visible; text-overflow: ellipsis;">
+                                                    <h:outputLabel value="#{bip.inwardChargeType.name}"/>
                                                 </td>
                                                 <td style="margin-top: -10px;">
                                                 </td>
@@ -441,8 +454,10 @@
                                     <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
                                         <h:panelGroup rendered="#{bip.inwardChargeType eq 'AdministrationCharge' and bip.adjustedValue != 0}" style="font-size: 12px;">
                                             <tr style="width: 100%; font-weight: 400; line-height: 18px;">
-                                                <td style="text-align: left; font-size: 13px!important; margin-top: -10px;">
-                                                    <h:outputLabel value="#{bip.inwardChargeType.name}" />
+                                                <td style="text-align: left; font-size: 13px !important;
+                                                    max-width: 150px; white-space: nowrap;
+                                                    overflow: visible; text-overflow: ellipsis;">
+                                                    <h:outputLabel value="#{bip.inwardChargeType.name}"/>
                                                 </td>
                                                 <td style="margin-top: -10px;">
                                                 </td>
@@ -460,9 +475,11 @@
                                 <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
                                     <h:panelGroup rendered="#{bip.inwardChargeType ne 'RoomCharges' and bip.inwardChargeType ne 'ProfessionalCharge' and bip.inwardChargeType ne 'DoctorAndNurses' and bip.inwardChargeType ne 'AdmissionFee' and bip.inwardChargeType ne 'NursingCharges' and bip.inwardChargeType ne 'MOCharges' and bip.inwardChargeType ne 'LinenCharges' and bip.inwardChargeType ne 'MedicalCareICU' and bip.inwardChargeType ne 'AdministrationCharge' and bip.inwardChargeType ne 'Medicine' and (bip.inwardChargeType ne 'MedicinesAndSurgicalSupplies' or !configOptionApplicationController.getBooleanValueByKey('Separate Medicines and Surgical Supplies Tab', false)) and bip.inwardChargeType ne 'Laboratory' and bip.adjustedValue != 0}" style="font-size: 12px;">
                                         <tr style="width: 100%; font-weight: 400; line-height: 18px;">
-                                            <td style="text-align: left; font-size: 13px!important; margin-top: -10px;">
-                                                <h:outputLabel value="#{bip.inwardChargeType.name}" />
-                                            </td>
+                                            <td style="text-align: left; font-size: 13px !important;
+                                                    max-width: 150px; white-space: nowrap;
+                                                    overflow: visible; text-overflow: ellipsis;">
+                                                    <h:outputLabel value="#{bip.inwardChargeType.name}"/>
+                                                </td>
                                             <td style="margin-top: -10px;">
                                                 <h:panelGroup style="font-size: 10px;">
                                                     <h:panelGroup rendered="#{!(bip.inwardChargeType eq 'ProfessionalCharge' and bip.inwardChargeType eq 'RoomCharges' and bip.inwardChargeType eq 'DoctorAndNurses')}">
@@ -501,9 +518,11 @@
                                 <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
                                     <h:panelGroup rendered="#{bip.inwardChargeType eq 'Medicine' and bip.adjustedValue != 0}" style="font-size: 12px;">
                                         <tr style="width: 100%; font-weight: 400; line-height: 18px;">
-                                            <td style="text-align: left; font-size: 13px!important; margin-top: -10px;">
-                                                <h:outputLabel value="#{bip.inwardChargeType.name}" />
-                                            </td>
+                                            <td style="text-align: left; font-size: 13px !important;
+                                                    max-width: 150px; white-space: nowrap;
+                                                    overflow: visible; text-overflow: ellipsis;">
+                                                    <h:outputLabel value="#{bip.inwardChargeType.name}"/>
+                                                </td>
                                             <td style="margin-top: -10px;">
                                             </td>
                                             <td style="width: 30%; text-align: right; font-size: 13px!important;">
@@ -519,9 +538,11 @@
                                 <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
                                     <h:panelGroup rendered="#{configOptionApplicationController.getBooleanValueByKey('Separate Medicines and Surgical Supplies Tab', false) and bip.inwardChargeType eq 'MedicinesAndSurgicalSupplies' and bip.adjustedValue != 0}" style="font-size: 12px;">
                                         <tr style="width: 100%; font-weight: 400; line-height: 18px;">
-                                            <td style="text-align: left; font-size: 13px!important; margin-top: -10px;">
-                                                <h:outputLabel value="#{bip.inwardChargeType.name}" />
-                                            </td>
+                                            <td style="text-align: left; font-size: 13px !important;
+                                                    max-width: 150px; white-space: nowrap;
+                                                    overflow: visible; text-overflow: ellipsis;">
+                                                    <h:outputLabel value="#{bip.inwardChargeType.name}"/>
+                                                </td>
                                             <td style="margin-top: -10px;">
                                             </td>
                                             <td style="width: 30%; text-align: right; font-size: 13px!important;">
@@ -537,9 +558,11 @@
                                 <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
                                     <h:panelGroup rendered="#{bip.inwardChargeType eq 'Laboratory' and bip.adjustedValue != 0}" style="font-size: 12px;">
                                         <tr style="width: 100%; font-weight: 400; line-height: 18px;">
-                                            <td style="text-align: left; font-size: 13px!important; margin-top: -10px;">
-                                                <h:outputLabel value="#{bip.inwardChargeType.name}" />
-                                            </td>
+                                            <td style="text-align: left; font-size: 13px !important;
+                                                    max-width: 150px; white-space: nowrap;
+                                                    overflow: visible; text-overflow: ellipsis;">
+                                                    <h:outputLabel value="#{bip.inwardChargeType.name}"/>
+                                                </td>
                                             <td style="margin-top: -10px;">
                                             </td>
                                             <td style="width: 30%; text-align: right; font-size: 13px!important;">
@@ -556,8 +579,10 @@
                                     <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
                                         <h:panelGroup rendered="#{bip.inwardChargeType eq 'DoctorAndNurses' and bip.adjustedValue != 0}" style="font-size: 12px;">
                                             <tr style="width: 100%; font-weight: 400; line-height: 18px;">
-                                                <td style="text-align: left; font-size: 13px!important; margin-top: -10px;">
-                                                    <h:outputLabel value="#{bip.inwardChargeType.name}" />
+                                                <td style="text-align: left; font-size: 13px !important;
+                                                    max-width: 150px; white-space: nowrap;
+                                                    overflow: visible; text-overflow: ellipsis;">
+                                                    <h:outputLabel value="#{bip.inwardChargeType.name}"/>
                                                 </td>
                                                 <td style="margin-top: -10px;">
                                                     <h:panelGroup style="font-size: 10px;">
@@ -608,8 +633,10 @@
                                     <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
                                         <h:panelGroup rendered="#{bip.inwardChargeType eq 'ProfessionalCharge' and bip.adjustedValue != 0}" style="font-size: 12px;">
                                             <tr style="width: 100%; font-weight: 400; line-height: 18px;">
-                                                <td style="text-align: left; font-size: 13px!important; margin-top: -10px;">
-                                                    <h:outputLabel value="#{bip.inwardChargeType.name}" />
+                                                <td style="text-align: left; font-size: 13px !important;
+                                                    max-width: 150px; white-space: nowrap;
+                                                    overflow: visible; text-overflow: ellipsis;">
+                                                    <h:outputLabel value="#{bip.inwardChargeType.name}"/>
                                                 </td>
                                                 <td style="margin-top: -10px;">
                                                     <h:panelGroup style="font-size: 10px;">
@@ -651,8 +678,10 @@
                                     <ui:repeat value="#{bhtSummeryController.getSummaryOfDoctorChargers(cc.attrs.bill.billItems,cc.attrs.bill.patientEncounter)}" var="bip">
                                         <h:panelGroup rendered="#{(bip.inwardChargeType eq 'ProfessionalCharge' or bip.inwardChargeType eq 'DoctorAndNurses') and bip.adjustedValue != 0}" style="font-size: 12px;">
                                             <tr style="width: 100%; font-weight: 400; line-height: 18px;">
-                                                <td style="text-align: left; font-size: 13px!important; margin-top: -10px;">
-                                                    <h:outputLabel value="#{bip.inwardChargeType.name}" />
+                                                <td style="text-align: left; font-size: 13px !important;
+                                                    max-width: 150px; white-space: nowrap;
+                                                    overflow: visible; text-overflow: ellipsis;">
+                                                    <h:outputLabel value="#{bip.inwardChargeType.name}"/>
                                                 </td>
                                                 <td style="margin-top: -10px;">
                                                     <h:panelGroup style="font-size: 10px;">

--- a/src/main/webapp/resources/inward/bill/finalBillCustom4.xhtml
+++ b/src/main/webapp/resources/inward/bill/finalBillCustom4.xhtml
@@ -44,23 +44,22 @@
 
                         <tr>
                             <td colspan="4">
-                                <h:outputLabel class="mark" style="font-size: 18px;" value="**Hospital Bill**" rendered="#{cc.attrs.hosCopy eq true }"/>
-                                <h:outputLabel class="mark" style="font-size: 18px;" value="**Original Bill**" rendered="#{cc.attrs.duplicate ne true }"/>
-                                <h:outputLabel class="mark" style="font-size: 18px;" value="**Duplicate Bill**" rendered="#{cc.attrs.duplicate eq true}"/>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td colspan="4">
                                 <h:outputLabel style="font-size: 17px;" value="#{configOptionApplicationController.getLongTextValueByKey('Final Bill Title','Tax Invoice')}"/>
                             </td>
                         </tr>
 
+                        <tr>
+                            <td colspan="4">
+                                <h:outputLabel class="mark" style="font-size: 18px;" value="**Hospital Bill**" rendered="#{cc.attrs.hosCopy eq true }"/>
+                                <h:outputLabel class="mark" style="font-size: 18px;" value="**Duplicate Bill**" rendered="#{cc.attrs.duplicate eq true}"/>
+                            </td>
+                        </tr>
                     </table>
 
 
                     <!-- ===== A4 Bill Header (BHT, Name, ...) - auto-wrapping 2-column grid ===== -->
-                    <div style="font-size: 13px; width: 90%; margin-left: 5%; margin-right: 5%" class="mt-4 mb-4">
-                        <div class="row gx-0">
+                    <div style="font-size: 13px; width: 90%; margin-left: 5%; margin-right: 5%; line-height: 1.2;" class="mt-4 mb-4">
+                        <div class="row gx-0 custom4-header-details-row">
 
                             <!-- BHT No -->
                             <div class="col-6 d-flex mb-1">


### PR DESCRIPTION
## Summary

A batch of print-layout fixes for Custom Bill 3 (`finalBillCustom4.xhtml`), used on the Inward Final Bill print/reprint pages:

- Patient Name and Address now wrap onto a second line instead of overflowing when the value is long.
- Address, Phone No, and Guardian show "N/A" instead of a blank value when missing (matching the existing NIC field behavior).
- Reordered the title block ("Final Bill Title" now above the Hospital Bill/Duplicate Bill mark) and removed the unused "Original Bill" mark.
- Long charge-type descriptions (e.g. "Resident Medical Officer Charges") no longer wrap onto a second line in the charges table.
- "Paid By Patient" deposit/payment details (bill no, method, amount, deposit/payment type) now stay aligned and on one line.
- Removed the "Page X of Y" page number from the print view.
- Tightened line spacing throughout the bill so it prints more compactly on the letterhead.
- Removed the "Prepared by" signature line from the footer, leaving Patient/Guardian and Cashier only.
- On the Approve Final Bill page, moved the Approve/Reject action above the read-only bill preview.
- Moved the unapproved-bill heading outside the Custom Bill 3 preview panel on the reprint page.

Closes #23681

## Test plan

- [ ] Print/preview Custom Bill 3 for an inward bill with a long patient name/address and confirm 2-line wrap with no overflow.
- [ ] Confirm Address/Phone No/Guardian show "N/A" when missing.
- [ ] Print a bill with a long charge description (e.g. Resident Medical Officer Charges) and confirm it stays on one line.
- [ ] Print a bill with multiple deposit/payment records and confirm each stays aligned on one line.
- [ ] Confirm no page number appears in the print view.
- [ ] Confirm the footer shows only Patient/Guardian and Cashier signature blocks.
- [ ] Open the Approve Final Bill page and confirm the Approve/Reject action appears above the read-only preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Interface**
  * Clarified that final bill approval is read-only and repositioned approval actions.
  * Improved final bill headers, patient details, guardian information, and signature layout.
  * Empty patient information now displays “N/A.”
  * Charge descriptions use improved truncation and spacing for readability.
  * Paid-by-patient references now display key billing details more clearly.

* **Bug Fixes**
  * Corrected the placement of approval notices and bill content.
  * Improved custom bill preview heading placement and first-page numbering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->