### PR TITLE
Merge hotfix batch: settings save, excel export, final-bill dialog, reprint print options

### DIFF
--- a/src/main/java/com/divudi/bean/common/CreditCompanyDueController.java
+++ b/src/main/java/com/divudi/bean/common/CreditCompanyDueController.java
@@ -1534,6 +1534,238 @@ public class CreditCompanyDueController implements Serializable {
         }
     }
 
+    /**
+     * Excel export for the Inward Credit Due search
+     * ({@code credit/inward_due_search_credit_company.xhtml}). The on-screen
+     * table uses a grouped {@code p:subTable} (institution -> bills), which
+     * {@code p:dataExporter} cannot serialize - it always produces an empty
+     * workbook for that structure. Building the workbook directly with POI
+     * (same pattern as {@link #downloadExcel()} for the OPD due search)
+     * avoids that limitation.
+     */
+    public void downloadInwardCreditDueExcel() {
+        FacesContext facesContext = FacesContext.getCurrentInstance();
+        HttpServletResponse response = (HttpServletResponse) facesContext.getExternalContext().getResponse();
+
+        List<InstitutionEncounters> data = institutionEncounters == null ? Collections.emptyList() : institutionEncounters;
+
+        try (XSSFWorkbook workbook = new XSSFWorkbook()) {
+            Sheet sheet = workbook.createSheet("Inward Credit Due");
+
+            org.apache.poi.ss.usermodel.Font boldFont = workbook.createFont();
+            boldFont.setBold(true);
+
+            org.apache.poi.ss.usermodel.Font titleFont = workbook.createFont();
+            titleFont.setBold(true);
+            titleFont.setFontHeightInPoints((short) 15);
+
+            CellStyle titleStyle = workbook.createCellStyle();
+            titleStyle.setFont(titleFont);
+            titleStyle.setAlignment(HorizontalAlignment.CENTER);
+
+            CellStyle filterStyle = workbook.createCellStyle();
+            filterStyle.setAlignment(HorizontalAlignment.CENTER);
+
+            CellStyle sectionHeaderStyle = workbook.createCellStyle();
+            sectionHeaderStyle.setFont(boldFont);
+
+            CellStyle headerStyle = workbook.createCellStyle();
+            headerStyle.setFont(boldFont);
+            headerStyle.setAlignment(HorizontalAlignment.CENTER);
+            headerStyle.setBorderBottom(BorderStyle.THIN);
+            headerStyle.setBorderTop(BorderStyle.THIN);
+            headerStyle.setBorderLeft(BorderStyle.THIN);
+            headerStyle.setBorderRight(BorderStyle.THIN);
+
+            CellStyle dataStyle = workbook.createCellStyle();
+            dataStyle.setBorderBottom(BorderStyle.THIN);
+            dataStyle.setBorderTop(BorderStyle.THIN);
+            dataStyle.setBorderLeft(BorderStyle.THIN);
+            dataStyle.setBorderRight(BorderStyle.THIN);
+
+            CellStyle dateStyle = workbook.createCellStyle();
+            CreationHelper createHelper = workbook.getCreationHelper();
+            dateStyle.cloneStyleFrom(dataStyle);
+            dateStyle.setDataFormat(createHelper.createDataFormat().getFormat("yyyy-MM-dd"));
+
+            DataFormat format = workbook.createDataFormat();
+            CellStyle numberStyle = workbook.createCellStyle();
+            numberStyle.cloneStyleFrom(dataStyle);
+            numberStyle.setDataFormat(format.getFormat("#,##0.00"));
+
+            int headerCount = 8;
+            int rowIndex = 0;
+
+            SimpleDateFormat sdf = new SimpleDateFormat(sessionController.getApplicationPreference().getLongDateTimeFormat());
+
+            Row titleRow = sheet.createRow(rowIndex++);
+            Cell titleCell = titleRow.createCell(0);
+            titleCell.setCellValue("Due Search (Credit Company) - Inward");
+            titleCell.setCellStyle(titleStyle);
+            sheet.addMergedRegion(new CellRangeAddress(rowIndex - 1, rowIndex - 1, 0, headerCount - 1));
+
+            Row dateRow = sheet.createRow(rowIndex++);
+            Cell dateCell = dateRow.createCell(0);
+            dateCell.setCellValue(
+                    "From : " + (getFromDate() != null ? sdf.format(getFromDate()) : "-")
+                    + "    To : " + (getToDate() != null ? sdf.format(getToDate()) : "-")
+                    + "    Date Basis : " + ("admissionDate".equals(dateBasis) ? "Admission Date" : "Discharge Date"));
+            dateCell.setCellStyle(filterStyle);
+            sheet.addMergedRegion(new CellRangeAddress(rowIndex - 1, rowIndex - 1, 0, headerCount - 1));
+
+            Row filterRow = sheet.createRow(rowIndex++);
+            Cell filterCell = filterRow.createCell(0);
+            filterCell.setCellValue(
+                    "Admission Type : " + (admissionType != null ? admissionType.getName() : "All")
+                    + "    Payment Method : " + (paymentMethod != null ? paymentMethod.getLabel() : "All")
+                    + "    Institution : " + (institution != null ? institution.getName() : "All"));
+            filterCell.setCellStyle(filterStyle);
+            sheet.addMergedRegion(new CellRangeAddress(rowIndex - 1, rowIndex - 1, 0, headerCount - 1));
+
+            rowIndex++;
+
+            Row headerRow = sheet.createRow(rowIndex++);
+            int headerIndex = 0;
+            headerIndex = createHeaderCell(headerRow, headerIndex, "BHT No", headerStyle);
+            headerIndex = createHeaderCell(headerRow, headerIndex, "Date Of Admission", headerStyle);
+            headerIndex = createHeaderCell(headerRow, headerIndex, "Date Of Discharge", headerStyle);
+            headerIndex = createHeaderCell(headerRow, headerIndex, "Patient Name", headerStyle);
+            headerIndex = createHeaderCell(headerRow, headerIndex, "Credit Company", headerStyle);
+            headerIndex = createHeaderCell(headerRow, headerIndex, "Bill Amount", headerStyle);
+            headerIndex = createHeaderCell(headerRow, headerIndex, "Paid", headerStyle);
+            createHeaderCell(headerRow, headerIndex, "Outstanding", headerStyle);
+
+            for (InstitutionEncounters ins : data) {
+                if (ins == null) {
+                    continue;
+                }
+
+                Row institutionRow = sheet.createRow(rowIndex++);
+                Cell institutionCell = institutionRow.createCell(0);
+                institutionCell.setCellValue(ins.getInstitution() != null ? ins.getInstitution().getName() : "");
+                institutionCell.setCellStyle(sectionHeaderStyle);
+                sheet.addMergedRegion(new CellRangeAddress(institutionRow.getRowNum(), institutionRow.getRowNum(), 0, headerCount - 1));
+
+                for (Bill bill : ins.getBills()) {
+                    if (bill == null) {
+                        continue;
+                    }
+                    Row dataRow = sheet.createRow(rowIndex++);
+                    int dataIndex = 0;
+
+                    Cell bhtCell = dataRow.createCell(dataIndex++);
+                    bhtCell.setCellValue(bill.getPatientEncounter() != null ? bill.getPatientEncounter().getBhtNo() : "");
+                    bhtCell.setCellStyle(dataStyle);
+
+                    Cell admissionCell = dataRow.createCell(dataIndex++);
+                    Date doa = bill.getPatientEncounter() != null ? bill.getPatientEncounter().getDateOfAdmission() : null;
+                    if (doa != null) {
+                        admissionCell.setCellValue(doa);
+                        admissionCell.setCellStyle(dateStyle);
+                    } else {
+                        admissionCell.setCellValue("");
+                        admissionCell.setCellStyle(dataStyle);
+                    }
+
+                    Cell dischargeCell = dataRow.createCell(dataIndex++);
+                    Date dod = bill.getPatientEncounter() != null ? bill.getPatientEncounter().getDateOfDischarge() : null;
+                    if (dod != null) {
+                        dischargeCell.setCellValue(dod);
+                        dischargeCell.setCellStyle(dateStyle);
+                    } else {
+                        dischargeCell.setCellValue("");
+                        dischargeCell.setCellStyle(dataStyle);
+                    }
+
+                    Cell nameCell = dataRow.createCell(dataIndex++);
+                    nameCell.setCellValue(bill.getPatient() != null && bill.getPatient().getPerson() != null
+                            ? bill.getPatient().getPerson().getNameWithTitle() : "");
+                    nameCell.setCellStyle(dataStyle);
+
+                    Cell companyCell = dataRow.createCell(dataIndex++);
+                    companyCell.setCellValue(bill.getCreditCompany() != null ? bill.getCreditCompany().getName() : "");
+                    companyCell.setCellStyle(dataStyle);
+
+                    Cell amountCell = dataRow.createCell(dataIndex++);
+                    amountCell.setCellValue(bill.getNetTotal());
+                    amountCell.setCellStyle(numberStyle);
+
+                    Cell paidCell = dataRow.createCell(dataIndex++);
+                    paidCell.setCellValue(bill.getPaidAmount());
+                    paidCell.setCellStyle(numberStyle);
+
+                    Cell outstandingCell = dataRow.createCell(dataIndex);
+                    outstandingCell.setCellValue(bill.getNetTotal() - bill.getPaidAmount());
+                    outstandingCell.setCellStyle(numberStyle);
+                }
+
+                Row subTotalRow = sheet.createRow(rowIndex++);
+                Cell subTotalLabel = subTotalRow.createCell(0);
+                subTotalLabel.setCellValue("Sub Total");
+                subTotalLabel.setCellStyle(headerStyle);
+                sheet.addMergedRegion(new CellRangeAddress(subTotalRow.getRowNum(), subTotalRow.getRowNum(), 0, 4));
+
+                for (int i = 1; i <= 4; i++) {
+                    subTotalRow.createCell(i);
+                }
+
+                Cell subTotalAmount = subTotalRow.createCell(5);
+                subTotalAmount.setCellValue(ins.getTotal());
+                subTotalAmount.setCellStyle(numberStyle);
+
+                Cell subTotalPaid = subTotalRow.createCell(6);
+                subTotalPaid.setCellValue(ins.getPaidTotal());
+                subTotalPaid.setCellStyle(numberStyle);
+
+                Cell subTotalOutstanding = subTotalRow.createCell(7);
+                subTotalOutstanding.setCellValue(ins.getTotal() - ins.getPaidTotal());
+                subTotalOutstanding.setCellStyle(numberStyle);
+            }
+
+            Row grandTotalRow = sheet.createRow(rowIndex++);
+            Cell grandTotalLabel = grandTotalRow.createCell(0);
+            grandTotalLabel.setCellValue("Grand Total");
+            grandTotalLabel.setCellStyle(headerStyle);
+            sheet.addMergedRegion(new CellRangeAddress(grandTotalRow.getRowNum(), grandTotalRow.getRowNum(), 0, 4));
+
+            for (int i = 1; i <= 4; i++) {
+                grandTotalRow.createCell(i);
+            }
+
+            Cell grandTotalAmount = grandTotalRow.createCell(5);
+            grandTotalAmount.setCellValue(finalTotal);
+            grandTotalAmount.setCellStyle(numberStyle);
+
+            Cell grandTotalPaid = grandTotalRow.createCell(6);
+            grandTotalPaid.setCellValue(finalPaidTotal);
+            grandTotalPaid.setCellStyle(numberStyle);
+
+            Cell grandTotalOutstanding = grandTotalRow.createCell(7);
+            grandTotalOutstanding.setCellValue(finalTotal - finalPaidTotal);
+            grandTotalOutstanding.setCellStyle(numberStyle);
+
+            if (sessionController != null && sessionController.getLoggedUser() != null
+                    && sessionController.getLoggedUser().getWebUserPerson() != null) {
+                Row printedByRow = sheet.createRow(rowIndex++);
+                printedByRow.createCell(0).setCellValue(
+                        "Printed By : " + sessionController.getLoggedUser().getWebUserPerson().getName());
+            }
+
+            for (int i = 0; i < headerCount; i++) {
+                sheet.autoSizeColumn(i);
+            }
+
+            response.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+            response.setHeader("Content-Disposition", "attachment; filename=Inward_Credit_Due_Report.xlsx");
+            try (OutputStream outputStream = response.getOutputStream()) {
+                workbook.write(outputStream);
+                facesContext.responseComplete();
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
     //    public void createInwardCreditDueWithAdditionalFilters() {
 //        Date startTime = new Date();
 //

--- a/src/main/webapp/credit/inward_due_search_credit_company.xhtml
+++ b/src/main/webapp/credit/inward_due_search_credit_company.xhtml
@@ -60,9 +60,11 @@
                                 <p:printer target="lst"  />
                             </p:commandButton>
 
-                            <p:commandButton class="ui-button-success" icon="fas fa-file-excel" actionListener="#{creditCompanyDueController.createInwardCreditDue()}" ajax="false" value="Excel"  >
-                                <p:dataExporter type="xlsx" target="lst" fileName="Due Search(Credit Company)"  />
-                            </p:commandButton>
+                            <p:commandButton class="ui-button-success" icon="fas fa-file-excel"
+                                             actionListener="#{creditCompanyDueController.createInwardCreditDue()}"
+                                             action="#{creditCompanyDueController.downloadInwardCreditDueExcel()}"
+                                             ajax="false" value="Excel"  />
+
                         </h:panelGrid>
                         <p:dataTable id="lst" value="#{creditCompanyDueController.institutionEncounters}" var="i">
                             <f:facet name="header">
@@ -84,9 +86,9 @@
                                     <p:column headerText="Date Of Discharge"/>
                                     <p:column headerText="Patient Name"/>
                                     <p:column headerText="Credit Company"/>
-                                    <p:column headerText="Bill Amount"/>
-                                    <p:column headerText="Paid"/>
-                                    <p:column headerText="Outstanding"/>
+                                    <p:column headerText="Bill Amount" class="text-end"/>
+                                    <p:column headerText="Paid" class="text-end"/>
+                                    <p:column headerText="Outstanding" class="text-end"/>
                                 </p:row>
                             </p:columnGroup>
                             <p:subTable value="#{i.bills}" var="bill">

--- a/src/main/webapp/inward/inward_bill_final.xhtml
+++ b/src/main/webapp/inward/inward_bill_final.xhtml
@@ -24,6 +24,13 @@
                 margin-top: 0 !important;
                 padding-top: 0 !important;
                 }
+                .save-final-bill-loading-dialog {
+                position: fixed !important;
+                top: 50% !important;
+                left: 50% !important;
+                margin: 0 !important;
+                transform: translate(-50%, -50%) !important;
+                }
             </h:outputStylesheet>
         </h:head>
 
@@ -95,8 +102,10 @@
                                     styleClass="ui-button-success"
                                     icon="fa fa-check"
                                     style="width: 150px; padding: 1px;border: 1px solid ; margin: auto;"
+                                    onclick="PF('saveFinalBillLoadingDlg').show();"
                                     rendered="#{webUserController.hasPrivilege('InwardSettleFinalBill')}">
                                 </p:commandButton>
+                                
                             </div>
 
                         </div>
@@ -1203,6 +1212,24 @@
 
                     </p:panel>
                 </p:panel>
+
+                <p:dialog 
+                    widgetVar="saveFinalBillLoadingDlg"
+                    modal="true"
+                    closable="false"
+                    showHeader="true"
+                    header="Processing - Please Wait"
+                    position="center"
+                    appendTo="@(body)"
+                    styleClass="save-final-bill-loading-dialog"
+                    style="min-width: 320px; text-align: center;">
+                    <div style="padding: 20px;">
+                        <i class="pi pi-spin pi-spinner" style="font-size: 3rem; color: #4CAF50;"></i>
+                        <p style="margin-top: 15px; font-size: 1rem;">Saving the final bill, please wait...</p>
+                        <p style="color: #888; font-size: 0.85rem;">Do not refresh or close this page.</p>
+                    </div>
+                </p:dialog>
+
             </h:form>
 
         </h:panelGroup>

--- a/src/main/webapp/inward/inward_reprint_bill_deposit.xhtml
+++ b/src/main/webapp/inward/inward_reprint_bill_deposit.xhtml
@@ -171,22 +171,162 @@
                             </f:facet>
 
                             <div class="d-flex justify-content-center">
-                                <h:panelGroup id="gpBillPreview" >
+                                <h:panelGroup id="gpBillPreview" layout="block" class="w-100">
 
-                                    <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Payment Bill A4 Paper', false)}" >
-                                        <bill:A4PaperPaymentBill bill="#{inwardSearch.bill}" duplicate="true"/>
+                                    <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Payment Bill A4 Paper', false)}" layout="block">
+                                        <div class="row">
+                                            <div class="col-lg-6">
+                                                <p:panel>
+                                                    <f:facet name="header">
+                                                        <div class="d-flex justify-content-between">
+                                                            <div><h:outputLabel value="Original" class="mt-2"/></div>
+                                                            <div>
+                                                                <p:commandButton icon="fa fa-print" value="Print" class="ui-button-info" ajax="false">
+                                                                    <p:printer target="originalA4DepositBillPreview" ></p:printer>
+                                                                </p:commandButton>
+                                                            </div>
+                                                        </div>
+                                                    </f:facet>
+                                                    <h:panelGroup id="originalA4DepositBillPreview">
+                                                        <bill:A4PaperPaymentBill bill="#{inwardSearch.bill}" duplicate="false"/>
+                                                    </h:panelGroup>
+                                                </p:panel>
+                                            </div>
+                                            <div class="col-lg-6">
+                                                <p:panel>
+                                                    <f:facet name="header">
+                                                        <div class="d-flex justify-content-between">
+                                                            <div><h:outputLabel value="Duplicate" class="mt-2"/></div>
+                                                            <div>
+                                                                <p:commandButton icon="fa fa-print" value="Print" class="ui-button-info" ajax="false">
+                                                                    <p:printer target="duplicateA4DepositBillPreview" ></p:printer>
+                                                                </p:commandButton>
+                                                            </div>
+                                                        </div>
+                                                    </f:facet>
+                                                    <h:panelGroup id="duplicateA4DepositBillPreview">
+                                                        <bill:A4PaperPaymentBill bill="#{inwardSearch.bill}" duplicate="true"/>
+                                                    </h:panelGroup>
+                                                </p:panel>
+                                            </div>
+                                        </div>
                                     </h:panelGroup>
 
-                                    <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Payment Bill Five Five Paper', false)}" >
-                                        <bill:FiveFivePaymentBill bill="#{inwardSearch.bill}" duplicate="true" />
+                                    <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Payment Bill Five Five Paper', false)}" layout="block">
+                                        <div class="row">
+                                            <div class="col-lg-6">
+                                                <p:panel>
+                                                    <f:facet name="header">
+                                                        <div class="d-flex justify-content-between">
+                                                            <div><h:outputLabel value="Original" class="mt-2"/></div>
+                                                            <div>
+                                                                <p:commandButton icon="fa fa-print" value="Print" class="ui-button-info" ajax="false">
+                                                                    <p:printer target="originalFiveFiveDepositBillPreview" ></p:printer>
+                                                                </p:commandButton>
+                                                            </div>
+                                                        </div>
+                                                    </f:facet>
+                                                    <h:panelGroup id="originalFiveFiveDepositBillPreview">
+                                                        <bill:FiveFivePaymentBill bill="#{inwardSearch.bill}" duplicate="false" />
+                                                    </h:panelGroup>
+                                                </p:panel>
+                                            </div>
+                                            <div class="col-lg-6">
+                                                <p:panel>
+                                                    <f:facet name="header">
+                                                        <div class="d-flex justify-content-between">
+                                                            <div><h:outputLabel value="Duplicate" class="mt-2"/></div>
+                                                            <div>
+                                                                <p:commandButton icon="fa fa-print" value="Print" class="ui-button-info" ajax="false">
+                                                                    <p:printer target="duplicateFiveFiveDepositBillPreview" ></p:printer>
+                                                                </p:commandButton>
+                                                            </div>
+                                                        </div>
+                                                    </f:facet>
+                                                    <h:panelGroup id="duplicateFiveFiveDepositBillPreview">
+                                                        <bill:FiveFivePaymentBill bill="#{inwardSearch.bill}" duplicate="true" />
+                                                    </h:panelGroup>
+                                                </p:panel>
+                                            </div>
+                                        </div>
                                     </h:panelGroup>
 
-                                    <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Payment Bill POS Paper', true)}" style="align-items: center;">
-                                        <bill:posPaperPaymentBill bill="#{inwardSearch.bill}"/>
+                                    <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Payment Bill POS Paper', true)}" layout="block">
+                                        <div class="row">
+                                            <div class="col-lg-6">
+                                                <p:panel>
+                                                    <f:facet name="header">
+                                                        <div class="d-flex justify-content-between">
+                                                            <div><h:outputLabel value="Original" class="mt-2"/></div>
+                                                            <div>
+                                                                <p:commandButton icon="fa fa-print" value="Print" class="ui-button-info" ajax="false">
+                                                                    <p:printer target="originalPosDepositBillPreview" ></p:printer>
+                                                                </p:commandButton>
+                                                            </div>
+                                                        </div>
+                                                    </f:facet>
+                                                    <h:panelGroup id="originalPosDepositBillPreview" style="display:flex; justify-content:center;">
+                                                        <bill:posPaperPaymentBill bill="#{inwardSearch.bill}" duplicate="false"/>
+                                                    </h:panelGroup>
+                                                </p:panel>
+                                            </div>
+                                            <div class="col-lg-6">
+                                                <p:panel>
+                                                    <f:facet name="header">
+                                                        <div class="d-flex justify-content-between">
+                                                            <div><h:outputLabel value="Duplicate" class="mt-2"/></div>
+                                                            <div>
+                                                                <p:commandButton icon="fa fa-print" value="Print" class="ui-button-info" ajax="false">
+                                                                    <p:printer target="duplicatePosDepositBillPreview" ></p:printer>
+                                                                </p:commandButton>
+                                                            </div>
+                                                        </div>
+                                                    </f:facet>
+                                                    <h:panelGroup id="duplicatePosDepositBillPreview" style="display:flex; justify-content:center;">
+                                                        <bill:posPaperPaymentBill bill="#{inwardSearch.bill}" duplicate="true"/>
+                                                    </h:panelGroup>
+                                                </p:panel>
+                                            </div>
+                                        </div>
                                     </h:panelGroup>
 
-                                    <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Payment Bill Five Five Custom 3 Paper', false)}" >
-                                        <prints:five_five_custom_3_inward_payments bill="#{inwardSearch.bill}" duplicate="true" />
+                                    <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Payment Bill Five Five Custom 3 Paper', false)}" layout="block">
+                                        <div class="row">
+                                            <div class="col-lg-6">
+                                                <p:panel>
+                                                    <f:facet name="header">
+                                                        <div class="d-flex justify-content-between">
+                                                            <div><h:outputLabel value="Original" class="mt-2"/></div>
+                                                            <div>
+                                                                <p:commandButton icon="fa fa-print" value="Print" class="ui-button-info" ajax="false">
+                                                                    <p:printer target="originalCustom3DepositBillPreview" ></p:printer>
+                                                                </p:commandButton>
+                                                            </div>
+                                                        </div>
+                                                    </f:facet>
+                                                    <h:panelGroup id="originalCustom3DepositBillPreview">
+                                                        <prints:five_five_custom_3_inward_payments bill="#{inwardSearch.bill}" duplicate="false" />
+                                                    </h:panelGroup>
+                                                </p:panel>
+                                            </div>
+                                            <div class="col-lg-6">
+                                                <p:panel>
+                                                    <f:facet name="header">
+                                                        <div class="d-flex justify-content-between">
+                                                            <div><h:outputLabel value="Duplicate" class="mt-2"/></div>
+                                                            <div>
+                                                                <p:commandButton icon="fa fa-print" value="Print" class="ui-button-info" ajax="false">
+                                                                    <p:printer target="duplicateCustom3DepositBillPreview" ></p:printer>
+                                                                </p:commandButton>
+                                                            </div>
+                                                        </div>
+                                                    </f:facet>
+                                                    <h:panelGroup id="duplicateCustom3DepositBillPreview">
+                                                        <prints:five_five_custom_3_inward_payments bill="#{inwardSearch.bill}" duplicate="true" />
+                                                    </h:panelGroup>
+                                                </p:panel>
+                                            </div>
+                                        </div>
                                     </h:panelGroup>
 
                                 </h:panelGroup>

--- a/src/main/webapp/inward/inward_reprint_bill_final.xhtml
+++ b/src/main/webapp/inward/inward_reprint_bill_final.xhtml
@@ -856,7 +856,7 @@
 
                                         <p:ajax event="open" listener="#{bhtSummeryController.loadCustom2Config}" update="custom2ConfigForm" />
 
-                                        <h:form id="custom2ConfigForm" rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}">
+                                        <h:panelGroup id="custom2ConfigForm" layout="block" rendered="#{webUserController.hasPrivilege('ChangeReceiptPrintingPaperTypes')}">
                                             <div class="card-body">
                                                 <h6>Which formats print</h6>
                                                 <div class="mb-3">
@@ -941,7 +941,7 @@
                                                         type="button" />
                                                 </div>
                                             </div>
-                                        </h:form>
+                                        </h:panelGroup>
                                     </p:dialog>
                                 </p:tab>
                             </p:tabView>

--- a/src/main/webapp/inward/inward_reprint_bill_payment.xhtml
+++ b/src/main/webapp/inward/inward_reprint_bill_payment.xhtml
@@ -189,22 +189,162 @@
                             </f:facet>
 
                             <div class="d-flex justify-content-center">
-                                <h:panelGroup id="gpBillPreview" >
+                                <h:panelGroup id="gpBillPreview" layout="block" class="w-100">
 
-                                    <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Payment Bill A4 Paper', false)}" >
-                                        <bill:A4PaperPaymentBill bill="#{inwardSearch.bill}" duplicate="true"/>                        
+                                    <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Payment Bill A4 Paper', false)}" layout="block">
+                                        <div class="row">
+                                            <div class="col-lg-6">
+                                                <p:panel>
+                                                    <f:facet name="header">
+                                                        <div class="d-flex justify-content-between">
+                                                            <div><h:outputLabel value="Original" class="mt-2"/></div>
+                                                            <div>
+                                                                <p:commandButton icon="fa fa-print" value="Print" class="ui-button-info" ajax="false">
+                                                                    <p:printer target="originalA4PaymentBillPreview" ></p:printer>
+                                                                </p:commandButton>
+                                                            </div>
+                                                        </div>
+                                                    </f:facet>
+                                                    <h:panelGroup id="originalA4PaymentBillPreview">
+                                                        <bill:A4PaperPaymentBill bill="#{inwardSearch.bill}" duplicate="false"/>
+                                                    </h:panelGroup>
+                                                </p:panel>
+                                            </div>
+                                            <div class="col-lg-6">
+                                                <p:panel>
+                                                    <f:facet name="header">
+                                                        <div class="d-flex justify-content-between">
+                                                            <div><h:outputLabel value="Duplicate" class="mt-2"/></div>
+                                                            <div>
+                                                                <p:commandButton icon="fa fa-print" value="Print" class="ui-button-info" ajax="false">
+                                                                    <p:printer target="duplicateA4PaymentBillPreview" ></p:printer>
+                                                                </p:commandButton>
+                                                            </div>
+                                                        </div>
+                                                    </f:facet>
+                                                    <h:panelGroup id="duplicateA4PaymentBillPreview">
+                                                        <bill:A4PaperPaymentBill bill="#{inwardSearch.bill}" duplicate="true"/>
+                                                    </h:panelGroup>
+                                                </p:panel>
+                                            </div>
+                                        </div>
                                     </h:panelGroup>
 
-                                    <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Payment Bill Five Five Paper', false)}" >
-                                        <bill:FiveFivePaymentBill bill="#{inwardSearch.bill}" duplicate="true" />    
-                                    </h:panelGroup> 
-
-                                    <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Payment Bill POS Paper', true)}" style="align-items: center;">
-                                        <bill:posPaperPaymentBill bill="#{inwardSearch.bill}"/> 
+                                    <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Payment Bill Five Five Paper', false)}" layout="block">
+                                        <div class="row">
+                                            <div class="col-lg-6">
+                                                <p:panel>
+                                                    <f:facet name="header">
+                                                        <div class="d-flex justify-content-between">
+                                                            <div><h:outputLabel value="Original" class="mt-2"/></div>
+                                                            <div>
+                                                                <p:commandButton icon="fa fa-print" value="Print" class="ui-button-info" ajax="false">
+                                                                    <p:printer target="originalFiveFivePaymentBillPreview" ></p:printer>
+                                                                </p:commandButton>
+                                                            </div>
+                                                        </div>
+                                                    </f:facet>
+                                                    <h:panelGroup id="originalFiveFivePaymentBillPreview">
+                                                        <bill:FiveFivePaymentBill bill="#{inwardSearch.bill}" duplicate="false" />
+                                                    </h:panelGroup>
+                                                </p:panel>
+                                            </div>
+                                            <div class="col-lg-6">
+                                                <p:panel>
+                                                    <f:facet name="header">
+                                                        <div class="d-flex justify-content-between">
+                                                            <div><h:outputLabel value="Duplicate" class="mt-2"/></div>
+                                                            <div>
+                                                                <p:commandButton icon="fa fa-print" value="Print" class="ui-button-info" ajax="false">
+                                                                    <p:printer target="duplicateFiveFivePaymentBillPreview" ></p:printer>
+                                                                </p:commandButton>
+                                                            </div>
+                                                        </div>
+                                                    </f:facet>
+                                                    <h:panelGroup id="duplicateFiveFivePaymentBillPreview">
+                                                        <bill:FiveFivePaymentBill bill="#{inwardSearch.bill}" duplicate="true" />
+                                                    </h:panelGroup>
+                                                </p:panel>
+                                            </div>
+                                        </div>
                                     </h:panelGroup>
 
-                                    <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Payment Bill Five Five Custom 3 Paper', false)}" >
-                                        <prints:five_five_custom_3_inward_payments bill="#{inwardSearch.bill}" duplicate="true" />
+                                    <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Payment Bill POS Paper', true)}" layout="block">
+                                        <div class="row">
+                                            <div class="col-lg-6">
+                                                <p:panel>
+                                                    <f:facet name="header">
+                                                        <div class="d-flex justify-content-between">
+                                                            <div><h:outputLabel value="Original" class="mt-2"/></div>
+                                                            <div>
+                                                                <p:commandButton icon="fa fa-print" value="Print" class="ui-button-info" ajax="false">
+                                                                    <p:printer target="originalPosPaymentBillPreview" ></p:printer>
+                                                                </p:commandButton>
+                                                            </div>
+                                                        </div>
+                                                    </f:facet>
+                                                    <h:panelGroup id="originalPosPaymentBillPreview" style="display:flex; justify-content:center;">
+                                                        <bill:posPaperPaymentBill bill="#{inwardSearch.bill}" duplicate="false"/>
+                                                    </h:panelGroup>
+                                                </p:panel>
+                                            </div>
+                                            <div class="col-lg-6">
+                                                <p:panel>
+                                                    <f:facet name="header">
+                                                        <div class="d-flex justify-content-between">
+                                                            <div><h:outputLabel value="Duplicate" class="mt-2"/></div>
+                                                            <div>
+                                                                <p:commandButton icon="fa fa-print" value="Print" class="ui-button-info" ajax="false">
+                                                                    <p:printer target="duplicatePosPaymentBillPreview" ></p:printer>
+                                                                </p:commandButton>
+                                                            </div>
+                                                        </div>
+                                                    </f:facet>
+                                                    <h:panelGroup id="duplicatePosPaymentBillPreview" style="display:flex; justify-content:center;">
+                                                        <bill:posPaperPaymentBill bill="#{inwardSearch.bill}" duplicate="true"/>
+                                                    </h:panelGroup>
+                                                </p:panel>
+                                            </div>
+                                        </div>
+                                    </h:panelGroup>
+
+                                    <h:panelGroup rendered="#{configOptionController.getBooleanValueByKey('Inward Payment Bill Five Five Custom 3 Paper', false)}" layout="block">
+                                        <div class="row">
+                                            <div class="col-lg-6">
+                                                <p:panel>
+                                                    <f:facet name="header">
+                                                        <div class="d-flex justify-content-between">
+                                                            <div><h:outputLabel value="Original" class="mt-2"/></div>
+                                                            <div>
+                                                                <p:commandButton icon="fa fa-print" value="Print" class="ui-button-info" ajax="false">
+                                                                    <p:printer target="originalCustom3PaymentBillPreview" ></p:printer>
+                                                                </p:commandButton>
+                                                            </div>
+                                                        </div>
+                                                    </f:facet>
+                                                    <h:panelGroup id="originalCustom3PaymentBillPreview">
+                                                        <prints:five_five_custom_3_inward_payments bill="#{inwardSearch.bill}" duplicate="false" />
+                                                    </h:panelGroup>
+                                                </p:panel>
+                                            </div>
+                                            <div class="col-lg-6">
+                                                <p:panel>
+                                                    <f:facet name="header">
+                                                        <div class="d-flex justify-content-between">
+                                                            <div><h:outputLabel value="Duplicate" class="mt-2"/></div>
+                                                            <div>
+                                                                <p:commandButton icon="fa fa-print" value="Print" class="ui-button-info" ajax="false">
+                                                                    <p:printer target="duplicateCustom3PaymentBillPreview" ></p:printer>
+                                                                </p:commandButton>
+                                                            </div>
+                                                        </div>
+                                                    </f:facet>
+                                                    <h:panelGroup id="duplicateCustom3PaymentBillPreview">
+                                                        <prints:five_five_custom_3_inward_payments bill="#{inwardSearch.bill}" duplicate="true" />
+                                                    </h:panelGroup>
+                                                </p:panel>
+                                            </div>
+                                        </div>
                                     </h:panelGroup>
 
                                 </h:panelGroup>


### PR DESCRIPTION
## Summary
Full parity with hotfix PR #23761 (`coop-stg-migrated`) — all 4 commits / 6 files, now against `development`.

### 1. Custom Bills Settings dialog not saving (Closes #23758)
**Page:** `src/main/webapp/inward/inward_reprint_bill_final.xhtml` — Final Bill reprint, **Custom Bills** tab → **Settings**.
Dialog's `<h:form id="custom2ConfigForm">` was invalidly nested inside the page's outer `<h:form>`; browsers silently drop the inner form tag, so option changes never actually reached `BhtSummeryController.saveCustom2Config()`. Replaced the nested `<h:form>` with an `<h:panelGroup>` of the same id.

### 2. Inward Credit Due Excel export downloads empty (Closes #23759)
**Page:** `src/main/webapp/credit/inward_due_search_credit_company.xhtml`.
The table groups bills per credit company via `<p:subTable>`, which PrimeFaces' `<p:dataExporter>` cannot serialize. Added `CreditCompanyDueController.downloadInwardCreditDueExcel()`, a direct Apache POI export (project's documented pattern for this limitation), and wired the Excel button to it.

