### PR TITLE
fix(pharmacy): scale BHT issue Qty cap by strength on substitution

### DIFF
--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
@@ -61,6 +61,7 @@ import com.divudi.core.entity.clinical.ClinicalFindingValue;
 import com.divudi.core.data.dto.StockDTO;
 import com.divudi.core.entity.BillItemFinanceDetails;
 import com.divudi.core.entity.pharmacy.ItemBatch;
+import com.divudi.core.entity.pharmacy.MeasurementUnit;
 import com.divudi.core.facade.BillFacade;
 import com.divudi.core.facade.BillFeeFacade;
 import com.divudi.core.facade.BillItemFacade;
@@ -484,7 +485,7 @@ public class PharmacySaleBhtController implements Serializable {
         }
 
         if (tmp.getReferanceBillItem() != null) {
-            double remaining = getRemainingQuantityForItem(tmp.getReferanceBillItem());
+            double remaining = getRemainingQuantityForItem(tmp.getReferanceBillItem(), tmp.getItem());
             if (tmp.getQty() > remaining) {
                 JsfUtil.addErrorMessage("Cannot issue " + tmp.getQty()
                         + " units of " + tmp.getItem().getName() + ". Only " + remaining + " units remaining to be issued.");
@@ -1792,7 +1793,7 @@ public class PharmacySaleBhtController implements Serializable {
                 continue;
             }
             BillItem freshRefItem = billItemFacade.findWithoutCache(refItem.getId());
-            freshRefItem.setRemainingQty(getRemainingQuantityForItem(freshRefItem));
+            freshRefItem.setRemainingQty(getRemainingQuantityForItem(freshRefItem, null));
             billItemFacade.editAndCommit(freshRefItem);
         }
 
@@ -2202,7 +2203,22 @@ public class PharmacySaleBhtController implements Serializable {
 //        getBillFacade().edit(bill);
     }
     
-    public double getRemainingQuantityForItem(BillItem referenceItem) {
+    /**
+     * Remaining quantity (in the *issuing* item's units) still owed against a BHT
+     * medicine request line, capped by what's already been issued/cancelled/returned
+     * against it.
+     *
+     * When the issuing item differs from the originally requested item (a
+     * pharmacist substitute — see {@link com.divudi.service.pharmacy.PharmacySubstituteService}),
+     * the requested-item unit count is scaled by the strength ratio between the two
+     * items so a weaker-strength substitute can be issued in a proportionally higher
+     * quantity for the same total dose (e.g. 10x500mg requested -> 20x250mg allowed).
+     * Falls back to the plain unit-count cap (no scaling) whenever either item is
+     * missing strength master data or the two don't share a strength unit — this
+     * cap must never block or allow unbounded issuing just because master data is
+     * incomplete. See issue #23718.
+     */
+    public double getRemainingQuantityForItem(BillItem referenceItem, Item issuingItem) {
         if (referenceItem == null || referenceItem.getId() == null) {
             return 0.0;
         }
@@ -2223,7 +2239,24 @@ public class PharmacySaleBhtController implements Serializable {
                 BillTypeAtomic.ISSUE_MEDICINE_ON_REQUEST_INWARD_CANCELLATION,
                 BillTypeAtomic.ISSUE_MEDICINE_ON_REQUEST_INWARD_RETURN));
         double alreadyIssued = getBillItemFacade().findDoubleByJpql(jpql, params);
-        return Math.max(0.0, referenceItem.getQty() - alreadyIssued);
+        double remaining = Math.max(0.0, referenceItem.getQty() - alreadyIssued);
+        return scaleForStrengthSubstitution(referenceItem.getItem(), issuingItem, remaining);
+    }
+
+    private double scaleForStrengthSubstitution(Item requestedItem, Item issuingItem, double remaining) {
+        if (issuingItem == null || requestedItem == null || issuingItem.equals(requestedItem)) {
+            return remaining;
+        }
+        Double reqStrength = requestedItem.getStrengthOfAnIssueUnit();
+        Double issStrength = issuingItem.getStrengthOfAnIssueUnit();
+        MeasurementUnit reqUnit = requestedItem.getStrengthUnit();
+        MeasurementUnit issUnit = issuingItem.getStrengthUnit();
+        if (reqStrength == null || issStrength == null || issStrength <= 0.0
+                || reqUnit == null || issUnit == null
+                || reqUnit.getId() == null || !reqUnit.getId().equals(issUnit.getId())) {
+            return remaining;
+        }
+        return remaining * (reqStrength / issStrength);
     }
 
     public boolean isFullyIssued(Bill requestBill) {
@@ -2235,7 +2268,7 @@ public class PharmacySaleBhtController implements Serializable {
             return false;
         }
         for (BillItem item : freshBill.getBillItems()) {
-            if (getRemainingQuantityForItem(item) > 0.001) {
+            if (getRemainingQuantityForItem(item, null) > 0.001) {
                 return false;
             }
         }

--- a/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
+++ b/src/main/java/com/divudi/bean/pharmacy/PharmacySaleBhtController.java
@@ -2251,7 +2251,8 @@ public class PharmacySaleBhtController implements Serializable {
         Double issStrength = issuingItem.getStrengthOfAnIssueUnit();
         MeasurementUnit reqUnit = requestedItem.getStrengthUnit();
         MeasurementUnit issUnit = issuingItem.getStrengthUnit();
-        if (reqStrength == null || issStrength == null || issStrength <= 0.0
+        if (reqStrength == null || reqStrength <= 0.0
+                || issStrength == null || issStrength <= 0.0
                 || reqUnit == null || issUnit == null
                 || reqUnit.getId() == null || !reqUnit.getId().equals(issUnit.getId())) {
             return remaining;


### PR DESCRIPTION
## Summary
- Fixes #23718: on the Ward Pharmacy BHT Issue screen, substituting the Issuing Bill Item to a different strength of the same drug (e.g. requested Amoxicillin 500mg × 10, issued as 250mg) still capped Qty at the originally requested unit count (10), silently blocking the clinically correct equivalent quantity (20).
- `PharmacySaleBhtController.getRemainingQuantityForItem` now takes the issuing item as a second parameter and scales the remaining unit count by the strength ratio (`requestedItem.strengthOfAnIssueUnit / issuingItem.strengthOfAnIssueUnit`) when both items have that master data populated and share the same `strengthUnit`. Falls back to the original plain-unit-count cap whenever that data is missing or mismatched — never blocks, never allows unbounded issuing on incomplete master data.
- All 3 call sites of the renamed method were updated (`onEditing` passes the actual issuing item; the other two pass `null`, preserving old unscaled behavior where there's no distinct issuing item).

## Test plan
Verified end-to-end on local Payara (department: Main Pharmacy), menu path: **Pharmacy → BHT Issue Requests → search BHT No → Issue Medicines**.

- Created a fresh request for BHT/57767: Amoxicillin/Axcil 500mg Capsules × 10.
- Populated local test master data for `Item.strengthOfAnIssueUnit`/`strengthUnit` on Amoxicillin/Axcil 500mg (500/mg) and 250mg (250/mg), which was NULL in the dev DB.
- **Before**: substituting to Axcil 250mg Capsules and editing Qty to 20 reverted to 10.
  ![Before fix](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23718-before-qty-reverts-to-10.png)
- **After**: the same substitution now accepts Qty 20 (10×500mg = 20×250mg), Gross/Margin/Net recalculate correctly.
  ![After fix](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23718-after-qty-scaled-to-20.png)
- **Cap still enforced**: Qty 21 clamps back to 20, not the old unscaled 10.
  ![Fallback still works](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23718-fix-cap-clamps-at-scaled-max.png)
- Settled via **Issue to BHT** and confirmed in the DB: `BILL.ID=14080273` (`ISSUE_MEDICINE_ON_REQUEST_INWARD`) → `BILLITEM.QTY=20` for Axcil 250mg Capsules, matching the printed bill (20 × 28.60 = 572.00).
- `mvn clean package` — build succeeds, all 287 existing tests pass.

## Documentation
Updated [Inward-BHT-Issue-Against-Request](https://github.com/hmislk/hmis/wiki/Inward-BHT-Issue-Against-Request) — new section documenting the strength-scaled substitution behavior with before/after/fallback screenshots, plus the relevant "Only `<remaining>` units remaining" error-message bullet.

Closes #23718

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Pharmacy issuing now calculates remaining quantities proportionally when a pharmacist substitutes an item with a different strength.
  - Weaker-strength substitutes can be issued in an adjusted quantity to provide the equivalent strength.
  - Quantity calculations remain unchanged when strength information is unavailable, invalid, or uses incompatible measurement units.
  - Editing, acceptance, and fully-issued checks now consistently reflect the selected substitute item.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->