### PR TITLE
fix(pharmacy): show GRN Summary Report amounts as positive values

### DIFF
--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -3645,10 +3645,14 @@ let idx = -1;
 headers.each(function (i) { if (this.textContent.trim() === 'Inventory Reports') idx = i; });
 w.select(idx);
 ```
-Then `browser_wait_for({time: 1.5})` before searching the DOM for the target
-report button — `select()` still triggers the same lazy-load AJAX, it just
-does so through the real widget lifecycle instead of a spoofed click, so the
-panel populates instead of toggling shut.
+`select()` still triggers the same lazy-load AJAX that a real click would,
+it just does so through the real widget lifecycle instead of a spoofed
+click, so the panel populates instead of toggling shut — but the AJAX is
+still async, so don't search the DOM immediately after `select()`. Per §5a,
+wait on content rather than a fixed delay: `browser_wait_for({text: '<a
+label expected in that category, e.g. "1. Closing Stock">'})` before
+searching the DOM for the target report button. A fixed-time wait risks
+checking before a slow response has populated the panel.
 
 ## 124. A report's menu button can be privilege-gated per the *session department*, not the department whose data the report covers — switch department, not the report's own filter
 

--- a/developer_docs/testing/playwright-e2e-workflow.md
+++ b/developer_docs/testing/playwright-e2e-workflow.md
@@ -14,7 +14,7 @@ waste a session.
 
 ## Contents
 
-122 sections. **The workflow is §0-§8; everything from §9 on is an independent
+124 sections. **The workflow is §0-§8; everything from §9 on is an independent
 gotcha** — jump straight to the one you need rather than reading the file.
 
 **Workflow**
@@ -149,6 +149,8 @@ gotcha** — jump straight to the one you need rather than reading the file.
 - [120. Verifying a `p:fileDownload` export: POST the form with `fetch` and decode locally](#120-verifying-a-pfiledownload-export-post-the-form-with-fetch-and-decode-locally)
 - [121. `p:ajax update="..."` targeting a raw `<div id="...">` throws `ComponentNotFoundException` at render time — wrap it in `h:panelGroup`](#121-pajax-update-targeting-a-raw-div-id-throws-componentnotfoundexception-at-render-time--wrap-it-in-hpanelgroup)
 - [122. A `p:commandButton`'s `process="X"` that excludes the button itself silently skips its own `action` — no exception, no error, a real `200 OK` with the *previous* data](#122-a-pcommandbuttons-processx-that-excludes-the-button-itself-silently-skips-its-own-action--no-exception-no-error-a-real-200-ok-with-the-previous-data)
+- [123. `reports/index.xhtml`'s report-category accordion needs the PrimeFaces widget API, not a plain click, to reliably expand a tab](#123-reportsindexxhtmls-report-category-accordion-needs-the-primefaces-widget-api-not-a-plain-click-to-reliably-expand-a-tab)
+- [124. A report's menu button can be privilege-gated per the *session department*, not the department whose data the report covers — switch department, not the report's own filter](#124-a-reports-menu-button-can-be-privilege-gated-per-the-session-department-not-the-department-whose-data-the-report-covers--switch-department-not-the-reports-own-filter)
 - [Quick checklist](#quick-checklist)
 
 ---
@@ -3618,3 +3620,56 @@ check EclipseLink SQL logging, `eclipselink.logging.level.sql=FINE` in
 never prints despite a `200` response, the action isn't being invoked at
 all — go straight to the button's `process`/`execute` attribute rather than
 debugging the method's own logic.
+
+## 123. `reports/index.xhtml`'s report-category accordion needs the PrimeFaces widget API, not a plain click, to reliably expand a tab
+
+Found while testing issue #23604 (GRN Summary Report). The category strip
+("Inventory Reports", "Financial Reports", …) at the top of
+`reports/index.xhtml` looks like a `p:tabView` (ARIA `role="tab"`/`tablist`)
+but is actually a `p:accordionPanel` whose headers are styled to look like
+tabs. A `browser_click` (or `getByRole('tab', {name: ...}).click()`) on a
+header is unreliable for two reasons: (1) the panel's report buttons are lazy
+— the ARIA state can flip to `expanded`/`selected` before the AJAX call that
+actually populates the panel content has returned, so an immediate DOM check
+finds an "open" but still-empty panel; (2) a raw `element.click()` via
+`browser_evaluate` bypasses jQuery's bound handler and can **toggle the
+accordion closed** if PrimeFaces already considered it open from an earlier
+click, silently undoing the navigation.
+
+Reliable pattern: drive the PrimeFaces widget directly instead of clicking.
+```js
+const w = PrimeFaces.widgets['widget_j_idt533_reportsAccordion']; // find via
+  // Object.keys(PrimeFaces.widgets).filter(k => /reportsAccordion$/.test(k))
+const headers = w.headers;
+let idx = -1;
+headers.each(function (i) { if (this.textContent.trim() === 'Inventory Reports') idx = i; });
+w.select(idx);
+```
+Then `browser_wait_for({time: 1.5})` before searching the DOM for the target
+report button — `select()` still triggers the same lazy-load AJAX, it just
+does so through the real widget lifecycle instead of a spoofed click, so the
+panel populates instead of toggling shut.
+
+## 124. A report's menu button can be privilege-gated per the *session department*, not the department whose data the report covers — switch department, not the report's own filter
+
+Also found on issue #23604. `reports/index.xhtml`'s report buttons are each
+wrapped `rendered="#{webUserController.hasPrivilege('ReportsGrnSummaryReport')}"`,
+and `WebUserController.hasPrivilege()` checks
+`sessionController.getUserPrivileges()` — the privilege set loaded for
+whichever department was picked on the **Select Department** screen at
+login, not the department the report will actually query. A local test user
+can hold `ReportsGrnSummaryReport` for one department (e.g. `Inward`) but not
+another (e.g. `Main Pharmacy`) — querying
+`WEBUSERPRIVILEGE.DEPARTMENT_ID` confirms which. If the button is missing
+(or, per §123, the whole accordion panel renders as a set of empty
+`<div class="d-flex...">` wrappers with **zero** child buttons — every
+`rendered` in the panel evaluating false, not just one), check this before
+assuming a defect: query
+`SELECT wup.PRIVILEGE, d.NAME FROM WEBUSERPRIVILEGE wup JOIN WEBUSER wu ON wu.ID=wup.WEBUSER_ID LEFT JOIN DEPARTMENT d ON d.ID=wup.DEPARTMENT_ID WHERE wu.NAME='<user>' AND wup.PRIVILEGE LIKE '%<ReportPrivilege>%'`.
+
+If the privilege exists only for a different department, switch to that
+department per §17 (`logout.xhtml` → login → **Select Department**) to reach
+the report's menu entry — the report page's own `Institution`/`Site`/
+`Department-Store` filter fields are independent of the session department,
+so once on the page, point those filters back at the department whose data
+you actually need to verify.

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacyController.java
@@ -10728,6 +10728,24 @@ public class PharmacyController implements Serializable {
         return amt != null ? amt : BigDecimal.ZERO;
     }
 
+    /**
+     * Display-only magnitude of {@link Bill#getNetTotal()} for the GRN Summary
+     * Report's "Amount" column — the signed value is intentional (negative for
+     * purchases/money-out, positive for cancellations/returns/money-back), but
+     * showing the sign to end users on a per-row report is confusing. See issue #23604.
+     */
+    public double getGrnDisplayAmount(Bill bill) {
+        return bill == null ? 0.0 : Math.abs(bill.getNetTotal());
+    }
+
+    /**
+     * Display-only magnitude of {@link Bill#getDiscount()} for the GRN Summary
+     * Report — see {@link #getGrnDisplayAmount(Bill)}. See issue #23604.
+     */
+    public double getGrnDisplayDiscount(Bill bill) {
+        return bill == null ? 0.0 : Math.abs(bill.getDiscount());
+    }
+
     public Double calculateTotalGrnAmount() {
         double total = 0.0;
 
@@ -11439,8 +11457,8 @@ public class PharmacyController implements Serializable {
                         ? (f.getToInstitution() != null ? f.getToInstitution().getName() : "-")
                         : (f.getFromInstitution() != null ? f.getFromInstitution().getName() : "-"), bodyFontSmall));
                 table.addCell(textCell(f.getPaymentMethod() != null ? f.getPaymentMethod().getLabel() : "-", bodyFontSmall));
-                table.addCell(numCell(f.getNetTotal(), bodyFontSmall));
-                table.addCell(numCell(f.getDiscount(), bodyFontSmall));
+                table.addCell(numCell(getGrnDisplayAmount(f), bodyFontSmall));
+                table.addCell(numCell(getGrnDisplayDiscount(f), bodyFontSmall));
                 table.addCell(numCell(stockAmount.doubleValue(), bodyFontSmall));
                 table.addCell(textCell(grnSummaryStatusLabel(f), bodyFontSmall));
             }
@@ -11455,8 +11473,8 @@ public class PharmacyController implements Serializable {
             footerCell.setHorizontalAlignment(com.itextpdf.text.Element.ALIGN_CENTER);
             table.addCell(footerCell);
 
-            table.addCell(numCell(calculateTotalGrnAmount(), bodyFontSmall));
-            table.addCell(numCell(totalDiscount.doubleValue(), bodyFontSmall));
+            table.addCell(numCell(Math.abs(calculateTotalGrnAmount()), bodyFontSmall));
+            table.addCell(numCell(Math.abs(totalDiscount.doubleValue()), bodyFontSmall));
             table.addCell(numCell(totalStockAmount.doubleValue(), bodyFontSmall));
             com.itextpdf.text.pdf.PdfPCell blankStatusFooterCell = new com.itextpdf.text.pdf.PdfPCell(new com.itextpdf.text.Phrase(""));
             blankStatusFooterCell.setBackgroundColor(com.itextpdf.text.BaseColor.LIGHT_GRAY);

--- a/src/main/webapp/reports/inventoryReports/grn_summary_report.xhtml
+++ b/src/main/webapp/reports/inventoryReports/grn_summary_report.xhtml
@@ -283,12 +283,12 @@
                                     <h:outputText value="#{bill.paymentMethod.label}"/>
                                 </p:column>
                                 <p:column headerText="Amount" styleClass="text-end">
-                                    <h:outputText value="#{bill.netTotal}">
+                                    <h:outputText value="#{pharmacyController.getGrnDisplayAmount(bill)}">
                                         <f:convertNumber pattern="#,##0.00"/>
                                     </h:outputText>
                                 </p:column>
                                 <p:column headerText="Dis. Amount" styleClass="text-end">
-                                    <h:outputText value="#{bill.discount}">
+                                    <h:outputText value="#{pharmacyController.getGrnDisplayDiscount(bill)}">
                                         <f:convertNumber pattern="#,##0.00"/>
                                     </h:outputText>
                                 </p:column>


### PR DESCRIPTION
## Summary

- The GRN Summary Report's **Amount** / **Dis. Amount** columns printed `Bill.netTotal`/`discount` raw, exposing HMIS's internal signed accounting convention directly to end users: `PHARMACY_GRN`/`PHARMACY_DIRECT_PURCHASE` (purchases) are **always negative** (money out), `PHARMACY_GRN_CANCELLED`/`PHARMACY_GRN_RETURN` (reversals) are **always positive** (money back in, via `Bill.invertAndAssignValuesFromOtherBill()` — the exact-opposite contra-bill used for whole-bill cancellations). Confirmed this is intentional and correct at the data layer by querying `BILL.NETTOTAL` min/max per `BILLTYPEATOMIC` against the local DB, not just by reading code — so this is a **display-only** fix, no data or calculation changes.
- Every plain GRN row (not just cancelled ones) was showing a minus sign, which reads as an error — the report's own **Status** column already says Approved/Cancelled/Returned, so the sign is redundant on a per-row report.
- Added `getGrnDisplayAmount(Bill)` / `getGrnDisplayDiscount(Bill)` display-only helpers (`Math.abs`) to `PharmacyController`, wired into the on-screen table, the PDF export, and the PDF's Total footer. The Excel export needed no code change — `p:dataExporter` reads the already-rendered table.
- `calculateTotalGrnAmount()`, `calculateTotalPOAmount()`, `Bill.invertAndAssignValuesFromOtherBill()`, and every other query/report reading `netTotal`/`discount` are untouched.

## Test plan

- [x] Local Payara build + redeploy
- [x] Playwright, through the real menus (Analytics/Reports → Inventory Reports → 15. GRN Summary Report), Department/Store = Main Pharmacy:
  - [x] Ordinary GRN rows, previously negative (e.g. `-809,022.76`), now show `809,022.76`
  - [x] A cancelled GRN (`MPGRNCAN/33`) shows Amount `85,897.50` — unchanged/still-positive, confirming no regression on rows that were already correct
  - [x] A returned GRN (`MP//26/034607`) shows Amount `69,500.00`
  - [x] PDF export and its Total footer match the on-screen positive values
  - [x] Excel (Download) export matches
- [x] Post-fix DB spot-check: `BILL.NETTOTAL` for the same rows is still stored exactly as before (e.g. `-809022.76429595` for the plain GRN) — confirms only the report's display changed, not the underlying data
- [x] Two new Playwright/dev gotchas documented in `developer_docs/testing/playwright-e2e-workflow.md` (§123, §124) — driving `reports/index.xhtml`'s report-category accordion via the PrimeFaces widget API, and a report menu button being privilege-gated per session department rather than per the department whose data it reports on

## Documentation

Wiki page created: https://github.com/hmislk/hmis/wiki/GRN-Summary-Report — includes before/after screenshots for a plain GRN row, a cancelled row, and a returned row, plus a note on the per-department privilege gate for anyone else navigating to this report.

Closes #23604

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * GRN Summary Report amounts and discounts now display as positive magnitudes consistently in both the on-screen report and PDF export.
  * Report totals now match the displayed per-row values.

* **Documentation**
  * Updated the Playwright end-to-end testing guide’s contents and section count.
  * Added guidance for report-category accordion interactions and privilege-based visibility of report menu buttons.
  * Improved accordion testing guidance to wait for expected report-button content instead of relying on a fixed delay.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->