### PR TITLE
fix(inward): raw-text print response handling + spooler-based print agent

### DIFF
--- a/developer_docs/printing/RawPrinterHelper.ps1
+++ b/developer_docs/printing/RawPrinterHelper.ps1
@@ -48,9 +48,21 @@ public class RawPrinterHelper {
                     Marshal.Copy(bytes, 0, pUnmanagedBytes, bytes.Length);
                     bSuccess = WritePrinter(hPrinter, pUnmanagedBytes, bytes.Length, out dwWritten);
                     Marshal.FreeCoTaskMem(pUnmanagedBytes);
-                    EndPagePrinter(hPrinter);
+                    if (!bSuccess) {
+                        error = "WritePrinter failed: " + Marshal.GetLastWin32Error();
+                    } else if (dwWritten != bytes.Length) {
+                        bSuccess = false;
+                        error = "WritePrinter wrote " + dwWritten + " of " + bytes.Length + " bytes";
+                    }
+                    if (!EndPagePrinter(hPrinter) && bSuccess) {
+                        bSuccess = false;
+                        error = "EndPagePrinter failed: " + Marshal.GetLastWin32Error();
+                    }
                 } else { error = "StartPagePrinter failed: " + Marshal.GetLastWin32Error(); }
-                EndDocPrinter(hPrinter);
+                if (!EndDocPrinter(hPrinter) && bSuccess) {
+                    bSuccess = false;
+                    error = "EndDocPrinter failed: " + Marshal.GetLastWin32Error();
+                }
             } else { error = "StartDocPrinter failed: " + Marshal.GetLastWin32Error(); }
             ClosePrinter(hPrinter);
         } else { error = "OpenPrinter failed: " + Marshal.GetLastWin32Error(); }

--- a/developer_docs/printing/RawPrinterHelper.ps1
+++ b/developer_docs/printing/RawPrinterHelper.ps1
@@ -1,0 +1,64 @@
+<#
+  RawPrinterHelper.ps1
+  Sends raw bytes to an already-installed Windows printer object via the
+  Print Spooler API (OpenPrinter/StartDocPrinter/WritePrinter), bypassing GDI
+  rendering. Used instead of raw SMB "copy /b \host\share" because the
+  cashier PC's account has no direct file-share permission on the print
+  share, but printing through the locally installed printer connection
+  (Settings > Printers & scanners) works via the spooler's own session.
+#>
+
+$RawPrinterHelperSource = @"
+using System;
+using System.Runtime.InteropServices;
+public class RawPrinterHelper {
+    [StructLayout(LayoutKind.Sequential, CharSet=CharSet.Ansi)]
+    public class DOCINFOA {
+        [MarshalAs(UnmanagedType.LPStr)] public string pDocName;
+        [MarshalAs(UnmanagedType.LPStr)] public string pOutputFile;
+        [MarshalAs(UnmanagedType.LPStr)] public string pDataType;
+    }
+    [DllImport("winspool.Drv", EntryPoint="OpenPrinterA", SetLastError=true, CharSet=CharSet.Ansi, ExactSpelling=true)]
+    public static extern bool OpenPrinter(string szPrinter, out IntPtr hPrinter, IntPtr pd);
+    [DllImport("winspool.Drv", EntryPoint="ClosePrinter", SetLastError=true, ExactSpelling=true)]
+    public static extern bool ClosePrinter(IntPtr hPrinter);
+    [DllImport("winspool.Drv", EntryPoint="StartDocPrinterA", SetLastError=true, CharSet=CharSet.Ansi, ExactSpelling=true)]
+    public static extern bool StartDocPrinter(IntPtr hPrinter, Int32 level, DOCINFOA di);
+    [DllImport("winspool.Drv", EntryPoint="EndDocPrinter", SetLastError=true, ExactSpelling=true)]
+    public static extern bool EndDocPrinter(IntPtr hPrinter);
+    [DllImport("winspool.Drv", EntryPoint="StartPagePrinter", SetLastError=true, ExactSpelling=true)]
+    public static extern bool StartPagePrinter(IntPtr hPrinter);
+    [DllImport("winspool.Drv", EntryPoint="EndPagePrinter", SetLastError=true, ExactSpelling=true)]
+    public static extern bool EndPagePrinter(IntPtr hPrinter);
+    [DllImport("winspool.Drv", EntryPoint="WritePrinter", SetLastError=true, ExactSpelling=true)]
+    public static extern bool WritePrinter(IntPtr hPrinter, IntPtr pBytes, Int32 dwCount, out Int32 dwWritten);
+
+    public static bool SendBytesToPrinter(string szPrinterName, byte[] bytes, out string error) {
+        IntPtr hPrinter;
+        DOCINFOA di = new DOCINFOA();
+        Int32 dwWritten = 0;
+        bool bSuccess = false;
+        error = "";
+        di.pDocName = "HMIS Raw Print Job";
+        di.pDataType = "RAW";
+        if (OpenPrinter(szPrinterName, out hPrinter, IntPtr.Zero)) {
+            if (StartDocPrinter(hPrinter, 1, di)) {
+                if (StartPagePrinter(hPrinter)) {
+                    IntPtr pUnmanagedBytes = Marshal.AllocCoTaskMem(bytes.Length);
+                    Marshal.Copy(bytes, 0, pUnmanagedBytes, bytes.Length);
+                    bSuccess = WritePrinter(hPrinter, pUnmanagedBytes, bytes.Length, out dwWritten);
+                    Marshal.FreeCoTaskMem(pUnmanagedBytes);
+                    EndPagePrinter(hPrinter);
+                } else { error = "StartPagePrinter failed: " + Marshal.GetLastWin32Error(); }
+                EndDocPrinter(hPrinter);
+            } else { error = "StartDocPrinter failed: " + Marshal.GetLastWin32Error(); }
+            ClosePrinter(hPrinter);
+        } else { error = "OpenPrinter failed: " + Marshal.GetLastWin32Error(); }
+        return bSuccess;
+    }
+}
+"@
+
+if (-not ("RawPrinterHelper" -as [type])) {
+    Add-Type -TypeDefinition $RawPrinterHelperSource -Language CSharp
+}

