### PR TITLE
fix(inward): move receipts to the confirmed final bill version on Set as Confirmed

### DIFF
--- a/src/main/java/com/divudi/bean/inward/InwardSearch.java
+++ b/src/main/java/com/divudi/bean/inward/InwardSearch.java
@@ -876,9 +876,49 @@ public class InwardSearch implements Serializable {
         pe.setNetTotal(newConfirmed.getNetTotal());
         getPatientEncounterFacade().edit(pe);
 
+        relinkPaymentBillsToConfirmedVersion(pe, newConfirmed);
+
         auditService.logEncounterAudit(pe, "Final Bill Version Confirmed",
                 previousFinalBillId, newConfirmed.getId(), sessionController.getLoggedUser(),
                 "Bill", newConfirmed.getId());
+    }
+
+    /**
+     * Re-points the admission's payment receipts at {@code newConfirmed}.
+     * <p>
+     * Every final bill print lists the "Paid By Patient" / "Paid By Company"
+     * breakdown from {@code pe.finalBill.backwardReferenceBills} — the receipts
+     * whose {@code forwardReferenceBill} is the confirmed version. Settle keeps
+     * that in step via {@code BhtSummeryController#updatePaymentBillList()},
+     * but confirming a different version only moved {@code pe.finalBill}: the
+     * receipts stayed on whichever version was settled last, and the newly
+     * confirmed version printed the paid total with no breakdown lines.
+     * <p>
+     * Uses the same receipt set as settle (the admission's and its child
+     * admissions' {@code InwardPaymentBill}s) so both paths agree. The previous
+     * holder's in-memory collection is trimmed and merged too, so the shared
+     * cache does not keep listing a receipt against a version it has left.
+     */
+    private void relinkPaymentBillsToConfirmedVersion(PatientEncounter pe, Bill newConfirmed) {
+        List<PatientEncounter> childEncounters = getInwardBean().fetchChildPatientEncounter(pe);
+        List<Bill> paymentBills = getInwardBean().fetchPaymentBill(pe, childEncounters);
+        if (paymentBills == null || paymentBills.isEmpty()) {
+            return;
+        }
+        for (Bill payment : paymentBills) {
+            Bill previousHolder = payment.getForwardReferenceBill();
+            if (previousHolder == null || !previousHolder.getId().equals(newConfirmed.getId())) {
+                payment.setForwardReferenceBill(newConfirmed);
+                getBillFacade().edit(payment);
+                if (previousHolder != null && previousHolder.getBackwardReferenceBills().remove(payment)) {
+                    getBillFacade().edit(previousHolder);
+                }
+            }
+            if (!newConfirmed.getBackwardReferenceBills().contains(payment)) {
+                newConfirmed.getBackwardReferenceBills().add(payment);
+            }
+        }
+        getBillFacade().edit(newConfirmed);
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes the missing **Paid By Patient** breakdown lines on inward final bill prints when an admission has more than one final bill version and a version other than the last-settled one is the confirmed final bill (e.g. coop BHT/57953, `Inward/INWFINAL/204/2`).

Closes #23706

## Root cause

All final bill prints list receipts from `pe.finalBill.backwardReferenceBills` (receipts whose `forwardReferenceBill` is the confirmed version).

- Settle calls `updatePaymentBillList()`, which re-points every `InwardPaymentBill` to the new version.
- `InwardSearch.setAsConfirmedFinalBillInternal()` moved `pe.finalBill` only. The receipts stayed on the previously settled version, so the confirmed version printed the total with no lines.

The same method runs for the auto-promotion after cancelling the confirmed version, so that path is fixed too.

## Change

`InwardSearch.java` only: new `relinkPaymentBillsToConfirmedVersion(pe, newConfirmed)`, called from `setAsConfirmedFinalBillInternal()`. It uses the same receipt set as settle (`InwardBeanController.fetchPaymentBill(pe, fetchChildPatientEncounter(pe))`). It re-points each receipt to the confirmed version and keeps the in-memory `backwardReferenceBills` collections of the old and new holders in step.

## Verification status

- ✅ Bug reproduced locally before the fix: BHT/56160 → Manage Final Bills → Approve `/96` → Set as Confirmed. `pe.finalBill` moved to `/96`, the receipt stayed on `/98`, and both the standard final bill and Custom Bill 3 printed `Paid By Patient 10,000.00` with no breakdown line.
- ✅ Compiles (`mvn clean package`).
- ✅ Fix verified end-to-end locally (same admission, fixed build): Approve + Set as Confirmed `/98`, then Set as Confirmed `/96` again. The receipt's `forwardReferenceBill` moved from `/98` to `/96` in the DB, and the `/96` print (standard final bill and Custom Bill 3) now shows `Paid By Patient | InwardINWPAY/10  Cash  10,000.00 | 10,000.00`. No domain restart was needed, so the shared-cache collections stay consistent. No exceptions in `server.log`.

Menu path: *Menu → Inpatient → Search → Admissions → (BHT) → Inpatient Dashboard → Manage Final Bills → Approve / Set as Confirmed → View / Print*.

## Not covered

Admissions that are **already** affected (e.g. BHT/57953) are not repaired by this change. It only prevents new cases. Their receipts need a one-off data repair to re-point `forwardReferenceBill` at the confirmed version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
