### PR TITLE
feat(api): close five /api/services gaps that block loading a service master

### DIFF
--- a/developer_docs/api/using-apis/API_SERVICE_MANAGEMENT.md
+++ b/developer_docs/api/using-apis/API_SERVICE_MANAGEMENT.md
@@ -36,6 +36,7 @@ GET /api/services/search
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `query` | string | No | Name substring (case-insensitive) |
+| `code` | string | No | Item code substring. Use this to make a bulk load idempotent — item code is the natural key a spreadsheet of services carries |
 | `serviceType` | string | No | `OPD`, `Inward`, or omit for both |
 | `categoryId` | long | No | Filter by ServiceCategory ID |
 | `inactive` | boolean | No | `true` = inactive only, `false` = active only |
@@ -65,10 +66,18 @@ curl -H "Finance: <key>" \
       "inactive": false,
       "categoryId": 5,
       "categoryName": "Surgical",
+      "financialCategoryId": 88,
+      "financialCategoryName": "INCOME ACCOUNTS:Operation Theatre Charges",
       "inwardChargeType": "WardProcedures"
     }
   ]
 }
+```
+
+Look a service up by its code before creating it:
+
+```bash
+curl -H "Finance: <key>" "https://host/hmis/api/services/search?code=SM-RH-0122&limit=5"
 ```
 
 ---
@@ -117,7 +126,13 @@ curl -H "Finance: <key>" "https://host/hmis/api/services/101"
         "discountAllowed": false,
         "retired": false,
         "institutionId": 1,
-        "institutionName": "General Hospital"
+        "institutionName": "General Hospital",
+        "forInstitutionId": null,
+        "forInstitutionName": null,
+        "forDepartmentId": null,
+        "forDepartmentName": null,
+        "forCategoryId": null,
+        "forCategoryName": null
       }
     ],
     "message": "Service found successfully"
@@ -142,7 +157,8 @@ Content-Type: application/json
 | `code` | string | No | Auto-generated from name if omitted |
 | `printName` | string | No | Display name for printing |
 | `fullName` | string | No | Full descriptive name |
-| `categoryId` | long | No | ServiceCategory ID |
+| `categoryId` | long | No | Category ID (any Category subtype, not only `ServiceCategory`) |
+| `financialCategoryId` | long | No | Financial category / income account — a `Category` whose `categoryType` is `FINANCIAL_CATEGORY`. Look one up with [`/item-categories/search`](#search-any-category) |
 | `institutionId` | long | No | Institution ID |
 | `departmentId` | long | No | Department ID |
 | `inwardChargeType` | string | Req. for Inward | Enum value from [InwardChargeType reference](#inwardchargetype-reference) |
@@ -193,7 +209,8 @@ PUT /api/services/{id}
 Content-Type: application/json
 ```
 
-Only provided (non-null) fields are updated.
+Only provided (non-null) fields are updated. Accepts the same fields as create, including
+`financialCategoryId`.
 
 **Example:**
 ```bash
@@ -272,6 +289,13 @@ Content-Type: application/json
 
 After adding a fee, the service's `total` and `totalForForeigner` are automatically recalculated.
 
+Every fee in a response also carries `forInstitutionId`/`forInstitutionName`,
+`forDepartmentId`/`forDepartmentName` and `forCategoryId`/`forCategoryName`. These are the
+scoping keys: a **base** fee has all three null, a **site or collecting-centre** fee carries
+`forInstitution`, and a **category-specific** fee carries `forCategory`. Note that `institutionId`
+is a different field — it is who the fee is payable to, not what scopes it — so without the `for*`
+keys a base fee cannot be told apart from a scoped one.
+
 **Example:**
 ```bash
 curl -X POST \
@@ -311,7 +335,79 @@ Soft-deletes the fee (sets `retired=true`). Service totals are recalculated.
 
 ---
 