--- a/developer_docs/printing/print-agent-config.example.json
+++ b/developer_docs/printing/print-agent-config.example.json
@@ -1,0 +1,6 @@
+{
+  "WatchFolder": "C:\\hmis-print",
+  "PrinterPath": "\\\\localhost\\LQ310",
+  "FileGlob": "inward-*.prn",
+  "PollSeconds": 2
+}

--- a/developer_docs/printing/raw-text-print-agent.ps1
+++ b/developer_docs/printing/raw-text-print-agent.ps1
@@ -33,10 +33,28 @@ $PollSeconds = 2                      # how often to check the folder
 if (Test-Path $ConfigPath) {
     try {
         $cfg = Get-Content -LiteralPath $ConfigPath -Raw | ConvertFrom-Json
-        if ($cfg.WatchFolder) { $WatchFolder = $cfg.WatchFolder }
-        if ($cfg.PrinterPath) { $PrinterPath = $cfg.PrinterPath }
-        if ($cfg.FileGlob)    { $FileGlob    = $cfg.FileGlob }
-        if ($cfg.PollSeconds) { $PollSeconds = [int]$cfg.PollSeconds }
+
+        # Validate into temp variables first so a bad value can't leave the
+        # config partially applied (some fields overridden, others still
+        # defaults) while the warning below claims "using built-in defaults".
+        $newWatchFolder = $WatchFolder
+        $newPrinterPath = $PrinterPath
+        $newFileGlob    = $FileGlob
+        $newPollSeconds = $PollSeconds
+        if ($cfg.WatchFolder) { $newWatchFolder = $cfg.WatchFolder }
+        if ($cfg.PrinterPath) { $newPrinterPath = $cfg.PrinterPath }
+        if ($cfg.FileGlob)    { $newFileGlob    = $cfg.FileGlob }
+        if ($cfg.PollSeconds) {
+            $newPollSeconds = [int]$cfg.PollSeconds
+            if ($newPollSeconds -lt 1) {
+                throw "PollSeconds must be at least 1, got $($cfg.PollSeconds)"
+            }
+        }
+
+        $WatchFolder = $newWatchFolder
+        $PrinterPath = $newPrinterPath
+        $FileGlob    = $newFileGlob
+        $PollSeconds = $newPollSeconds
     } catch {
         Write-Warning ("Could not parse {0}, using built-in defaults: {1}" -f $ConfigPath, $_.Exception.Message)
     }
@@ -51,6 +69,7 @@ function Write-Log($msg) {
 }
 
 function Send-Raw($file) {
+    $printed = $false
     for ($i = 0; $i -lt 5; $i++) {
         try {
             $bytes = [System.IO.File]::ReadAllBytes($file)
@@ -59,14 +78,34 @@ function Send-Raw($file) {
             if (-not $ok) {
                 throw "spooler write failed: $err"
             }
-            Remove-Item -LiteralPath $file -Force
-            Write-Log ("printed and removed {0}" -f (Split-Path $file -Leaf))
-            return
+            $printed = $true
+            break
         } catch {
             Start-Sleep -Milliseconds 400
         }
     }
-    Write-Log ("WARNING: could not print {0} after retries, left in place for manual retry" -f (Split-Path $file -Leaf))
+    if (-not $printed) {
+        Write-Log ("WARNING: could not print {0} after retries, left in place for manual retry" -f (Split-Path $file -Leaf))
+        return
+    }
+
+    # Printing already succeeded above — from here on, never let a cleanup
+    # failure fall back into a retry (that would resubmit an already-printed
+    # receipt). Remove-Item's non-terminating errors are made catchable with
+    # -ErrorAction Stop so a locked/permission-denied delete is handled here
+    # instead of silently leaving the file for the next poll to reprint.
+    try {
+        Remove-Item -LiteralPath $file -Force -ErrorAction Stop
+        Write-Log ("printed and removed {0}" -f (Split-Path $file -Leaf))
+    } catch {
+        $renamedLeaf = (Split-Path $file -Leaf) + ".printed"
+        try {
+            Rename-Item -LiteralPath $file -NewName $renamedLeaf -Force -ErrorAction Stop
+            Write-Log ("WARNING: printed {0} but could not delete it ({1}); renamed to {2} for manual cleanup" -f (Split-Path $file -Leaf), $_.Exception.Message, $renamedLeaf)
+        } catch {
+            Write-Log ("WARNING: printed {0} but could neither delete nor rename it ({1}); it WILL be resubmitted next poll" -f (Split-Path $file -Leaf), $_.Exception.Message)
+        }
+    }
 }
 
 Write-Log ("watching {0} for {1} -> {2} (polling every {3}s)" -f $WatchFolder, $FileGlob, $PrinterPath, $PollSeconds)

--- a/developer_docs/printing/raw-text-print-agent.ps1
+++ b/developer_docs/printing/raw-text-print-agent.ps1
@@ -1,51 +1,76 @@
 <#
   raw-text-print-agent.ps1
-  Watches a folder for inward-*.prn files and raw-copies each to a dot-matrix
-  printer (bypassing the Windows print driver / rasteriser), then deletes it.
+  Watches a folder for .prn files and raw-copies each to a dot-matrix printer
+  (bypassing the Windows print driver / rasteriser), then deletes it.
+  Settings come from print-agent-config.json (same folder as this script) so
+  the printer path/target folder can be changed without editing this file.
+  See print-agent-config.example.json and the wiki page
+  "Dot-Matrix-Printing-for-Inward-Deposit-and-Payment-Receipts" for setup.
 
-  Setup on the cashier PC:
-    1. Share the Epson LQ-310, e.g. share name "LQ310", OR note its LPT port.
-    2. Edit the three settings below.
-    3. Set Chrome: Settings > Downloads > Location = the watch folder, and turn
-       OFF "Ask where to save each file".
-    4. Task Scheduler > Create Task > Trigger "At log on" > Action:
-         powershell.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden `
-           -File "C:\hmis-print\raw-text-print-agent.ps1"
+  Runs with no admin rights required: launch it from the per-user Startup
+  folder (a small .vbs that runs this hidden), not Task Scheduler, if
+  Task Scheduler requires elevation you don't have.
 #>
 
-# ---- settings -------------------------------------------------------------
-$WatchFolder = "C:\hmis-print"          # where the browser saves .prn files
-$PrinterPath = "\\localhost\LQ310"      # printer share  (or "\\.\LPT1")
-$FileGlob    = "inward-*.prn"           # only touch our receipts
-$PollSeconds = 2                        # how often to check the folder
+$ScriptDir  = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ConfigPath = Join-Path $ScriptDir "print-agent-config.json"
+$LogPath    = Join-Path $ScriptDir "agent.log"
+
+# Sends raw bytes via the Print Spooler API (winspool.drv), using whatever
+# printer connection is already installed in Windows (Settings > Printers &
+# scanners). Use this instead of raw SMB "copy /b file \host\share" when the
+# client account has file-share permission denied on the print server but can
+# still print through the locally installed printer connection object.
+. (Join-Path $ScriptDir "RawPrinterHelper.ps1")
+
+# ---- defaults, overridden by config file if present ------------------------
+$WatchFolder = "C:\hmis-print"        # where the browser saves .prn files
+$PrinterPath = "\\localhost\LQ310"    # installed printer name, or "\\.\LPT1"
+$FileGlob    = "inward-*.prn"         # only touch our receipts
+$PollSeconds = 2                      # how often to check the folder
 # ------------------------------------------------------------------------------
 
+if (Test-Path $ConfigPath) {
+    try {
+        $cfg = Get-Content -LiteralPath $ConfigPath -Raw | ConvertFrom-Json
+        if ($cfg.WatchFolder) { $WatchFolder = $cfg.WatchFolder }
+        if ($cfg.PrinterPath) { $PrinterPath = $cfg.PrinterPath }
+        if ($cfg.FileGlob)    { $FileGlob    = $cfg.FileGlob }
+        if ($cfg.PollSeconds) { $PollSeconds = [int]$cfg.PollSeconds }
+    } catch {
+        Write-Warning ("Could not parse {0}, using built-in defaults: {1}" -f $ConfigPath, $_.Exception.Message)
+    }
+}
+
 if (-not (Test-Path $WatchFolder)) { New-Item -ItemType Directory -Path $WatchFolder | Out-Null }
+
+function Write-Log($msg) {
+    $line = "{0}  {1}" -f (Get-Date -Format "yyyy-MM-dd HH:mm:ss"), $msg
+    Write-Host $line
+    Add-Content -LiteralPath $LogPath -Value $line
+}
 
 function Send-Raw($file) {
     for ($i = 0; $i -lt 5; $i++) {
         try {
-            # /b = binary copy, no EOF translation, no driver involvement
-            cmd /c copy /b "`"$file`"" "$PrinterPath" | Out-Null
-            if ($LASTEXITCODE -ne 0) {
-                throw "copy /b exited with code $LASTEXITCODE"
+            $bytes = [System.IO.File]::ReadAllBytes($file)
+            $err = ""
+            $ok = [RawPrinterHelper]::SendBytesToPrinter($PrinterPath, $bytes, [ref]$err)
+            if (-not $ok) {
+                throw "spooler write failed: $err"
             }
             Remove-Item -LiteralPath $file -Force
-            Write-Host ("{0}  printed {1}" -f (Get-Date), (Split-Path $file -Leaf))
+            Write-Log ("printed and removed {0}" -f (Split-Path $file -Leaf))
             return
         } catch {
-            Start-Sleep -Milliseconds 400   # file may still be locked by the browser
+            Start-Sleep -Milliseconds 400
         }
     }
-    Write-Warning ("Could not print {0} after retries" -f $file)
+    Write-Log ("WARNING: could not print {0} after retries, left in place for manual retry" -f (Split-Path $file -Leaf))
 }
 
