### PR TITLE
fix(inward): correct Checked User name on interim bill fee/payment tabs

### DIFF
--- a/src/main/webapp/inward/inward_bill_intrim.xhtml
+++ b/src/main/webapp/inward/inward_bill_intrim.xhtml
@@ -1471,7 +1471,7 @@
                                         </p:column>
 
                                         <p:column headerText="Checked User">
-                                            <h:outputLabel value="#{pf.bill.checkedBy.creater.webUserPerson.nameWithTitle}"/>
+                                            <h:outputLabel value="#{pf.bill.checkedBy.webUserPerson.nameWithTitle}"/>
                                         </p:column>
                                         <p:column headerText="Checked At">
                                             <h:outputLabel value="#{pf.bill.checkeAt}">
@@ -1578,7 +1578,7 @@
                                         </p:column>
 
                                         <p:column headerText="Checked User">
-                                            <h:outputLabel value="#{pf.bill.checkedBy.creater.webUserPerson.nameWithTitle}"/>
+                                            <h:outputLabel value="#{pf.bill.checkedBy.webUserPerson.nameWithTitle}"/>
                                         </p:column>
 
                                         <p:column headerText="Checked At">
@@ -1676,7 +1676,7 @@
                                         </p:column>
 
                                         <p:column headerText="Checked User">
-                                            <h:outputLabel value="#{p.checkedBy.creater.webUserPerson.nameWithTitle}"/>
+                                            <h:outputLabel value="#{p.checkedBy.webUserPerson.nameWithTitle}"/>
                                         </p:column>
 
                                         <p:column headerText="Checked At">
@@ -1771,7 +1771,7 @@
                                         </p:column>
 
                                         <p:column headerText="Checked User">
-                                            <h:outputLabel value="#{p.checkedBy.creater.webUserPerson.nameWithTitle}"/>
+                                            <h:outputLabel value="#{p.checkedBy.webUserPerson.nameWithTitle}"/>
                                         </p:column>
 
                                         <p:column headerText="Checked At">

--- a/src/main/webapp/inward/inward_bill_intrim_estimate.xhtml
+++ b/src/main/webapp/inward/inward_bill_intrim_estimate.xhtml
@@ -684,7 +684,7 @@
                                         </h:panelGroup>
                                     </p:column>
                                     <p:column headerText="Checked User">
-                                        <h:outputLabel value="#{pf.bill.checkedBy.creater.webUserPerson.name}"/>
+                                        <h:outputLabel value="#{pf.bill.checkedBy.webUserPerson.name}"/>
                                     </p:column>
                                     <p:column headerText="Checked At">
                                         <h:outputLabel value="#{pf.bill.checkeAt}">
@@ -740,7 +740,7 @@
                                         </h:panelGroup>
                                     </p:column>
                                     <p:column headerText="Checked User">
-                                        <h:outputLabel value="#{pf.bill.checkedBy.creater.webUserPerson.name}"/>
+                                        <h:outputLabel value="#{pf.bill.checkedBy.webUserPerson.name}"/>
                                     </p:column>
                                     <p:column headerText="Checked At">
                                         <h:outputLabel value="#{pf.bill.checkeAt}">
@@ -795,7 +795,7 @@
                                         </h:outputLabel>
                                     </p:column>
                                     <p:column headerText="Checked User">
-                                        <h:outputLabel value="#{p.checkedBy.creater.webUserPerson.name}"/>
+                                        <h:outputLabel value="#{p.checkedBy.webUserPerson.name}"/>
                                     </p:column>
                                     <p:column headerText="Checked At">
                                         <h:outputLabel value="#{p.checkeAt}">


### PR DESCRIPTION
## Summary

The **Checked User** column on the Interim Bill's fee/payment tabs was showing the wrong (or blank) name — not the staff member who actually clicked **Mark As Checked**.

## Root Cause

`Bill.checkedBy` is the `WebUser` who clicked **Mark As Checked** (`InwardSearch.markAsChecked()` sets `b.setCheckedBy(getSessionController().getLoggedUser())`).

`WebUser` also has an unrelated field `creater` — the `WebUser` who *registered that user's own login account*, not anything about bill-checking.

`inward_bill_intrim.xhtml`'s "Checked User" column read:
```xhtml
#{pf.bill.checkedBy.creater.webUserPerson.nameWithTitle}
```
— an extra `.creater` hop that displays whoever *created the checking user's account* instead of the checking user's own name. The correct, established pattern used elsewhere on the very same page skips that hop, e.g.:
```xhtml
#{pt.bill.checkedBy.webUserPerson.name}
```

The same one-line defect had been copy-pasted into 4 tabs of `inward_bill_intrim.xhtml` (Professional Fees, Assistant Charges, Deposits & Payments, Post Final Payment) and 3 matching spots in the sibling `inward_bill_intrim_estimate.xhtml`. All 7 are fixed identically.

## Verification

Pure JSF/XHTML change (no Java touched) — per CLAUDE.md this doesn't strictly require compile/test, but I verified end-to-end against local Payara anyway:

- Menu path: **Inward → Search → Professional Bill** → search BHT/57251 → **View Bill** → **Mark As Checked** (as user `buddhika`, department Inward).
- Confirmed in DB: `BILL.CHECKEDBY_ID` on `Inward/INWPRO/389` now points to `buddhika`'s `WEBUSER` row, whose own `CREATER_ID` is `NULL` (so the old buggy expression would have rendered blank there — a clean demonstration of the fix, since this local DB has no professional-fee bill checked by a user whose account was itself created by another admin).
- Menu path: **Inpatient Dashboard → Interim Bill → Professional Fees tab** for BHT/57251 — the **Checked User** column now correctly shows **"Dr. Buddhika"**, matching the DB.

![Professional Fees tab showing the Checked User column populated with the reviewing staff member's name](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23605-professional-fees-checked-user.png)

*The Checked User column shows the actual staff member who clicked Mark As Checked on the fee bill — distinct from the Added User who originally entered the fee.*

## Documentation

Updated [Finance-Inpatient-Interim-Bills](https://github.com/hmislk/hmis/wiki/Finance-Inpatient-Interim-Bills) with a new section explaining the Added User / Checked User / Checked At columns across the four affected tabs.

Fixes #23605

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the “Checked User” labels across billing tables and payment tabs to display the actual person who checked the item.
  - Updated affected Professional Fees, Assistant Charges, Deposits & Payments, and Post Final Payment views for consistent checker information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->