### PR TITLE
feat(theatre): make the surgery service item list a per-department setting

### DIFF
--- a/src/main/java/com/divudi/bean/common/EnumController.java
+++ b/src/main/java/com/divudi/bean/common/EnumController.java
@@ -494,6 +494,10 @@ public class EnumController implements Serializable {
         return sts;
     }
 
+    public TheatreItemListingStrategy[] getTheatreItemListingStrategys() {
+        return TheatreItemListingStrategy.values();
+    }
+
     public ItemListingStrategy[] getInwardItemListingStrategys() {
         ItemListingStrategy[] sts
                 = {ItemListingStrategy.ALL_ITEMS,

--- a/src/main/java/com/divudi/bean/common/ItemController.java
+++ b/src/main/java/com/divudi/bean/common/ItemController.java
@@ -38,6 +38,7 @@ import com.divudi.core.util.JsfUtil;
 import com.divudi.bean.lab.InvestigationController;
 import com.divudi.bean.hr.StaffController;
 import com.divudi.core.data.SessionNumberType;
+import com.divudi.core.data.TheatreItemListingStrategy;
 import com.divudi.core.data.Sex;
 import com.divudi.core.entity.UserPreference;
 import com.divudi.core.facade.DepartmentFacade;
@@ -3342,30 +3343,66 @@ public class ItemController implements Serializable {
         JsfUtil.addSuccessMessage("All Servies and Investigations were made to allow discounts.");
     }
 
+    /**
+     * Items offered by the theatre surgery service bill's autocomplete
+     * (theater/inward_bill_surgery_service.xhtml).
+     *
+     * Which items qualify is a per-department setting
+     * ({@link UserPreference#getTheatreItemListingStrategy()}): a hospital that
+     * maintains a dedicated Theatre Service master keeps the default
+     * THEATRE_SERVICES, while one that bills theatre consumables from its
+     * existing OPD/Inward service master uses ALL_SERVICES or maps the items it
+     * wants to the theatre department and uses
+     * ITEMS_MAPPED_TO_LOGGED_DEPARTMENT.
+     */
     public List<Item> completeTheatreItems(String query) {
-        List<Item> suggestions;
-        HashMap m = new HashMap();
-        String sql;
-        if (query == null) {
-            suggestions = new ArrayList<>();
-        } else {
-            sql = "select c from Item c "
-                    + " where c.retired=false "
-                    + " and type(c)=:the "
-                    //                    + " and type(c)!=:pac "
-                    //                    + " and (type(c)=:ser "
-                    //                    + " or type(c)=:inv "
-                    //                    + " or type(c)=:the)  "
-                    + " and (c.name) like :q"
-                    + " order by c.name";
-//            m.put("pac", Packege.class);
-//            m.put("ser", Service.class);
-//            m.put("inv", Investigation.class);
-            m.put("the", TheatreService.class);
-            m.put("q", "%" + query.toUpperCase() + "%");
-            suggestions = getFacade().findByJpql(sql, m, 20);
+        if (query == null || query.trim().isEmpty()) {
+            return new ArrayList<>();
         }
-        return suggestions;
+
+        TheatreItemListingStrategy strategy = getSessionController()
+                .getDepartmentPreference().getTheatreItemListingStrategy();
+
+        Map<String, Object> m = new HashMap<>();
+        m.put("q", "%" + query.trim().toUpperCase() + "%");
+        String sql;
+
+        switch (strategy) {
+            case ALL_SERVICES:
+                // Service is the common superclass of InwardService and
+                // TheatreService, so this covers all three in one query.
+                sql = "select c from Service c "
+                        + " where c.retired=false "
+                        + " and (c.inactive=false or c.inactive is null) "
+                        + " and (c.name) like :q"
+                        + " order by c.name";
+                break;
+
+            case ITEMS_MAPPED_TO_LOGGED_DEPARTMENT:
+                sql = "select im.item from ItemMapping im "
+                        + " where im.retired=false "
+                        + " and im.item.retired=false "
+                        + " and (im.item.inactive=false or im.item.inactive is null) "
+                        + " and im.department=:dept "
+                        + " and (im.item.name) like :q"
+                        + " order by im.item.name";
+                m.put("dept", getSessionController().getDepartment());
+                break;
+
+            case THEATRE_SERVICES:
+            default:
+                sql = "select c from Item c "
+                        + " where c.retired=false "
+                        + " and (c.inactive=false or c.inactive is null) "
+                        + " and type(c)=:the "
+                        + " and (c.name) like :q"
+                        + " order by c.name";
+                m.put("the", TheatreService.class);
+                break;
+        }
+
+        List<Item> suggestions = getFacade().findByJpql(sql, m, 20);
+        return suggestions != null ? suggestions : new ArrayList<>();
     }
 
     Category category;

--- a/src/main/java/com/divudi/core/data/TheatreItemListingStrategy.java
+++ b/src/main/java/com/divudi/core/data/TheatreItemListingStrategy.java
@@ -1,0 +1,33 @@
+/*
+ * Open Hospital Management Information System
+ * Dr M H B Ariyaratne
+ * buddhika.ari@gmail.com
+ */
+package com.divudi.core.data;
+
+/**
+ * Controls which items the theatre surgery service bill
+ * (theater/inward_bill_surgery_service.xhtml) offers in its item autocomplete.
+ *
+ * Held per department on {@link com.divudi.core.entity.UserPreference}, so one
+ * hospital can bill theatre consumables from its existing OPD/Inward service
+ * master while another keeps a dedicated Theatre Service master.
+ *
+ * @author Dr M H B Ariyaratne <buddhika.ari at gmail.com>
+ */
+public enum TheatreItemListingStrategy {
+
+    THEATRE_SERVICES("Theatre Services Only"),
+    ALL_SERVICES("All Services"),
+    ITEMS_MAPPED_TO_LOGGED_DEPARTMENT("Services Mapped to the Logged Department");
+
+    private final String label;
+
+    TheatreItemListingStrategy(String label) {
+        this.label = label;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+}

--- a/src/main/java/com/divudi/core/entity/UserPreference.java
+++ b/src/main/java/com/divudi/core/entity/UserPreference.java
@@ -12,6 +12,7 @@ import com.divudi.core.data.OpdTokenNumberGenerationStrategy;
 import com.divudi.core.data.PaperType;
 import com.divudi.core.data.PaymentMethod;
 import com.divudi.core.data.RestAuthenticationType;
+import com.divudi.core.data.TheatreItemListingStrategy;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -229,6 +230,9 @@ public class UserPreference implements Serializable {
 
     @Enumerated(value = EnumType.STRING)
     private ItemListingStrategy inwardItemListingStrategy;
+
+    @Enumerated(value = EnumType.STRING)
+    private TheatreItemListingStrategy theatreItemListingStrategy;
 
     @Enumerated(value = EnumType.STRING)
     private OpdTokenNumberGenerationStrategy opdTokenNumberGenerationStrategy;
@@ -1298,6 +1302,23 @@ public class UserPreference implements Serializable {
 
     public void setInwardItemListingStrategy(ItemListingStrategy inwardItemListingStrategy) {
         this.inwardItemListingStrategy = inwardItemListingStrategy;
+    }
+
+    /**
+     * Strategy used by the theatre surgery service bill's item autocomplete.
+     * Defaults to {@link TheatreItemListingStrategy#THEATRE_SERVICES} so
+     * departments that have never set it keep the long-standing behaviour of
+     * listing only dedicated Theatre Service items.
+     */
+    public TheatreItemListingStrategy getTheatreItemListingStrategy() {
+        if (theatreItemListingStrategy == null) {
+            return TheatreItemListingStrategy.THEATRE_SERVICES;
+        }
+        return theatreItemListingStrategy;
+    }
+
+    public void setTheatreItemListingStrategy(TheatreItemListingStrategy theatreItemListingStrategy) {
+        this.theatreItemListingStrategy = theatreItemListingStrategy;
     }
 
     public Integer getNumberOfOPDBillCopies() {

--- a/src/main/webapp/admin/institutions/admin_mange_department_preferences.xhtml
+++ b/src/main/webapp/admin/institutions/admin_mange_department_preferences.xhtml
@@ -318,6 +318,15 @@
                                         <f:selectItems value="#{enumController.inwardItemListingStrategys}"></f:selectItems>
                                     </p:selectOneMenu>
 
+                                    <h:outputLabel 
+                                        class="form-label"
+                                        value="Theatre Item Listing Strategy" ></h:outputLabel>
+                                    <p:selectOneMenu 
+                                        value="#{sessionController.currentPreference.theatreItemListingStrategy}"
+                                        class="form-control">
+                                        <f:selectItems value="#{enumController.theatreItemListingStrategys}" var="tils" itemLabel="#{tils.label}" itemValue="#{tils}"></f:selectItems>
+                                    </p:selectOneMenu>
+
                                     <h:outputText value="Header for Inpatient Final Bill" ></h:outputText>
                                     <p:inputTextarea value="#{sessionController.currentPreference.inpatientFinalBillPrintHeader}" class="w-100" rows="20"/>
 

--- a/src/main/webapp/admin/institutions/admin_mange_user_options.xhtml
+++ b/src/main/webapp/admin/institutions/admin_mange_user_options.xhtml
@@ -319,6 +319,15 @@
                                         <f:selectItems value="#{enumController.inwardItemListingStrategys}"></f:selectItems>
                                     </p:selectOneMenu>
 
+                                    <h:outputLabel 
+                                        class="form-label"
+                                        value="Theatre Item Listing Strategy" ></h:outputLabel>
+                                    <p:selectOneMenu 
+                                        value="#{sessionController.currentPreference.theatreItemListingStrategy}"
+                                        class="form-control">
+                                        <f:selectItems value="#{enumController.theatreItemListingStrategys}" var="tils" itemLabel="#{tils.label}" itemValue="#{tils}"></f:selectItems>
+                                    </p:selectOneMenu>
+
                                     <h:outputText value="Header for Inpatient Final Bill" ></h:outputText>
                                     <p:inputTextarea value="#{sessionController.currentPreference.inpatientFinalBillPrintHeader}" class="w-100" rows="20"/>
 


### PR DESCRIPTION
Closes #23743

## Problem

`theater/inward_bill_surgery_service.xhtml` binds its item autocomplete to
`ItemController.completeTheatreItems`, which was hardcoded to `type(c) = TheatreService`. Every
deployment checked has an empty `TheatreService` master, so the screen listed nothing and no
surgery service could be billed from it at all:

| Deployment | Non-retired `TheatreService` items |
|---|---|
| Ruhunu local staging (`rhLocal`) | 0 |
| Galle Co-operative (local restore of production) | 0 |

Hospitals keep theatre consumables and charges in the ordinary OPD/Inward service master instead.
On rhLocal the 88 theatre services the hospital wants to bill all exist and are correctly priced,
but as DTYPE `Service` — unreachable from this page. No department mapping, item mapping or
`ConfigOption` affected the query.

## Change

New per-department `UserPreference.theatreItemListingStrategy`, mirroring the existing
`inwardItemListingStrategy` used by the inward service bill, exposed on both
*Department Preferences* and *User Options* under the **In-ward** tab:

| Value | Lists |
|---|---|
| `THEATRE_SERVICES` (**default**) | `TheatreService` only — today's behaviour |
| `ALL_SERVICES` | `Service`, `InwardService` and `TheatreService`, via one polymorphic `FROM Service` query since the latter two extend `Service` |
| `ITEMS_MAPPED_TO_LOGGED_DEPARTMENT` | items mapped to the logged department via `ItemMapping` |

The getter returns `THEATRE_SERVICES` when the column is null, so **no deployment changes
behaviour on upgrade** — a hospital with a populated Theatre Service master is unaffected.

All three branches now also exclude inactive items, matching every sibling method
(`fetchInwardItems`). A deactivated item should not be billable, and the two widened branches would
otherwise surface hundreds of them.

## Verification

Built and deployed locally (Payara, Galle Co-operative DB restore), driven end-to-end with
Playwright. Menu path: *Administration → Manage Institutions → Preferences → Department
Preferences → In-ward tab*, then *Inpatient → Search → Admissions → Inpatient Dashboard →
view Surgeries → Add Services & Investigations*.

| Strategy | Result |
|---|---|
| `THEATRE_SERVICES` (dept with no preference row, falls back to default) | "No results found" — behaviour unchanged |
| `ALL_SERVICES` | OPD `Service` and `InwardService` items listed; `DRESSING CHARGES OT C&D` selected, added, priced at **300.00** from its `ItemFee` (Hospital Fee), and settled to bills `Inward//26/000584` / `Inward//26/000585`, confirmed in the DB |
| `ITEMS_MAPPED_TO_LOGGED_DEPARTMENT` | Searching "x ray" returned exactly the 9 items mapped to the Inward department in `itemmapping`, correctly excluding unmapped `X Ray (Dental)`, `X Ray (Normal)`, `X Ray Whole Spine — AP` |

Round-trip of the preference through the page and `USERPREFERENCE.THEATREITEMLISTINGSTRATEGY`
confirmed in both directions.

## Deployment note

`USERPREFERENCE.THEATREITEMLISTINGSTRATEGY` is a new column — it goes in via `/generate-ddl` +
**Add Missing Columns**, not a migration script.

The setting is read through `SessionController.getDepartmentPreference()`, which is loaded at
login, so a change takes effect on the user's **next login** — the same as the existing inward
strategy. Worth saying to staff so a saved change doesn't look like it failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThiYJBdNquvCrnjDDBvsZR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a theatre item listing strategy preference for departments and users.
  - Administrators can choose whether theatre billing searches show theatre services, all services, or items mapped to the logged-in department.
  - Theatre item searches now follow the selected strategy, with theatre services used by default.
  - Blank searches return no results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->