-Write-Host ("{0}  watching {1} for {2} -> {3} (polling every {4}s)" -f (Get-Date), $WatchFolder, $FileGlob, $PrinterPath, $PollSeconds)
+Write-Log ("watching {0} for {1} -> {2} (polling every {3}s)" -f $WatchFolder, $FileGlob, $PrinterPath, $PollSeconds)
 
-# Simple poll loop instead of FileSystemWatcher: Register-ObjectEvent's -Action
-# scriptblock runs in a separate event-job runspace that does not inherit this
-# script's functions or variables, so Send-Raw/$PrinterPath would be undefined
-# there. A poll loop is simpler and reliable for a low-volume receipt printer.
 while ($true) {
     Get-ChildItem -Path $WatchFolder -Filter $FileGlob -File -ErrorAction SilentlyContinue |
         ForEach-Object { Send-Raw $_.FullName }

--- a/src/main/java/com/divudi/bean/inward/InwardDepositController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardDepositController.java
@@ -1143,6 +1143,7 @@ public class InwardDepositController implements Serializable, ControllerWithMult
             os.flush();
         } catch (java.io.IOException e) {
             JsfUtil.addErrorMessage("Could not generate the raw text receipt: " + e.getMessage());
+            context.responseComplete();
             return;
         }
         context.responseComplete();

