### PR TITLE
fix(inward): make bundled Custom Bill 3 match the non-bundled print

### DIFF
--- a/src/main/webapp/resources/inward/bill/finalBillCustom4.xhtml
+++ b/src/main/webapp/resources/inward/bill/finalBillCustom4.xhtml
@@ -741,7 +741,9 @@
                                      BhtSummeryController#getBundledFinalBillRows. -->
                                 <ui:repeat value="#{bhtSummeryController.getBundledFinalBillRows(cc.attrs.bill)}" var="row">
                                     <tr style="width: 100%; font-weight: 400; line-height: 18px;">
-                                        <td style="text-align: left;font-size: 13px!important; margin-top: -10px;">
+                                        <td style="text-align: left; font-size: 13px !important;
+                                                    max-width: 150px; white-space: nowrap;
+                                                    overflow: visible; text-overflow: ellipsis;">
                                             <h:outputLabel value="#{row.label}" />
                                         </td>
                                         <td style="margin-top: -10px;">
@@ -761,7 +763,9 @@
                                     <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
                                         <h:panelGroup rendered="#{bip.inwardChargeType eq 'DoctorAndNurses' and bip.adjustedValue != 0}" style="font-size: 12px;">
                                             <tr style="width: 100%; font-weight: 400; line-height: 18px;">
-                                                <td style="text-align: left; font-size: 13px!important; margin-top: -10px;">
+                                                <td style="text-align: left; font-size: 13px !important;
+                                                            max-width: 150px; white-space: nowrap;
+                                                            overflow: visible; text-overflow: ellipsis;">
                                                     <h:outputLabel value="#{configOptionApplicationController.getInwardChargeTypeLabel(bip.inwardChargeType)}" />
                                                 </td>
                                                 <td style="margin-top: -10px;">
@@ -809,13 +813,15 @@
                                         <ui:repeat value="#{cc.attrs.bill.billItems}" var="bip">
                                             <h:panelGroup rendered="#{bip.inwardChargeType eq 'ProfessionalCharge' and bip.adjustedValue != 0}" style="font-size: 12px;">
                                                 <tr style="width: 100%; font-weight: 400; line-height: 18px;">
-                                                    <td style="text-align: left; font-size: 13px!important; margin-top: -10px;">
+                                                    <td style="text-align: left; font-size: 13px !important;
+                                                                max-width: 150px; white-space: nowrap;
+                                                                overflow: visible; text-overflow: ellipsis;">
                                                         <h:outputLabel value="#{configOptionApplicationController.getInwardChargeTypeLabel(bip.inwardChargeType)}" />
                                                     </td>
                                                     <td style="margin-top: -10px;">
                                                         <table>
                                                             <ui:repeat value="#{bip.proFees}" var="fe">
-                                                                <h:panelGroup rendered="#{fe.feeAdjusted ne 0 and fe.bill.cancelled eq false and fe.bill.billClass eq 'class com.divudi.core.entity.BilledBill'}">
+                                                                <h:panelGroup style="line-height: 1.0;" rendered="#{fe.feeAdjusted ne 0 and fe.bill.cancelled eq false and fe.bill.billClass eq 'class com.divudi.core.entity.BilledBill'}">
                                                                     <tr>
                                                                         <td style="text-align: left; font-size: 10px!important;">
                                                                             <h:panelGroup>#{fe.staff.person.nameWithTitle}<h:outputText value=" (#{fe.staff.speciality.name})" rendered="#{fe.staff.speciality ne null}"/></h:panelGroup>
@@ -853,7 +859,9 @@
                                     <ui:repeat value="#{bhtSummeryController.getSummaryOfDoctorChargers(cc.attrs.bill.billItems,cc.attrs.bill.patientEncounter,cc.attrs.showProfessional)}" var="bip">
                                         <h:panelGroup rendered="#{(bip.inwardChargeType eq 'ProfessionalCharge' or bip.inwardChargeType eq 'DoctorAndNurses') and bip.adjustedValue != 0}" style="font-size: 12px;">
                                             <tr style="width: 100%; font-weight: 400; line-height: 18px;">
-                                                <td style="text-align: left; font-size: 13px!important; margin-top: -10px;">
+                                                <td style="text-align: left; font-size: 13px !important;
+                                                            max-width: 150px; white-space: nowrap;
+                                                            overflow: visible; text-overflow: ellipsis;">
                                                     <h:outputLabel value="#{configOptionApplicationController.getInwardChargeTypeLabel(bip.inwardChargeType)}" />
                                                 </td>
                                                 <td style="margin-top: -10px;">

