### PR TITLE
docs: note in-progress home-hosted QA migration in deployment guide

### DIFF
--- a/developer_docs/deployment/qa-deployment-guide.md
+++ b/developer_docs/deployment/qa-deployment-guide.md
@@ -5,6 +5,19 @@
 > `git push origin development:hims-qa1 --force` flow they used are **retired**.
 > QA now runs on the migrated Azure estate via the `hims-qaN-migrated` branches.
 
+> **🚧 2026-09-12: migration off Azure to home-hosted machines is in
+> progress.** QA1-3 are already live on home machines (QA4 close behind);
+> everything below this point still describes the Azure estate, which
+> remains the working environment until cutover. The home setup — trigger
+> branches (`home-qaN`, not `hims-qaN-home` — that pattern collides with
+> the `QA Branches Rules` ruleset below), self-hosted-runner workflows
+> (`hims_qaN_home_ci_cd.yml`), per-machine runbooks, and all the gotchas
+> hit along the way — is tracked separately in the private
+> [`hmislk/qa-home-infra`](https://github.com/hmislk/qa-home-infra) repo
+> (`MASTER-PLAN.md` for status, `GOTCHAS.md` for the detail). This guide
+> will be rewritten again once cutover completes and the Azure
+> `hims-qaN-migrated` branches are retired.
+
 ## How QA deployment works now
 
 Four QA apps (`qa1`–`qa4`) run on **one** Payara domain on the migrated Azure


### PR DESCRIPTION
## Summary
- Adds a pointer in `qa-deployment-guide.md` to the in-progress migration
  off the Azure QA estate onto home-hosted machines (QA1-3 already live,
  QA4 close behind), tracked in the private `hmislk/qa-home-infra` repo.
- No change to the guide's Azure-estate content, which remains accurate
  and current until cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdnJvLPPvG7vmHoSXnVhF2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the QA deployment guide with the current status of the transition from Azure-hosted environments to home-hosted machines.
  - Clarified which QA environments are already running on the new infrastructure and which remain on Azure during the transition.
  - Added interim guidance for deployment workflows and noted that the guide will be revised after the migration is complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->