### PR TITLE
fix(inward): keep final bill row names and merge same-named rows when bundling

### DIFF
--- a/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
+++ b/src/main/java/com/divudi/bean/common/ConfigOptionApplicationController.java
@@ -1506,6 +1506,19 @@ public class ConfigOptionApplicationController implements Serializable {
         return option.getOptionValue();
     }
 
+    /**
+     * Read-only variant of {@link #getLongTextValueByKey(String, String)} —
+     * returns {@code defaultValue} without persisting a new ConfigOption row
+     * when the key does not yet exist.
+     */
+    public String getLongTextValueByKeyReadOnly(String key, String defaultValue) {
+        ConfigOption option = getApplicationOption(key);
+        if (option == null || option.getValueType() != OptionValueType.LONG_TEXT) {
+            return defaultValue;
+        }
+        return option.getOptionValue();
+    }
+
     public String getInwardChargeTypeLabel(InwardChargeType type) {
         String key = "Inward Charge Type Label - " + type.name();
         String custom = getShortTextValueByKey(key, "");
@@ -1513,6 +1526,51 @@ public class ConfigOptionApplicationController implements Serializable {
             return type.getLabel();
         }
         return custom;
+    }
+
+    /**
+     * Display name for an inward charge type <b>on the Final Bill print only</b>.
+     * <p>
+     * Two naming mechanisms exist side by side:
+     * <ul>
+     * <li>legacy — {@code "Inward Charge Type - Name For <default label>"},
+     * loaded onto the enum's mutable {@code name} field at login by
+     * {@code SessionController#init()}. This is what the Final Bill has always
+     * printed, via {@code #{bip.inwardChargeType.name}}.</li>
+     * <li>current — {@code "Inward Charge Type Label - <EnumName>"}, read by
+     * {@link #getInwardChargeTypeLabel(InwardChargeType)} and used by the
+     * interim bill, the charge-type breakdown/detail reports, the invoice
+     * journal and the config API.</li>
+     * </ul>
+     * The bundled Final Bill row builder resolved labels through the current
+     * key, so switching on "Inward Final Bill - Bundle Grouped Charge Types"
+     * silently renamed rows: COOP has 22 legacy names ("Resident Medical
+     * Officer Charges", "Radiology &amp; Imaging", "Theatre Surgical
+     * Consumables &amp; Drugs" …) and would have lost all of them just by
+     * enabling bundling.
+     * <p>
+     * Legacy therefore wins here, so enabling bundling changes only how rows
+     * are <em>grouped</em>, never what they are <em>called</em>. This resolver
+     * is deliberately separate from
+     * {@link #getInwardChargeTypeLabel(InwardChargeType)} so nothing outside
+     * the Final Bill changes.
+     * <p>
+     * The legacy read is read-only: {@code SessionController#init()} already
+     * creates all of those rows at login, so this never needs to create one —
+     * and must not create a full set from a session-less context.
+     */
+    public String getInwardChargeTypeFinalBillLabel(InwardChargeType type) {
+        String legacy = getLongTextValueByKeyReadOnly(
+                "Inward Charge Type - Name For " + type.getLabel(), "");
+        if (legacy != null && !legacy.trim().isEmpty()) {
+            return legacy;
+        }
+        String custom = getShortTextValueByKeyReadOnly(
+                "Inward Charge Type Label - " + type.name(), "");
+        if (custom != null && !custom.trim().isEmpty()) {
+            return custom;
+        }
+        return type.getLabel();
     }
 
     public void saveInwardChargeTypeLabel(InwardChargeType type, String customLabel) {

--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -4592,10 +4592,30 @@ public class BhtSummeryController implements Serializable {
             }
         }
 
-        List<FinalBillPrintRowDTO> rows = new ArrayList<>(individualRows);
+        // Merge on the FINAL printed label, not on the group key alone: an
+        // ungrouped charge type whose own label already reads the same as a
+        // group ("Room Charges" the charge type vs "Room Charges" the group)
+        // would otherwise print as a second, visually identical line that no
+        // one reading the bill can tell apart — which is exactly what COOP hit
+        // after grouping two of three room-related charge types and leaving
+        // RoomCharges itself ungrouped. Two rows carrying the same label are
+        // indistinguishable on paper, so they are always one row.
+        Map<String, Double> amountByLabel = new LinkedHashMap<>();
+        Map<String, Integer> orderByLabel = new LinkedHashMap<>();
+        for (FinalBillPrintRowDTO row : individualRows) {
+            amountByLabel.merge(row.getLabel(), row.getAmount(), Double::sum);
+            orderByLabel.merge(row.getLabel(), row.getOrder(), Math::min);
+        }
         for (Map.Entry<String, Double> entry : groupedTotals.entrySet()) {
             String group = entry.getKey();
-            rows.add(new FinalBillPrintRowDTO(group, entry.getValue(), groupedOrder.get(group)));
+            amountByLabel.merge(group, entry.getValue(), Double::sum);
+            orderByLabel.merge(group, groupedOrder.get(group), Math::min);
+        }
+
+        List<FinalBillPrintRowDTO> rows = new ArrayList<>();
+        for (Map.Entry<String, Double> entry : amountByLabel.entrySet()) {
+            rows.add(new FinalBillPrintRowDTO(entry.getKey(), entry.getValue(),
+                    orderByLabel.get(entry.getKey())));
         }
 
         rows.removeIf(row -> Math.abs(row.getAmount()) < 0.005);