-### C. Service Category CRUD
+#### Recalculate Totals
+```
+POST /api/services/{id}/recalculate-totals
+```
+
+Recomputes the item's `total` and `totalForForeigner` by summing its current non-retired fees,
+and persists them.
+
+These two fields are denormalised. They go stale whenever fees are written outside this API
+(bulk fee uploads, direct edits), and several list screens and reports read them rather than
+summing fees — so a stale `0.00` reads as "this service has no charge" even though its fees are
+correct. Until this endpoint existed the recalculation only ran as a side effect of a fee
+create/update/delete, so the only way to repair a total was to pointlessly rewrite a fee.
+
+Works for any `Item` subtype, not only services.
+
+```bash
+curl -X POST -H "Finance: <key>"   "https://host/hmis/api/services/101/recalculate-totals"
+```
+
+**Response:** the full `ServiceResponseDTO` with the refreshed totals.
+
+> **Caution:** the recalculation sums *every* non-retired fee on the item, including
+> site-, department- and collecting-centre-specific ones. If an item carries duplicate fee rows
+> (the same charge recorded once as a base fee and once scoped to an institution), the recalculated
+> total will be the sum of both. Check `forInstitution`/`forDepartment`/`forCategory` on
+> `GET /api/services/{id}/fees` first.
+
+---
+
+### C. Category Lookup
+
+#### Search Any Category
+```
+GET /api/services/item-categories/search?query=theatre&categoryType=FINANCIAL_CATEGORY&limit=20
+```
+
+**Query Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `query` | string | No | Name substring |
+| `categoryType` | string | No | A `CategoryType` name, e.g. `FINANCIAL_CATEGORY`, `SERVICE_CATEGORY` |
+| `limit` | int | No | Max results (default 30, max 100) |
+
+`/categories/search` (below) only sees rows whose DTYPE is `ServiceCategory`, yet a service's
+`categoryId` may point at any `Category` subtype and its `financialCategoryId` is a plain
+`Category` of type `FINANCIAL_CATEGORY`. Without this endpoint a caller can set a `categoryId`
+it has no way to look up.
+
+**Response:**
+```json
+{
+  "status": "success",
+  "code": 200,
+  "data": [
+    {
+      "id": 88,
+      "name": "INCOME ACCOUNTS:Operation Theatre Charges",
+      "code": "income_accounts_operation_theatre_charges",
+      "categoryType": "FINANCIAL_CATEGORY",
+      "retired": false
+    }
+  ]
+}
+```
+
+An invalid `categoryType` returns `400`. Rows created before the `categoryType` column was
+populated return `"categoryType": null` and are only reachable without the filter.
+
+---
+
+#### ServiceCategory CRUD
 
 #### Search Categories
 ```

--- a/src/main/java/com/divudi/core/data/dto/service/ItemFeeDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/service/ItemFeeDTO.java
@@ -29,6 +29,16 @@ public class ItemFeeDTO {
     private Long staffId;
     private String staffName;
 
+    // Scoping keys. A base fee has all three null; a site or collecting-centre
+    // fee carries forInstitution, a category-specific fee carries forCategory.
+    // Without these a caller cannot tell a base fee from a scoped one.
+    private Long forInstitutionId;
+    private String forInstitutionName;
+    private Long forDepartmentId;
+    private String forDepartmentName;
+    private Long forCategoryId;
+    private String forCategoryName;
+
     public ItemFeeDTO() {
     }
 
@@ -158,5 +168,53 @@ public class ItemFeeDTO {
 
     public void setStaffName(String staffName) {
         this.staffName = staffName;
+    }
+
+    public Long getForInstitutionId() {
+        return forInstitutionId;
+    }
+
+    public void setForInstitutionId(Long forInstitutionId) {
+        this.forInstitutionId = forInstitutionId;
+    }
+
+    public String getForInstitutionName() {
+        return forInstitutionName;
+    }
+
+    public void setForInstitutionName(String forInstitutionName) {
+        this.forInstitutionName = forInstitutionName;
+    }
+
+    public Long getForDepartmentId() {
+        return forDepartmentId;
+    }
+
+    public void setForDepartmentId(Long forDepartmentId) {
+        this.forDepartmentId = forDepartmentId;
+    }
+
+    public String getForDepartmentName() {
+        return forDepartmentName;
+    }
+
+    public void setForDepartmentName(String forDepartmentName) {
+        this.forDepartmentName = forDepartmentName;
+    }
+
+    public Long getForCategoryId() {
+        return forCategoryId;
+    }
+
+    public void setForCategoryId(Long forCategoryId) {
+        this.forCategoryId = forCategoryId;
+    }
+
+    public String getForCategoryName() {
+        return forCategoryName;
+    }
+
+    public void setForCategoryName(String forCategoryName) {
+        this.forCategoryName = forCategoryName;
     }
 }

--- a/src/main/java/com/divudi/core/data/dto/service/ServiceCategoryDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/service/ServiceCategoryDTO.java
@@ -18,6 +18,7 @@ public class ServiceCategoryDTO {
     private String name;
     private String code;
     private String description;
+    private String categoryType; // CategoryType name, e.g. FINANCIAL_CATEGORY; null for untyped rows
     private boolean retired;
     private Date createdAt;
     private String message;
@@ -79,5 +80,13 @@ public class ServiceCategoryDTO {
 
     public void setMessage(String message) {
         this.message = message;
+    }
+
+    public String getCategoryType() {
+        return categoryType;
+    }
+
+    public void setCategoryType(String categoryType) {
+        this.categoryType = categoryType;
     }
 }

--- a/src/main/java/com/divudi/core/data/dto/service/ServiceCreateRequestDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/service/ServiceCreateRequestDTO.java
@@ -18,6 +18,7 @@ public class ServiceCreateRequestDTO {
     private String printName;
     private String fullName;
     private Long categoryId;
+    private Long financialCategoryId; // Category with categoryType FINANCIAL_CATEGORY (income account)
     private Long institutionId;
     private Long departmentId;
     private String inwardChargeType; // required when serviceType=Inward
@@ -97,6 +98,14 @@ public class ServiceCreateRequestDTO {
 
     public void setCategoryId(Long categoryId) {
         this.categoryId = categoryId;
+    }
+
+    public Long getFinancialCategoryId() {
+        return financialCategoryId;
+    }
+
+    public void setFinancialCategoryId(Long financialCategoryId) {
+        this.financialCategoryId = financialCategoryId;
     }
 
     public Long getInstitutionId() {

--- a/src/main/java/com/divudi/core/data/dto/service/ServiceResponseDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/service/ServiceResponseDTO.java
@@ -36,6 +36,8 @@ public class ServiceResponseDTO {
     private String inwardChargeType;
     private Long categoryId;
     private String categoryName;
+    private Long financialCategoryId;
+    private String financialCategoryName;
     private Long institutionId;
     private String institutionName;
     private Long departmentId;
@@ -213,6 +215,22 @@ public class ServiceResponseDTO {
 
     public void setCategoryName(String categoryName) {
         this.categoryName = categoryName;
+    }
+
+    public Long getFinancialCategoryId() {
+        return financialCategoryId;
+    }
+
+    public void setFinancialCategoryId(Long financialCategoryId) {
+        this.financialCategoryId = financialCategoryId;
+    }
+
+    public String getFinancialCategoryName() {
+        return financialCategoryName;
+    }
+
+    public void setFinancialCategoryName(String financialCategoryName) {
+        this.financialCategoryName = financialCategoryName;
     }
 
     public Long getInstitutionId() {

--- a/src/main/java/com/divudi/core/data/dto/service/ServiceSearchResultDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/service/ServiceSearchResultDTO.java
@@ -23,6 +23,8 @@ public class ServiceSearchResultDTO {
     private boolean inactive;
     private Long categoryId;
     private String categoryName;
+    private Long financialCategoryId;
+    private String financialCategoryName;
     private String inwardChargeType;
 
     public ServiceSearchResultDTO() {
@@ -114,6 +116,22 @@ public class ServiceSearchResultDTO {
 
     public void setCategoryName(String categoryName) {
         this.categoryName = categoryName;
+    }
+
+    public Long getFinancialCategoryId() {
+        return financialCategoryId;
+    }
+
+    public void setFinancialCategoryId(Long financialCategoryId) {
+        this.financialCategoryId = financialCategoryId;
+    }
+
+    public String getFinancialCategoryName() {
+        return financialCategoryName;
+    }
+
+    public void setFinancialCategoryName(String financialCategoryName) {
+        this.financialCategoryName = financialCategoryName;
     }
 
     public String getInwardChargeType() {

--- a/src/main/java/com/divudi/core/data/dto/service/ServiceUpdateRequestDTO.java
+++ b/src/main/java/com/divudi/core/data/dto/service/ServiceUpdateRequestDTO.java
@@ -18,6 +18,7 @@ public class ServiceUpdateRequestDTO {
     private String printName;
     private String fullName;
     private Long categoryId;
+    private Long financialCategoryId;
     private Long institutionId;
     private Long departmentId;
     private String inwardChargeType;
@@ -37,7 +38,8 @@ public class ServiceUpdateRequestDTO {
     public boolean isValid() {
         // At least one field must be set
         return name != null || code != null || printName != null || fullName != null
-                || categoryId != null || institutionId != null || departmentId != null
+                || categoryId != null || financialCategoryId != null
+                || institutionId != null || departmentId != null
                 || inwardChargeType != null || inactive != null || discountAllowed != null
                 || userChangable != null || chargesVisibleForInward != null
                 || marginNotAllowed != null || requestForQuentity != null
@@ -82,6 +84,14 @@ public class ServiceUpdateRequestDTO {
 
     public void setCategoryId(Long categoryId) {
         this.categoryId = categoryId;
+    }
+
+    public Long getFinancialCategoryId() {
+        return financialCategoryId;
+    }
+
+    public void setFinancialCategoryId(Long financialCategoryId) {
+        this.financialCategoryId = financialCategoryId;
     }
 
     public Long getInstitutionId() {

--- a/src/main/java/com/divudi/service/service/ServiceApiService.java
+++ b/src/main/java/com/divudi/service/service/ServiceApiService.java
@@ -15,6 +15,7 @@ import com.divudi.core.data.dto.service.ServiceResponseDTO;
 import com.divudi.core.data.dto.service.ServiceSearchResultDTO;
 import com.divudi.core.data.dto.service.ServiceUpdateRequestDTO;
 import com.divudi.core.data.inward.InwardChargeType;
+import com.divudi.core.data.CategoryType;
 import com.divudi.core.entity.Category;
 import com.divudi.core.entity.Department;
 import com.divudi.core.entity.Institution;
@@ -104,6 +105,18 @@ public class ServiceApiService implements Serializable {
      */
     public List<ServiceSearchResultDTO> searchServices(String query, String serviceType,
             Long categoryId, Boolean inactive, int limit) throws Exception {
+        return searchServices(query, null, serviceType, categoryId, inactive, limit);
+    }
+
+    /**
+     * Search services by name and/or item code.
+     *
+     * The code filter makes a bulk load idempotent: item code is the natural key
+     * a spreadsheet of services carries, and without it a caller cannot tell
+     * "already loaded" from "not loaded yet" except by an inexact name match.
+     */
+    public List<ServiceSearchResultDTO> searchServices(String query, String code, String serviceType,
+            Long categoryId, Boolean inactive, int limit) throws Exception {
 
         Map<String, Object> params = new HashMap<>();
         params.put("query", "%" + (query != null ? query : "") + "%");
@@ -128,6 +141,11 @@ public class ServiceApiService implements Serializable {
             jpql.append("AND i.name LIKE :query ");
         } else {
             params.remove("query");
+        }
+
+        if (code != null && !code.trim().isEmpty()) {
+            jpql.append("AND i.code LIKE :code ");
+            params.put("code", "%" + code.trim() + "%");
         }
 
         if (categoryId != null) {
@@ -248,6 +266,10 @@ public class ServiceApiService implements Serializable {
             service.setCategory(category);
         }
 
+        if (request.getFinancialCategoryId() != null) {
+            service.setFinancialCategory(loadFinancialCategory(request.getFinancialCategoryId()));
+        }
+
         if (request.getInstitutionId() != null) {
             Institution institution = institutionFacade.find(request.getInstitutionId());
             if (institution == null) {
@@ -364,6 +386,9 @@ public class ServiceApiService implements Serializable {
                 throw new Exception("Category not found with ID: " + request.getCategoryId());
             }
             service.setCategory(category);
+        }
+        if (request.getFinancialCategoryId() != null) {
+            service.setFinancialCategory(loadFinancialCategory(request.getFinancialCategoryId()));
         }
         if (request.getInstitutionId() != null) {
             Institution institution = institutionFacade.find(request.getInstitutionId());
@@ -1125,6 +1150,10 @@ public class ServiceApiService implements Serializable {
             dto.setCategoryId(item.getCategory().getId());
             dto.setCategoryName(item.getCategory().getName());
         }
+        if (item.getFinancialCategory() != null) {
+            dto.setFinancialCategoryId(item.getFinancialCategory().getId());
+            dto.setFinancialCategoryName(item.getFinancialCategory().getName());
+        }
         if (item.getInwardChargeType() != null) {
             dto.setInwardChargeType(item.getInwardChargeType().name());
         }
@@ -1162,6 +1191,10 @@ public class ServiceApiService implements Serializable {
         if (item.getCategory() != null) {
             dto.setCategoryId(item.getCategory().getId());
             dto.setCategoryName(item.getCategory().getName());
+        }
+        if (item.getFinancialCategory() != null) {
+            dto.setFinancialCategoryId(item.getFinancialCategory().getId());
+            dto.setFinancialCategoryName(item.getFinancialCategory().getName());
         }
         if (item.getInstitution() != null) {
             dto.setInstitutionId(item.getInstitution().getId());
@@ -1209,6 +1242,18 @@ public class ServiceApiService implements Serializable {
         dto.setDiscountAllowed(fee.isDiscountAllowed());
         dto.setMarginAllowed(fee.getMarginAllowed());
         dto.setRetired(fee.isRetired());
+        if (fee.getForInstitution() != null) {
+            dto.setForInstitutionId(fee.getForInstitution().getId());
+            dto.setForInstitutionName(fee.getForInstitution().getName());
+        }
+        if (fee.getForDepartment() != null) {
+            dto.setForDepartmentId(fee.getForDepartment().getId());
+            dto.setForDepartmentName(fee.getForDepartment().getName());
+        }
+        if (fee.getForCategory() != null) {
+            dto.setForCategoryId(fee.getForCategory().getId());
+            dto.setForCategoryName(fee.getForCategory().getName());
+        }
         if (fee.getInstitution() != null) {
             dto.setInstitutionId(fee.getInstitution().getId());
             dto.setInstitutionName(fee.getInstitution().getName());
@@ -1232,14 +1277,114 @@ public class ServiceApiService implements Serializable {
      * Build a ServiceCategoryDTO from a ServiceCategory entity.
      */
     private ServiceCategoryDTO buildServiceCategoryDTO(ServiceCategory category, String message) {
+        return buildCategoryDTO(category, message);
+    }
+
+    /**
+     * Build a category DTO from any Category row, not only a ServiceCategory.
+     */
+    private ServiceCategoryDTO buildCategoryDTO(Category category, String message) {
         ServiceCategoryDTO dto = new ServiceCategoryDTO();
         dto.setId(category.getId());
         dto.setName(category.getName());
         dto.setCode(category.getCode());
         dto.setDescription(category.getDescription());
+        dto.setCategoryType(category.getCategoryType() != null ? category.getCategoryType().name() : null);
         dto.setRetired(category.isRetired());
         dto.setCreatedAt(category.getCreatedAt());
         dto.setMessage(message);
         return dto;
+    }
+
+    // =========================================================================
+    // Generic Category lookup
+    // =========================================================================
+
+    /**
+     * Search any Category row, optionally narrowed to one CategoryType.
+     *
+     * {@link #searchServiceCategories(String, int)} only sees rows whose DTYPE is
+     * ServiceCategory, yet a service's category may be any Category subtype and
+     * its financial category is a plain Category of type FINANCIAL_CATEGORY.
+     * Without this a caller can set a categoryId it has no way to look up.
+     *
+     * @param categoryType optional {@link CategoryType} name, e.g. FINANCIAL_CATEGORY
+     */
+    public List<ServiceCategoryDTO> searchCategories(String query, String categoryType, int limit) throws Exception {
+        Map<String, Object> params = new HashMap<>();
+        StringBuilder jpql = new StringBuilder();
+        jpql.append("SELECT c FROM Category c WHERE c.retired = false ");
+
+        if (query != null && !query.trim().isEmpty()) {
+            jpql.append("AND c.name LIKE :query ");
+            params.put("query", "%" + query.trim() + "%");
+        }
+
+        if (categoryType != null && !categoryType.trim().isEmpty()) {
+            CategoryType type;
+            try {
+                type = CategoryType.valueOf(categoryType.trim());
+            } catch (IllegalArgumentException e) {
+                throw new Exception("Invalid categoryType: " + categoryType);
+            }
+            jpql.append("AND c.categoryType = :type ");
+            params.put("type", type);
+        }
+
+        jpql.append("ORDER BY c.name");
+
+        @SuppressWarnings("unchecked")
+        List<Category> results = (List<Category>) categoryFacade.findByJpql(
+                jpql.toString(), params, TemporalType.TIMESTAMP, limit);
+
+        List<ServiceCategoryDTO> dtos = new ArrayList<>();
+        if (results != null) {
+            for (Category cat : results) {
+                dtos.add(buildCategoryDTO(cat, null));
+            }
+        }
+        return dtos;
+    }
+
+    /**
+     * Resolve a financial category (income account) by id.
+     */
+    private Category loadFinancialCategory(Long financialCategoryId) throws Exception {
+        Category category = categoryFacade.find(financialCategoryId);
+        if (category == null || category.isRetired()) {
+            throw new Exception("Financial category not found with ID: " + financialCategoryId);
+        }
+        return category;
+    }
+
+    // =========================================================================
+    // Total recalculation
+    // =========================================================================
+
+    /**
+     * Recalculate an item's denormalised total and totalForForeigner from its
+     * current fees and persist them.
+     *
+     * These fields go stale whenever fees are written outside this API (bulk
+     * fee uploads, direct edits), and several list screens and reports read
+     * them rather than summing fees, so a stale 0.00 reads as "this service has
+     * no charge". Until now the recalculation only ran as a side effect of a
+     * fee create/update/delete, so there was no way to repair it without
+     * pointlessly rewriting a fee.
+     */
+    public ServiceResponseDTO recalculateTotals(Long id) throws Exception {
+        if (id == null) {
+            throw new Exception("Item ID is required");
+        }
+        Item item = itemFacade.find(id);
+        if (item == null) {
+            throw new Exception("Item not found with ID: " + id);
+        }
+        if (item.isRetired()) {
+            throw new Exception("Item is retired");
+        }
+        recalculateItemTotal(item);
+        List<ItemFee> fees = fetchFeesForItem(item);
+        return buildServiceResponseDTO(item, fees, "Totals recalculated successfully");
     }
 }

--- a/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
+++ b/src/main/java/com/divudi/ws/common/CapabilityStatementResource.java
@@ -517,7 +517,19 @@ public class CapabilityStatementResource {
                         + "— at least one is required. itemType targets every item of that subtype directly (e.g. every "
                         + "Investigation) since there is no API to enumerate every category id to loop over instead; "
                         + "categoryId alone still works and is not InvestigationCategory-restricted. "
-                        + "/fees/margin-disabled?categoryId=X (GET diagnostic list of fees with marginAllowed=false/null).",
+                        + "/fees/margin-disabled?categoryId=X (GET diagnostic list of fees with marginAllowed=false/null). "
+                        + "GET /search also filters on code (item code, substring), so a bulk load can be made idempotent on "
+                        + "the natural key rather than on an inexact name match. "
+                        + "financialCategoryId (a Category of type FINANCIAL_CATEGORY — the income account) is settable on "
+                        + "POST and PUT and returned on search and get. "
+                        + "/item-categories/search?query=X&categoryType=Y (GET any Category row, not only the ServiceCategory "
+                        + "DTYPE that /categories/search sees, so the categories services actually use and FINANCIAL_CATEGORY "
+                        + "rows are discoverable). "
+                        + "/{id}/recalculate-totals (POST recompute the denormalised total/totalForForeigner from current fees; "
+                        + "they go stale when fees are written outside this API and several screens read them instead of "
+                        + "summing fees). "
+                        + "Fee responses carry forInstitution/forDepartment/forCategory, which distinguish a base fee from a "
+                        + "site-, department- or collecting-centre-specific one.",
                         "API Key",
                         "GET", "POST", "PUT", "PATCH", "DELETE"))
                 .add(resource("Timed Items", "/api/timed-items",

--- a/src/main/java/com/divudi/ws/service/ServiceApi.java
+++ b/src/main/java/com/divudi/ws/service/ServiceApi.java
@@ -84,6 +84,7 @@ public class ServiceApi {
             }
 
             String query = uriInfo.getQueryParameters().getFirst("query");
+            String code = uriInfo.getQueryParameters().getFirst("code");
             String serviceType = uriInfo.getQueryParameters().getFirst("serviceType");
             String categoryIdStr = uriInfo.getQueryParameters().getFirst("categoryId");
             String inactiveStr = uriInfo.getQueryParameters().getFirst("inactive");
@@ -114,7 +115,7 @@ public class ServiceApi {
             }
 
             List<ServiceSearchResultDTO> results = serviceApiService.searchServices(
-                    query, serviceType, categoryId, inactive, limit);
+                    query, code, serviceType, categoryId, inactive, limit);
             return successResponse(results);
 
         } catch (Exception e) {
@@ -630,6 +631,78 @@ public class ServiceApi {
      * Search service categories.
      * GET /api/services/categories/search?query=surgery&limit=20
      */
+    /**
+     * Recalculate an item's total and totalForForeigner from its current fees.
+     * POST /api/services/{id}/recalculate-totals
+     */
+    @POST
+    @Path("/{id}/recalculate-totals")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response recalculateTotals(@PathParam("id") Long id) {
+        try {
+            String key = requestContext.getHeader("Finance");
+            WebUser user = validateApiKey(key);
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            ServiceResponseDTO response = serviceApiService.recalculateTotals(id);
+            return successResponse(response);
+
+        } catch (Exception e) {
+            String msg = e.getMessage();
+            if (msg != null && msg.contains("not found")) {
+                return errorResponse(msg, 404);
+            }
+            return errorResponse("An error occurred: " + (msg != null ? msg : "Unknown error"), 500);
+        }
+    }
+
+    /**
+     * Search any Category row, optionally narrowed to one CategoryType.
+     * Unlike /categories/search this is not limited to the ServiceCategory
+     * DTYPE, so it can find the categories services actually use and the
+     * FINANCIAL_CATEGORY rows used as income accounts.
+     *
+     * GET /api/services/item-categories/search?query=theatre&categoryType=FINANCIAL_CATEGORY&limit=20
+     */
+    @GET
+    @Path("/item-categories/search")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response searchAllCategories() {
+        try {
+            String key = requestContext.getHeader("Finance");
+            WebUser user = validateApiKey(key);
+            if (user == null) {
+                return errorResponse("Not a valid key", 401);
+            }
+
+            String query = uriInfo.getQueryParameters().getFirst("query");
+            String categoryType = uriInfo.getQueryParameters().getFirst("categoryType");
+            String limitStr = uriInfo.getQueryParameters().getFirst("limit");
+
+            int limit = 30;
+            if (limitStr != null && !limitStr.trim().isEmpty()) {
+                try {
+                    int parsed = Integer.parseInt(limitStr.trim());
+                    limit = Math.min(Math.max(parsed, 1), 100);
+                } catch (NumberFormatException e) {
+                    return errorResponse("Invalid limit format", 400);
+                }
+            }
+
+            List<ServiceCategoryDTO> results = serviceApiService.searchCategories(query, categoryType, limit);
+            return successResponse(results);
+
+        } catch (Exception e) {
+            String msg = e.getMessage();
+            if (msg != null && msg.startsWith("Invalid categoryType")) {
+                return errorResponse(msg, 400);
+            }
+            return errorResponse("An error occurred: " + (msg != null ? msg : "Unknown error"), 500);
+        }
+    }
+
     @GET
     @Path("/categories/search")
     @Produces(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
Closes #23745

Found while reconciling an 88-row theatre service sheet against Ruhunu local staging. All five
changes are **additive** — no existing request or response field changes meaning.

## Gaps closed

### 1. `financialCategory` could not be set or read
`Item.financialCategory` — the income account, e.g. `INCOME ACCOUNTS:Operation Theatre Service` —
is a column every service sheet carries, and the API had no field for it, so it had to be filled in
by hand on every item afterwards. Adds `financialCategoryId` on `POST`/`PUT` and
`financialCategoryId` + `financialCategoryName` on the search and get responses.

### 2. `GET /search` matched on `name` only
Item code is the natural key a sheet carries. Adds a `code` substring filter so a bulk load can be
made idempotent on it rather than on an inexact name match.

### 3. `GET /categories/search` only sees the `ServiceCategory` DTYPE
Yet `POST /services` resolves `categoryId` against the generic `Category`, and `financialCategory`
rows are plain `Category` — you could create against a category you had no way to look up. Adds
`GET /item-categories/search?query=&categoryType=` over any `Category` row, with an optional
`CategoryType` filter (invalid values return `400`).

### 4. `ItemFeeDTO` omitted the scoping keys
`forInstitution` / `forDepartment` / `forCategory` are what distinguish a **base** fee (all three
null) from a **site**, **department** or **collecting-centre** fee. `institutionId` is a different
thing — who the fee is payable to — so it does not substitute. Without these a caller genuinely
cannot tell the two apart.

### 5. No way to repair `Item.total` / `totalForForeigner`
These are denormalised and go stale whenever fees are written outside this API. Several list
screens and reports read them rather than summing fees, so a stale `0.00` reads as *"this service
has no charge"*. Recalculation only ran as a side effect of a fee create/update/delete, so
repairing a total meant pointlessly rewriting a fee. Adds `POST /{id}/recalculate-totals`, which
works for any `Item` subtype.

This is not hypothetical: on rhLocal all 88 theatre services carry correct fees yet report
`total: 0.0`, and each has two identical `Hospital Fee` rows the API gave no way to classify.

## Verification

Built and deployed locally (Payara, Galle Co-operative DB restore), exercised with curl and
cross-checked in the database.

| Check | Result |
|---|---|
| `GET /search?code=ac6` | Returns `AMBULANCE CHARGES 68-5569` — code filter works |
| `POST` with `financialCategoryId: 5` | Created, response carries `financialCategoryId: 5, financialCategoryName: "Dressing Charges"` |
| `GET /search?code=ZZ-API-GAP-1` | Round-trips the financial category on the search DTO too |
| `PUT` with only `financialCategoryId` | Updates (`isValid()` extended to count it, else the request was rejected as empty) |
| `PUT` with a non-existent financial category id | `404 Financial category not found with ID: 99999999` |
| `GET /item-categories/search?categoryType=SERVICE_CATEGORY` | Returns typed rows with `categoryType` |
| `GET /item-categories/search?categoryType=NOPE` | `400 Invalid categoryType: NOPE` |
| Fee with no scoping | `forInstitutionId/forDepartmentId/forCategoryId` all null — reads as a base fee |
| Same fee after setting `FORINSTITUTION_ID=2, FORDEPARTMENT_ID=486` in the DB | `forInstitutionName: "Galle Co Operative Hospital"`, `forDepartmentName: "Inward"` |
| `total` set to 0 in the DB, then `POST /{id}/recalculate-totals` | `total`/`totalForForeigner` back to `250.0`, confirmed in the DB |
| `POST /99999999/recalculate-totals` | `404 Item not found with ID: 99999999` |

Test service retired afterwards.

## Note on recalculation

`recalculate-totals` sums **every** non-retired fee on the item, including scoped ones — the same
rule the existing fee-write side effect already used. If an item carries duplicate rows (the same
charge once as a base fee and once scoped to an institution), the recalculated total is the sum of
both. That is why gap 4 matters: check `forInstitution`/`forDepartment`/`forCategory` first. The
API doc says this at the endpoint.

Capability statement and `developer_docs/api/using-apis/API_SERVICE_MANAGEMENT.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThiYJBdNquvCrnjDDBvsZR
