### PR TITLE
fix(inward): list Paid By Patient breakdown from the admission, not reference links

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -611,31 +611,28 @@ public class BhtSummeryController implements Serializable {
     }
 
     /**
+     * "Paid By Patient" breakdown rows for a final bill print — the
+     * admission's deposits, payments and their refunds, read from the
+     * admission itself. See
+     * {@link InwardBeanController#fetchPatientPaymentBillsForFinalBill(PatientEncounter)}.
+     */
+    public List<Bill> getPatientPaymentBillsForFinalBill(Bill bill) {
+        if (bill == null) {
+            return new ArrayList<>();
+        }
+        return getInwardBean().fetchPatientPaymentBillsForFinalBill(bill.getPatientEncounter());
+    }
+
+    /**
      * Sum of prior payments/receipts recorded against this admission — the
-     * Custom3 bill's "Deposit" line. Same backwardReferenceBills source and
-     * qualifying filter as the Custom2 receipts table (finalBillCustom2.xhtml
-     * lines 280-291), just summed instead of rendered row by row.
+     * Custom3 bill's "Deposit" line. Same source as the "Paid By Patient"
+     * breakdown ({@link #getPatientPaymentBillsForFinalBill(Bill)}), just
+     * summed instead of rendered row by row.
      */
     public double getCustom3DepositTotal(Bill bill) {
-        if (bill == null) {
-            return 0.0;
-        }
-        List<Bill> receipts = (bill.getPatientEncounter() != null && bill.getPatientEncounter().getFinalBill() != null)
-                ? bill.getPatientEncounter().getFinalBill().getBackwardReferenceBills()
-                : bill.getBackwardReferenceBills();
         double total = 0.0;
-        if (receipts == null) {
-            return total;
-        }
-        for (Bill b : receipts) {
-            if (b.getNetTotal() == 0.0) {
-                continue;
-            }
-            boolean qualifies = (!b.isCancelled() && "class com.divudi.core.entity.BilledBill".equals(b.getBillClass()))
-                    || (!b.isCancelled() && b.getRefundedBill() == null && "class com.divudi.core.entity.RefundBill".equals(b.getBillClass()));
-            if (qualifies) {
-                total += b.getNetTotal();
-            }
+        for (Bill b : getPatientPaymentBillsForFinalBill(bill)) {
+            total += b.getNetTotal();
         }
         return total;
     }

--- a/src/main/java/com/divudi/bean/inward/InwardBeanController.java
+++ b/src/main/java/com/divudi/bean/inward/InwardBeanController.java
@@ -1979,6 +1979,38 @@ public class InwardBeanController implements Serializable {
 
     }
 
+    /**
+     * The admission's own deposits and payments, and their refunds, for the
+     * "Paid By Patient" breakdown on the final bill prints.
+     * <p>
+     * Read straight from {@code Bill.patientEncounter} — deliberately NOT from
+     * the {@code forwardReferenceBill}/{@code backwardReferenceBills} links to
+     * a final bill version, which drift when an admission has more than one
+     * version and left the confirmed version printing the paid total with no
+     * lines. Appointment deposits are not listed: they are converted into an
+     * Inward Deposit, which is. Credit company receipts are not part of this
+     * list.
+     */
+    public List<Bill> fetchPatientPaymentBillsForFinalBill(PatientEncounter patientEncounter) {
+        if (patientEncounter == null || patientEncounter.getId() == null) {
+            return new ArrayList<>();
+        }
+        String jpql = "select b from Bill b "
+                + " where b.retired = false "
+                + " and b.cancelled = false "
+                + " and b.patientEncounter = :pe "
+                + " and b.billTypeAtomic in :bts "
+                + " order by b.createdAt";
+        Map<String, Object> params = new HashMap<>();
+        params.put("pe", patientEncounter);
+        params.put("bts", Arrays.asList(
+                BillTypeAtomic.INWARD_DEPOSIT,
+                BillTypeAtomic.INWARD_DEPOSIT_REFUND,
+                BillTypeAtomic.INWARD_PAYMENT,
+                BillTypeAtomic.INWARD_PAYMENT_REFUND));
+        return getBillFacade().findByJpql(jpql, params);
+    }
+
     public List<Bill> fetchPostFinalPaymentBill(PatientEncounter patientEncounter, List<PatientEncounter> cpts) {
 
         HashMap hm = new HashMap();

--- a/src/main/webapp/resources/inward/bill/finalBill.xhtml
+++ b/src/main/webapp/resources/inward/bill/finalBill.xhtml
@@ -967,9 +967,9 @@
                                         </td>
                                         <td>
                                             <table>
-                                                <ui:repeat value="#{cc.attrs.bill.patientEncounter.finalBill ne null ? cc.attrs.bill.patientEncounter.finalBill.backwardReferenceBills : cc.attrs.bill.backwardReferenceBills}" var="b">
+                                                <ui:repeat value="#{bhtSummeryController.getPatientPaymentBillsForFinalBill(cc.attrs.bill)}" var="b">
                                                     
-                                                    <h:panelGroup rendered="#{(b.netTotal ne 0 ) and ((b.cancelled eq false and b.billClass eq 'class com.divudi.core.entity.BilledBill')or(b.cancelled eq false and b.refundedBill eq null and b.billClass eq 'class com.divudi.core.entity.RefundBill')) and b.billTypeAtomic ne 'INPATIENT_CREDIT_COMPANY_PAYMENT_RECEIVED'}">
+                                                    <h:panelGroup rendered="#{b.netTotal ne 0}">
                                                         
                                                         <div class="d-flex gap-3" style="font-size: 11px;">
                                                             <h:outputLabel value="#{b.deptId}"/>

--- a/src/main/webapp/resources/inward/bill/finalBillBundledCustom1.xhtml
+++ b/src/main/webapp/resources/inward/bill/finalBillBundledCustom1.xhtml
@@ -457,15 +457,8 @@
                                         </td>
                                         <td>
                                             <table>
-                                                <ui:repeat value="#{cc.attrs.bill.patientEncounter.finalBill ne null ? cc.attrs.bill.patientEncounter.finalBill.backwardReferenceBills : cc.attrs.bill.backwardReferenceBills}" var="b">
-                                                    <h:panelGroup rendered="#{(b.netTotal ne 0 )
-                                                                              and
-                                                                              ((b.cancelled eq false
-                                                                              and b.billClass eq 'class com.divudi.core.entity.BilledBill')
-                                                                              or
-                                                                              (b.cancelled eq false
-                                                                              and b.refundedBill eq null
-                                                                              and b.billClass eq 'class com.divudi.core.entity.RefundBill')) and b.billTypeAtomic ne 'INPATIENT_CREDIT_COMPANY_PAYMENT_RECEIVED'}">
+                                                <ui:repeat value="#{bhtSummeryController.getPatientPaymentBillsForFinalBill(cc.attrs.bill)}" var="b">
+                                                    <h:panelGroup rendered="#{b.netTotal ne 0}">
                                                         <div class="d-flex gap-3" style="font-size: 11px;">
                                                             <h:outputLabel value="#{b.deptId}"/>
                                                             <h:outputLabel value="#{b.paymentMethod}" rendered="#{configOptionApplicationController.getBooleanValueByKey('Show Payment Method on Payments on Final Bill On Final Bill Print',false)}"/>

--- a/src/main/webapp/resources/inward/bill/finalBillCustom2.xhtml
+++ b/src/main/webapp/resources/inward/bill/finalBillCustom2.xhtml
@@ -342,8 +342,8 @@
                             <td style="text-align: right; font-weight: bold;">Receipt Amount</td>
                             <td style="text-align: right; font-weight: bold;">Adjusted Amount</td>
                         </tr>
-                        <ui:repeat value="#{cc.attrs.bill.patientEncounter.finalBill ne null ? cc.attrs.bill.patientEncounter.finalBill.backwardReferenceBills : cc.attrs.bill.backwardReferenceBills}" var="b">
-                            <h:panelGroup rendered="#{(b.netTotal ne 0) and ((b.cancelled eq false and b.billClass eq 'class com.divudi.core.entity.BilledBill') or (b.cancelled eq false and b.refundedBill eq null and b.billClass eq 'class com.divudi.core.entity.RefundBill'))}">
+                        <ui:repeat value="#{bhtSummeryController.getPatientPaymentBillsForFinalBill(cc.attrs.bill)}" var="b">
+                            <h:panelGroup rendered="#{b.netTotal ne 0}">
                                 <tr>
                                     <td><h:outputLabel value="#{b.deptId}"/></td>
                                     <td><h:outputLabel value="#{b.createdAt}"><f:convertDateTime pattern="dd/MM/yyyy HH:mm" /></h:outputLabel></td>
@@ -365,8 +365,8 @@
                             <td style="font-weight: bold;">Payment type</td>
                             <td style="text-align: right; font-weight: bold;">Amount</td>
                         </tr>
-                        <ui:repeat value="#{cc.attrs.bill.patientEncounter.finalBill ne null ? cc.attrs.bill.patientEncounter.finalBill.backwardReferenceBills : cc.attrs.bill.backwardReferenceBills}" var="b">
-                            <h:panelGroup rendered="#{(b.netTotal ne 0) and ((b.cancelled eq false and b.billClass eq 'class com.divudi.core.entity.BilledBill') or (b.cancelled eq false and b.refundedBill eq null and b.billClass eq 'class com.divudi.core.entity.RefundBill'))}">
+                        <ui:repeat value="#{bhtSummeryController.getPatientPaymentBillsForFinalBill(cc.attrs.bill)}" var="b">
+                            <h:panelGroup rendered="#{b.netTotal ne 0}">
                                 <tr>
                                     <td><h:outputLabel value="#{b.deptId}"/></td>
                                     <td><h:outputLabel value="#{b.createdAt}"><f:convertDateTime pattern="dd/MM/yyyy HH:mm" /></h:outputLabel></td>

--- a/src/main/webapp/resources/inward/bill/finalBillCustom4.xhtml
+++ b/src/main/webapp/resources/inward/bill/finalBillCustom4.xhtml
@@ -982,15 +982,8 @@
                                         </td>
                                         <td>
                                             <table>
-                                                <ui:repeat value="#{cc.attrs.bill.patientEncounter.finalBill ne null ? cc.attrs.bill.patientEncounter.finalBill.backwardReferenceBills : cc.attrs.bill.backwardReferenceBills}" var="b">
-                                                    <h:panelGroup style="line-height: 1.05;" rendered="#{(b.netTotal ne 0 )
-                                                                              and
-                                                                              ((b.cancelled eq false
-                                                                              and b.billClass eq 'class com.divudi.core.entity.BilledBill')
-                                                                              or
-                                                                              (b.cancelled eq false
-                                                                              and b.refundedBill eq null
-                                                                              and b.billClass eq 'class com.divudi.core.entity.RefundBill')) and b.billTypeAtomic ne 'INPATIENT_CREDIT_COMPANY_PAYMENT_RECEIVED'}">
+                                                <ui:repeat value="#{bhtSummeryController.getPatientPaymentBillsForFinalBill(cc.attrs.bill)}" var="b">
+                                                    <h:panelGroup style="line-height: 1.05;" rendered="#{b.netTotal ne 0}">
 
                                                         <div class="d-flex gap-3" style="font-size: 11px;">
                                                             <h:outputLabel value="#{b.deptId}" style="width: 110px;"/>

