### PR TITLE
fix(inward): make final bill header image size/style configurable

### DIFF
--- a/src/main/webapp/resources/inward/bill/finalBill.xhtml
+++ b/src/main/webapp/resources/inward/bill/finalBill.xhtml
@@ -55,9 +55,9 @@
                     <table class="headingPrinting" >
                         <h:panelGroup rendered="#{not empty configOptionApplicationController.getLongTextValueByKey('Inaptient Final Bill Header Image URL')}" >
                             <tr >
-                                <td colspan="4">
+                                <td colspan="4" style="text-align: center;">
                                     <h:graphicImage
-                                        style="width: 100%;"
+                                        style="#{configOptionApplicationController.getLongTextValueByKey('Inward Final Bill Header Image Style','width: 200px; height: auto;')}"
                                         class="mb-4"
                                         url="#{configOptionApplicationController.getLongTextValueByKey('Inaptient Final Bill Header Image URL')}"
                                         >

--- a/src/main/webapp/resources/inward/bill/finalBillBundledCustom1.xhtml
+++ b/src/main/webapp/resources/inward/bill/finalBillBundledCustom1.xhtml
@@ -71,9 +71,9 @@
                     <table class="headingPrinting" >
                         <h:panelGroup rendered="#{not empty configOptionApplicationController.getLongTextValueByKey('Inaptient Final Bill Header Image URL')}" >
                             <tr >
-                                <td colspan="4">
+                                <td colspan="4" style="text-align: center;">
                                     <h:graphicImage
-                                        style="width: 100%;"
+                                        style="#{configOptionApplicationController.getLongTextValueByKey('Inward Final Bill Header Image Style','width: 200px; height: auto;')}"
                                         class="mb-4"
                                         url="#{configOptionApplicationController.getLongTextValueByKey('Inaptient Final Bill Header Image URL')}"
                                         >

--- a/src/main/webapp/resources/inward/bill/finalBillCustom2.xhtml
+++ b/src/main/webapp/resources/inward/bill/finalBillCustom2.xhtml
@@ -49,9 +49,9 @@
                 </h:panelGroup>
 
                 <h:panelGroup rendered="#{not empty configOptionApplicationController.getLongTextValueByKey('Inaptient Final Bill Header Image URL')}" >
-                    <div class="mb-2">
+                    <div class="mb-2" style="text-align: center;">
                         <h:graphicImage
-                            style="width: 100%;"
+                            style="#{configOptionApplicationController.getLongTextValueByKey('Inward Final Bill Header Image Style','width: 200px; height: auto;')}"
                             class="mb-4"
                             url="#{configOptionApplicationController.getLongTextValueByKey('Inaptient Final Bill Header Image URL')}"
                             >

--- a/src/main/webapp/resources/inward/bill/finalBillGreenSheet.xhtml
+++ b/src/main/webapp/resources/inward/bill/finalBillGreenSheet.xhtml
@@ -54,9 +54,9 @@
                     <table class="headingPrinting" >
                         <h:panelGroup rendered="#{not empty configOptionApplicationController.getLongTextValueByKey('Inaptient Final Bill Header Image URL')}" >
                             <tr >
-                                <td colspan="4">
+                                <td colspan="4" style="text-align: center;">
                                     <h:graphicImage
-                                        style="width: 100%;"
+                                        style="#{configOptionApplicationController.getLongTextValueByKey('Inward Final Bill Header Image Style','width: 200px; height: auto;')}"
                                         class="mb-4"
                                         url="#{configOptionApplicationController.getLongTextValueByKey('Inaptient Final Bill Header Image URL')}"
                                         >

--- a/src/main/webapp/resources/inward/bill/finalBill_vat.xhtml
+++ b/src/main/webapp/resources/inward/bill/finalBill_vat.xhtml
@@ -88,9 +88,9 @@
 
                 <h:panelGroup rendered="#{not empty configOptionApplicationController.getLongTextValueByKey('Inaptient Final Bill Header Image URL')}" >
                     <div class="row">
-                        <div class="col-12">
+                        <div class="col-12" style="text-align: center;">
                             <h:graphicImage
-                                style="width: 100%;"
+                                style="#{configOptionApplicationController.getLongTextValueByKey('Inward Final Bill Header Image Style','width: 200px; height: auto;')}"
                                 class="mb-4"
                                 url="#{configOptionApplicationController.getLongTextValueByKey('Inaptient Final Bill Header Image URL')}"
                                 >

--- a/src/main/webapp/resources/inward/bill/finalProfessionalBill.xhtml
+++ b/src/main/webapp/resources/inward/bill/finalProfessionalBill.xhtml
@@ -52,9 +52,9 @@
                     <table class="headingPrinting" >
                         <h:panelGroup rendered="#{not empty configOptionApplicationController.getLongTextValueByKey('Inaptient Final Bill Header Image URL')}" >
                             <tr >
-                                <td colspan="4">
+                                <td colspan="4" style="text-align: center;">
                                     <h:graphicImage
-                                        style="width: 100%;"
+                                        style="#{configOptionApplicationController.getLongTextValueByKey('Inward Final Bill Header Image Style','width: 200px; height: auto;')}"
                                         class="mb-4"
                                         url="#{configOptionApplicationController.getLongTextValueByKey('Inaptient Final Bill Header Image URL')}"
                                         >


### PR DESCRIPTION
## Summary

Follow-up to #23685 (issue #23600). After deploying the header/logo feature to `rh-local-staging` with Ruhunu Hospital's real logo, the logo rendered at `width: 100%` — dominating the whole page for a real (non-square, higher-resolution) hospital logo.

- Replaced the hardcoded `style="width: 100%;"` with a single configurable style string driven by a new `ConfigOption`: **`Inward Final Bill Header Image Style`** (default `width: 200px; height: auto;`).
- An admin can now change size, aspect ratio, or add borders/margins entirely via **Administration → Manage Institutions → Application Options**, with no code change or redeploy ever needed for this again.
- Centered the image in its container (`text-align: center` on the wrapping cell/div).
- Applied consistently across all six Final Bill formats that support the header/logo: standard Final Bill, Bundled Custom 1, Custom Bill 2, Green Sheet, VAT, Professional Bill. Custom Bill 3/4 are unchanged (they intentionally have no digital header — pre-printed letterhead).

## Verification (local Payara, Galle Co-Operative Hospital test data, BHT/57601)

- Confirmed the new key auto-vivifies in the `CONFIGOPTION` table with the documented default (`width: 200px; height: auto;`) the first time a final bill is viewed.
- Confirmed the default renders correctly (200px, no layout errors) via the app's own Application Options screen and Final Bill Search → reprint.
- Confirmed the value is live-configurable with **no redeploy**: edited the key to `width: 100px; height: auto; border: 2px solid red;` via the UI and the reprinted bill picked it up immediately (100px width, red border).
- Reverted both test config values back to their defaults afterward.

This was also spot-checked on `rh-local-staging` (Ruhunu Hospital's own local server) via the app's REST API (`Config`-scoped key) before this fix — that's what surfaced the sizing issue in the first place. The fix itself was verified locally; deploying to `rh-local-staging` is left to the user's own CI/CD trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Centered header images across inward final and professional bills.
  * Added configurable header image styling through the **Inward Final Bill Header Image Style** setting.
  * Applied a default image size of 200px wide with automatic height when no custom style is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->