### 3. Processing dialog on Save Final Bill (Closes #23756)
**Page:** `src/main/webapp/inward/inward_bill_final.xhtml`.
Added a "Processing - Please Wait" modal on the Save Final Bill button, mirroring the existing pattern on the Interim Bill's Create Final Bill button.

### 4. Original bill print option on payment/deposit reprint pages (Closes #23757)
**Pages:** `src/main/webapp/inward/inward_reprint_bill_payment.xhtml`, `src/main/webapp/inward/inward_reprint_bill_deposit.xhtml`.
These pages always printed `duplicate="true"` with no way to print an Original copy. Added Original/Duplicate side-by-side printing (A4, 5x5, POS, 5x5 Custom 3 formats), each with its own Print button, matching the existing convention on `inward_reprint_bill_final.xhtml`.

## Issues
Closes #23758
Closes #23759
Closes #23756
Closes #23757

## Test plan
- [ ] Menu → Inpatient → Search → Final Bill for an approved final bill → Custom Bills tab → Settings → toggle an option → Apply & Close → reopen Settings and confirm it stuck.
- [ ] Menu → Credit → Inward Credit Due → set filters → Process → Excel → confirm the downloaded workbook contains the same rows/sub-totals/grand total shown on screen.
- [ ] Save an Interim/Final Bill → confirm the "Processing - Please Wait" dialog shows and stays centered.
- [ ] Reprint a payment/deposit bill → confirm Original and Duplicate copies both print correctly across all formats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UYy6s6R7myMEgoGE7Wjxh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Excel export for Inward Credit Due search results, including institution details, bill information, subtotals, totals, filters, and print details.
  - Added side-by-side Original and Duplicate bill previews for supported paper formats, with individual print controls.

- **UI Improvements**
  - Improved alignment for Bill Amount, Paid, and Outstanding columns.
  - Added a loading dialog when saving final bills.
  - Updated bill configuration dialog structure while preserving existing save, cancel, and access controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->