### PR TITLE
fix(inward): remove trailing blank page from Professional Bill print

### DIFF
--- a/src/main/webapp/resources/inward/bill/finalProfessionalBill.xhtml
+++ b/src/main/webapp/resources/inward/bill/finalProfessionalBill.xhtml
@@ -19,11 +19,25 @@
     <!-- IMPLEMENTATION -->
     <cc:implementation>
 
+        <!-- This composite is always printed alone (one p:printer target = one
+             instance of this composite), never combined with other .a4bill
+             siblings. printing.css's shared ".a4bill{page-break-after:always}"
+             rule (meant to separate consecutive bills when several are printed
+             together) then leaves a trailing blank page after the only content
+             there is. Override it locally rather than touching the shared rule
+             other consumers may still depend on for separation (issue #23713). -->
+        <style>
+            @media print {
+                .finalProfessionalBillA4 {
+                    page-break-after: auto !important;
+                }
+            }
+        </style>
         <h:outputStylesheet library="css" name="printing.css"></h:outputStylesheet>
         <div  >
             <h:panelGroup id="gpBillPreview" style="margin: auto; padding: 0px; " >
 
-                <div class="a4bill"  >
+                <div class="a4bill finalProfessionalBillA4"  >
 
                     <h:panelGroup rendered="#{configOptionApplicationController.getLongTextValueByKey('Inward Final Bill Header Template') ne ''}">
                         <div class="row">


### PR DESCRIPTION
## What

Fixes the Professional Bill print button on the Final Bill reprint screen (`inward_reprint_bill_final.xhtml` → **Professional Bill** tab) producing a second, completely blank page after the real content.

## Root cause

`printing.css` forces `page-break-after: always !important` on the shared `.a4bill` class so several bills printed back-to-back each start a clean page. `finalProfessionalBill.xhtml` is always printed alone (one `p:printer` target per composite instance), so that same rule left a forced page-break after the only content there was — nothing left to fill the page it broke to, hence a trailing blank page.

## Fix

A composite-local print-only CSS override in `finalProfessionalBill.xhtml` (new `.finalProfessionalBillA4` class layered on top of `.a4bill`), following the same pattern already used in `finalBillCustom3.xhtml` (a `<style>` block inside `<cc:implementation>`). This is deliberately scoped to just this one composite rather than touching the shared `printing.css` rule — that class is used by 50+ other print composites app-wide, some of which (multi-item print loops) may rely on the page-break for separation between consecutive items.

## Verification

Reproduced and verified locally against Payara (`rh` domain), department **Inward**:

1. **Before** — Inward → Search → Final Bill Search → BHT/57601 → `Inward/INWFINAL/189/1` → **Professional Bill** tab → **Professional Bill** print button → saved as PDF: 2 pages, page 1 has the correct consultant fee table, page 2 completely blank.
2. Confirmed the root cause via print-media emulation (`page.emulateMedia({media:'print'})`) rather than clicking the real print button, which opens a native OS print dialog that hangs browser automation (documented gotcha, `developer_docs/testing/playwright-e2e-workflow.md` §43).
3. Applied the fix, rebuilt, redeployed locally.
4. Confirmed via print-media emulation that the fixed composite's `.a4bill` div now computes `page-break-after: auto`, while unrelated `.a4bill` divs elsewhere on the same page (Custom Bills tab) still correctly compute `page-break-after: always` — the fix is properly scoped.
5. **After** — same bill, same button, saved as PDF: **1 page** ("Page 1 of 1"), no trailing blank page, all content present.

## Documentation

Updated the [Inpatient Final Bill](https://github.com/hmislk/hmis/wiki/Finance-Inpatient-Final-Bill) wiki page with a new section documenting the bug and fix, including before/after screenshots (patient name and BHT No redacted).

Fixes #23713

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed professional bill printing to prevent an unnecessary trailing blank page.
  - Improved print layout so the bill prints as a standalone document.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->