--- a/src/main/java/com/divudi/bean/inward/InwardPaymentController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardPaymentController.java
@@ -1137,6 +1137,7 @@ public class InwardPaymentController implements Serializable, ControllerWithMult
             os.flush();
         } catch (java.io.IOException e) {
             JsfUtil.addErrorMessage("Could not generate the raw text receipt: " + e.getMessage());
+            context.responseComplete();
             return;
         }
         context.responseComplete();

--- a/src/main/java/com/divudi/bean/inward/InwardSearch.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSearch.java
@@ -3459,6 +3459,7 @@ public class InwardSearch implements Serializable {
             os.flush();
         } catch (java.io.IOException e) {
             JsfUtil.addErrorMessage("Could not generate the raw text receipt: " + e.getMessage());
+            context.responseComplete();
             return;
         }
         context.responseComplete();


### PR DESCRIPTION
## What

Fix: the raw-text print methods (InwardDepositController.streamCurrentDepositReceiptAsRawText, InwardPaymentController.streamCurrentPaymentReceiptAsRawText, InwardSearch.streamReprintReceiptAsRawText, added in #23660) never called context.responseComplete() on the IOException catch path. Per this repo's own documented pattern (developer_docs/feature/excel-export-html-table.md), skipping that call lets JSF try to render the normal HTML view on top of an already-committed/partial binary response, corrupting it. All three now call responseComplete() before returning on failure, matching the success path.

Rewrite: developer_docs/printing/raw-text-print-agent.ps1 now reads its settings (watch folder, printer target, file pattern, poll interval) from a sibling print-agent-config.json instead of hardcoded values, and logs activity to agent.log.

Fix: the agent now sends bytes through the Windows Print Spooler API (OpenPrinter/StartDocPrinter/WritePrinter, new RawPrinterHelper.ps1) against the already-installed printer connection object, instead of a raw SMB copy /b file to a network share. In real-world testing the cashier account had no direct file-share permission on the print server (copy /b failed with "Access is denied") even though the same account could print through the printer connection already set up in Windows Settings.

Docs: added print-agent-config.example.json as a template.

## Why

Coop's cashier PC hit both issues live: a failed raw-text print left the browser page half-corrupted (missing responseComplete()), and once that was fixed, the documented watched-folder agent's copy /b to the shared printer queue failed with Access Denied due to the account's network permissions. Switching to the Print Spooler API against the locally installed printer connection resolved it without needing any change to network share permissions.

## Testing

Manually reproduced the stuck files on the cashier PC, confirmed the old copy /b path failed with "Access is denied", switched the agent to the spooler-API approach, and confirmed both previously-stuck .prn files printed immediately and correctly on the physical Epson LQ-310 after the fix. The responseComplete() fix mirrors the existing successful-path call and the pattern documented for other binary-streaming endpoints in this repo; no behavior change on the success path.

## Follow-up (not in this PR)

The wiki's Track B setup (Dot-Matrix-Printing-for-Inward-Deposit-and-Payment-Receipts) currently documents a Task Scheduler entry for autostart. On PCs where Task Scheduler requires elevation the cashier doesn't have, a per-user Startup-folder launcher (a small hidden .vbs) works instead and needs no admin rights, worth adding as an alternative in the wiki.

---

Generated with Claude Code (https://claude.com/claude-code)

https://claude.ai/code/session_01WVhAns94TgyEJsLfw7h6Vt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Windows print agent that sends raw print files directly to installed printers.
  * Added optional configuration for the watch folder, printer, filename pattern, and polling interval.
  * Added an example configuration file and centralized logging.

* **Bug Fixes**
  * Improved detection of incomplete or failed print jobs.
  * Improved handling of receipt-printing failures by properly completing responses.
  * Failed print files remain available for manual retry, with clearer warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->