### PR TITLE
Hotfix (COOP staging): print professional charges not entered as professional fees as one Other Professional Charges line

### DIFF
--- a/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
+++ b/src/main/java/com/divudi/bean/inward/BhtSummeryController.java
@@ -1063,16 +1063,30 @@ public class BhtSummeryController implements Serializable {
         updateTotal();
     }
 
-    public void changeAdjustedProValue(BillFee billFee) {
-        getBillFeeFacade().edit(billFee);
-        for (ChargeItemTotal chargeItemTotal : chargeItemTotals) {
-            switch (chargeItemTotal.getInwardChargeType()) {
-                case ProfessionalCharge:
-                    chargeItemTotal.setAdjustedTotal(getInwardBean().getProfessionalCharge(getPatientEncounter(), childPatientEncouters));
-                    break;
+    /**
+     * ProfessionalCharge adjusted total as a delta off the category total: the
+     * category total plus, for each fee, how far its effective adjusted value
+     * ({@code feeAdjusted != 0 ? feeAdjusted : feeValue}) has moved from its
+     * own feeValue. Delta-based so it never drops the service-item part
+     * (service items typed ProfessionalCharge), hospital-fee-only items,
+     * timed charges, or additional charges folded into the category total —
+     * only ever applying the doctor-level adjustments the user actually made.
+     * Static and CDI-free so it can be unit tested directly.
+     */
+    static double professionalAdjustedTotal(double total, List<BillFee> editableFees) {
+        double delta = 0;
+        if (editableFees != null) {
+            for (BillFee bf : editableFees) {
+                double effectiveAdjusted = bf.getFeeAdjusted() != 0 ? bf.getFeeAdjusted() : bf.getFeeValue();
+                delta += effectiveAdjusted - bf.getFeeValue();
             }
         }
+        return total + delta;
+    }
 
+    public void changeAdjustedProValue(BillFee billFee) {
+        getBillFeeFacade().edit(billFee);
+        refreshProfessionalChargeAdjustedTotal();
         updateTotal();
     }
 
@@ -1209,23 +1223,25 @@ public class BhtSummeryController implements Serializable {
     }
 
     /**
-     * Refreshes the ProfessionalCharge category adjusted total from the grouped
-     * doctor fees the user actually sees. When the config flag merges assisting
-     * fees into {@code profesionallFee}, those fees live on a different bill
-     * type, so summing only {@code getProfessionalCharge(...)}
-     * (InwardProfessional) would silently drop the assisting-fee adjustments
-     * from settlement. Summing the grouped totals keeps the category total
-     * consistent with the displayed table in both the merged and non-merged
-     * configurations.
+     * Refreshes the ProfessionalCharge category adjusted total as a delta off
+     * the category total ({@link #professionalAdjustedTotal}), using every fee
+     * the user actually sees in the grouped doctor table. Delta-based — rather
+     * than replacing the total outright — because the category total also
+     * contains service items typed ProfessionalCharge (plus timed/additional
+     * charges), which the doctor rows never cover; applying only the delta
+     * from the doctor-level adjustments actually made leaves that part of the
+     * total untouched. This also keeps the total consistent when the config
+     * flag merges assisting fees into {@code profesionallFee}, since those are
+     * included via the same grouped list.
      */
     private void refreshProfessionalChargeAdjustedTotal() {
-        double groupedAdjusted = 0;
+        List<BillFee> fees = new ArrayList<>();
         for (DoctorFeeGroup g : getGroupedProfessionalFees()) {
-            groupedAdjusted += g.getTotalAdjusted();
+            fees.addAll(g.getFees());
         }
         for (ChargeItemTotal chargeItemTotal : chargeItemTotals) {
             if (chargeItemTotal.getInwardChargeType() == InwardChargeType.ProfessionalCharge) {
-                chargeItemTotal.setAdjustedTotal(groupedAdjusted);
+                chargeItemTotal.setAdjustedTotal(professionalAdjustedTotal(chargeItemTotal.getTotal(), fees));
             }
         }
     }
@@ -1261,6 +1277,33 @@ public class BhtSummeryController implements Serializable {
 
     public void setSelectedDoctorFeeGroup(DoctorFeeGroup selectedDoctorFeeGroup) {
         this.selectedDoctorFeeGroup = selectedDoctorFeeGroup;
+    }
+
+    /**
+     * The part of the ProfessionalCharge category total that is not listed
+     * against any doctor row in {@link #getGroupedProfessionalFees()} — i.e.
+     * everything charged through service items typed ProfessionalCharge
+     * (whether or not they carry a Staff fee, and whether or not that fee is
+     * attached to a doctor). Shown on the final bill page as a single "Other
+     * Professional Charges" line under Professional Charge so the printed
+     * lines always add up to the category total (issue #23723).
+     */
+    public double getUnattributedProfessionalChargeTotal() {
+        double proTotal = 0;
+        if (chargeItemTotals != null) {
+            for (ChargeItemTotal cit : chargeItemTotals) {
+                if (cit.getInwardChargeType() == InwardChargeType.ProfessionalCharge) {
+                    proTotal = cit.getTotal();
+                    break;
+                }
+            }
+        }
+        double grouped = 0;
+        for (DoctorFeeGroup g : getGroupedProfessionalFees()) {
+            grouped += g.getTotal();
+        }
+        double unattributed = proTotal - grouped;
+        return unattributed < 0.005 ? 0 : unattributed;
     }
 
     public List<Bill> getEtuMedicineIssues() {
@@ -4090,10 +4133,40 @@ public class BhtSummeryController implements Serializable {
     }
 
     /**
+     * Pure per-staff summation used by {@link #addMergedDoctorFeesToProFees}:
+     * sums {@code feeValue} and the effective adjusted value ({@code
+     * feeAdjusted != 0 ? feeAdjusted : feeValue}) across every fee for the
+     * same doctor, in first-appearance order after sorting by orderNo. Static
+     * and CDI-free so it can be unit tested without standing up the bean.
+     *
+     * @return staff -&gt; {@code {feeValueSum, feeAdjustedSum}}
+     */
+    static Map<Staff, double[]> sumFeesByStaff(List<BillFee> fees) {
+        List<BillFee> ordered = new ArrayList<>(fees);
+        ordered.sort(Comparator.comparingInt(BillFee::getOrderNo));
+        Map<Staff, double[]> sums = new LinkedHashMap<>();
+        for (BillFee bf : ordered) {
+            Staff staff = bf.getStaff();
+            if (staff == null) {
+                continue;
+            }
+            double adjusted = bf.getFeeAdjusted() != 0 ? bf.getFeeAdjusted() : bf.getFeeValue();
+            double[] sum = sums.computeIfAbsent(staff, s -> new double[2]);
+            sum[0] += bf.getFeeValue();
+            sum[1] += adjusted;
+        }
+        return sums;
+    }
+
+    /**
      * Stores ONE professional fee per doctor on the saved bill: a doctor's
      * individual fees are merged into a single new BillFee (summed feeValue and
-     * feeAdjusted) attached to the final/temp bill item via referenceBillItem,
-     * preserving the manual doctor order via orderNo.
+     * feeAdjusted, via {@link #sumFeesByStaff}) attached to the final/temp bill
+     * item via referenceBillItem, preserving the manual doctor order via
+     * orderNo. A doctor whose summed feeValue AND feeAdjusted both net to ~0
+     * (e.g. a fully refunded fee) is skipped entirely — not added to {@code
+     * bItem.getProFees()} and not persisted — since there is nothing left to
+     * show or pay.
      * <p>
      * The original per-encounter fees are left untouched on their
      * InwardProfessional bills, so doctor-payment/commission reports (which
@@ -4103,28 +4176,29 @@ public class BhtSummeryController implements Serializable {
      * are kept in memory only.
      */
     private void addMergedDoctorFeesToProFees(List<BillFee> sourceFees, BillItem bItem, boolean persist) {
+        Map<Staff, double[]> sums = sumFeesByStaff(sourceFees);
         Map<Staff, BillFee> merged = new LinkedHashMap<>();
         for (BillFee bf : feesOrderedByOrderNo(sourceFees)) {
             Staff staff = bf.getStaff();
-            if (staff == null) {
+            if (staff == null || merged.containsKey(staff)) {
                 continue;
             }
-            double adjusted = bf.getFeeAdjusted() != 0 ? bf.getFeeAdjusted() : bf.getFeeValue();
-            BillFee m = merged.get(staff);
-            if (m == null) {
-                m = new BillFee();
-                m.setStaff(staff);
-                m.setFee(bf.getFee());
-                m.setBill(bItem.getBill());
-                m.setBillItem(bItem);
-                m.setReferenceBillItem(bItem);
-                m.setOrderNo(bf.getOrderNo());
-                m.setCreatedAt(new Date());
-                m.setCreater(getSessionController().getLoggedUser());
-                merged.put(staff, m);
+            double[] sum = sums.get(staff);
+            if (Math.abs(sum[0]) < 0.005 && Math.abs(sum[1]) < 0.005) {
+                continue;
             }
-            m.setFeeValue(m.getFeeValue() + bf.getFeeValue());
-            m.setFeeAdjusted(m.getFeeAdjusted() + adjusted);
+            BillFee m = new BillFee();
+            m.setStaff(staff);
+            m.setFee(bf.getFee());
+            m.setBill(bItem.getBill());
+            m.setBillItem(bItem);
+            m.setReferenceBillItem(bItem);
+            m.setOrderNo(bf.getOrderNo());
+            m.setCreatedAt(new Date());
+            m.setCreater(getSessionController().getLoggedUser());
+            m.setFeeValue(sum[0]);
+            m.setFeeAdjusted(sum[1]);
+            merged.put(staff, m);
         }
         for (BillFee m : merged.values()) {
             if (persist) {
@@ -5591,9 +5665,20 @@ public class BhtSummeryController implements Serializable {
         // ChargeItemTotal does not exist at all (issue #23543).
         for (ChargeItemTotal cit : chargeItemTotals) {
             if (cit.getInwardChargeType() == InwardChargeType.ProfessionalCharge) {
-                cit.setGross(proGross);
-                cit.setMargin(proMargin);
-                cit.setVat(proVat);
+                // ProfessionalCharge combines two sources (issue #23723): the
+                // InwardProfessional-bill pro fees (proGross/proMargin/proVat,
+                // same as before) PLUS the service/investigation-item part
+                // (serviceBreakdown + timedItemTotals) that the general loop
+                // above already computes for every other charge type — the old
+                // code here overwrote that part instead of adding to it.
+                double[] serviceValues = serviceBreakdown.get(InwardChargeType.ProfessionalCharge);
+                Double timedTotal = timedItemTotals.get(InwardChargeType.ProfessionalCharge);
+                double serviceGross = serviceValues != null ? serviceValues[0] : 0.0;
+                double serviceMargin = serviceValues != null ? serviceValues[1] : 0.0;
+                double serviceVat = serviceValues != null ? serviceValues[2] : 0.0;
+                cit.setGross(serviceGross + (timedTotal != null ? timedTotal : 0.0) + proGross);
+                cit.setMargin(serviceMargin + proMargin);
+                cit.setVat(serviceVat + proVat);
             } else if (cit.getInwardChargeType() == InwardChargeType.DoctorAndNurses) {
                 cit.setGross(docGross);
                 cit.setMargin(docMargin);

--- a/src/main/java/com/divudi/core/entity/BillItem.java
+++ b/src/main/java/com/divudi/core/entity/BillItem.java
@@ -1003,6 +1003,27 @@ public class BillItem implements Serializable, RetirableEntity {
         this.proFees = proFees;
     }
 
+    /**
+     * The part of this line's adjustedValue not covered by any doctor in
+     * proFees — e.g. a service item typed ProfessionalCharge, whether or not
+     * it carries a Staff fee, and whether or not that fee is attached to a
+     * doctor. Used by final-bill print templates to show the part of the
+     * Professional Charge total that is not listed against any doctor, so
+     * the printed lines always add up (issue #23723).
+     */
+    public double getUnattributedProfessionalFeeValue() {
+        double proFeesTotal = 0;
+        if (proFees != null) {
+            for (BillFee bf : proFees) {
+                if (bf != null) {
+                    proFeesTotal += bf.getFeeAdjusted();
+                }
+            }
+        }
+        double result = adjustedValue - proFeesTotal;
+        return result < 0.005 ? 0 : result;
+    }
+
     public String getDescreption() {
         return descreption;
     }

--- a/src/main/webapp/inward/inward_bill_final.xhtml
+++ b/src/main/webapp/inward/inward_bill_final.xhtml
@@ -854,7 +854,7 @@
                                 <p:inputText autocomplete="off" value="#{g.totalAdjusted}" style="text-align: right;">
                                     <f:convertNumber pattern="#,##0.00"/>
                                     <p:ajax event="blur" process="@this"
-                                            update=":#{p:resolveFirstComponentWithId('professionalFeeTable',view).clientId} :#{p:resolveFirstComponentWithId('dList',view).clientId} :#{p:resolveFirstComponentWithId('tot',view).clientId}"
+                                            update=":#{p:resolveFirstComponentWithId('professionalFeeTable',view).clientId} :#{p:resolveFirstComponentWithId('dList',view).clientId} :#{p:resolveFirstComponentWithId('tot',view).clientId} :#{p:resolveFirstComponentWithId('unattributedProfessionalNoteWrap',view).clientId}"
                                             listener="#{bhtSummeryController.changeGroupedAdjustedValue(g)}"/>
                                     <p:ajax process="@this" event="keyup"
                                             update=":#{p:resolveFirstComponentWithId('settle',view).clientId} :#{p:resolveFirstComponentWithId('saveProvisional',view).clientId}"
@@ -874,6 +874,19 @@
                             </p:column>
 
                         </p:dataTable>
+
+                        <!-- Professional charges that were not entered through Add Professional Fee
+                             (service items typed ProfessionalCharge) are not listed per doctor; they
+                             print as one "Other Professional Charges" line on the bill. -->
+                        <h:panelGroup id="unattributedProfessionalNoteWrap">
+                            <h:panelGroup id="unattributedProfessionalNote" layout="block" styleClass="mt-2 text-muted"
+                                          rendered="#{bhtSummeryController.unattributedProfessionalChargeTotal ge 0.01}">
+                                <h:outputText value="Other professional charges, not entered as professional fees (printed as one line): "/>
+                                <h:outputText value="#{bhtSummeryController.unattributedProfessionalChargeTotal}">
+                                    <f:convertNumber pattern="#,##0.00"/>
+                                </h:outputText>
+                            </h:panelGroup>
+                        </h:panelGroup>
                     </p:panel>
 
                     <p:dialog header="Fee Breakdown"
@@ -915,7 +928,7 @@
                                         <p:inputText autocomplete="off" value="#{fb.feeAdjusted}" style="text-align: right;">
                                             <f:convertNumber pattern="#,##0.00"/>
                                             <p:ajax event="blur" process="@this"
-                                                    update=":#{p:resolveFirstComponentWithId('breakdownTable',view).clientId} :#{p:resolveFirstComponentWithId('professionalFeeTable',view).clientId} :#{p:resolveFirstComponentWithId('dList',view).clientId} :#{p:resolveFirstComponentWithId('tot',view).clientId}"
+                                                    update=":#{p:resolveFirstComponentWithId('breakdownTable',view).clientId} :#{p:resolveFirstComponentWithId('professionalFeeTable',view).clientId} :#{p:resolveFirstComponentWithId('dList',view).clientId} :#{p:resolveFirstComponentWithId('tot',view).clientId} :#{p:resolveFirstComponentWithId('unattributedProfessionalNoteWrap',view).clientId}"
                                                     listener="#{bhtSummeryController.changeFeeAdjustedInBreakdown(fb)}"/>
                                             <p:ajax process="@this" event="keyup"
                                                     update=":#{p:resolveFirstComponentWithId('settle',view).clientId} :#{p:resolveFirstComponentWithId('saveProvisional',view).clientId}"

--- a/src/main/webapp/resources/inward/bill/finalBill.xhtml
+++ b/src/main/webapp/resources/inward/bill/finalBill.xhtml
@@ -266,6 +266,22 @@
                                                                 </tr>
                                                             </h:panelGroup>
                                                         </ui:repeat>
+                                                            <h:panelGroup rendered="#{bip.unattributedProfessionalFeeValue ge 0.01}">
+                                                                <tr>
+                                                                    <td style="text-align: left;font-size: 10px!important;" width="90%">
+                                                                        <h:panelGroup>
+                                                                            #{configOptionApplicationController.getShortTextValueByKey('Inward Final Bill - Label For Other Professional Charges', 'Other Professional Charges')}
+                                                                        </h:panelGroup>
+                                                                    </td>
+                                                                    <td  style="text-align: right;font-size: 10px!important; padding-left: 15px;" width="100%">
+                                                                        <h:panelGroup>
+                                                                            <h:outputLabel value="#{bip.unattributedProfessionalFeeValue}">
+                                                                                <f:convertNumber pattern="#,##0.00" />
+                                                                            </h:outputLabel>
+                                                                        </h:panelGroup>
+                                                                    </td>
+                                                                </tr>
+                                                            </h:panelGroup>
                                                     </table>
                                                 </h:panelGroup>
                                                 <h:panelGroup rendered="#{!configOptionApplicationController.getBooleanValueByKey('Hide Room Charges Details in Final Bill',false)}" >
@@ -662,6 +678,18 @@
                                                                         </tr>
                                                                     </h:panelGroup>
                                                                 </ui:repeat>
+                                                                    <h:panelGroup rendered="#{bip.unattributedProfessionalFeeValue ge 0.01}">
+                                                                        <tr>
+                                                                            <td style="text-align: left; font-size: 10px!important;">
+                                                                                <h:panelGroup>#{configOptionApplicationController.getShortTextValueByKey('Inward Final Bill - Label For Other Professional Charges', 'Other Professional Charges')}</h:panelGroup>
+                                                                            </td>
+                                                                            <td style="text-align: right; font-size: 10px!important; padding-left: 25px;">
+                                                                                <h:outputLabel value="#{bip.unattributedProfessionalFeeValue}">
+                                                                                    <f:convertNumber pattern="#,##0.00" />
+                                                                                </h:outputLabel>
+                                                                            </td>
+                                                                        </tr>
+                                                                    </h:panelGroup>
                                                             </table>
                                                         </h:panelGroup>
                                                     </h:panelGroup>
@@ -706,6 +734,19 @@
                                                                         </tr>
                                                                     </h:panelGroup>
                                                                 </ui:repeat>
+                                                                    <h:panelGroup rendered="#{bip.unattributedProfessionalFeeValue ge 0.01}">
+                                                                        <tr>
+                                                                            <td style="text-align: left; font-size: 10px!important;">
+                                                                                <h:panelGroup>#{configOptionApplicationController.getShortTextValueByKey('Inward Final Bill - Label For Other Professional Charges', 'Other Professional Charges')}</h:panelGroup>
+                                                                            </td>
+                                                                            <td>&emsp;</td>
+                                                                            <td style="text-align: right; font-size: 10px!important;">
+                                                                                <h:outputLabel value="#{bip.unattributedProfessionalFeeValue}">
+                                                                                    <f:convertNumber pattern="#,##0.00" />
+                                                                                </h:outputLabel>
+                                                                            </td>
+                                                                        </tr>
+                                                                    </h:panelGroup>
                                                             </table>
                                                         </h:panelGroup>
                                                     </h:panelGroup>
@@ -821,6 +862,18 @@
                                                                     </tr>
                                                                 </h:panelGroup>
                                                             </ui:repeat>
+                                                                <h:panelGroup rendered="#{bip.unattributedProfessionalFeeValue ge 0.01}">
+                                                                    <tr>
+                                                                        <td style="text-align: left; font-size: 10px!important;">
+                                                                            <h:panelGroup>#{configOptionApplicationController.getShortTextValueByKey('Inward Final Bill - Label For Other Professional Charges', 'Other Professional Charges')}</h:panelGroup>
+                                                                        </td>
+                                                                        <td style="text-align: right; font-size: 10px!important; padding-left: 25px;">
+                                                                            <h:outputLabel value="#{bip.unattributedProfessionalFeeValue}">
+                                                                                <f:convertNumber pattern="#,##0.00" />
+                                                                            </h:outputLabel>
+                                                                        </td>
+                                                                    </tr>
+                                                                </h:panelGroup>
                                                         </table>
                                                     </td>
                                                     <td style="width: 30%; text-align: right; font-size: 13px!important;">
@@ -866,6 +919,19 @@
                                                                 </tr>
                                                             </h:panelGroup>
                                                         </ui:repeat>
+                                                            <h:panelGroup rendered="#{bip.unattributedProfessionalFeeValue ge 0.01}">
+                                                                <tr>
+                                                                    <td style="text-align: left; font-size: 10px!important;">
+                                                                        <h:panelGroup>#{configOptionApplicationController.getShortTextValueByKey('Inward Final Bill - Label For Other Professional Charges', 'Other Professional Charges')}</h:panelGroup>
+                                                                    </td>
+                                                                    <td>&emsp;</td>
+                                                                    <td style="text-align: right; font-size: 10px!important;">
+                                                                        <h:outputLabel value="#{bip.unattributedProfessionalFeeValue}">
+                                                                            <f:convertNumber pattern="#,##0.00" />
+                                                                        </h:outputLabel>
+                                                                    </td>
+                                                                </tr>
+                                                            </h:panelGroup>
                                                     </table>
                                                 </td>
                                                 <td style="width: 30%; text-align: right; font-size: 13px!important;">

--- a/src/main/webapp/resources/inward/bill/finalBillBundledCustom1.xhtml
+++ b/src/main/webapp/resources/inward/bill/finalBillBundledCustom1.xhtml
@@ -313,6 +313,18 @@
                                                                 </tr>
                                                             </h:panelGroup>
                                                         </ui:repeat>
+                                                            <h:panelGroup rendered="#{bip.unattributedProfessionalFeeValue ge 0.01}">
+                                                                <tr>
+                                                                    <td style="text-align: left; font-size: 10px!important;">
+                                                                        <h:panelGroup>#{configOptionApplicationController.getShortTextValueByKey('Inward Final Bill - Label For Other Professional Charges', 'Other Professional Charges')}</h:panelGroup>
+                                                                    </td>
+                                                                    <td style="text-align: right; font-size: 10px!important; padding-left: 25px;">
+                                                                        <h:outputLabel value="#{bip.unattributedProfessionalFeeValue}">
+                                                                            <f:convertNumber pattern="#,##0.00" />
+                                                                        </h:outputLabel>
+                                                                    </td>
+                                                                </tr>
+                                                            </h:panelGroup>
                                                     </table>
                                                 </td>
                                                 <td style="width: 30%; text-align: right; font-size: 13px!important;">
@@ -358,6 +370,19 @@
                                                             </tr>
                                                         </h:panelGroup>
                                                     </ui:repeat>
+                                                        <h:panelGroup rendered="#{bip.unattributedProfessionalFeeValue ge 0.01}">
+                                                            <tr>
+                                                                <td style="text-align: left; font-size: 10px!important;">
+                                                                    <h:panelGroup>#{configOptionApplicationController.getShortTextValueByKey('Inward Final Bill - Label For Other Professional Charges', 'Other Professional Charges')}</h:panelGroup>
+                                                                </td>
+                                                                <td>&emsp;</td>
+                                                                <td style="text-align: right; font-size: 10px!important;">
+                                                                    <h:outputLabel value="#{bip.unattributedProfessionalFeeValue}">
+                                                                        <f:convertNumber pattern="#,##0.00" />
+                                                                    </h:outputLabel>
+                                                                </td>
+                                                            </tr>
+                                                        </h:panelGroup>
                                                 </table>
                                             </td>
                                             <td style="width: 30%; text-align: right; font-size: 13px!important;">

--- a/src/main/webapp/resources/inward/bill/finalBillCustom2.xhtml
+++ b/src/main/webapp/resources/inward/bill/finalBillCustom2.xhtml
@@ -232,6 +232,18 @@
                                     </tr>
                                 </h:panelGroup>
                             </ui:repeat>
+                                <h:panelGroup rendered="#{bip.unattributedProfessionalFeeValue ge 0.01}">
+                                    <tr>
+                                        <td>
+                                            <h:outputLabel value="#{configOptionApplicationController.getShortTextValueByKey('Inward Final Bill - Label For Other Professional Charges', 'Other Professional Charges')}"/>
+                                        </td>
+                                        <td style="text-align: right;">
+                                            <h:outputLabel value="#{bip.unattributedProfessionalFeeValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                        </td>
+                                    </tr>
+                                </h:panelGroup>
                         </h:panelGroup>
                     </ui:repeat>
                     <tr style="border-top: 1px solid #000;">

--- a/src/main/webapp/resources/inward/bill/finalBillCustom3.xhtml
+++ b/src/main/webapp/resources/inward/bill/finalBillCustom3.xhtml
@@ -122,6 +122,18 @@
                                     </tr>
                                 </h:panelGroup>
                             </ui:repeat>
+                                <h:panelGroup rendered="#{bip.unattributedProfessionalFeeValue ge 0.01}">
+                                    <tr>
+                                        <td style="text-align: left;">
+                                            <h:outputLabel value="#{configOptionApplicationController.getShortTextValueByKey('Inward Final Bill - Label For Other Professional Charges', 'Other Professional Charges')}" />
+                                        </td>
+                                        <td style="text-align: right;">
+                                            <h:outputLabel value="#{bip.unattributedProfessionalFeeValue}">
+                                                <f:convertNumber pattern="#,##0.00" />
+                                            </h:outputLabel>
+                                        </td>
+                                    </tr>
+                                </h:panelGroup>
                         </h:panelGroup>
                     </ui:repeat>
                 </tbody>

--- a/src/main/webapp/resources/inward/bill/finalBillCustom4.xhtml
+++ b/src/main/webapp/resources/inward/bill/finalBillCustom4.xhtml
@@ -245,6 +245,22 @@
                                                                 </tr>
                                                             </h:panelGroup>
                                                         </ui:repeat>
+                                                            <h:panelGroup rendered="#{bip.unattributedProfessionalFeeValue ge 0.01}">
+                                                                <tr>
+                                                                    <td style="text-align: left;font-size: 10px!important;" width="90%">
+                                                                        <h:panelGroup>
+                                                                            #{configOptionApplicationController.getShortTextValueByKey('Inward Final Bill - Label For Other Professional Charges', 'Other Professional Charges')}
+                                                                        </h:panelGroup>
+                                                                    </td>
+                                                                    <td  style="text-align: right;font-size: 10px!important; padding-left: 15px;" width="100%">
+                                                                            <h:panelGroup>
+                                                                                <h:outputLabel value="#{bip.unattributedProfessionalFeeValue}">
+                                                                                    <f:convertNumber pattern="#,##0.00" />
+                                                                                </h:outputLabel>
+                                                                            </h:panelGroup>
+                                                                    </td>
+                                                                </tr>
+                                                            </h:panelGroup>
                                                     </table>
                                                 </h:panelGroup>
                                                 <h:panelGroup rendered="#{!configOptionApplicationController.getBooleanValueByKey('Hide Room Charges Details in Final Bill',false)}" >
@@ -667,6 +683,18 @@
                                                                         </tr>
                                                                     </h:panelGroup>
                                                                 </ui:repeat>
+                                                                    <h:panelGroup rendered="#{bip.unattributedProfessionalFeeValue ge 0.01}">
+                                                                        <tr>
+                                                                            <td style="text-align: left; font-size: 10px!important;">
+                                                                                <h:panelGroup>#{configOptionApplicationController.getShortTextValueByKey('Inward Final Bill - Label For Other Professional Charges', 'Other Professional Charges')}</h:panelGroup>
+                                                                            </td>
+                                                                            <td style="text-align: right; font-size: 10px!important; padding-left: 25px;">
+                                                                                <h:outputLabel value="#{bip.unattributedProfessionalFeeValue}">
+                                                                                    <f:convertNumber pattern="#,##0.00" />
+                                                                                </h:outputLabel>
+                                                                            </td>
+                                                                        </tr>
+                                                                    </h:panelGroup>
                                                             </table>
                                                         </h:panelGroup>
                                                     </h:panelGroup>
@@ -713,6 +741,19 @@
                                                                         </tr>
                                                                     </h:panelGroup>
                                                                 </ui:repeat>
+                                                                    <h:panelGroup rendered="#{bip.unattributedProfessionalFeeValue ge 0.01}">
+                                                                        <tr>
+                                                                            <td style="text-align: left; font-size: 10px!important;">
+                                                                                <h:panelGroup>#{configOptionApplicationController.getShortTextValueByKey('Inward Final Bill - Label For Other Professional Charges', 'Other Professional Charges')}</h:panelGroup>
+                                                                            </td>
+                                                                            <td>&emsp;</td>
+                                                                            <td style="text-align: right; font-size: 10px!important;">
+                                                                                <h:outputLabel value="#{bip.unattributedProfessionalFeeValue}">
+                                                                                    <f:convertNumber pattern="#,##0.00" />
+                                                                                </h:outputLabel>
+                                                                            </td>
+                                                                        </tr>
+                                                                    </h:panelGroup>
                                                             </table>
                                                         </h:panelGroup>
                                                     </h:panelGroup>
@@ -834,6 +875,18 @@
                                                                     </tr>
                                                                 </h:panelGroup>
                                                             </ui:repeat>
+                                                                <h:panelGroup rendered="#{bip.unattributedProfessionalFeeValue ge 0.01}">
+                                                                    <tr>
+                                                                        <td style="text-align: left; font-size: 10px!important;">
+                                                                            <h:panelGroup>#{configOptionApplicationController.getShortTextValueByKey('Inward Final Bill - Label For Other Professional Charges', 'Other Professional Charges')}</h:panelGroup>
+                                                                        </td>
+                                                                        <td style="text-align: right; font-size: 10px!important; padding-left: 25px;">
+                                                                            <h:outputLabel value="#{bip.unattributedProfessionalFeeValue}">
+                                                                                <f:convertNumber pattern="#,##0.00" />
+                                                                            </h:outputLabel>
+                                                                        </td>
+                                                                    </tr>
+                                                                </h:panelGroup>
                                                         </table>
                                                     </td>
                                                     <td style="width: 30%; text-align: right; font-size: 13px!important;">
@@ -881,6 +934,19 @@
                                                                 </tr>
                                                             </h:panelGroup>
                                                         </ui:repeat>
+                                                            <h:panelGroup rendered="#{bip.unattributedProfessionalFeeValue ge 0.01}">
+                                                                <tr>
+                                                                    <td style="text-align: left; font-size: 10px!important;">
+                                                                        <h:panelGroup>#{configOptionApplicationController.getShortTextValueByKey('Inward Final Bill - Label For Other Professional Charges', 'Other Professional Charges')}</h:panelGroup>
+                                                                    </td>
+                                                                    <td>&emsp;</td>
+                                                                    <td style="text-align: right; font-size: 10px!important;">
+                                                                        <h:outputLabel value="#{bip.unattributedProfessionalFeeValue}">
+                                                                            <f:convertNumber pattern="#,##0.00" />
+                                                                        </h:outputLabel>
+                                                                    </td>
+                                                                </tr>
+                                                            </h:panelGroup>
                                                     </table>
                                                 </td>
                                                 <td style="width: 30%; text-align: right; font-size: 13px!important;">

--- a/src/main/webapp/resources/inward/bill/finalBillGreenSheet.xhtml
+++ b/src/main/webapp/resources/inward/bill/finalBillGreenSheet.xhtml
@@ -273,6 +273,23 @@
                                                             </tr>
                                                         </h:panelGroup>
                                                     </ui:repeat>
+                                                        <h:panelGroup rendered="#{bip.unattributedProfessionalFeeValue ge 0.01}" style="">
+                                                            <tr>
+
+                                                                <td style="text-align: left;font-size: 8px!important;">
+                                                                    <h:panelGroup>
+                                                                        #{configOptionApplicationController.getShortTextValueByKey('Inward Final Bill - Label For Other Professional Charges', 'Other Professional Charges')}
+                                                                    </h:panelGroup>
+                                                                </td>
+                                                                <td  style="text-align: right;font-size: 8px!important;">
+                                                                    <h:panelGroup>
+                                                                        <h:outputLabel value="#{bip.unattributedProfessionalFeeValue}">
+                                                                            <f:convertNumber pattern="#,##0.00" />
+                                                                        </h:outputLabel>
+                                                                    </h:panelGroup>
+                                                                </td>
+                                                            </tr>
+                                                        </h:panelGroup>
                                                 </table>
                                             </h:panelGroup>
                                             <h:panelGroup rendered="sessionController.userPreference.applicationInstitution ne 'Ruhuna'">

--- a/src/main/webapp/resources/inward/bill/finalBill_Cancel.xhtml
+++ b/src/main/webapp/resources/inward/bill/finalBill_Cancel.xhtml
@@ -224,6 +224,23 @@
                                                             </tr>
                                                         </h:panelGroup>
                                                     </ui:repeat>
+                                                        <h:panelGroup rendered="#{bip.unattributedProfessionalFeeValue ge 0.01}" style="">
+                                                            <tr>
+
+                                                                <td style="text-align: left;font-size: 8px!important;">
+                                                                    <h:panelGroup>
+                                                                        #{configOptionApplicationController.getShortTextValueByKey('Inward Final Bill - Label For Other Professional Charges', 'Other Professional Charges')}
+                                                                    </h:panelGroup>
+                                                                </td>
+                                                                <td  style="text-align: right;font-size: 8px!important;">
+                                                                    <h:panelGroup>
+                                                                        <h:outputLabel value="#{bip.unattributedProfessionalFeeValue}">
+                                                                            <f:convertNumber pattern="#,##0.00" />
+                                                                        </h:outputLabel>
+                                                                    </h:panelGroup>
+                                                                </td>
+                                                            </tr>
+                                                        </h:panelGroup>
                                                 </table>
                                             </h:panelGroup>
                                             <h:panelGroup rendered="sessionController.userPreference.applicationInstitution ne 'Ruhuna'">

--- a/src/main/webapp/resources/inward/bill/finalBill_vat.xhtml
+++ b/src/main/webapp/resources/inward/bill/finalBill_vat.xhtml
@@ -252,6 +252,23 @@
                                                                 </tr>
                                                             </h:panelGroup>
                                                         </ui:repeat>
+                                                            <h:panelGroup rendered="#{bip.unattributedProfessionalFeeValue ge 0.01}" style="">
+                                                                <tr>
+
+                                                                    <td style="text-align: left;font-size: 8px!important;">
+                                                                        <h:panelGroup>
+                                                                            #{configOptionApplicationController.getShortTextValueByKey('Inward Final Bill - Label For Other Professional Charges', 'Other Professional Charges')}
+                                                                        </h:panelGroup>
+                                                                    </td>
+                                                                    <td  style="text-align: right;font-size: 8px!important;">
+                                                                        <h:panelGroup>
+                                                                            <h:outputLabel value="#{bip.unattributedProfessionalFeeValue}">
+                                                                                <f:convertNumber pattern="#,##0.00" />
+                                                                            </h:outputLabel>
+                                                                        </h:panelGroup>
+                                                                    </td>
+                                                                </tr>
+                                                            </h:panelGroup>
                                                     </table>
                                                 </h:panelGroup>
                                                 <h:panelGroup>

--- a/src/main/webapp/resources/inward/bill/finalProfessionalBill.xhtml
+++ b/src/main/webapp/resources/inward/bill/finalProfessionalBill.xhtml
@@ -288,6 +288,17 @@
                                         </h:panelGroup>
                                     </p:column>
                                     <p:columnGroup type="footer">
+                                        <p:row rendered="#{bip.unattributedProfessionalFeeValue ge 0.01}">
+                                            <p:column style="text-align: left!important;"
+                                                      footerText="#{configOptionApplicationController.getShortTextValueByKey('Inward Final Bill - Label For Other Professional Charges', 'Other Professional Charges')}"/>
+                                            <p:column style="text-align: right;" >
+                                                <f:facet name="footer">
+                                                    <h:outputLabel value="#{bip.unattributedProfessionalFeeValue}">
+                                                        <f:convertNumber pattern="#,##0.00" />
+                                                    </h:outputLabel>
+                                                </f:facet>
+                                            </p:column>
+                                        </p:row>
                                         <p:row>
                                             <p:column footerText="Total"/>
                                             <p:column style="text-align: right;" >

--- a/src/test/java/com/divudi/bean/inward/BhtSummeryControllerProfessionalChargeTest.java
+++ b/src/test/java/com/divudi/bean/inward/BhtSummeryControllerProfessionalChargeTest.java
@@ -1,0 +1,185 @@
+package com.divudi.bean.inward;
+
+import com.divudi.core.entity.BillItem;
+import com.divudi.core.entity.BillFee;
+import com.divudi.core.entity.Staff;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Regression tests for issue #23723's ProfessionalCharge money fix: adjusting
+ * one doctor's fee on the Final Bill must move the ProfessionalCharge
+ * category's adjusted total by that fee's delta only, never by replacing it
+ * with the sum of the doctor rows (which does not cover the whole category —
+ * the category total also contains service items typed ProfessionalCharge,
+ * plus timed/additional charges, that the per-doctor list never lists).
+ * <p>
+ * These tests cover the pure, CDI-free pieces of the fix:
+ * <ul>
+ * <li>{@link BhtSummeryController#sumFeesByStaff(List)} — the per-staff
+ * summation {@code addMergedDoctorFeesToProFees} uses to merge a doctor's
+ * individual fees into one, and to net a refunded fee against its
+ * original.</li>
+ * <li>{@link BhtSummeryController#professionalAdjustedTotal(double, List)} —
+ * the delta-based adjusted-total helper that keeps the untouched part of the
+ * ProfessionalCharge total (the part not covered by any doctor row) when a
+ * doctor's fee is adjusted.</li>
+ * <li>{@link BillItem#getUnattributedProfessionalFeeValue()} — the remainder
+ * of a bill item's adjustedValue not covered by any doctor in proFees.</li>
+ * </ul>
+ * Per-staff equality is id-based ({@code Staff.equals}/{@code hashCode}), so
+ * distinct ids are used throughout to avoid accidentally merging two
+ * different doctors (both otherwise default to id=null).
+ */
+class BhtSummeryControllerProfessionalChargeTest {
+
+    private static Staff staff(long id) {
+        Staff s = new Staff();
+        s.setId(id);
+        return s;
+    }
+
+    private static BillFee fee(Staff staff, double feeValue, double feeAdjusted, int orderNo) {
+        BillFee bf = new BillFee();
+        bf.setStaff(staff);
+        bf.setFeeValue(feeValue);
+        bf.setFeeAdjusted(feeAdjusted);
+        bf.setOrderNo(orderNo);
+        return bf;
+    }
+
+    // ---- sumFeesByStaff -----------------------------------------------
+
+    @Test
+    void sumFeesByStaff_sumsTwoFees_forSameDoctor() {
+        Staff doctor = staff(1L);
+        // Two individual fees for the same doctor must be summed together.
+        // The second fee's non-zero feeAdjusted differs from its feeValue, so
+        // the effective-adjusted rule (feeAdjusted != 0 ? feeAdjusted :
+        // feeValue) is exercised for both fees in the merge.
+        BillFee feeOne = fee(doctor, 10_000.0, 0.0, 0);
+        BillFee feeTwo = fee(doctor, 7_500.0, 6_000.0, 1);
+
+        Map<Staff, double[]> sums = BhtSummeryController.sumFeesByStaff(Arrays.asList(feeOne, feeTwo));
+
+        assertEquals(1, sums.size());
+        double[] sum = sums.get(doctor);
+        assertEquals(17_500.0, sum[0], 0.001, "feeValue sum");
+        assertEquals(16_000.0, sum[1], 0.001, "adjusted sum uses feeTwo's feeAdjusted, not its feeValue");
+    }
+
+    @Test
+    void sumFeesByStaff_netsToZero_forPositiveFeeAndNegativeRefund() {
+        Staff doctor = staff(2L);
+        // A billed fee fully reversed by a refund's negative contra fee for
+        // the same doctor nets to zero — the condition
+        // addMergedDoctorFeesToProFees uses (abs < 0.005 on both sums) to
+        // skip persisting/showing a doctor row with nothing left to pay.
+        BillFee billed = fee(doctor, 5_000.0, 0.0, 0);
+        BillFee refund = fee(doctor, -5_000.0, 0.0, 1);
+
+        Map<Staff, double[]> sums = BhtSummeryController.sumFeesByStaff(Arrays.asList(billed, refund));
+
+        double[] sum = sums.get(doctor);
+        assertEquals(0.0, sum[0], 0.005);
+        assertEquals(0.0, sum[1], 0.005);
+    }
+
+    @Test
+    void sumFeesByStaff_keepsDoctorsSeparate() {
+        Staff docA = staff(3L);
+        Staff docB = staff(4L);
+        BillFee feeA = fee(docA, 1_000.0, 0.0, 0);
+        BillFee feeB = fee(docB, 2_000.0, 0.0, 1);
+
+        Map<Staff, double[]> sums = BhtSummeryController.sumFeesByStaff(Arrays.asList(feeA, feeB));
+
+        assertEquals(2, sums.size());
+        assertEquals(1_000.0, sums.get(docA)[0], 0.001);
+        assertEquals(2_000.0, sums.get(docB)[0], 0.001);
+    }
+
+    // ---- professionalAdjustedTotal --------------------------------------
+
+    @Test
+    void professionalAdjustedTotal_keepsUnattributedPart_whenADoctorFeeIsAdjusted() {
+        // Total already includes both the doctor-row part and the
+        // unattributed part (service items typed ProfessionalCharge, timed/
+        // additional charges); adjusting one doctor's fee down by 2000 must
+        // only move the total by that 2000, never dropping the untouched
+        // unattributed part.
+        BillFee editableFee = fee(staff(5L), 10_000.0, 8_000.0, 0);
+
+        double result = BhtSummeryController.professionalAdjustedTotal(26_500.0, Collections.singletonList(editableFee));
+
+        assertEquals(24_500.0, result, 0.001);
+    }
+
+    @Test
+    void professionalAdjustedTotal_noEditableFees_returnsTotalUnchanged() {
+        double result = BhtSummeryController.professionalAdjustedTotal(26_500.0, new ArrayList<>());
+        assertEquals(26_500.0, result, 0.001);
+
+        double resultNull = BhtSummeryController.professionalAdjustedTotal(26_500.0, null);
+        assertEquals(26_500.0, resultNull, 0.001);
+    }
+
+    @Test
+    void professionalAdjustedTotal_sumsMultipleEditableFeeDeltas() {
+        BillFee feeA = fee(staff(6L), 10_000.0, 8_000.0, 0); // -2000
+        BillFee feeB = fee(staff(7L), 5_000.0, 5_500.0, 1);  // +500
+
+        double result = BhtSummeryController.professionalAdjustedTotal(26_500.0, Arrays.asList(feeA, feeB));
+
+        assertEquals(25_000.0, result, 0.001);
+    }
+
+    // ---- BillItem.getUnattributedProfessionalFeeValue ----------------------
+
+    @Test
+    void getUnattributedProfessionalFeeValue_returnsRemainder() {
+        BillItem bi = new BillItem();
+        bi.setAdjustedValue(26_500.0);
+        List<BillFee> proFees = new ArrayList<>();
+        proFees.add(feeWithAdjusted(10_000.0));
+        proFees.add(feeWithAdjusted(7_500.0));
+        proFees.add(feeWithAdjusted(1_500.0));
+        bi.setProFees(proFees);
+
+        assertEquals(7_500.0, bi.getUnattributedProfessionalFeeValue(), 0.001);
+    }
+
+    @Test
+    void getUnattributedProfessionalFeeValue_returnsZero_whenBalanced() {
+        BillItem bi = new BillItem();
+        bi.setAdjustedValue(19_000.0);
+        List<BillFee> proFees = new ArrayList<>();
+        proFees.add(feeWithAdjusted(12_000.0));
+        proFees.add(feeWithAdjusted(7_000.0));
+        bi.setProFees(proFees);
+
+        assertEquals(0.0, bi.getUnattributedProfessionalFeeValue(), 0.001);
+    }
+
+    @Test
+    void getUnattributedProfessionalFeeValue_nullSafe_whenProFeesNull() {
+        BillItem bi = new BillItem();
+        bi.setAdjustedValue(500.0);
+        bi.setProFees(null);
+
+        assertEquals(500.0, bi.getUnattributedProfessionalFeeValue(), 0.001);
+    }
+
+    private static BillFee feeWithAdjusted(double feeAdjusted) {
+        BillFee bf = new BillFee();
+        bf.setFeeAdjusted(feeAdjusted);
+        return bf;
+    }
+}


### PR DESCRIPTION
## Hotfix for coop staging

Brings #23732 (merged to `development` as 01fd760) to `coop-stg-migrated`, where Galle Co-op's inpatient staff work. Closes #23723.

**Please do not merge until you're ready for the CI/CD deploy** — merging triggers a redeploy of staging.

## What it fixes

The inward final bill's **Professional Charge** total is fed from two places: fees entered through **Add Professional Fee**, and service items whose charge type is `ProfessionalCharge` — e.g. an MRI "REPORTING - Dr ..." item billed by the Karapitiya Diagnostic Centre with the radiologist's fee bundled in. Only the first kind was listed, so the printed doctors didn't add up to the total. On BHT/57944 the bill showed 26,500 against three doctors totalling 19,000, and a radiologist fee that had been charged twice was invisible.

**The rule now:** a doctor is named only when the fee was entered through Add Professional Fee. Everything else under Professional Charge is summed into one **Other Professional Charges** line, so the lines always add up. If a hospital wants the doctor named, the fee is entered as a professional fee and an administrator supplies that service without its professional component.

Also included:
- **Money fix** — adjusting a doctor's fee on the final bill no longer drops service-item professional charges from the Professional Charge total (it previously replaced the total with the sum of the professional-fee doctors).
- Charge Types gross/margin/VAT for Professional Charge adds the service part instead of overwriting it.
- The label is a ConfigOption: `Inward Final Bill - Label For Other Professional Charges` (default "Other Professional Charges").

## How this branch was made

Branched from `origin/coop-stg-migrated` and cherry-picked the two commits of #23732 (source only — the `developer_docs` change was left out, since staging carries its own copy). Staging's own hotfixes are untouched: the diff against `coop-stg-migrated` is purely additive, including in `finalProfessionalBill.xhtml` and `finalBill_vat.xhtml`, which #23728 had changed.

## Verification

- `mvn test -Dtest=BhtSummeryController*Test` **on this branch**: 36/36 pass, full project compiles.
- E2E on a local copy of the coop database, two admissions with the same doctor:
  - **MRI without a professional component** + fee entered through Add Professional Fee → the MRI prints under its own charge type and the doctor is **named** (2,500), no Other line.
  - **MRI with the fee bundled in** + 5,000 of entered professional fees → Professional Charge 5,500 = doctor named 5,000 + **Other Professional Charges 500**.
- Checked in the database and on the Custom Bill 3, standard Final Bill, Professional Bill and reprint outputs.

![Doctor named when entered as a professional fee](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23723-a-separate-professional-fee-named.png)

![Bundled reporting fee printing as Other Professional Charges](https://raw.githubusercontent.com/wiki/hmislk/hmis/images/23723-b-bundled-other-professional-charges.png)

*(Doctor names replaced, patient details cropped.)*

## After deploying to staging

BHT/57944 itself still needs correcting by hospital staff: cancel the duplicate professional fee `Inward/INWPRO/436` and redo the final bill (correct net total 77,210.46 instead of 84,710.46).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BgPvMGQWN7ZqF5yWoSzAuq