@@ -4641,7 +4661,11 @@ public class BhtSummeryController implements Serializable {
             }
             groupByType.put(type, configOptionApplicationController.getInwardChargeTypeFinalBillGroup(type));
             orderByType.put(type, configOptionApplicationController.getInwardChargeTypeFinalBillOrder(type));
-            labelByType.put(type, configOptionApplicationController.getInwardChargeTypeLabel(type));
+            // Final-bill-specific resolver: keeps the legacy per-hospital charge
+            // type names the non-bundled Final Bill already prints, so turning
+            // bundling on changes grouping only, never row names. See
+            // ConfigOptionApplicationController#getInwardChargeTypeFinalBillLabel.
+            labelByType.put(type, configOptionApplicationController.getInwardChargeTypeFinalBillLabel(type));
         }
 
         return buildBundledRows(items, groupByType, orderByType, labelByType);

--- a/src/test/java/com/divudi/bean/inward/BhtSummeryControllerBundledRowsTest.java
+++ b/src/test/java/com/divudi/bean/inward/BhtSummeryControllerBundledRowsTest.java
@@ -171,4 +171,37 @@ class BhtSummeryControllerBundledRowsTest {
 
         assertTrue(rows.isEmpty());
     }
+
+    @Test
+    void mergesUngroupedChargeTypeWhoseLabelMatchesAGroupName() {
+        // COOP: AdministrationCharge and MaintainCharges grouped as "Room Charges",
+        // RoomCharges itself left ungrouped — its own label already reads
+        // "Room Charges", so it must not print as a second identical line.
+        List<BillItem> items = new ArrayList<>();
+        items.add(chargeItem(InwardChargeType.RoomCharges, 3200.0));
+        items.add(chargeItem(InwardChargeType.AdministrationCharge, 800.0));
+        items.add(chargeItem(InwardChargeType.MaintainCharges, 1800.0));
+
+        Map<InwardChargeType, String> groups = emptyGroups(
+                InwardChargeType.RoomCharges,
+                InwardChargeType.AdministrationCharge,
+                InwardChargeType.MaintainCharges);
+        groups.put(InwardChargeType.AdministrationCharge, "Room Charges");
+        groups.put(InwardChargeType.MaintainCharges, "Room Charges");
+
+        List<FinalBillPrintRowDTO> rows = BhtSummeryController.buildBundledRows(
+                items,
+                groups,
+                sequentialOrders(InwardChargeType.RoomCharges,
+                        InwardChargeType.AdministrationCharge,
+                        InwardChargeType.MaintainCharges),
+                defaultLabels(InwardChargeType.RoomCharges,
+                        InwardChargeType.AdministrationCharge,
+                        InwardChargeType.MaintainCharges));
+
+        assertEquals(1, rows.size());
+        assertEquals("Room Charges", rows.get(0).getLabel());
+        assertEquals(5800.0, rows.get(0).getAmount());
+    }
+
 }


### PR DESCRIPTION
Two Final Bill bundling defects found while investigating why COOP's BHT/57939 bill printed **two identical "Room Charges" lines**. `Closes #23698`

Scope is the Final Bill print only. Charge types stay separate — and keep their current names — on the interim bill, the charge-type breakdown/detail reports, the invoice journal and the config API.

## 1. Enabling bundling renamed rows

Charge-type names live under two keys:

| | Key | Read by |
|---|---|---|
| Legacy | `Inward Charge Type - Name For <default label>` | `SessionController.init()` → `InwardChargeType.name` → what the Final Bill prints today |
| Current | `Inward Charge Type Label - <EnumName>` | `getInwardChargeTypeLabel()` — interim bill, breakdown/detail reports, invoice journal, `ConfigResource` |

`getBundledFinalBillRows()` read only the current key, so switching on `Inward Final Bill - Bundle Grouped Charge Types` reverted every legacy name to the raw enum label. COOP has **22** legacy names; four are visible on `Inward/INWFINAL/202/1` alone:

| Charge type | Prints today | Would have become |
|---|---|---|
| `MOCharges` | Resident Medical Officer Charges | MO Charges |
| `Radiology` | Radiology & Imaging | Radiology |
| `Theatre_Medicine` | Theatre Surgical Consumables & Drugs | Theatre Medicine |
| `AdmissionFee` | Admission Fee | Admission Charge |

New `getInwardChargeTypeFinalBillLabel()` prefers the legacy name, then the current key, then the enum label. It is a **separate resolver** from `getInwardChargeTypeLabel()` precisely so nothing outside the Final Bill changes. Enabling bundling now changes how rows are grouped, never what they are called.

## 2. Same-named rows were not merged

`buildBundledRows()` concatenated `individualRows` and `groupedTotals` without merging, so an ungrouped charge type whose own label matched a group name printed as a second, identical line. COOP grouped `AdministrationCharge` + `MaintainCharges` as `Room Charges` but left `RoomCharges` itself ungrouped — its own label is also "Room Charges".

Rows are now merged on the final printed label (amounts summed, earliest order kept). Two lines with the same name cannot be told apart on paper, so they are always one line.

## Also

`getLongTextValueByKeyReadOnly()`, so resolving a label never lazily creates ConfigOption rows.

## Testing

`BhtSummeryControllerBundledRowsTest` — 8 tests, all passing, including a new case reproducing the COOP configuration (RoomCharges 3,200 ungrouped + AdministrationCharge 800 + MaintainCharges 1,800 grouped) and asserting one row of **5,800.00**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