--- a/src/main/webapp/resources/inward/bill/finalBillGreenSheet.xhtml
+++ b/src/main/webapp/resources/inward/bill/finalBillGreenSheet.xhtml
@@ -409,16 +409,9 @@
                                     <h:outputLabel   value="Paid By Patient " rendered="#{cc.attrs.bill.paidAmount !=0}"/>
                                 </td>
                                 <td style="text-align: left;font-size: 13px!important;">
-                                    <ui:repeat value="#{cc.attrs.bill.backwardReferenceBills}" var="b">
+                                    <ui:repeat value="#{bhtSummeryController.getPatientPaymentBillsForFinalBill(cc.attrs.bill)}" var="b">
                                         <h:panelGroup
-                                            rendered="#{(b.netTotal ne 0 )
-                                                        and
-                                                        ((b.cancelled eq false
-                                                        and b.billClass eq 'class com.divudi.core.entity.BilledBill')
-                                                        or
-                                                        (b.cancelled eq false
-                                                        and b.refundedBill eq null
-                                                        and b.billClass eq 'class com.divudi.core.entity.RefundBill'))}" >
+                                            rendered="#{b.netTotal ne 0}" >
 
                                             <div class="d-flex gap-2">
                                                 <h:outputLabel value="#{b.deptId} - "/>

