### PR TITLE
fix(reports): show Gross and WHT totals on OPD Professional Payments report

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -14,7 +14,7 @@ waste a session.
 
 ## Contents
 
-121 sections. **The workflow is §0-§8; everything from §9 on is an independent
+122 sections. **The workflow is §0-§8; everything from §9 on is an independent
 gotcha** — jump straight to the one you need rather than reading the file.
 
 **Workflow**
@@ -146,6 +146,7 @@ gotcha** — jump straight to the one you need rather than reading the file.
 - [117. `p:tabView` renders every tab's markup — a text-matched `browser_evaluate` click hits a hidden tab's copy](#117-ptabview-renders-every-tabs-markup--a-text-matched-browser_evaluate-click-hits-a-hidden-tabs-copy)
 - [118. Verifying an `@Asynchronous` dispatch: read the thread name in `server.log`, not the wall clock](#118-verifying-an-asynchronous-dispatch-read-the-thread-name-in-serverlog-not-the-wall-clock)
 - [119. The local dev box has no email or SMS gateway — verify the queued row, not the delivery](#119-the-local-dev-box-has-no-email-or-sms-gateway--verify-the-queued-row-not-the-delivery)
+- [120. Verifying a `p:fileDownload` export: POST the form with `fetch` and decode locally](#120-verifying-a-pfiledownload-export-post-the-form-with-fetch-and-decode-locally)
 - [Quick checklist](#quick-checklist)
 
 ---
@@ -785,6 +786,33 @@ to force `SessionController.fillUserPrivileges()` to re-read it — the privileg
 cached per session at login and won't pick up a new row otherwise. This came up testing
 `BhtSummeryController.settle()` (`InwardSettleFinalBill`), where the local `buddhika`
 user had the privilege for `Store`/`Main Pharmacy` departments but not `Inward`.
+
+**Prefer granting it through the app over an `INSERT`.** *Administration → Manage Users
+→ View Staff Users → filter the user → select the row → Manage Privileges → pick the
+department → **List Privileges** → tick the node → **Update User Privileges*** does the
+same thing through the real screen, and confirms the privilege label a user would look
+for. Two things to watch:
+
+- **The tree pre-loads the user's current selection, so check the count before saving.**
+  Read it back before clicking Update — it should equal the existing active row count
+  plus the one you ticked:
+  ```js
+  Array.from(document.querySelectorAll('.ui-treenode > .ui-treenode-content .ui-chkbox-box'))
+       .filter(b => b.querySelector('.ui-icon-check')).length
+  ```
+- **The save is a full replace, and it can silently retire a privilege the tree didn't
+  represent.** Granting `ReportsProfessionalPayments` for issue #23676 also flipped
+  `LabBillSearch` to `RETIRED = 1` for the same department — with `RETIREDAT` and
+  `RETIRER_ID` left `NULL`, so nothing in the row says who did it. Snapshot the active
+  set before and diff it after:
+  ```sql
+  SELECT PRIVILEGE FROM webuserprivilege
+  WHERE WEBUSER_ID = <id> AND DEPARTMENT_ID = <dept> AND RETIRED = 0 ORDER BY PRIVILEGE;
+  ```
+
+Either way, finish with §17 (logout → login → reselect department): the privilege list is
+cached per session at login, so a freshly granted privilege does **not** appear until you
+log back in — the report button stays absent and it looks like the grant failed.
 
 **Before inserting a row, check whether some *other* department already has it** — picking
 that department on the login screen needs no DB write at all and is the faster route:
@@ -3470,3 +3498,58 @@ deployment with a configured gateway).
 Companion to §41 (an empty `TRIGGERSUBSCRIPTION` table silently produces zero
 notifications): check the subscription rows exist *and* the recipient has an
 address on file before concluding anything from a quiet run.
+
+## 120. Verifying a `p:fileDownload` export: POST the form with `fetch` and decode locally
+
+Clicking a `p:fileDownload` button in Playwright kills the MCP session — the browser
+starts a native download the driver never returns from. So an Excel/PDF export can't be
+verified by clicking it, and "the numbers are right on screen" is not evidence the
+export is right: the on-screen footer and the export read different getters, which is
+exactly how issue #23676 shipped (the screen had no Gross/WHT footer at all while
+`ExcelController` null-guarded `bundle.getGrossTotal()` to `0.0` and `PdfController`
+printed the literal `null`).
+
+Submit the same POST the button would, from inside the page, and hand the bytes back as
+base64. Generate the report first — these exports read the `bundle` already in session:
+
+```js
+async () => {
+  const form = document.getElementById('<formId>');
+  const fd = new FormData(form);
+  fd.append('<buttonId>', '<buttonId>');          // the p:commandButton's own name/value
+  const res = await fetch(form.action, { method: 'POST', body: fd, credentials: 'same-origin' });
+  const bytes = new Uint8Array(await res.arrayBuffer());
+  let bin = ''; for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+  return JSON.stringify({ status: res.status, ct: res.headers.get('content-type'),
+                          cd: res.headers.get('content-disposition'), len: bytes.length,
+                          b64: btoa(bin) });
+}
+```
+
+Pass `filename:` to `browser_evaluate` so the base64 goes to a file instead of the
+transcript, then decode it:
+
+```powershell
+$o = Get-Content <result>.json -Raw | ConvertFrom-Json
+[IO.File]::WriteAllBytes("tmp\export.xlsx", [Convert]::FromBase64String($o.b64))
+```
+
+`Content-Disposition` also proves the filename logic (date range, report name) that no
+screenshot shows.
+
+**Reading the file back:**
+
+- **`.xlsx`** — `Expand-Archive` refuses the extension, so copy to `.zip` first, then
+  read `xl/worksheets/sheet1.xml`. Numeric cells hold raw values, so the totals row is
+  directly assertable without resolving `sharedStrings.xml`:
+  ```powershell
+  Copy-Item export.xlsx export.zip; Expand-Archive export.zip -DestinationPath ex -Force
+  [regex]::Matches((Get-Content ex\xl\worksheets\sheet1.xml -Raw), '<row[^>]*>.*?</row>') |
+    Select-Object -Last 1 | ForEach-Object { $_.Value }
+  ```
+- **`.pdf`** — `Read` needs poppler, which the dev box doesn't have. iText streams are
+  zlib-deflated: walk each `stream`…`endstream`, skip the 2-byte zlib header, run it
+  through `DeflateStream`, and pull the text out of the `(…)` literals. That recovers
+  the whole table including the totals row, which is enough to assert on.
+
+Both are read-only and touch no local state, so they're safe to repeat.

--- a/src/main/java/com/divudi/bean/common/SearchController.java
+++ b/src/main/java/com/divudi/bean/common/SearchController.java
@@ -11756,7 +11756,10 @@ public class SearchController implements Serializable {
             billTypesAtomics.add(BillTypeAtomic.OPD_PROFESSIONAL_PAYMENT_BILL_RETURN);
 
             bundle = createBundleForOpdProfessionalPayments(billTypesAtomics);
-            bundle.calculateTotalByBills();
+            // Populates total (net), grossTotal and tax - the three money columns
+            // this report renders. calculateTotalByBills() sets only total, which
+            // left the Gross and WHT totals blank on screen and in the exports.
+            bundle.calculateTotalNetTotalTaxByBills();
             bundle.setName("OPD Professional Payments Report");
             bundle.setBundleType("opdProfessionalPayments");
         }, ProfessionalPaymentReport.OPD_PROFESSIONAL_PAYMENTS_REPORT, sessionController.getLoggedUser());

--- a/src/main/webapp/reports/professional_payment_reports/professional_payments_opd.xhtml
+++ b/src/main/webapp/reports/professional_payment_reports/professional_payments_opd.xhtml
@@ -337,16 +337,26 @@
                                 <h:outputLabel value="#{row.bill.toStaff.person.name}" />
                             </p:column>
 
-                            <p:column style="text-align: right;" headerText="Gross" width="100" sortBy="#{row.bill.total}" filterBy="#{row.bill.total}" >                              
+                            <p:column style="text-align: right;" headerText="Gross" width="100" sortBy="#{row.bill.total}" filterBy="#{row.bill.total}" >
                                 <h:outputLabel value="#{row.bill.total}" >
                                     <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
                                 </h:outputLabel>
+                                <f:facet name="footer" >
+                                    <h:outputText value="#{searchController.bundle.grossTotal}" >
+                                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                    </h:outputText>
+                                </f:facet>
                             </p:column>
 
-                            <p:column style="text-align: right;" headerText="WHT" width="100" sortBy="#{row.bill.tax}" filterBy="#{row.bill.tax}" >                              
+                            <p:column style="text-align: right;" headerText="WHT" width="100" sortBy="#{row.bill.tax}" filterBy="#{row.bill.tax}" >
                                 <h:outputLabel value="#{row.bill.tax}" >
                                     <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
                                 </h:outputLabel>
+                                <f:facet name="footer" >
+                                    <h:outputText value="#{searchController.bundle.tax}" >
+                                        <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                    </h:outputText>
+                                </f:facet>
                             </p:column>
 
                             <p:column style="text-align: right;" headerText="Value" width="100" sortBy="#{row.bill.netTotal}" filterBy="#{row.bill.netTotal}" >                              

--- a/src/main/webapp/reports/professional_payment_reports/professional_payments_opd_print.xhtml
+++ b/src/main/webapp/reports/professional_payment_reports/professional_payments_opd_print.xhtml
@@ -160,6 +160,11 @@
                                         <h:outputText value="#{row.bill.total}" >
                                             <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
                                         </h:outputText>
+                                        <f:facet name="footer" >
+                                            <h:outputText value="#{searchController.bundle.grossTotal}" >
+                                                <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                            </h:outputText>
+                                        </f:facet>
                                     </p:column>
 
                                     <p:column
@@ -169,6 +174,11 @@
                                         <h:outputText value="#{row.bill.tax}" >
                                             <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
                                         </h:outputText>
+                                        <f:facet name="footer" >
+                                            <h:outputText value="#{searchController.bundle.tax}" >
+                                                <f:convertNumber pattern="#,##0.00" ></f:convertNumber>
+                                            </h:outputText>
+                                        </f:facet>
                                     </p:column>
 
                                     <p:column


### PR DESCRIPTION
## Problem

On **Reports → Professional Payment Reports → Professional Payments**, only the **Value** (net) column had a grand total. **Gross Total** and **WHT Total** were missing entirely.

Root cause, confirmed by reading the code:

1. `SearchController.searchOpdProfessionalPaymentBills()` called `bundle.calculateTotalByBills()`, which sets only `total` (`Σ netTotal`) and leaves `grossTotal` and `tax` **null**.
2. Neither `professional_payments_opd.xhtml` nor its print view had a `<f:facet name="footer">` on the Gross or WHT columns, so nothing was rendered even if the bundle had been populated.

The sibling **WHT Individual Receipts** report — which shares the *identical* Excel/PDF export branch (`case "whtIndividualReceipts": case "opdProfessionalPayments":` in `ExcelController` and `PdfController`) — already calls `calculateTotalNetTotalTaxByBills()`, which populates all three. This report was simply wired to the wrong calculator.

That also broke both exports, which already read the missing getters:
- **Excel** — `ExcelController.addDataToWhtIndividualReceipts()` null-guards `getGrossTotal()`/`getTax()` to `0.0`, so it always exported `0.00`.
- **PDF** — `PdfController.populateTableForWhtIndividualReceipts()` does `String.format("%,.2f", bundle.getGrossTotal())` on a null, printing the literal `null`.

## Change

- `SearchController.searchOpdProfessionalPaymentBills()` → `bundle.calculateTotalNetTotalTaxByBills()`. No new method; this reuses the existing calculator (`ReportTemplateRowBundle:1457`), which is null-safe via `safeDouble` and sets exactly the three values the report renders per row.
- Added footer facets for **Gross** (`bundle.grossTotal`) and **WHT** (`bundle.tax`) to `professional_payments_opd.xhtml` and `professional_payments_opd_print.xhtml`, mirroring the existing Value footer's `#,##0.00` converter.

The one-line controller change is what fixes the Excel and PDF exports — no change was needed in `ExcelController` or `PdfController`.

Deliberately **not** touched: `cashier/my_professional_payments.xhtml` / `searchMyProfessionalPaymentBills()`, a different report that also uses `calculateTotalByBills()`. Out of scope for this issue. No schema change, so no DDL regeneration.

## Verification

Local Payara, local `ruhunu` DB (Ruhunu is the reporting hospital and the only local copy with non-zero WHT on these bills). Reached **through the menus**: *Main menu → Reports & Analytics → Reports → Professional Payment Reports tab → Professional Payments*.

Note for reviewers: the `ReportsProfessionalPayments` privilege did not exist for any user in the local Ruhunu copy, so the button never rendered. It was granted via *Administration → Manage Users → Manage Privileges* (then logout/login, since the privilege list is session-cached) — a test-environment gap, not part of this change.

**22 July 2026** (6 bills, includes a payment/cancellation pair and a return):

| Surface | Gross | WHT | Value |
|---|---|---|---|
| Report screen | -257,105.30 | 2,105.26 | -255,000.04 |
| Print view | -257,105.30 | 2,105.26 | -255,000.04 |
| Excel totals row | -257105.3 | 2105.265 | -255000.035 |
| PDF totals row | -257,105.30 | 2,105.27 | -255,000.04 |
| **DB** `SUM(total)`, `SUM(tax)`, `SUM(netTotal)` | **-257105.30** | **2105.26** | **-255000.04** |

Also checked the whole of **July 2026** (50 bills): screen showed `-984,800.18 / 15,000.01 / -969,800.17`, matching the same query over that range exactly.

The exports were verified by POSTing the form in-page with `fetch` and decoding the response locally (clicking a `p:fileDownload` button kills the Playwright MCP session) — the `.xlsx` worksheet XML and the deflated PDF text stream were both read back and asserted on, rather than inferred from the screen.

Cashier and consultant names are blurred in both screenshots below.

![OPD Professional Payments report showing the Gross, WHT and Value column totals](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/opd_professional_payments_results_table.png)

*Results table for 22 July 2026 — the totals row now carries Gross and WHT alongside Value.*

![Print view of the OPD Professional Payments report with the filter header and the column totals](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/opd_professional_payments_print_view.png)

*Print view — the same three totals beneath the table.*

## Documentation

No wiki page existed for this report screen, and the change is user-visible, so one was created:

- **[Finance — OPD Professional Payments Report](https://github.com/hmislk/hmis/wiki/Finance-OPD-Professional-Payments-Report)** (new) — navigation path, filters, column meanings, the totals row, and the print/Excel/PDF outputs.
- Linked from [Finance — Doctor Payment Overview](https://github.com/hmislk/hmis/wiki/Finance-Doctor-Payment-Overview) and the [Wiki Article Index](https://github.com/hmislk/hmis/wiki/Wiki-Article-Index).

Two testing gotchas found along the way were added to `developer_docs/testing/playwright-e2e-workflow.md`: §120 on verifying a `p:fileDownload` export without killing the MCP session, and a note in §20 that the Manage Privileges bulk save is a full replace which can silently retire a privilege the tree didn't represent.

Closes #23676

🤖 Generated with [Claude Code](https://claude.com/claude-code)