--- a/src/main/webapp/resources/inward/bill/finalBillCustom4.xhtml
+++ b/src/main/webapp/resources/inward/bill/finalBillCustom4.xhtml
@@ -766,7 +766,7 @@
                                                 <td style="text-align: left; font-size: 13px !important;
                                                             max-width: 150px; white-space: nowrap;
                                                             overflow: visible; text-overflow: ellipsis;">
-                                                    <h:outputLabel value="#{configOptionApplicationController.getInwardChargeTypeLabel(bip.inwardChargeType)}" />
+                                                    <h:outputLabel value="#{configOptionApplicationController.getInwardChargeTypeFinalBillLabel(bip.inwardChargeType)}" />
                                                 </td>
                                                 <td style="margin-top: -10px;">
                                                     <table>
@@ -816,7 +816,7 @@
                                                     <td style="text-align: left; font-size: 13px !important;
                                                                 max-width: 150px; white-space: nowrap;
                                                                 overflow: visible; text-overflow: ellipsis;">
-                                                        <h:outputLabel value="#{configOptionApplicationController.getInwardChargeTypeLabel(bip.inwardChargeType)}" />
+                                                        <h:outputLabel value="#{configOptionApplicationController.getInwardChargeTypeFinalBillLabel(bip.inwardChargeType)}" />
                                                     </td>
                                                     <td style="margin-top: -10px;">
                                                         <table>
@@ -862,7 +862,7 @@
                                                 <td style="text-align: left; font-size: 13px !important;
                                                             max-width: 150px; white-space: nowrap;
                                                             overflow: visible; text-overflow: ellipsis;">
-                                                    <h:outputLabel value="#{configOptionApplicationController.getInwardChargeTypeLabel(bip.inwardChargeType)}" />
+                                                    <h:outputLabel value="#{configOptionApplicationController.getInwardChargeTypeFinalBillLabel(bip.inwardChargeType)}" />
                                                 </td>
                                                 <td style="margin-top: -10px;">
                                                     <table>


### PR DESCRIPTION
## Problem

After charge-type bundling was turned on for Galle Co-op, Custom Bill 3 lost the print-layout improvements from #23682 and started printing a different name for the Assisting Charge row.

Nothing was lost from the file. `finalBillCustom4.xhtml` renders its charge ladder through **two mutually exclusive blocks**:

| Block | Lines | Gate |
|---|---|---|
| Flat / organized ladders | 207–731 | `!bundleGroupedChargeTypesOnFinalBill` |
| Bundled group rows | 738–895 | `bundleGroupedChargeTypesOnFinalBill` |

The #23682 fixes landed **only in the first block** — all 15 `nowrap` cells sit between lines 215 and 690. That was reasonable at the time: bundling was off everywhere, so the second block was effectively dead markup. Switching bundling on swapped the render path to a block that had never been exercised.

## Fix 1 — row styling (`07468d6`)

Port the #23682 styling into the bundled block:

- `max-width: 150px; white-space: nowrap; overflow: visible; text-overflow: ellipsis;` on the four label cells — bundled group row, `DoctorAndNurses`, `ProfessionalCharge`, summed-per-doctor variant
- `line-height: 1.0;` on the professional-fee detail rows

## Fix 2 — charge-type naming (`d71fea1`)

The bundled block resolved names through **two different mechanisms on the same bill**: grouped rows via `row.label` → `getInwardChargeTypeFinalBillLabel()` (legacy key first, then custom label, then enum default), but the three doctor/professional rows via `getInwardChargeTypeLabel()`, which reads only the newer `Inward Charge Type Label - <EnumName>` key.

The non-bundled block prints `bip.inwardChargeType.name` — the legacy value — so the two paths disagreed wherever a hospital customised the legacy key and left the newer one blank. That is the normal state: `SessionController` seeds every legacy row at login, while the newer key stays empty until an admin fills it in.

Observed on coop:

| Row | Bundling OFF | Bundling ON (before) |
|---|---|---|
| DoctorAndNurses | **Assisting Doctor Charges** | Assisting Charge ❌ |
| ProfessionalCharge | Professional Charge | Professional Charge ✓ |

All three cells now use `getInwardChargeTypeFinalBillLabel`.

## Scope

XHTML only, Custom Bill 3 only. **No change when bundling is off** — the first block is byte-identical to `development`. `finalBill.xhtml` also carries a bundled block but its two blocks already use identical styling, so it is deliberately left untouched.

## Testing

- File verified well-formed XML
- Label divergence confirmed against live coop config rows before and after

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved charge-type bundling display in final bills.
  - Updated bundled charge labels to remain on a single line and display more clearly within the available space.
  - Adjusted label sizing and overflow behavior for Doctor and Nurse, Professional Charge, and aggregated doctor-charge rows.
  - Improved vertical spacing in Professional Charge fee details for more consistent presentation.
  - Standardized charge labels across related final-bill sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->