--- a/src/main/webapp/resources/inward/bill/finalBill_1.xhtml
+++ b/src/main/webapp/resources/inward/bill/finalBill_1.xhtml
@@ -174,15 +174,8 @@
                                 </td>
                                 <td>
                                     <table>
-                                        <ui:repeat value="#{cc.attrs.bill.backwardReferenceBills}" var="b">
-                                            <h:panelGroup  rendered="#{(b.netTotal ne 0 )
-                                                                       and
-                                                                       ((b.cancelled eq false
-                                                                       and b.billClass eq 'class com.divudi.core.entity.BilledBill')
-                                                                       or
-                                                                       (b.cancelled eq false
-                                                                       and b.refundedBill eq null
-                                                                       and b.billClass eq 'class com.divudi.core.entity.RefundBill'))}" >
+                                        <ui:repeat value="#{bhtSummeryController.getPatientPaymentBillsForFinalBill(cc.attrs.bill)}" var="b">
+                                            <h:panelGroup  rendered="#{b.netTotal ne 0}" >
                                                 <tr>
                                                     <td>
                                                         #{b.deptId}


### PR DESCRIPTION
## Summary

The **Paid By Patient** breakdown on inward final bill prints is now read from the admission (`Bill.patientEncounter`) instead of the `forwardReferenceBill` / `backwardReferenceBills` links to a final bill version. Every final bill version of an admission prints the same set of deposits and payments.

This fixes already-affected admissions such as coop **BHT/57953** without any data repair.

Closes #23709

## What is listed

Bills where `patientEncounter` = the admission, not retired, not cancelled, of type:
- `INWARD_DEPOSIT`, `INWARD_DEPOSIT_REFUND`
- `INWARD_PAYMENT`, `INWARD_PAYMENT_REFUND`

Not listed:
- Appointment deposits: they are converted into an Inward Deposit, which is listed. Bills with no encounter are ignored.
- Credit company / insurance receipts. The **Paid By Company** section is unchanged.

## Change

- `InwardBeanController.fetchPatientPaymentBillsForFinalBill(PatientEncounter)`: new JPQL query.
- `BhtSummeryController.getPatientPaymentBillsForFinalBill(Bill)`: EL entry point. `getCustom3DepositTotal()` now sums the same list.
- Paid By Patient `ui:repeat` switched to it in `finalBill`, `finalBillBundledCustom1`, `finalBillCustom2` (both receipt tables), `finalBillCustom4`, `finalBillGreenSheet` and `finalBill_1`. The row filter reduces to `b.netTotal ne 0`, because the query already excludes cancelled and retired bills.

## Verification (local)

BHT/56160: I deliberately pointed its receipt's `forwardReferenceBill` at the non-confirmed version `/98` (the BHT/57953 shape). With this build, the confirmed version `/96` prints `Paid By Patient | InwardINWPAY/10  Cash  10,000.00 | 10,000.00` on both the standard final bill and Custom Bill 3. No exceptions in `server.log`. All six templates parse as well-formed XML, and the WAR builds.

Menu path: *Menu → Inpatient → Search → Admissions → (BHT) → Inpatient Dashboard → Manage Final Bills → View / Print*.

Not exercised locally: refund rows. The local coop snapshot has no `INWARD_*_REFUND` bills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the “Paid By Patient” breakdown on inward final bills by consistently including relevant patient deposits, payments, and refunds.
  * Updated final bill formats to display payment entries in chronological order and handle missing or invalid encounter details safely.
  * Corrected deposit totals to reflect the complete set of applicable patient payment transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->